### PR TITLE
dynamic_modules: [go/cpp]: add http set_dynamic_metadata_struct and set_dynamic_typed_metadata ABI callbacks

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-metadata-struct.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-metadata-struct.rst
@@ -1,4 +1,5 @@
 Added ``envoy_dynamic_module_callback_http_set_dynamic_metadata_struct`` ABI callback that
 sets an entire dynamic metadata namespace from a serialized ``google.protobuf.Struct`` in one
 call, letting a module publish nested/structured metadata instead of only flat scalar keys. The
-Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_metadata_struct``.
+Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_metadata_struct``, the C++ SDK as
+``HttpFilterHandle::setMetadataStruct`` and the Go SDK as ``HttpFilterHandle.SetMetadataStruct``.

--- a/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-typed-metadata.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-http-set-dynamic-typed-metadata.rst
@@ -3,4 +3,5 @@ typed dynamic metadata namespace from a serialized ``google.protobuf.Any``. Unli
 ``envoy_dynamic_module_callback_http_set_dynamic_metadata_struct`` it preserves the exact message
 type (via the Any ``type_url``) in ``typed_filter_metadata``, so consumers such as ext_authz
 (``typed_metadata_context_namespaces``) receive the original message rather than a lossy Struct. The
-Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_typed_metadata``.
+Rust SDK exposes this as ``EnvoyHttpFilter::set_dynamic_typed_metadata``, the C++ SDK as
+``HttpFilterHandle::setTypedMetadata`` and the Go SDK as ``HttpFilterHandle.SetTypedMetadata``.

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -482,6 +482,24 @@ public:
   }
 
   /**
+   * Sets an entire metadata namespace from a serialized google.protobuf.Struct. The struct is
+   * merged into the namespace and existing entries with the same key are overwritten. A buffer
+   * that does not parse as a google.protobuf.Struct is a no-op.
+   * @param ns The metadata namespace.
+   * @param serialized_struct The serialized google.protobuf.Struct to set.
+   */
+  virtual void setMetadataStruct(std::string_view ns, std::string_view serialized_struct) = 0;
+
+  /**
+   * Sets an entire typed metadata namespace from a serialized google.protobuf.Any. The Any is
+   * merged into the namespace's typed_filter_metadata entry, preserving the exact message type via
+   * the Any type_url. A buffer that does not parse as a google.protobuf.Any is a no-op.
+   * @param ns The metadata namespace.
+   * @param serialized_any The serialized google.protobuf.Any to set.
+   */
+  virtual void setTypedMetadata(std::string_view ns, std::string_view serialized_any) = 0;
+
+  /**
    * Appends a numeric value to the dynamic metadata list stored under the given namespace and key.
    * If the key does not exist, a new list is created. Returns false if the key exists but is not a
    * list, or if the metadata is not accessible.

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -437,6 +437,19 @@ public:
         envoy_dynamic_module_type_module_buffer{key.data(), key.size()}, value);
   }
 
+  void setMetadataStruct(std::string_view ns, std::string_view serialized_struct) override {
+    envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+        host_plugin_ptr_, envoy_dynamic_module_type_module_buffer{ns.data(), ns.size()},
+        envoy_dynamic_module_type_module_buffer{serialized_struct.data(),
+                                                serialized_struct.size()});
+  }
+
+  void setTypedMetadata(std::string_view ns, std::string_view serialized_any) override {
+    envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+        host_plugin_ptr_, envoy_dynamic_module_type_module_buffer{ns.data(), ns.size()},
+        envoy_dynamic_module_type_module_buffer{serialized_any.data(), serialized_any.size()});
+  }
+
   bool addMetadataList(std::string_view ns, std::string_view key, double value) override {
     return envoy_dynamic_module_callback_http_add_dynamic_metadata_list_number(
         host_plugin_ptr_, envoy_dynamic_module_type_module_buffer{ns.data(), ns.size()},

--- a/source/extensions/dynamic_modules/sdk/go/abi/internal.go
+++ b/source/extensions/dynamic_modules/sdk/go/abi/internal.go
@@ -861,6 +861,26 @@ func (h *dymHttpFilterHandle) SetMetadata(metadataNamespace, key string, value a
 	runtime.KeepAlive(strValue)
 }
 
+func (h *dymHttpFilterHandle) SetMetadataStruct(metadataNamespace string, serializedStruct []byte) {
+	C.envoy_dynamic_module_callback_http_set_dynamic_metadata_struct(
+		h.hostPluginPtr,
+		stringToModuleBuffer(metadataNamespace),
+		bytesToModuleBuffer(serializedStruct),
+	)
+	runtime.KeepAlive(metadataNamespace)
+	runtime.KeepAlive(serializedStruct)
+}
+
+func (h *dymHttpFilterHandle) SetTypedMetadata(metadataNamespace string, serializedAny []byte) {
+	C.envoy_dynamic_module_callback_http_set_dynamic_typed_metadata(
+		h.hostPluginPtr,
+		stringToModuleBuffer(metadataNamespace),
+		bytesToModuleBuffer(serializedAny),
+	)
+	runtime.KeepAlive(metadataNamespace)
+	runtime.KeepAlive(serializedAny)
+}
+
 func (h *dymHttpFilterHandle) GetAttributeNumber(
 	attributeID shared.AttributeID,
 ) (float64, bool) {

--- a/source/extensions/dynamic_modules/sdk/go/shared/http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/http.go
@@ -163,6 +163,17 @@ type HttpFilterHandle interface {
 	// SetMetadata sets the dynamic metadata value of the stream.
 	SetMetadata(metadataNamespace, key string, value any)
 
+	// SetMetadataStruct sets an entire dynamic metadata namespace from a serialized
+	// google.protobuf.Struct. The struct is merged into the namespace and existing entries with the
+	// same key are overwritten. A buffer that does not parse as a google.protobuf.Struct is a no-op.
+	SetMetadataStruct(metadataNamespace string, serializedStruct []byte)
+
+	// SetTypedMetadata sets an entire typed dynamic metadata namespace from a serialized
+	// google.protobuf.Any. The Any is merged into the namespace's typed_filter_metadata entry,
+	// preserving the exact message type via the Any type_url. A buffer that does not parse as a
+	// google.protobuf.Any is a no-op.
+	SetTypedMetadata(metadataNamespace string, serializedAny []byte)
+
 	// GetMetadataKeys retrieves all keys in the given metadata namespace.
 	// Returns list of keys in the namespace, or nil if the namespace does not exist.
 	// NOTE: The memory of underlying data may not be managed by Go GC. So you should

--- a/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/mocks/mock_http.go
@@ -1540,6 +1540,18 @@ func (mr *MockHttpFilterHandleMockRecorder) SetMetadata(metadataNamespace, key, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMetadata", reflect.TypeOf((*MockHttpFilterHandle)(nil).SetMetadata), metadataNamespace, key, value)
 }
 
+// SetMetadataStruct mocks base method.
+func (m *MockHttpFilterHandle) SetMetadataStruct(metadataNamespace string, serializedStruct []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMetadataStruct", metadataNamespace, serializedStruct)
+}
+
+// SetMetadataStruct indicates an expected call of SetMetadataStruct.
+func (mr *MockHttpFilterHandleMockRecorder) SetMetadataStruct(metadataNamespace, serializedStruct any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMetadataStruct", reflect.TypeOf((*MockHttpFilterHandle)(nil).SetMetadataStruct), metadataNamespace, serializedStruct)
+}
+
 // SetSocketOptionBytes mocks base method.
 func (m *MockHttpFilterHandle) SetSocketOptionBytes(level, name int64, state shared.SocketOptionState, direction shared.SocketDirection, value []byte) bool {
 	m.ctrl.T.Helper()
@@ -1566,6 +1578,18 @@ func (m *MockHttpFilterHandle) SetSocketOptionInt(level, name int64, state share
 func (mr *MockHttpFilterHandleMockRecorder) SetSocketOptionInt(level, name, state, direction, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSocketOptionInt", reflect.TypeOf((*MockHttpFilterHandle)(nil).SetSocketOptionInt), level, name, state, direction, value)
+}
+
+// SetTypedMetadata mocks base method.
+func (m *MockHttpFilterHandle) SetTypedMetadata(metadataNamespace string, serializedAny []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTypedMetadata", metadataNamespace, serializedAny)
+}
+
+// SetTypedMetadata indicates an expected call of SetTypedMetadata.
+func (mr *MockHttpFilterHandleMockRecorder) SetTypedMetadata(metadataNamespace, serializedAny any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTypedMetadata", reflect.TypeOf((*MockHttpFilterHandle)(nil).SetTypedMetadata), metadataNamespace, serializedAny)
 }
 
 // SetUpstreamOverrideHost mocks base method.

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -453,9 +453,8 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
   key = ns_res_header->second.fields().find("key");
   ASSERT_NE(key, ns_res_header->second.fields().end());
   EXPECT_EQ(key->second.number_value(), 123);
-  // Multiple string entries set in one namespace via the batch setter. The batch SDK wrapper is
-  // Rust-only, so scope these assertions to the rust parameterization like the other language
-  // guards in the dynamic_modules integration tests.
+  // The batch and raw-bytes SDK wrappers are Rust-only, so scope these assertions to the rust
+  // parameterization like the other language guards in the dynamic_modules integration tests.
   if (GetParam() == "rust") {
     auto ns_req_header_batch = metadata.filter_metadata().find("ns_req_header_batch");
     ASSERT_NE(ns_req_header_batch, metadata.filter_metadata().end());
@@ -474,18 +473,18 @@ TEST_P(DynamicModuleHttpLanguageTests, DynamicMetadataCallbacks) {
     auto bytes_key = ns_req_header_bytes->second.fields().find("key");
     ASSERT_NE(bytes_key, ns_req_header_bytes->second.fields().end());
     EXPECT_EQ(bytes_key->second.string_value(), std::string("\xff\x00\xfe", 3));
-    // A whole namespace set from a serialized google.protobuf.Struct via the struct setter.
-    auto ns_req_header_struct = metadata.filter_metadata().find("ns_req_header_struct");
-    ASSERT_NE(ns_req_header_struct, metadata.filter_metadata().end());
-    auto struct_k = ns_req_header_struct->second.fields().find("k");
-    ASSERT_NE(struct_k, ns_req_header_struct->second.fields().end());
-    EXPECT_EQ(struct_k->second.string_value(), "v");
-    // A whole typed namespace set from a serialized google.protobuf.Any via the typed setter.
-    auto ns_req_header_typed = metadata.typed_filter_metadata().find("ns_req_header_typed");
-    ASSERT_NE(ns_req_header_typed, metadata.typed_filter_metadata().end());
-    EXPECT_EQ(ns_req_header_typed->second.type_url(), "t/x");
-    EXPECT_EQ(ns_req_header_typed->second.value(), std::string("\x01\x02", 2));
   }
+  // A whole namespace set from a serialized google.protobuf.Struct via the struct setter.
+  auto ns_req_header_struct = metadata.filter_metadata().find("ns_req_header_struct");
+  ASSERT_NE(ns_req_header_struct, metadata.filter_metadata().end());
+  auto struct_k = ns_req_header_struct->second.fields().find("k");
+  ASSERT_NE(struct_k, ns_req_header_struct->second.fields().end());
+  EXPECT_EQ(struct_k->second.string_value(), "v");
+  // A whole typed namespace set from a serialized google.protobuf.Any via the typed setter.
+  auto ns_req_header_typed = metadata.typed_filter_metadata().find("ns_req_header_typed");
+  ASSERT_NE(ns_req_header_typed, metadata.typed_filter_metadata().end());
+  EXPECT_EQ(ns_req_header_typed->second.type_url(), "t/x");
+  EXPECT_EQ(ns_req_header_typed->second.value(), std::string("\x01\x02", 2));
   auto ns_req_body = metadata.filter_metadata().find("ns_req_body");
   ASSERT_NE(ns_req_body, metadata.filter_metadata().end());
   key = ns_req_body->second.fields().find("key");

--- a/test/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
+++ b/test/extensions/dynamic_modules/sdk/cpp/sdk_mocks.h
@@ -119,6 +119,10 @@ public:
               (override));
   MOCK_METHOD(void, setMetadata, (std::string_view ns, std::string_view key, bool value),
               (override));
+  MOCK_METHOD(void, setMetadataStruct, (std::string_view ns, std::string_view serialized_struct),
+              (override));
+  MOCK_METHOD(void, setTypedMetadata, (std::string_view ns, std::string_view serialized_any),
+              (override));
   MOCK_METHOD(bool, addMetadataList, (std::string_view ns, std::string_view key, double value),
               (override));
   MOCK_METHOD(bool, addMetadataList,

--- a/test/extensions/dynamic_modules/test_data/cpp/http.cc
+++ b/test/extensions/dynamic_modules/test_data/cpp/http.cc
@@ -628,6 +628,26 @@ public:
       assert(false && "metadata type mismatch not detected");
     }
 
+    // Set a whole namespace from a serialized google.protobuf.Struct { "k": "v" }, asserted
+    // end-to-end by the C++ integration test in filter_test.cc. The bytes are hand-encoded because
+    // the test module has no protobuf dependency:
+    //   0a 08              field 1 (fields), LEN 8
+    //     0a 01 6b           entry.key   = "k"
+    //     12 03 1a 01 76     entry.value = Value { string_value = "v" }
+    static constexpr char serialized_struct[] = {0x0a, 0x08, 0x0a, 0x01, 0x6b,
+                                                 0x12, 0x03, 0x1a, 0x01, 0x76};
+    handle_.setMetadataStruct("ns_req_header_struct",
+                              std::string_view(serialized_struct, sizeof(serialized_struct)));
+
+    // Set a whole typed namespace from a serialized google.protobuf.Any, asserted end-to-end by
+    // the C++ integration test in filter_test.cc. The bytes are hand-encoded because the test
+    // module has no protobuf dependency:
+    //   0a 03 74 2f 78     field 1 (type_url) = "t/x"
+    //   12 02 01 02        field 2 (value)    = 0x01 0x02
+    static constexpr char serialized_any[] = {0x0a, 0x03, 0x74, 0x2f, 0x78, 0x12, 0x02, 0x01, 0x02};
+    handle_.setTypedMetadata("ns_req_header_typed",
+                             std::string_view(serialized_any, sizeof(serialized_any)));
+
     // Try getting metadata from router, cluster, and host.
     // In C++ SDK namespaces like "envoy.filters.http.router" are needed if mapped directly,
     // but here we just rely on generic metadata get if possible or assume implementation detail

--- a/test/extensions/dynamic_modules/test_data/go/http/http.go
+++ b/test/extensions/dynamic_modules/test_data/go/http/http.go
@@ -525,6 +525,23 @@ func (p *dynamicMetadataCallbacksFilter) OnRequestHeaders(headers shared.HeaderM
 		panic("metadata type mismatch not detected")
 	}
 
+	// Set a whole namespace from a serialized google.protobuf.Struct { "k": "v" }, asserted
+	// end-to-end by the C++ integration test in filter_test.cc. The bytes are hand-encoded because
+	// the test module has no protobuf dependency:
+	//   0a 08              field 1 (fields), LEN 8
+	//     0a 01 6b           entry.key   = "k"
+	//     12 03 1a 01 76     entry.value = Value { string_value = "v" }
+	p.handle.SetMetadataStruct("ns_req_header_struct",
+		[]byte{0x0a, 0x08, 0x0a, 0x01, 0x6b, 0x12, 0x03, 0x1a, 0x01, 0x76})
+
+	// Set a whole typed namespace from a serialized google.protobuf.Any, asserted end-to-end by
+	// the C++ integration test in filter_test.cc. The bytes are hand-encoded because the test
+	// module has no protobuf dependency:
+	//   0a 03 74 2f 78     field 1 (type_url) = "t/x"
+	//   12 02 01 02        field 2 (value)    = 0x01 0x02
+	p.handle.SetTypedMetadata("ns_req_header_typed",
+		[]byte{0x0a, 0x03, 0x74, 0x2f, 0x78, 0x12, 0x02, 0x01, 0x02})
+
 	// Try getting metadata from router, cluster, and host.
 	if val, ok := p.handle.GetMetadataString(shared.MetadataSourceTypeRoute,
 		"metadata", "route_key"); !ok || val.ToUnsafeString() != "route" {


### PR DESCRIPTION
## Description

Ports https://github.com/envoyproxy/envoy/pull/46442 to CPP and Go SDK

Commit Message: dynamic_modules: [go/cpp]: add http set_dynamic_metadata_struct and set_dynamic_typed_metadata ABI callbacks
Additional Description:
Risk Level: Low
Testing: Added unit tests
Docs Changes: N/A
Release Notes: Added (changelog entries for both callbacks)