### PR TITLE
custom_response: expose existing local reply body to formatter

### DIFF
--- a/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
+++ b/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
@@ -26,7 +26,8 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // downstream.
 message LocalResponsePolicy {
   // Optional new local reply body text. It will be used
-  // in the ``%LOCAL_REPLY_BODY%`` command operator in the ``body_format``.
+  // in the ``%LOCAL_REPLY_BODY%`` command operator in the ``body_format``. If unset for an
+  // existing local reply, the existing body will be used instead.
   config.core.v3.DataSource body = 1;
 
   // Optional body format to be used for this response. If ``body_format`` is  not

--- a/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
+++ b/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
@@ -26,8 +26,9 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // downstream.
 message LocalResponsePolicy {
   // Optional new local reply body text. It will be used
-  // in the ``%LOCAL_REPLY_BODY%`` command operator in the ``body_format``. If unset for an
-  // existing local reply, the existing body will be used instead.
+  // in the ``%LOCAL_REPLY_BODY%`` command operator in the ``body_format``. If unset when
+  // ``body_format`` is configured for an existing local reply, the existing body will be used as
+  // the formatter input instead.
   config.core.v3.DataSource body = 1;
 
   // Optional body format to be used for this response. If ``body_format`` is  not

--- a/changelogs/current/bug_fixes/http__custom-response-local-reply-body.rst
+++ b/changelogs/current/bug_fixes/http__custom-response-local-reply-body.rst
@@ -1,0 +1,3 @@
+Fixed the custom response filter so ``%LOCAL_REPLY_BODY%`` in a local response policy's
+``body_format`` receives the existing local reply body when the policy does not configure its own
+``body``.

--- a/envoy/http/filter.h
+++ b/envoy/http/filter.h
@@ -979,6 +979,9 @@ public:
     // True if a reset will occur rather than the local reply (some prior filter
     // has returned ContinueAndResetStream)
     bool reset_imminent_;
+    // The body supplied to sendLocalReply(). This view is valid only for the duration of the
+    // onLocalReply() callback.
+    absl::string_view body_;
   };
 
   /**

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1044,7 +1044,7 @@ void DownstreamFilterManager::sendLocalReply(
   }
 
   streamInfo().setResponseCodeDetails(details);
-  StreamFilterBase::LocalReplyData data{code, grpc_status, details, false};
+  StreamFilterBase::LocalReplyData data{code, grpc_status, details, false, body};
   onLocalReply(data);
   if (data.reset_imminent_) {
     ENVOY_STREAM_LOG(debug, "Resetting stream due to {}. onLocalReply requested reset.", *this,

--- a/source/extensions/filters/http/custom_response/custom_response_filter.h
+++ b/source/extensions/filters/http/custom_response/custom_response_filter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "envoy/extensions/filters/http/custom_response/v3/custom_response.pb.h"
 #include "envoy/extensions/filters/http/custom_response/v3/custom_response.pb.validate.h"
 #include "envoy/http/filter.h"
@@ -32,8 +34,9 @@ public:
   }
 
   ::Envoy::Http::LocalErrorStatus
-  onLocalReply(const ::Envoy::Http::StreamFilterBase::LocalReplyData&) override {
+  onLocalReply(const ::Envoy::Http::StreamFilterBase::LocalReplyData& data) override {
     on_local_reply_called_ = true;
+    local_reply_body_ = std::string(data.body_);
     return ::Envoy::Http::LocalErrorStatus::Continue;
   }
 
@@ -41,6 +44,7 @@ public:
   ::Envoy::Http::StreamEncoderFilterCallbacks* encoderCallbacks() { return encoder_callbacks_; }
   ::Envoy::Http::StreamDecoderFilterCallbacks* decoderCallbacks() { return decoder_callbacks_; }
   bool onLocalReplyCalled() const { return on_local_reply_called_; }
+  absl::string_view localReplyBody() const { return local_reply_body_; }
 
   ~CustomResponseFilter() override = default;
 
@@ -49,6 +53,7 @@ public:
 private:
   const std::shared_ptr<const FilterConfig> config_;
   ::Envoy::Http::RequestHeaderMap* downstream_headers_ = nullptr;
+  std::string local_reply_body_;
   bool on_local_reply_called_ = false;
 };
 

--- a/source/extensions/filters/http/custom_response/custom_response_filter.h
+++ b/source/extensions/filters/http/custom_response/custom_response_filter.h
@@ -36,6 +36,8 @@ public:
   ::Envoy::Http::LocalErrorStatus
   onLocalReply(const ::Envoy::Http::StreamFilterBase::LocalReplyData& data) override {
     on_local_reply_called_ = true;
+    // LocalReplyData::body_ is valid only during this callback, so retain an owned copy for the
+    // local response policy to use later in encodeHeaders().
     local_reply_body_ = std::string(data.body_);
     return ::Envoy::Http::LocalErrorStatus::Continue;
   }

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -69,8 +69,14 @@ Envoy::Http::FilterHeadersStatus LocalResponsePolicy::encodeHeaders(
   ENVOY_BUG(encoder_callbacks->streamInfo().filterState()->getDataReadOnly<Policy>(
                 "envoy.filters.http.custom_response") == nullptr,
             "Filter State should not be set when using the LocalResponse policy.");
-  // Handle local body
-  std::string body(custom_response_filter.localReplyBody());
+  std::string body;
+  // When body_format is configured without an explicit body, seed %LOCAL_REPLY_BODY% with the
+  // body captured from the original local reply. Limiting this to the formatter path keeps an
+  // explicit body authoritative, while policies with neither body nor body_format retain their
+  // existing empty body behavior.
+  if (formatter_ && !local_body_.has_value()) {
+    body = std::string(custom_response_filter.localReplyBody());
+  }
   Envoy::Http::Code code = getStatusCodeForLocalReply(headers);
   formatBody(encoder_callbacks->streamInfo().getRequestHeaders() == nullptr
                  ? *Envoy::Http::StaticEmptyHeaders::get().request_headers

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -70,7 +70,7 @@ Envoy::Http::FilterHeadersStatus LocalResponsePolicy::encodeHeaders(
                 "envoy.filters.http.custom_response") == nullptr,
             "Filter State should not be set when using the LocalResponse policy.");
   // Handle local body
-  std::string body;
+  std::string body(custom_response_filter.localReplyBody());
   Envoy::Http::Code code = getStatusCodeForLocalReply(headers);
   formatBody(encoder_callbacks->streamInfo().getRequestHeaders() == nullptr
                  ? *Envoy::Http::StaticEmptyHeaders::get().request_headers

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -392,18 +392,21 @@ TEST_F(FilterManagerTest, OnLocalReply) {
       .WillOnce(Invoke(
           [&](const StreamFilterBase::LocalReplyData& local_reply_data) -> Http::LocalErrorStatus {
             EXPECT_THAT(local_reply_data.grpc_status_, testing::Optional(Grpc::Status::Internal));
+            EXPECT_EQ(local_reply_data.body_, "body");
             return Http::LocalErrorStatus::Continue;
           }));
   EXPECT_CALL(*stream_filter, onLocalReply(_))
       .WillOnce(Invoke(
           [&](const StreamFilterBase::LocalReplyData& local_reply_data) -> Http::LocalErrorStatus {
             EXPECT_THAT(local_reply_data.grpc_status_, testing::Optional(Grpc::Status::Internal));
+            EXPECT_EQ(local_reply_data.body_, "body");
             return LocalErrorStatus::ContinueAndResetStream;
           }));
   EXPECT_CALL(*encoder_filter, onLocalReply(_))
       .WillOnce(Invoke(
           [&](const StreamFilterBase::LocalReplyData& local_reply_data) -> Http::LocalErrorStatus {
             EXPECT_THAT(local_reply_data.grpc_status_, testing::Optional(Grpc::Status::Internal));
+            EXPECT_EQ(local_reply_data.body_, "body");
             return Http::LocalErrorStatus::Continue;
           }));
   EXPECT_CALL(filter_manager_callbacks_, resetStream(_, _));

--- a/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
@@ -79,6 +79,64 @@ TEST_F(CustomResponseFilterTest, LocalData) {
             ::Envoy::Http::FilterHeadersStatus::StopIteration);
 }
 
+TEST_F(CustomResponseFilterTest, ExistingLocalReplyBodyWithFormatter) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          body_format:
+            text_format_source:
+              inline_string: "%LOCAL_REPLY_BODY%"
+)EOF");
+  setupFilterAndCallback();
+
+  const ::Envoy::Http::StreamFilterBase::LocalReplyData local_reply_data{
+      ::Envoy::Http::Code::Unauthorized, std::nullopt, "details", false, "original body"};
+  EXPECT_EQ(filter_->onLocalReply(local_reply_data), ::Envoy::Http::LocalErrorStatus::Continue);
+
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(::Envoy::Http::Code::Unauthorized, "original body", _, _, _));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, ConfiguredBodyTakesPrecedenceOverExistingLocalReplyBody) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          body:
+            inline_string: "configured body"
+          body_format:
+            text_format_source:
+              inline_string: "[%LOCAL_REPLY_BODY%]"
+)EOF");
+  setupFilterAndCallback();
+
+  const ::Envoy::Http::StreamFilterBase::LocalReplyData local_reply_data{
+      ::Envoy::Http::Code::Unauthorized, std::nullopt, "details", false, "original body"};
+  EXPECT_EQ(filter_->onLocalReply(local_reply_data), ::Envoy::Http::LocalErrorStatus::Continue);
+
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(::Envoy::Http::Code::Unauthorized, "[configured body]", _, _, _));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
 TEST_F(CustomResponseFilterTest, RemoteData) {
   createConfig();
   setupFilterAndCallback();

--- a/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
@@ -137,6 +137,30 @@ TEST_F(CustomResponseFilterTest, ConfiguredBodyTakesPrecedenceOverExistingLocalR
             ::Envoy::Http::FilterHeadersStatus::StopIteration);
 }
 
+TEST_F(CustomResponseFilterTest, EmptyPolicyKeepsEmptyBody) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+)EOF");
+  setupFilterAndCallback();
+
+  const ::Envoy::Http::StreamFilterBase::LocalReplyData local_reply_data{
+      ::Envoy::Http::Code::Unauthorized, std::nullopt, "details", false, "original body"};
+  EXPECT_EQ(filter_->onLocalReply(local_reply_data), ::Envoy::Http::LocalErrorStatus::Continue);
+
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(::Envoy::Http::Code::Unauthorized, "", _, _, _));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
 TEST_F(CustomResponseFilterTest, RemoteData) {
   createConfig();
   setupFilterAndCallback();

--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -363,6 +363,41 @@ json_format:
       response->headers().get(::Envoy::Http::LowerCaseString("foo"))[0]->value().getStringView());
 }
 
+// Verify that a local response policy can format the body of an existing local reply.
+TEST_P(CustomResponseIntegrationTest, ExistingLocalReplyBodyWithFormatter) {
+  custom_response_filter_config_ = TestUtility::parseYaml<CustomResponse>(R"EOF(
+custom_response_matcher:
+  matcher_list:
+    matchers:
+    - predicate:
+        single_predicate:
+          input:
+            name: local_reply
+            typed_config:
+              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpResponseLocalReplyMatchInput
+          value_match:
+            exact: "true"
+      on_match:
+        action:
+          name: action
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+            body_format:
+              text_format_source:
+                inline_string: "formatted: %LOCAL_REPLY_BODY%"
+)EOF");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  default_request_headers_.setHost("default.host");
+  default_request_headers_.setPath("/default");
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("201", response->headers().getStatusValue());
+  EXPECT_EQ("formatted: Response body", response->body());
+}
+
 // Verify we get the correct custom response using the redirect policy.
 // TODO(pradeepcrao): Add a test that returns a redirected response from an
 // upstream.


### PR DESCRIPTION
Commit Message: custom_response: expose existing local reply body to formatter

Additional Description:
Pass the body supplied to `sendLocalReply()` through `LocalReplyData` so the custom response filter can seed `%LOCAL_REPLY_BODY%` when `LocalResponsePolicy.body` is unset. An explicitly configured policy body keeps precedence.

Reproducer: https://github.com/dio/envoy-custom-response-local-reply-body

PR build: https://github.com/dio/envoy-custom-response-local-reply-body/releases/tag/envoy-custom-response-local-reply-body-v1

Generative AI assisted with this change. I reviewed and understand the code and tests.

Risk Level: Low

Testing: Focused filter-manager, custom-response unit, and custom-response integration tests; the release asset also passes the reproducer's `make check-patched`.

Docs Changes: Clarified the `LocalResponsePolicy.body` fallback behavior.

Release Notes: Added a bug-fix changelog entry.

Platform Specific Features: N/A

Runtime guard: N/A. This is limited to local response policies that use `%LOCAL_REPLY_BODY%` without configuring `body`; those policies currently receive an empty value.

Fixes #45346

API Considerations: No wire or schema change. `LocalReplyData` gains an additive body view that is valid only for the duration of `onLocalReply()`.
