### PR TITLE
reverse_tunnel: resetFileEvents on iohandle close

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.cc
@@ -64,6 +64,10 @@ Api::IoCallUint64Result DownstreamReverseConnectionIOHandle::close() {
     return Api::ioCallUint64ResultNoError();
   }
 
+  // Similar to the IoSocketHandleImpl::close().
+  // TODO(aakugan): Implement logic for pings from the downstream side too.
+  resetFileEvents();
+
   // Notify the parent that this downstream connection has been closed.
   // This can trigger re-initiation of the reverse connection if needed.
   if (parent_) {

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle_test.cc
@@ -214,10 +214,12 @@ TEST_F(DownstreamReverseConnectionIOHandleTest, CloseMethod) {
     // First close - should notify parent and reset owned_socket.
     auto result1 = handle->close();
     EXPECT_EQ(result1.err_, nullptr);
+    EXPECT_ENVOY_BUG(handle->activateFileEvents(0), "Null file_event_");
 
     // Second close - should return immediately without notifying parent (fd < 0).
     auto result2 = handle->close();
     EXPECT_EQ(result2.err_, nullptr);
+    EXPECT_ENVOY_BUG(handle->activateFileEvents(0), "Null file_event_");
   }
 }
 


### PR DESCRIPTION
## Commit Message
reverse_tunnel: resetFileEvents on DownstreamReverseConnectionIoHandle close

## Description
Not doing this causes unexplained issues like 
1. client side timeouts on clients trying to access the tunnel.
2. ping failures on the upstream socket
3. overall unusable sockets.

Affects all sorts of connections but reverse conns have a bigger impact and the reason for the same is provided below.

Reason:
 One close -> fd termination but the file_event is active
 fd is reused and we register interest with libevent again 
 DeferredDelete of the conn -> delete of the io_handle -> file_event delete -> remove the interest

libevent stores event keyed by the fd.
This causes all events on the reused fd (handed to us by the os) to be lost.

## Testing
Unit tests.

## Other issues 
The downstream side does not proactively ping which would have caught this issue and terminated the connection preemptively. Added a Todo for the same out of scope for this PR.