### PR TITLE
http: refactor multiple interfaces to support extra context

### DIFF
--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -234,6 +234,22 @@ public:
 };
 
 /**
+ * Extra context that is passed to the HTTP filter factories in addition to the
+ * ServerFactoryContext. This bundles the small pieces of per-call state that used to be passed as
+ * loose arguments, so that new state can be added without changing every factory signature.
+ *
+ * NOTE: this struct holds references only and must not outlive the objects it refers to. It is
+ * expected to be created on the stack at the call site.
+ */
+struct ExtraFactoryContext {
+  // Validation visitor to be used when parsing/validating the filter configuration.
+  ProtobufMessage::ValidationVisitor& visitor;
+  // Prefix for stat logging. May be empty for contexts where no stat prefix is available, such as
+  // route specific filter configurations.
+  const std::string& stats_prefix;
+};
+
+/**
  * Implemented by each HTTP filter and registered via Registry::registerFactory or the
  * convenience class RegisterFactory.
  */
@@ -250,6 +266,19 @@ public:
    */
   virtual ProtobufTypes::MessagePtr createEmptyRouteConfigProto() {
     return createEmptyConfigProto();
+  }
+
+  /**
+   * @param config supplies the general protobuf configuration for the filter.
+   * @param context supplies the filter's context.
+   * @param extra_context supplies the filter's extra context.
+   * @return RouteSpecificFilterConfigConstSharedPtr allow the filter to pre-process per route
+   * config. Returned object will be stored in the loaded route configuration.
+   */
+  virtual absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createHttpFilterRouteConfig(const Protobuf::Message& config, ServerFactoryContext& context,
+                              ExtraFactoryContext& extra_context) {
+    return createRouteSpecificFilterConfig(config, context, extra_context.visitor);
   }
 
   /**
@@ -337,15 +366,17 @@ public:
    *
    * @param config supplies the general Protobuf message to be marshaled into a filter-specific
    * configuration.
-   * @param stat_prefix prefix for stat logging
    * @param context supplies the filter's context.
+   * @param extra_context supplies the filter's extra context.
    * @return Http::FilterFactoryCb the factory creation function.
    */
   virtual absl::StatusOr<Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
-                                   Server::Configuration::ServerFactoryContext& context) {
+  createHttpFilterFactoryFromProto(const Protobuf::Message& config,
+                                   Server::Configuration::ServerFactoryContext& context,
+                                   ExtraFactoryContext& extra_context) {
     // Delegate to createFilterFactoryFromProtoWithServerContext for backwards compatibility.
-    return createFilterFactoryFromProtoWithServerContext(config, stat_prefix, context);
+    return createFilterFactoryFromProtoWithServerContext(config, extra_context.stats_prefix,
+                                                         context);
   }
 
   /**

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -115,6 +115,7 @@ envoy_cc_library(
     deps = [
         "//envoy/server:factory_context_interface",
         "//envoy/server:filter_config_interface",
+        "//source/common/common:empty_string",
         "//source/common/config:utility_lib",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/status:statusor",

--- a/source/common/router/per_filter_config.cc
+++ b/source/common/router/per_filter_config.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/server/filter_config.h"
 
+#include "source/common/common/empty_string.h"
 #include "source/common/config/utility.h"
 
 namespace Envoy {
@@ -42,8 +43,10 @@ PerFilterConfigs::createRouteSpecificFilterConfig(
   ProtobufTypes::MessagePtr proto_config = factory->createEmptyRouteConfigProto();
   RETURN_IF_NOT_OK(
       Envoy::Config::Utility::translateOpaqueConfig(typed_config, validator, *proto_config));
+  // There is no stat prefix for the route specific filter configuration.
+  Server::Configuration::ExtraFactoryContext extra_context{validator, EMPTY_STRING};
   auto object_status_or_error =
-      factory->createRouteSpecificFilterConfig(*proto_config, factory_context, validator);
+      factory->createHttpFilterRouteConfig(*proto_config, factory_context, extra_context);
   RETURN_IF_NOT_OK(object_status_or_error.status());
   auto object = std::move(*object_status_or_error);
   if (object == nullptr) {

--- a/source/extensions/filters/http/a2a/config.cc
+++ b/source/extensions/filters/http/a2a/config.cc
@@ -13,16 +13,20 @@ absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createFilterFactor
     const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   // This filter only uses the server factory context, so delegate to the server-context variant.
-  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
-                                               context.serverFactoryContext());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           stats_prefix};
+  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
+                                               extra_context);
 }
 
 absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
   // Use the server factory context to access the root scope for stats.
-  auto config = std::make_shared<A2aFilterConfig>(proto_config, stats_prefix, context.scope());
+  auto config =
+      std::make_shared<A2aFilterConfig>(proto_config, extra_context.stats_prefix, context.scope());
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<A2aFilter>(config));

--- a/source/extensions/filters/http/a2a/config.h
+++ b/source/extensions/filters/http/a2a/config.h
@@ -22,8 +22,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace A2a

--- a/source/extensions/filters/http/adaptive_concurrency/config.h
+++ b/source/extensions/filters/http/adaptive_concurrency/config.h
@@ -30,9 +30,9 @@ public:
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override {
-    return createFilterFactory(proto_config, stats_prefix, context, context.scope());
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override {
+    return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
   }
 
 private:

--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -28,8 +28,9 @@ AdmissionControlFilterFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 AdmissionControlFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context, context.scope());
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
 }
 
 absl::StatusOr<Http::FilterFactoryCb> AdmissionControlFilterFactory::createFilterFactory(

--- a/source/extensions/filters/http/admission_control/config.h
+++ b/source/extensions/filters/http/admission_control/config.h
@@ -26,8 +26,8 @@ public:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
 private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(

--- a/source/extensions/filters/http/alternate_protocols_cache/config.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.cc
@@ -33,7 +33,8 @@ absl::StatusOr<Http::FilterFactoryCb>
 AlternateProtocolsCacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
         proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
   FilterConfigSharedPtr filter_config(
       std::make_shared<FilterConfig>(proto_config, context.httpServerPropertiesCacheManager(),

--- a/source/extensions/filters/http/alternate_protocols_cache/config.h
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.h
@@ -30,8 +30,8 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
           proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 DECLARE_FACTORY(AlternateProtocolsCacheFilterFactory);

--- a/source/extensions/filters/http/api_key_auth/config.cc
+++ b/source/extensions/filters/http/api_key_auth/config.cc
@@ -29,9 +29,9 @@ absl::StatusOr<Http::FilterFactoryCb> ApiKeyAuthFilterFactory::createFilterFacto
 
 absl::StatusOr<Http::FilterFactoryCb>
 ApiKeyAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
-    const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context.scope());
+    const ApiKeyAuthProto& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/api_key_auth/config.h
+++ b/source/extensions/filters/http/api_key_auth/config.h
@@ -21,8 +21,8 @@ private:
   createFilterFactoryFromProtoTyped(const ApiKeyAuthProto& config, const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
-      const ApiKeyAuthProto& config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const ApiKeyAuthProto& config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -136,9 +136,10 @@ AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
 
 absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
-  return createFilterFactoryFromProtoHelper(proto_config, stats_prefix, server_context,
-                                            server_context.scope(), false);
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactoryFromProtoHelper(proto_config, extra_context.stats_prefix,
+                                            server_context, server_context.scope(), false);
 }
 
 /*

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -42,8 +42,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -53,9 +53,10 @@ AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
 
 absl::StatusOr<Http::FilterFactoryCb>
 AwsRequestSigningFilterFactory::createHttpFilterFactoryFromProtoTyped(
-    const AwsRequestSigningProtoConfig& config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& server_context) {
-  return createFilterFactoryFromProtoHelper(config, stats_prefix, server_context,
+    const AwsRequestSigningProtoConfig& config,
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactoryFromProtoHelper(config, extra_context.stats_prefix, server_context,
                                             server_context.scope());
 }
 

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -40,8 +40,9 @@ private:
                                     Server::Configuration::ServerFactoryContext& context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
-      const AwsRequestSigningProtoConfig& proto_config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const AwsRequestSigningProtoConfig& proto_config,
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const AwsRequestSigningProtoPerRouteConfig& per_route_config,

--- a/source/extensions/filters/http/bandwidth_limit/config.cc
+++ b/source/extensions/filters/http/bandwidth_limit/config.cc
@@ -32,7 +32,8 @@ absl::StatusOr<Http::FilterFactoryCb> BandwidthLimitFilterConfig::createFilterFa
 absl::StatusOr<Http::FilterFactoryCb>
 BandwidthLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(proto_config, context, context.scope());
 }
 

--- a/source/extensions/filters/http/bandwidth_limit/config.h
+++ b/source/extensions/filters/http/bandwidth_limit/config.h
@@ -26,8 +26,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -82,8 +82,8 @@ absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createFilterFactor
 }
 
 absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
-    const BasicAuth& proto_config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
+    const BasicAuth& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   auto htpasswd_or = Config::DataSource::read(proto_config.users(), false, context.api());
   RETURN_IF_NOT_OK_REF(htpasswd_or.status());
   auto users_or = readHtpasswd(htpasswd_or.value());
@@ -91,7 +91,7 @@ absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createHttpFilterFa
   FilterConfigConstSharedPtr config = std::make_unique<FilterConfig>(
       std::move(users_or.value()), proto_config.forward_username_header(),
       proto_config.authentication_header(), proto_config.allow_missing(),
-      proto_config.emit_dynamic_metadata(), stats_prefix, context.scope());
+      proto_config.emit_dynamic_metadata(), extra_context.stats_prefix, context.scope());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<BasicAuthFilter>(config));
   };

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -24,8 +24,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -29,10 +29,10 @@ absl::StatusOr<Http::FilterFactoryCb> BufferFilterFactory::createFilterFactoryFr
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
 BufferFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
   ASSERT(proto_config.has_max_request_bytes());
   BufferFilterConfigSharedPtr filter_config(new BufferFilterConfig(proto_config));
-  return [filter_config, stats_prefix](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<BufferFilter>(filter_config));
   };
 }

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -27,7 +27,8 @@ private:
 
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
-      const std::string& stats, Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -40,7 +40,8 @@ absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFro
 
 absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(config, context);
 }
 

--- a/source/extensions/filters/http/cache/config.h
+++ b/source/extensions/filters/http/cache/config.h
@@ -21,8 +21,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths.

--- a/source/extensions/filters/http/cache_v2/config.cc
+++ b/source/extensions/filters/http/cache_v2/config.cc
@@ -47,7 +47,8 @@ absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFro
 
 absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(config, context);
 }
 

--- a/source/extensions/filters/http/cache_v2/config.h
+++ b/source/extensions/filters/http/cache_v2/config.h
@@ -21,8 +21,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths.

--- a/source/extensions/filters/http/cdn_loop/config.cc
+++ b/source/extensions/filters/http/cdn_loop/config.cc
@@ -25,13 +25,16 @@ absl::StatusOr<Http::FilterFactoryCb> CdnLoopFilterFactory::createFilterFactoryF
     const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   // This filter does not use the factory context, so delegate to the server-context variant.
-  return createHttpFilterFactoryFromProtoTyped(config, stats_prefix,
-                                               context.serverFactoryContext());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           stats_prefix};
+  return createHttpFilterFactoryFromProtoTyped(config, context.serverFactoryContext(),
+                                               extra_context);
 }
 
 absl::StatusOr<Http::FilterFactoryCb> CdnLoopFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::ServerFactoryContext& /*context*/) {
+    Server::Configuration::ServerFactoryContext& /*context*/,
+    Server::Configuration::ExtraFactoryContext&) {
   StatusOr<ParsedCdnId> context = parseCdnId(ParseContext(config.cdn_id()));
   if (!context.ok() || !context->context().atEnd()) {
     return absl::InvalidArgumentError(

--- a/source/extensions/filters/http/cdn_loop/config.h
+++ b/source/extensions/filters/http/cdn_loop/config.h
@@ -26,8 +26,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace CdnLoop

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -24,6 +24,16 @@ public:
   }
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createHttpFilterRouteConfig(const Protobuf::Message& proto_config,
+                              Server::Configuration::ServerFactoryContext& context,
+                              Server::Configuration::ExtraFactoryContext& extra_context) override {
+    return createHttpFilterRouteConfigTyped(
+        MessageUtil::downcastAndValidate<const RouteConfigProto&>(proto_config,
+                                                                  extra_context.visitor),
+        context, extra_context);
+  }
+
+  absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfig(const Protobuf::Message& proto_config,
                                   Server::Configuration::ServerFactoryContext& context,
                                   ProtobufMessage::ValidationVisitor& validator) override {
@@ -48,6 +58,14 @@ public:
 
 protected:
   CommonFactoryBase(const std::string& name) : name_(name) {}
+
+  virtual absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+  createHttpFilterRouteConfigTyped(const RouteConfigProto& proto_config,
+                                   Server::Configuration::ServerFactoryContext& context,
+                                   Server::Configuration::ExtraFactoryContext& extra_context) {
+    // Delegate to createRouteSpecificFilterConfigTyped for backwards compatibility.
+    return createRouteSpecificFilterConfigTyped(proto_config, context, extra_context.visitor);
+  }
 
   virtual absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const RouteConfigProto&,
@@ -88,21 +106,21 @@ public:
         stats_prefix, server_context);
   }
 
-  absl::StatusOr<Envoy::Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                   const std::string& stats_prefix,
-                                   Server::Configuration::ServerFactoryContext& context) override {
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProto(
+      const Protobuf::Message& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override {
     return createHttpFilterFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
                                                              context.messageValidationVisitor()),
-        stats_prefix, context);
+        context, extra_context);
   }
   virtual absl::StatusOr<Envoy::Http::FilterFactoryCb>
   createHttpFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                        const std::string& stats_prefix,
-                                        Server::Configuration::ServerFactoryContext& context) {
+                                        Server::Configuration::ServerFactoryContext& context,
+                                        Server::Configuration::ExtraFactoryContext& extra_context) {
     // Delegate to createFilterFactoryFromProtoWithServerContextTyped for backwards compatibility.
-    return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix, context);
+    return createFilterFactoryFromProtoWithServerContextTyped(proto_config,
+                                                              extra_context.stats_prefix, context);
   }
 
   [[deprecated("Use createHttpFilterFactoryFromProtoTyped instead")]]
@@ -135,22 +153,21 @@ public:
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) PURE;
 
-  absl::StatusOr<Envoy::Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                   const std::string& stats_prefix,
-                                   Server::Configuration::ServerFactoryContext& context) override {
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProto(
+      const Protobuf::Message& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override {
     return createHttpFilterFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
                                                              context.messageValidationVisitor()),
-        stats_prefix, context);
+        context, extra_context);
   }
   virtual absl::StatusOr<Envoy::Http::FilterFactoryCb>
   createHttpFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                        const std::string& stats_prefix,
-                                        Server::Configuration::ServerFactoryContext& context) {
+                                        Server::Configuration::ServerFactoryContext& context,
+                                        Server::Configuration::ExtraFactoryContext& extra_context) {
     UNREFERENCED_PARAMETER(proto_config);
-    UNREFERENCED_PARAMETER(stats_prefix);
     UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(extra_context);
     return absl::InvalidArgumentError(
         "Creating HTTP filter factory from server factory context is not supported");
   }
@@ -211,21 +228,21 @@ public:
         stats_prefix, server_context);
   }
 
-  absl::StatusOr<Envoy::Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                   const std::string& stats_prefix,
-                                   Server::Configuration::ServerFactoryContext& context) override {
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProto(
+      const Protobuf::Message& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override {
     return createHttpFilterFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
                                                              context.messageValidationVisitor()),
-        stats_prefix, context);
+        context, extra_context);
   }
   virtual absl::StatusOr<Envoy::Http::FilterFactoryCb>
   createHttpFilterFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                        const std::string& stats_prefix,
-                                        Server::Configuration::ServerFactoryContext& context) {
+                                        Server::Configuration::ServerFactoryContext& context,
+                                        Server::Configuration::ExtraFactoryContext& extra_context) {
     // Delegate to createFilterFactoryFromProtoWithServerContextTyped for backwards compatibility.
-    return createFilterFactoryFromProtoWithServerContextTyped(proto_config, stats_prefix, context);
+    return createFilterFactoryFromProtoWithServerContextTyped(proto_config,
+                                                              extra_context.stats_prefix, context);
   }
 
 private:

--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -160,8 +160,10 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionDown
   // If above failed, for downstream case, try to create the filter factory creation function
   // from server factory context if exists.
   if (callback == nullptr && context.server_factory_context_.has_value()) {
+    Server::Configuration::ExtraFactoryContext extra_context{validation_visitor,
+                                                             context.stat_prefix_};
     auto callback_or_status = factory.createHttpFilterFactoryFromProto(
-        *message, context.stat_prefix_, context.server_factory_context_.value());
+        *message, context.server_factory_context_.value(), extra_context);
     THROW_IF_NOT_OK_REF(callback_or_status.status());
     callback = callback_or_status.value();
   }
@@ -226,8 +228,10 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainActio
 
       // If above failed, try server factory context.
       if (callback == nullptr && context.server_factory_context_.has_value()) {
+        Server::Configuration::ExtraFactoryContext extra_context{validation_visitor,
+                                                                 context.stat_prefix_};
         auto callback_or_status = factory.createHttpFilterFactoryFromProto(
-            *message, context.stat_prefix_, context.server_factory_context_.value());
+            *message, context.server_factory_context_.value(), extra_context);
         THROW_IF_NOT_OK_REF(callback_or_status.status());
         callback = callback_or_status.value();
       }

--- a/source/extensions/filters/http/compressor/config.cc
+++ b/source/extensions/filters/http/compressor/config.cc
@@ -52,9 +52,10 @@ absl::StatusOr<Http::FilterFactoryCb> CompressorFilterFactory::createFilterFacto
 absl::StatusOr<Http::FilterFactoryCb>
 CompressorFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
-  return createFilterFactory(proto_config, stats_prefix, generic_context);
+  return createFilterFactory(proto_config, extra_context.stats_prefix, generic_context);
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/compressor/config.h
+++ b/source/extensions/filters/http/compressor/config.h
@@ -28,8 +28,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,

--- a/source/extensions/filters/http/connect_grpc_bridge/config.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.cc
@@ -23,7 +23,7 @@ ConnectGrpcFilterConfigFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 ConnectGrpcFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig&,
-    const std::string&, Server::Configuration::ServerFactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
   return [](Http::FilterChainFactoryCallbacks& callbacks) {
     callbacks.addStreamFilter(std::make_shared<ConnectGrpcBridgeFilter>());
   };

--- a/source/extensions/filters/http/connect_grpc_bridge/config.h
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.h
@@ -25,7 +25,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext&) override;
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace ConnectGrpcBridge

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -28,10 +28,11 @@ absl::StatusOr<Http::FilterFactoryCb> CorsFilterFactory::createFilterFactoryFrom
 }
 
 absl::StatusOr<Http::FilterFactoryCb> CorsFilterFactory::createHttpFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::cors::v3::Cors&, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
+    const envoy::extensions::filters::http::cors::v3::Cors&,
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   CorsFilterConfigSharedPtr config =
-      std::make_shared<CorsFilterConfig>(stats_prefix, context.scope());
+      std::make_shared<CorsFilterConfig>(extra_context.stats_prefix, context.scope());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CorsFilter>(config));
   };

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -25,8 +25,8 @@ public:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/credential_injector/config.cc
+++ b/source/extensions/filters/http/credential_injector/config.cc
@@ -59,9 +59,10 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb>
 CredentialInjectorFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector&
         proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactoryFromProtoHelper(proto_config, stats_prefix, context, context.scope(),
-                                            context.initManager());
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactoryFromProtoHelper(proto_config, extra_context.stats_prefix, context,
+                                            context.scope(), context.initManager());
 }
 
 REGISTER_FACTORY(CredentialInjectorFilterFactory,

--- a/source/extensions/filters/http/credential_injector/config.h
+++ b/source/extensions/filters/http/credential_injector/config.h
@@ -30,8 +30,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 using UpstreamCredentialInjectorFilterFactory = CredentialInjectorFilterFactory;

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -23,9 +23,10 @@ absl::StatusOr<Http::FilterFactoryCb> CsrfFilterFactory::createFilterFactoryFrom
 
 absl::StatusOr<Http::FilterFactoryCb> CsrfFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  CsrfFilterConfigSharedPtr config =
-      std::make_shared<CsrfFilterConfig>(policy, stats_prefix, context.scope(), context);
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  CsrfFilterConfigSharedPtr config = std::make_shared<CsrfFilterConfig>(
+      policy, extra_context.stats_prefix, context.scope(), context);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<CsrfFilter>(config));
   };

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -25,8 +25,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/custom_response/factory.cc
+++ b/source/extensions/filters/http/custom_response/factory.cc
@@ -27,8 +27,9 @@ CustomResponseFilterFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<::Envoy::Http::FilterFactoryCb>
 CustomResponseFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
-    const std::string& stats_prefix, Envoy::Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(config, stats_prefix, context);
+    Envoy::Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(config, extra_context.stats_prefix, context);
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/custom_response/factory.h
+++ b/source/extensions/filters/http/custom_response/factory.h
@@ -24,8 +24,8 @@ public:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<::Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.cc
@@ -43,7 +43,8 @@ DynamicForwardProxyFilterFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 DynamicForwardProxyFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(proto_config, context);
 }
 

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.h
@@ -27,8 +27,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig& config,

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -155,9 +155,9 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicModuleConfigFactory::createFilterFa
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
 DynamicModuleConfigFactory::createHttpFilterFactoryFromProtoTyped(
-    const FilterConfig& proto_config, const std::string& stat_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto_config, stat_prefix, context, context.scope());
+    const FilterConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/dynamic_modules/factory.h
+++ b/source/extensions/filters/http/dynamic_modules/factory.h
@@ -27,8 +27,8 @@ public:
                                dual_info.init_manager);
   }
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
-      const FilterConfig& proto_config, const std::string& stat_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const FilterConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const FilterConfig& proto_config, const std::string& stat_prefix,

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -22,10 +22,12 @@ namespace ExtAuthz {
 
 absl::StatusOr<Http::FilterFactoryCb> ExtAuthzFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   absl::Status creation_status = absl::OkStatus();
-  const auto filter_config = std::make_shared<FilterConfig>(
-      proto_config, server_context.scope(), stats_prefix, server_context, creation_status);
+  const auto filter_config =
+      std::make_shared<FilterConfig>(proto_config, server_context.scope(),
+                                     extra_context.stats_prefix, server_context, creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
   // The callback is created in main thread and executed in worker thread, variables except factory
   // context must be captured by value into the callback.

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -26,14 +26,16 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
-    return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
-                                                 context.serverFactoryContext());
+    Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                             stats_prefix};
+    return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
+                                                 extra_context);
   }
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& server_context) override;
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -132,7 +132,8 @@ ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 ExternalProcessingFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   // Verify configuration before creating FilterConfig
   RETURN_IF_NOT_OK(verifyFilterConfig(proto_config));
 
@@ -143,7 +144,7 @@ ExternalProcessingFilterConfig::createHttpFilterFactoryFromProtoTyped(
   absl::Status config_creation_status = absl::OkStatus();
   auto filter_config = std::make_shared<FilterConfig>(
       proto_config, std::chrono::milliseconds(message_timeout_ms), max_message_timeout_ms,
-      server_context.scope(), stats_prefix, false,
+      server_context.scope(), extra_context.stats_prefix, false,
       Envoy::Extensions::Filters::Common::Expr::getBuilder(server_context), server_context,
       config_creation_status);
   RETURN_IF_NOT_OK_REF(config_creation_status);

--- a/source/extensions/filters/http/ext_proc/config.h
+++ b/source/extensions/filters/http/ext_proc/config.h
@@ -37,8 +37,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& server_context) override;
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 using UpstreamExternalProcessingFilterConfig = ExternalProcessingFilterConfig;

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -25,9 +25,10 @@ absl::StatusOr<Http::FilterFactoryCb> FaultFilterFactory::createFilterFactoryFro
 
 absl::StatusOr<Http::FilterFactoryCb> FaultFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::fault::v3::HTTPFault& config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   FaultFilterConfigSharedPtr filter_config(std::make_shared<FaultFilterConfig>(
-      config, stats_prefix, server_context.scope(), server_context));
+      config, extra_context.stats_prefix, server_context.scope(), server_context));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<FaultFilter>(filter_config));
   };

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -25,8 +25,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& server_context) override;
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/file_system_buffer/config.cc
+++ b/source/extensions/filters/http/file_system_buffer/config.cc
@@ -40,8 +40,8 @@ FileSystemBufferFilterFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 FileSystemBufferFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const ProtoFileSystemBufferFilterConfig& config,
-    const std::string& stats_prefix ABSL_ATTRIBUTE_UNUSED,
-    Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   auto factory = AsyncFileManagerFactory::singleton(&context.singletonManager());
   auto manager = config.has_manager_config() ? factory->getAsyncFileManager(config.manager_config())
                                              : std::shared_ptr<AsyncFileManager>();

--- a/source/extensions/filters/http/file_system_buffer/config.h
+++ b/source/extensions/filters/http/file_system_buffer/config.h
@@ -31,8 +31,8 @@ public:
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&
           config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/filter_chain/filter.cc
+++ b/source/extensions/filters/http/filter_chain/filter.cc
@@ -32,8 +32,10 @@ absl::StatusOr<FilterFactoriesVector> createFilterFactoriesFromConfig(
 
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         filter_config, context.messageValidationVisitor(), factory);
+    Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                             stats_prefix};
     auto callback_or_error =
-        factory.createHttpFilterFactoryFromProto(*message, stats_prefix, context);
+        factory.createHttpFilterFactoryFromProto(*message, context, extra_context);
     RETURN_IF_NOT_OK_REF(callback_or_error.status());
 
     auto filter_config_provider =

--- a/source/extensions/filters/http/gcp_authn/filter_config.cc
+++ b/source/extensions/filters/http/gcp_authn/filter_config.cc
@@ -43,9 +43,9 @@ absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactory
 }
 
 absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createHttpFilterFactoryFromProtoTyped(
-    const GcpAuthnFilterConfig& config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(config, stats_prefix, context, context.scope());
+    const GcpAuthnFilterConfig& config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(config, extra_context.stats_prefix, context, context.scope());
 }
 
 /**

--- a/source/extensions/filters/http/gcp_authn/filter_config.h
+++ b/source/extensions/filters/http/gcp_authn/filter_config.h
@@ -23,8 +23,8 @@ public:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
 private:
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level

--- a/source/extensions/filters/http/geoip/config.cc
+++ b/source/extensions/filters/http/geoip/config.cc
@@ -57,9 +57,10 @@ absl::StatusOr<Http::FilterFactoryCb> GeoipFilterFactory::createFilterFactoryFro
 
 absl::StatusOr<Http::FilterFactoryCb> GeoipFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
-    const std::string& stat_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
-  return createFilterFactory(proto_config, stat_prefix, generic_context);
+  return createFilterFactory(proto_config, extra_context.stats_prefix, generic_context);
 }
 
 /**

--- a/source/extensions/filters/http/geoip/config.h
+++ b/source/extensions/filters/http/geoip/config.h
@@ -24,8 +24,8 @@ public:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
 private:
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level

--- a/source/extensions/filters/http/grpc_field_extraction/config.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/config.cc
@@ -39,7 +39,8 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb>
 FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
         proto_config,
-    const std::string&, Envoy::Server::Configuration::ServerFactoryContext& context) {
+    Envoy::Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
   absl::Status creation_status = absl::OkStatus();
   auto filter_config = std::make_shared<FilterConfig>(

--- a/source/extensions/filters/http/grpc_field_extraction/config.h
+++ b/source/extensions/filters/http/grpc_field_extraction/config.h
@@ -30,7 +30,8 @@ private:
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
           proto_config,
-      const std::string&, Envoy::Server::Configuration::ServerFactoryContext&) override;
+      Envoy::Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 } // namespace GrpcFieldExtraction
 } // namespace HttpFilters

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -22,7 +22,8 @@ GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 GrpcHttp1BridgeFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& factory_context) {
+    Server::Configuration::ServerFactoryContext& factory_context,
+    Server::Configuration::ExtraFactoryContext&) {
   return [&factory_context, proto_config](Http::FilterChainFactoryCallbacks& callbacks) {
     callbacks.addStreamFilter(
         std::make_shared<Http1BridgeFilter>(factory_context.grpcContext(), proto_config));

--- a/source/extensions/filters/http/grpc_http1_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.h
@@ -27,8 +27,8 @@ public:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& factory_context) override;
+      Server::Configuration::ServerFactoryContext& factory_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace GrpcHttp1Bridge

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -22,7 +22,7 @@ absl::StatusOr<Http::FilterFactoryCb> Config::createFilterFactoryFromProtoTyped(
 
 absl::StatusOr<Http::FilterFactoryCb> Config::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
-    const std::string&, Server::Configuration::ServerFactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
   return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Filter>(
         config.content_type(), config.withhold_grpc_frames(), config.response_size_header()));

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -25,8 +25,8 @@ public:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
-      const std::string& stat_prefix,
-      Envoy::Server::Configuration::ServerFactoryContext& context) override;
+      Envoy::Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
 private:
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
@@ -31,7 +31,8 @@ absl::StatusOr<Http::FilterFactoryCb>
 GrpcJsonReverseTranscoderFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
         GrpcJsonReverseTranscoder& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   absl::Status creation_status = absl::OkStatus();
   std::shared_ptr<GrpcJsonReverseTranscoderConfig> filter_config =
       std::make_shared<GrpcJsonReverseTranscoderConfig>(proto_config, context.api(),

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
@@ -27,7 +27,8 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
           GrpcJsonReverseTranscoder& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -31,13 +31,14 @@ absl::StatusOr<Http::FilterFactoryCb>
 GrpcJsonTranscoderFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
         proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   absl::Status creation_status = absl::OkStatus();
   JsonTranscoderConfigSharedPtr filter_config =
       std::make_shared<JsonTranscoderConfig>(proto_config, context.api(), creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
   auto stats = std::make_shared<GrpcJsonTranscoderFilterStats>(
-      GrpcJsonTranscoderFilterStats::generateStats(stats_prefix, context.scope()));
+      GrpcJsonTranscoderFilterStats::generateStats(extra_context.stats_prefix, context.scope()));
   return [filter_config, stats](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<JsonTranscoderFilter>(filter_config, stats));
   };

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -29,8 +29,8 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
           proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/grpc_web/config.cc
+++ b/source/extensions/filters/http/grpc_web/config.cc
@@ -19,8 +19,9 @@ absl::StatusOr<Http::FilterFactoryCb> GrpcWebFilterConfig::createFilterFactoryFr
 }
 
 absl::StatusOr<Http::FilterFactoryCb> GrpcWebFilterConfig::createHttpFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb&, const std::string&,
-    Server::Configuration::ServerFactoryContext& factory_context) {
+    const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb&,
+    Server::Configuration::ServerFactoryContext& factory_context,
+    Server::Configuration::ExtraFactoryContext&) {
   return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {
     callbacks.addStreamFilter(std::make_shared<GrpcWebFilter>(factory_context.grpcContext()));
   };

--- a/source/extensions/filters/http/grpc_web/config.h
+++ b/source/extensions/filters/http/grpc_web/config.h
@@ -23,8 +23,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& factory_context) override;
+      Server::Configuration::ServerFactoryContext& factory_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace GrpcWeb

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -24,8 +24,8 @@ HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
 
 absl::StatusOr<Http::FilterFactoryCb>
 HeaderMutationFactoryConfig::createHttpFilterFactoryFromProtoTyped(
-    const ProtoConfig& config, const std::string&,
-    Server::Configuration::ServerFactoryContext& context) {
+    const ProtoConfig& config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   absl::Status creation_status = absl::OkStatus();
   auto filter_config = std::make_shared<HeaderMutationConfig>(config, context, creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);

--- a/source/extensions/filters/http/header_mutation/config.h
+++ b/source/extensions/filters/http/header_mutation/config.h
@@ -26,8 +26,8 @@ private:
                                     Server::Configuration::ServerFactoryContext& context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
-      const ProtoConfig& proto_config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const PerRouteProtoConfig& proto_config,

--- a/source/extensions/filters/http/header_to_metadata/config.cc
+++ b/source/extensions/filters/http/header_to_metadata/config.cc
@@ -36,7 +36,8 @@ absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactor
 
 absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(proto_config, context, context.scope());
 }
 

--- a/source/extensions/filters/http/header_to_metadata/config.h
+++ b/source/extensions/filters/http/header_to_metadata/config.h
@@ -25,8 +25,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -72,8 +72,10 @@ absl::StatusOr<Http::FilterFactoryCb> HealthCheckFilterConfig::createFilterFacto
 absl::StatusOr<Http::FilterFactoryCb>
 HealthCheckFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactoryHelper(proto_config, stats_prefix, context, context.scope());
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactoryHelper(proto_config, extra_context.stats_prefix, context,
+                                   context.scope());
 }
 
 /**

--- a/source/extensions/filters/http/health_check/config.h
+++ b/source/extensions/filters/http/health_check/config.h
@@ -23,8 +23,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryHelper(
       const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,

--- a/source/extensions/filters/http/ip_tagging/config.cc
+++ b/source/extensions/filters/http/ip_tagging/config.cc
@@ -31,11 +31,12 @@ absl::StatusOr<Http::FilterFactoryCb> IpTaggingFilterFactory::createFilterFactor
 
 absl::StatusOr<Http::FilterFactoryCb> IpTaggingFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
-    const std::string& stat_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
   absl::StatusOr<IpTaggingFilterConfigSharedPtr> config = IpTaggingFilterConfig::create(
-      proto_config, stat_prefix, context.singletonManager(), context.scope(), context.runtime(),
-      context.api(), context.threadLocal(), context.mainThreadDispatcher(),
+      proto_config, extra_context.stats_prefix, context.singletonManager(), context.scope(),
+      context.runtime(), context.api(), context.threadLocal(), context.mainThreadDispatcher(),
       context.messageValidationVisitor());
   RETURN_IF_NOT_OK_REF(config.status());
   return

--- a/source/extensions/filters/http/ip_tagging/config.h
+++ b/source/extensions/filters/http/ip_tagging/config.h
@@ -25,8 +25,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace IpTagging

--- a/source/extensions/filters/http/json_to_metadata/config.cc
+++ b/source/extensions/filters/http/json_to_metadata/config.cc
@@ -32,7 +32,8 @@ absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactoryF
 
 absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(proto_config, context, context.scope());
 }
 

--- a/source/extensions/filters/http/json_to_metadata/config.h
+++ b/source/extensions/filters/http/json_to_metadata/config.h
@@ -24,7 +24,8 @@ private:
       const std::string&, Server::Configuration::FactoryContext&) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata&,
-      const std::string&, Server::Configuration::ServerFactoryContext&) override;
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/local_ratelimit/config.cc
+++ b/source/extensions/filters/http/local_ratelimit/config.cc
@@ -28,7 +28,8 @@ absl::StatusOr<Http::FilterFactoryCb> LocalRateLimitFilterConfig::createFilterFa
 absl::StatusOr<Http::FilterFactoryCb>
 LocalRateLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
   absl::Status creation_status = absl::OkStatus();
   FilterConfigSharedPtr filter_config =

--- a/source/extensions/filters/http/local_ratelimit/config.h
+++ b/source/extensions/filters/http/local_ratelimit/config.h
@@ -25,8 +25,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -29,11 +29,12 @@ absl::StatusOr<Http::FilterFactoryCb> LuaFilterConfig::createFilterFactoryFromPr
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb> LuaFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   absl::Status creation_status = absl::OkStatus();
   FilterConfigConstSharedPtr filter_config(new FilterConfig{
       proto_config, context.threadLocal(), context.clusterManager(), context.api(), context.scope(),
-      stats_prefix, context.options().concurrency(), creation_status});
+      extra_context.stats_prefix, context.options().concurrency(), creation_status});
   RETURN_IF_NOT_OK_REF(creation_status);
   auto& time_source = context.mainThreadDispatcher().timeSource();
   return [filter_config, &time_source](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -27,8 +27,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/mcp/config.cc
+++ b/source/extensions/filters/http/mcp/config.cc
@@ -23,9 +23,11 @@ absl::StatusOr<Http::FilterFactoryCb> McpFilterConfigFactory::createFilterFactor
 
 absl::StatusOr<Http::FilterFactoryCb> McpFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
-  auto config = std::make_shared<McpFilterConfig>(proto_config, stats_prefix, context.scope());
+  auto config =
+      std::make_shared<McpFilterConfig>(proto_config, extra_context.stats_prefix, context.scope());
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<McpFilter>(config));

--- a/source/extensions/filters/http/mcp/config.h
+++ b/source/extensions/filters/http/mcp/config.h
@@ -27,8 +27,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/mcp_json_rest_bridge/config.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/config.cc
@@ -16,15 +16,17 @@ McpJsonRestBridgeFilterConfigFactory::createFilterFactoryFromProtoTyped(
         proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   // This filter does not use the factory context, so delegate to the server-context variant.
-  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
-                                               context.serverFactoryContext());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           stats_prefix};
+  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
+                                               extra_context);
 }
 
 absl::StatusOr<Http::FilterFactoryCb>
 McpJsonRestBridgeFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
         proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
 
   if (proto_config.tool_config().has_tool_list_http_rule()) {
     const auto& rule = proto_config.tool_config().tool_list_http_rule();

--- a/source/extensions/filters/http/mcp_json_rest_bridge/config.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/config.h
@@ -30,7 +30,8 @@ private:
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
           proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext&) override;
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/mcp_router/config.cc
+++ b/source/extensions/filters/http/mcp_router/config.cc
@@ -33,8 +33,9 @@ McpRouterFilterConfigFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 McpRouterFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context, context.scope());
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
 }
 
 /**

--- a/source/extensions/filters/http/mcp_router/config.h
+++ b/source/extensions/filters/http/mcp_router/config.h
@@ -30,8 +30,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -178,8 +178,9 @@ absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createFilterFactoryFromProto
 
 absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto, stats_prefix, context, context.scope(), {});
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto, extra_context.stats_prefix, context, context.scope(), {});
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/oauth2/config.h
+++ b/source/extensions/filters/http/oauth2/config.h
@@ -23,10 +23,10 @@ public:
                                     const std::string&,
                                     Server::Configuration::FactoryContext&) override;
 
-  absl::StatusOr<Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProtoTyped(const envoy::extensions::filters::http::oauth2::v3::OAuth2&,
-                                        const std::string&,
-                                        Server::Configuration::ServerFactoryContext&) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::oauth2::v3::OAuth2&,
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const envoy::extensions::filters::http::oauth2::v3::OAuth2& config,

--- a/source/extensions/filters/http/on_demand/config.cc
+++ b/source/extensions/filters/http/on_demand/config.cc
@@ -24,7 +24,8 @@ absl::StatusOr<Http::FilterFactoryCb> OnDemandFilterFactory::createFilterFactory
 
 absl::StatusOr<Http::FilterFactoryCb> OnDemandFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   absl::Status creation_status = absl::OkStatus();
   OnDemandFilterConfigSharedPtr config = std::make_shared<OnDemandFilterConfig>(
       proto_config, context.clusterManager(), context.messageValidationVisitor(), creation_status);

--- a/source/extensions/filters/http/on_demand/config.h
+++ b/source/extensions/filters/http/on_demand/config.h
@@ -27,7 +27,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/original_src/original_src_config_factory.cc
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.cc
@@ -16,14 +16,16 @@ absl::StatusOr<Http::FilterFactoryCb> OriginalSrcConfigFactory::createFilterFact
     const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   // This filter does not use the factory context, so delegate to the server-context variant.
-  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
-                                               context.serverFactoryContext());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           stats_prefix};
+  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
+                                               extra_context);
 }
 
 absl::StatusOr<Http::FilterFactoryCb>
 OriginalSrcConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
   Config config(proto_config);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<OriginalSrcFilter>(config));

--- a/source/extensions/filters/http/original_src/original_src_config_factory.h
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.h
@@ -24,8 +24,8 @@ public:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
-      const std::string& stat_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace OriginalSrc

--- a/source/extensions/filters/http/proto_api_scrubber/config.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/config.cc
@@ -42,7 +42,8 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb>
 FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
         proto_config,
-    const std::string&, Envoy::Server::Configuration::ServerFactoryContext& context) {
+    Envoy::Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(proto_config, context, context.scope());
 }
 

--- a/source/extensions/filters/http/proto_api_scrubber/config.h
+++ b/source/extensions/filters/http/proto_api_scrubber/config.h
@@ -30,7 +30,8 @@ private:
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
           proto_config,
-      const std::string&, Envoy::Server::Configuration::ServerFactoryContext&) override;
+      Envoy::Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/proto_message_extraction/config.cc
+++ b/source/extensions/filters/http/proto_message_extraction/config.cc
@@ -39,7 +39,8 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb>
 FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::proto_message_extraction::v3::
         ProtoMessageExtractionConfig& proto_config,
-    const std::string&, Envoy::Server::Configuration::ServerFactoryContext& context) {
+    Envoy::Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   absl::Status creation_status = absl::OkStatus();
   auto filter_config = std::make_shared<FilterConfig>(
       proto_config, std::make_unique<ExtractorFactoryImpl>(), context.api(), creation_status);

--- a/source/extensions/filters/http/proto_message_extraction/config.h
+++ b/source/extensions/filters/http/proto_message_extraction/config.h
@@ -31,7 +31,8 @@ private:
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::proto_message_extraction::v3::
           ProtoMessageExtractionConfig& proto_config,
-      const std::string&, Envoy::Server::Configuration::ServerFactoryContext&) override;
+      Envoy::Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 } // namespace ProtoMessageExtraction
 } // namespace HttpFilters

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -51,7 +51,8 @@ absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactory
 
 absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return createFilterFactory(proto_config, context, context.scope());
 }
 

--- a/source/extensions/filters/http/ratelimit/config.h
+++ b/source/extensions/filters/http/ratelimit/config.h
@@ -27,8 +27,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. The FilterConfig stats are scoped to the given scope.

--- a/source/extensions/filters/http/rbac/config.cc
+++ b/source/extensions/filters/http/rbac/config.cc
@@ -28,10 +28,12 @@ RoleBasedAccessControlFilterConfigFactory::createFilterFactoryFromProtoTyped(
 absl::StatusOr<Http::FilterFactoryCb>
 RoleBasedAccessControlFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
   auto config = std::make_shared<RoleBasedAccessControlFilterConfig>(
-      proto_config, stats_prefix, context.scope(), context, context.messageValidationVisitor());
+      proto_config, extra_context.stats_prefix, context.scope(), context,
+      context.messageValidationVisitor());
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<RoleBasedAccessControlFilter>(config));

--- a/source/extensions/filters/http/rbac/config.h
+++ b/source/extensions/filters/http/rbac/config.h
@@ -28,8 +28,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/set_filter_state/config.cc
+++ b/source/extensions/filters/http/set_filter_state/config.cc
@@ -62,7 +62,8 @@ SetFilterStateConfig::createRouteSpecificFilterConfigTyped(
 
 absl::StatusOr<Http::FilterFactoryCb> SetFilterStateConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
   // TODO(wbpcode): these is a potential bug of message validation. The validation visitor
   // of server context should not be used here directly. But this is bug of

--- a/source/extensions/filters/http/set_filter_state/config.h
+++ b/source/extensions/filters/http/set_filter_state/config.h
@@ -45,8 +45,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& server_context) override;
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace SetFilterState

--- a/source/extensions/filters/http/set_metadata/config.cc
+++ b/source/extensions/filters/http/set_metadata/config.cc
@@ -28,9 +28,10 @@ absl::StatusOr<Http::FilterFactoryCb> SetMetadataConfig::createFilterFactoryFrom
 
 absl::StatusOr<Http::FilterFactoryCb> SetMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& server_context) {
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   ConfigSharedPtr filter_config(
-      std::make_shared<Config>(proto_config, server_context.scope(), stats_prefix));
+      std::make_shared<Config>(proto_config, server_context.scope(), extra_context.stats_prefix));
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(

--- a/source/extensions/filters/http/set_metadata/config.h
+++ b/source/extensions/filters/http/set_metadata/config.h
@@ -25,8 +25,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& server_context) override;
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/sse_to_metadata/config.cc
+++ b/source/extensions/filters/http/sse_to_metadata/config.cc
@@ -13,13 +13,16 @@ absl::StatusOr<Http::FilterFactoryCb> SseToMetadataConfig::createFilterFactoryFr
     const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   // This filter only uses the server factory context, so delegate to the server-context variant.
-  return createHttpFilterFactoryFromProtoTyped(proto_config, stats_prefix,
-                                               context.serverFactoryContext());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           stats_prefix};
+  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
+                                               extra_context);
 }
 
 absl::StatusOr<Http::FilterFactoryCb> SseToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
   // Create shared config (which instantiates the parser from TypedExtensionConfig)
   // Note: content_parser is validated as required by proto validation rules

--- a/source/extensions/filters/http/sse_to_metadata/config.h
+++ b/source/extensions/filters/http/sse_to_metadata/config.h
@@ -28,8 +28,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace SseToMetadata

--- a/source/extensions/filters/http/stateful_session/config.cc
+++ b/source/extensions/filters/http/stateful_session/config.cc
@@ -24,11 +24,11 @@ StatefulSessionFactoryConfig::createFilterFactoryFromProtoTyped(
 
 absl::StatusOr<Http::FilterFactoryCb>
 StatefulSessionFactoryConfig::createHttpFilterFactoryFromProtoTyped(
-    const ProtoConfig& proto_config, const std::string& stats_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
+    const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
-  auto filter_config(std::make_shared<StatefulSessionConfig>(proto_config, generic_context,
-                                                             stats_prefix, context.scope()));
+  auto filter_config(std::make_shared<StatefulSessionConfig>(
+      proto_config, generic_context, extra_context.stats_prefix, context.scope()));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new StatefulSession(filter_config)});
   };

--- a/source/extensions/filters/http/stateful_session/config.h
+++ b/source/extensions/filters/http/stateful_session/config.h
@@ -27,8 +27,8 @@ private:
                                     Server::Configuration::FactoryContext& context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
-      const ProtoConfig& proto_config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const PerRouteProtoConfig& proto_config,

--- a/source/extensions/filters/http/tap/config.cc
+++ b/source/extensions/filters/http/tap/config.cc
@@ -56,8 +56,9 @@ absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createFilterFactoryFromP
 
 absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
-    const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context, context.scope(),
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope(),
                              context.messageValidationVisitor());
 }
 

--- a/source/extensions/filters/http/tap/config.h
+++ b/source/extensions/filters/http/tap/config.h
@@ -24,8 +24,8 @@ private:
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. The FilterConfig stats are scoped to the given scope.

--- a/source/extensions/filters/http/thrift_to_metadata/config.cc
+++ b/source/extensions/filters/http/thrift_to_metadata/config.cc
@@ -29,7 +29,8 @@ absl::StatusOr<Http::FilterFactoryCb> ThriftToMetadataConfig::createFilterFactor
 
 absl::StatusOr<Http::FilterFactoryCb> ThriftToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata& proto_config,
-    const std::string&, Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   absl::Status creation_status = absl::OkStatus();
   std::shared_ptr<FilterConfig> config =
       std::make_shared<FilterConfig>(proto_config, context.scope(), creation_status);

--- a/source/extensions/filters/http/thrift_to_metadata/config.h
+++ b/source/extensions/filters/http/thrift_to_metadata/config.h
@@ -25,7 +25,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
-      const std::string&, Server::Configuration::ServerFactoryContext&) override;
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace ThriftToMetadata

--- a/source/extensions/filters/http/transform/config.cc
+++ b/source/extensions/filters/http/transform/config.cc
@@ -30,9 +30,9 @@ absl::StatusOr<Http::FilterFactoryCb> TransformFactoryConfig::createFilterFactor
 }
 
 absl::StatusOr<Http::FilterFactoryCb> TransformFactoryConfig::createHttpFilterFactoryFromProtoTyped(
-    const ProtoConfig& proto_config, const std::string& stat_prefix,
-    Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(proto_config, stat_prefix, context, context.scope());
+    const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/transform/config.h
+++ b/source/extensions/filters/http/transform/config.h
@@ -24,8 +24,8 @@ private:
                                     const std::string& stats_prefix,
                                     Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
-      const ProtoConfig& proto_config, const std::string& stats_prefix,
-      Server::Configuration::ServerFactoryContext& context) override;
+      const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
   // (ServerFactoryContext) paths. Stats are scoped to the given scope.

--- a/source/extensions/filters/http/wasm/config.h
+++ b/source/extensions/filters/http/wasm/config.h
@@ -46,14 +46,13 @@ public:
         stats_prefix, context, context.serverFactoryContext());
   }
 
-  absl::StatusOr<Envoy::Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                                   const std::string& stats_prefix,
-                                   Server::Configuration::ServerFactoryContext& context) override {
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProto(
+      const Protobuf::Message& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override {
     return createFilterFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const envoy::extensions::filters::http::wasm::v3::Wasm&>(
             proto_config, context.messageValidationVisitor()),
-        stats_prefix, context, context);
+        extra_context.stats_prefix, context, context);
   }
 
 private:

--- a/test/extensions/dynamic_modules/http/config_test.cc
+++ b/test/extensions/dynamic_modules/http/config_test.cc
@@ -148,8 +148,10 @@ TEST_F(DynamicModuleFilterConfigTest, RemoteSourceWithoutInitManagerReturnsError
 
   // The ServerFactoryContext path has no init manager, so remote sources should be rejected.
   DynamicModuleConfigFactory factory;
-  EXPECT_THAT(factory.createHttpFilterFactoryFromProto(proto_config, "stats",
-                                                       context_.server_factory_context_),
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context_.server_factory_context_.messageValidationVisitor(), "stats"};
+  EXPECT_THAT(factory.createHttpFilterFactoryFromProto(
+                  proto_config, context_.server_factory_context_, extra_context),
               HasStatus(absl::StatusCode::kInvalidArgument,
                         "Remote module sources require an init manager"));
 }

--- a/test/extensions/dynamic_modules/http/factory_test.cc
+++ b/test/extensions/dynamic_modules/http/factory_test.cc
@@ -266,9 +266,12 @@ filter_config:
       .WillByDefault(testing::Return(1));
 
   Envoy::Server::Configuration::DynamicModuleConfigFactory factory;
-  auto factory_cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "", context.server_factory_context_)
-          .value();
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context.server_factory_context_.messageValidationVisitor(), ""};
+  auto factory_cb = factory
+                        .createHttpFilterFactoryFromProto(
+                            proto_config, context.server_factory_context_, extra_context)
+                        .value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> callbacks;
 
   NiceMock<Event::MockDispatcher> dispatcher{"worker_0"};

--- a/test/extensions/filters/http/a2a/config_test.cc
+++ b/test/extensions/filters/http/a2a/config_test.cc
@@ -37,9 +37,11 @@ TEST_F(A2aFilterConfigFactoryTest, CreateFilterFactory) {
 TEST_F(A2aFilterConfigFactoryTest, CreateFilterWithServerContext) {
   envoy::extensions::filters::http::a2a::v3::A2a config;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory_.createHttpFilterFactoryFromProto(config, "stats", server_context).value();
+      factory_.createHttpFilterFactoryFromProto(config, server_context, extra_context).value();
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));

--- a/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_config_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/adaptive_concurrency_config_test.cc
@@ -64,10 +64,12 @@ enabled:
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor()).Times(testing::AnyNumber());
-  Http::FilterFactoryCb cb =
-      factory
-          .createHttpFilterFactoryFromProto(*proto_config, "stats", context.server_factory_context_)
-          .value();
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context.server_factory_context_.messageValidationVisitor(), "stats"};
+  Http::FilterFactoryCb cb = factory
+                                 .createHttpFilterFactoryFromProto(
+                                     *proto_config, context.server_factory_context_, extra_context)
+                                 .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -241,9 +241,11 @@ success_criteria:
   TestUtility::loadFromYamlAndValidate(yaml, proto);
 
   // createHttpFilterFactoryFromProto returns a StatusOr<FilterFactoryCb>; unwrap with value().
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context_.serverFactoryContext().messageValidationVisitor(), "stats_prefix"};
   auto cb =
       admission_control_filter_factory
-          .createHttpFilterFactoryFromProto(proto, "stats_prefix", context_.serverFactoryContext())
+          .createHttpFilterFactoryFromProto(proto, context_.serverFactoryContext(), extra_context)
           .value();
 
   EXPECT_TRUE(cb != nullptr);

--- a/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
+++ b/test/extensions/filters/http/alternate_protocols_cache/config_test.cc
@@ -31,8 +31,10 @@ TEST(AlternateProtocolsCacheFilterConfigTest, AlternateProtocolsCacheFilterWithS
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   AlternateProtocolsCacheFilterFactory factory;
   envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig proto_config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   NiceMock<Event::MockDispatcher> dispatcher;
   EXPECT_CALL(filter_callback, dispatcher()).WillRepeatedly(testing::ReturnRef(dispatcher));

--- a/test/extensions/filters/http/api_key_auth/config_test.cc
+++ b/test/extensions/filters/http/api_key_auth/config_test.cc
@@ -119,9 +119,11 @@ TEST(ApiKeyAuthFilterFactoryTest, CreateFilterWithServerContext) {
 
   ApiKeyAuthFilterFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context).value();
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));

--- a/test/extensions/filters/http/aws_lambda/config_test.cc
+++ b/test/extensions/filters/http/aws_lambda/config_test.cc
@@ -395,9 +395,11 @@ invocation_mode: asynchronous
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   AwsLambdaFilterFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   auto has_expected_settings = [](std::shared_ptr<Envoy::Http::StreamFilter> stream_filter) {
     auto filter = std::static_pointer_cast<Filter>(stream_filter);

--- a/test/extensions/filters/http/aws_request_signing/config_test.cc
+++ b/test/extensions/filters/http/aws_request_signing/config_test.cc
@@ -769,9 +769,11 @@ match_excluded_headers:
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   AwsRequestSigningFilterFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/bandwidth_limit/config_test.cc
+++ b/test/extensions/filters/http/bandwidth_limit/config_test.cc
@@ -41,9 +41,12 @@ TEST(Factory, CreateFilterWithServerContext) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   auto callback =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, server_context, extra_context)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/basic_auth/config_test.cc
+++ b/test/extensions/filters/http/basic_auth/config_test.cc
@@ -162,8 +162,11 @@ TEST(Factory, ValidConfigWithServerContext) {
   TestUtility::loadFromYaml(yaml, proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
-  auto callback = factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+  auto callback =
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/buffer/config_test.cc
+++ b/test/extensions/filters/http/buffer/config_test.cc
@@ -123,8 +123,10 @@ TEST(BufferFilterFactoryTest, BufferFilterCorrectProtoWithServerContext) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   BufferFilterFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/cache/config_test.cc
+++ b/test/extensions/filters/http/cache/config_test.cc
@@ -39,9 +39,12 @@ TEST_F(CacheFilterFactoryTest, Disabled) {
 
 TEST_F(CacheFilterFactoryTest, DisabledWithServerFactoryContext) {
   config_.mutable_disabled()->set_value(true);
-  Http::FilterFactoryCb cb =
-      factory_.createHttpFilterFactoryFromProto(config_, "stats", context_.server_factory_context_)
-          .value();
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context_.server_factory_context_.messageValidationVisitor(), "stats"};
+  Http::FilterFactoryCb cb = factory_
+                                 .createHttpFilterFactoryFromProto(
+                                     config_, context_.server_factory_context_, extra_context)
+                                 .value();
   Http::StreamFilterSharedPtr filter;
   EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));
   cb(filter_callback_);

--- a/test/extensions/filters/http/cache_v2/config_test.cc
+++ b/test/extensions/filters/http/cache_v2/config_test.cc
@@ -29,8 +29,11 @@ protected:
 TEST_F(CacheFilterFactoryTest, BasicWithServerFactoryContext) {
   std::ignore = config_.mutable_typed_config()->PackFrom(
       envoy::extensions::http::cache_v2::simple_http_cache::v3::SimpleHttpCacheV2Config());
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context_.serverFactoryContext().messageValidationVisitor(), "stats"};
   Http::FilterFactoryCb cb =
-      factory_.createHttpFilterFactoryFromProto(config_, "stats", context_.serverFactoryContext())
+      factory_
+          .createHttpFilterFactoryFromProto(config_, context_.serverFactoryContext(), extra_context)
           .value();
   Http::StreamFilterSharedPtr filter;
   EXPECT_CALL(filter_callback_, addStreamFilter(_)).WillOnce(::testing::SaveArg<0>(&filter));

--- a/test/extensions/filters/http/cdn_loop/config_test.cc
+++ b/test/extensions/filters/http/cdn_loop/config_test.cc
@@ -44,9 +44,11 @@ TEST(CdnLoopFilterFactoryTest, CreateFilterWithServerContext) {
   envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig config;
   config.set_cdn_id("cdn");
   CdnLoopFilterFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(config, server_context, extra_context).value();
   cb(filter_callbacks);
   EXPECT_NE(filter.get(), nullptr);
   EXPECT_NE(dynamic_cast<CdnLoopFilter*>(filter.get()), nullptr);

--- a/test/extensions/filters/http/common/factory_base_test.cc
+++ b/test/extensions/filters/http/common/factory_base_test.cc
@@ -92,11 +92,14 @@ TEST(FactoryBaseTest, ServerContextNotSupported) {
   EXPECT_THROW_WITH_MESSAGE(
       factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", server_context),
       EnvoyException, "Creating filter factory from server factory context is not supported");
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   // createHttpFilterFactoryFromProto delegates to the typed variant, which in turn delegates to the
   // (throwing) server-context implementation.
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).IgnoreError(),
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context)
+          .IgnoreError(),
       EnvoyException, "Creating filter factory from server factory context is not supported");
 }
 
@@ -118,8 +121,11 @@ TEST(FactoryBaseTest, ExceptionFreeServerContextNotSupported) {
   RouterProto proto_config;
 
   EXPECT_EQ("test.exception_free_factory_base", factory.name());
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
-  auto result = factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context);
+  auto result =
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context);
   EXPECT_THAT(
       result,
       HasStatus(absl::StatusCode::kInvalidArgument,
@@ -164,9 +170,12 @@ TEST(FactoryBaseTest, DualServerContextNotSupported) {
       factory.createFilterFactoryFromProtoWithServerContext(proto_config, "stats", server_context),
       EnvoyException,
       "DualFactoryBase: creating filter factory from server factory context is not supported");
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).IgnoreError(),
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context)
+          .IgnoreError(),
       EnvoyException,
       "DualFactoryBase: creating filter factory from server factory context is not supported");
 }

--- a/test/extensions/filters/http/composite/filter_test.cc
+++ b/test/extensions/filters/http/composite/filter_test.cc
@@ -1719,8 +1719,9 @@ public:
     return absl::InvalidArgumentError("boom");
   }
   absl::StatusOr<Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
-                                   Server::Configuration::ServerFactoryContext&) override {
+  createHttpFilterFactoryFromProto(const Protobuf::Message&,
+                                   Server::Configuration::ServerFactoryContext&,
+                                   Server::Configuration::ExtraFactoryContext&) override {
     return nullptr;
   }
 };

--- a/test/extensions/filters/http/compressor/config_test.cc
+++ b/test/extensions/filters/http/compressor/config_test.cc
@@ -167,9 +167,11 @@ TEST(CompressorFilterFactoryTests, CreateFilterWithServerContext) {
   Envoy::Registry::InjectFactory<
       Envoy::Compression::Compressor::NamedCompressorLibraryConfigFactory>
       reg(factory_impl);
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
+++ b/test/extensions/filters/http/connect_grpc_bridge/config_test.cc
@@ -31,8 +31,10 @@ TEST(ConnectGrpcBridgeFilterConfigTest, ConnectGrpcBridgeFilterWithServerContext
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   ConnectGrpcFilterConfigFactory factory;
   envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_)).Times(AtLeast(1));
   cb(filter_callback);

--- a/test/extensions/filters/http/cors/config_test.cc
+++ b/test/extensions/filters/http/cors/config_test.cc
@@ -28,8 +28,10 @@ TEST(CorsFilterConfigTest, CorsFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   CorsFilterFactory factory;
   envoy::extensions::filters::http::cors::v3::Cors config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/credential_injector/config_test.cc
+++ b/test/extensions/filters/http/credential_injector/config_test.cc
@@ -51,8 +51,12 @@ TEST(Factory, UnregisteredExtensionWithServerContext) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   CredentialInjectorFilterFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   EXPECT_THAT(
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).status().message(),
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context)
+          .status()
+          .message(),
       testing::HasSubstr("Didn't find a registered implementation for 'undefined_credential' with "
                          "type URL: 'test.mock_credential.Unregistered'"));
 }

--- a/test/extensions/filters/http/csrf/csrf_config_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_config_test.cc
@@ -36,8 +36,10 @@ TEST(CsrfFilterConfigTest, ServerContextOnlyFactory) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   CsrfFilterFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
-  auto cb = factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+  auto cb = factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   EXPECT_NE(cb, nullptr);
 
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
+++ b/test/extensions/filters/http/dynamic_forward_proxy/config_test.cc
@@ -41,8 +41,10 @@ TEST(DynamicForwardProxyFilterFactoryTest, ServerFactoryContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
 
   envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig proto_config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
 
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -224,8 +224,10 @@ TEST_F(ExtAuthzFilterHttpTest, FilterWithServerContext) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -223,9 +223,10 @@ TEST_F(ExtAuthzFilterHttpTest, FilterWithServerContext) {
   TestUtility::loadFromYaml(ext_authz_config_yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor());
+  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
                                                            "stats"};
+  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
       factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -106,9 +106,10 @@ TEST(HttpExtProcConfigTest, CorrectGrpcServiceConfigServerContext) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor());
+  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
                                                            "stats"};
+  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
       factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
@@ -403,9 +404,10 @@ TEST(HttpExtProcConfigTest, UpstreamConfig) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor());
+  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
                                                            "stats"};
+  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
       factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -107,8 +107,10 @@ TEST(HttpExtProcConfigTest, CorrectGrpcServiceConfigServerContext) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -134,8 +136,10 @@ TEST(HttpExtProcConfigTest, CorrectHttpServiceConfigServerContext) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor()).Times(testing::AtLeast(1));
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
@@ -327,7 +331,9 @@ TEST(HttpExtProcConfigTest, InvalidServiceConfigServerContext) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  auto result = factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context);
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
+  auto result = factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context);
   EXPECT_THAT(result, HasStatus(absl::StatusCode::kInvalidArgument,
                                 "One and only one of grpc_service or http_service must be "
                                 "configured"));
@@ -398,8 +404,10 @@ TEST(HttpExtProcConfigTest, UpstreamConfig) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   EXPECT_CALL(context, messageValidationVisitor());
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/fault/config_test.cc
+++ b/test/extensions/filters/http/fault/config_test.cc
@@ -62,8 +62,10 @@ TEST(FaultFilterConfigTest, FaultFilterCorrectJsonWithServerContext) {
   TestUtility::loadFromYamlAndValidate(yaml_string, config);
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FaultFilterFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/file_system_buffer/config_test.cc
+++ b/test/extensions/filters/http/file_system_buffer/config_test.cc
@@ -361,8 +361,10 @@ TEST_F(FileSystemBufferFilterConfigTest, ValidConfigWithServerContext) {
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FileSystemBufferFilterFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/filter_chain/filter_test.cc
+++ b/test/extensions/filters/http/filter_chain/filter_test.cc
@@ -47,8 +47,9 @@ public:
   }
 
   absl::StatusOr<Http::FilterFactoryCb>
-  createHttpFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
-                                   Server::Configuration::ServerFactoryContext&) override {
+  createHttpFilterFactoryFromProto(const Protobuf::Message&,
+                                   Server::Configuration::ServerFactoryContext&,
+                                   Server::Configuration::ExtraFactoryContext&) override {
     return [this](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(std::make_shared<Http::MockStreamDecoderFilter>());
       filter_added_++;

--- a/test/extensions/filters/http/geoip/config_test.cc
+++ b/test/extensions/filters/http/geoip/config_test.cc
@@ -130,10 +130,11 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigWithCorrectProto2) {
   GeoipFilterConfig filter_config;
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_CALL(context.server_factory_context_, messageValidationVisitor()).Times(2);
   GeoipFilterFactory factory;
+  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{
       context.server_factory_context_.messageValidationVisitor(), "geoip"};
+  EXPECT_CALL(context.server_factory_context_, messageValidationVisitor()).Times(2);
   Http::FilterFactoryCb cb = factory
                                  .createHttpFilterFactoryFromProto(
                                      filter_config, context.server_factory_context_, extra_context)

--- a/test/extensions/filters/http/geoip/config_test.cc
+++ b/test/extensions/filters/http/geoip/config_test.cc
@@ -132,10 +132,12 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigWithCorrectProto2) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   EXPECT_CALL(context.server_factory_context_, messageValidationVisitor()).Times(2);
   GeoipFilterFactory factory;
-  Http::FilterFactoryCb cb =
-      factory
-          .createHttpFilterFactoryFromProto(filter_config, "geoip", context.server_factory_context_)
-          .value();
+  Server::Configuration::ExtraFactoryContext extra_context{
+      context.server_factory_context_.messageValidationVisitor(), "geoip"};
+  Http::FilterFactoryCb cb = factory
+                                 .createHttpFilterFactoryFromProto(
+                                     filter_config, context.server_factory_context_, extra_context)
+                                 .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback,
               addStreamDecoderFilter(AllOf(HasUseXff(true), HasXffNumTrustedHops(1))));

--- a/test/extensions/filters/http/grpc_field_extraction/config_test.cc
+++ b/test/extensions/filters/http/grpc_field_extraction/config_test.cc
@@ -45,9 +45,11 @@ TEST_F(GrpcFieldExtractionFilterFactoryTest, CreateFilterFactoryFromProto) {
 TEST_F(GrpcFieldExtractionFilterFactoryTest, CreateFilterFactoryFromProtoWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   FilterFactoryCreator factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config_, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config_, context, extra_context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_bridge/config_test.cc
@@ -27,8 +27,10 @@ TEST(GrpcHttp1BridgeFilterConfigTest, GrpcHttp1BridgeFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   GrpcHttp1BridgeFilterConfig factory;
   envoy::extensions::filters::http::grpc_http1_bridge::v3::Config config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
+++ b/test/extensions/filters/http/grpc_http1_reverse_bridge/config_test.cc
@@ -67,8 +67,10 @@ withhold_grpc_frames: true
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   Config config_factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      config_factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      config_factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_json_reverse_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_reverse_transcoder/config_test.cc
@@ -32,10 +32,12 @@ TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
 
 TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFailWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   EXPECT_THAT(GrpcJsonReverseTranscoderFactory().createHttpFilterFactoryFromProto(
                   envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
                       GrpcJsonReverseTranscoder(),
-                  "stats", context),
+                  context, extra_context),
               Not(IsOk()));
 }
 
@@ -70,9 +72,11 @@ TEST_F(GrpcJsonReverseTranscoderFilterFactoryTest, CreateFilterFactoryFromProto)
 TEST_F(GrpcJsonReverseTranscoderFilterFactoryTest, CreateFilterFactoryFromProtoWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   GrpcJsonReverseTranscoderFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config_, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config_, context, extra_context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/config_test.cc
@@ -31,11 +31,13 @@ TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFail) {
 
 TEST(GrpcJsonTranscoderFilterConfigTest, ValidateFailWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   EXPECT_THROW(
       GrpcJsonTranscoderFilterConfig()
           .createHttpFilterFactoryFromProto(
               envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder(),
-              "stats", context)
+              context, extra_context)
           .value(),
       ProtoValidationException);
 }
@@ -71,9 +73,11 @@ TEST_F(GrpcJsonTranscoderFilterFactoryTest, CreateFilterFactoryFromProto) {
 TEST_F(GrpcJsonTranscoderFilterFactoryTest, CreateFilterFactoryFromProtoWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   GrpcJsonTranscoderFilterConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config_, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config_, context, extra_context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/grpc_web/config_test.cc
+++ b/test/extensions/filters/http/grpc_web/config_test.cc
@@ -27,8 +27,10 @@ TEST(GrpcWebFilterConfigTest, GrpcWebFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   GrpcWebFilterConfig factory;
   envoy::extensions::filters::http::grpc_web::v3::GrpcWeb config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/header_mutation/config_test.cc
+++ b/test/extensions/filters/http/header_mutation/config_test.cc
@@ -208,8 +208,10 @@ TEST(FactoryTest, FactoryTestWithServerContext) {
   // type (the base NamedHttpFilterConfigFactory pointer exposes only the Protobuf::Message
   // overload, which routes through the legacy path).
   HeaderMutationFactoryConfig header_mutation_factory;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      mock_server_context.messageValidationVisitor(), "test"};
   auto cb = header_mutation_factory
-                .createHttpFilterFactoryFromProto(proto_config, "test", mock_server_context)
+                .createHttpFilterFactoryFromProto(proto_config, mock_server_context, extra_context)
                 .value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));

--- a/test/extensions/filters/http/header_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/header_to_metadata/config_test.cc
@@ -143,9 +143,11 @@ request_rules:
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
   HeaderToMetadataConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/health_check/config_test.cc
+++ b/test/extensions/filters/http/health_check/config_test.cc
@@ -294,8 +294,10 @@ TEST(HealthCheckFilterConfig, HealthCheckFilterWithServerContext) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   HealthCheckFilterConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -1255,8 +1255,11 @@ ip_tags:
 
   IpTaggingFilterFactory factory;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "prefix."};
 
-  auto cb_or = factory.createHttpFilterFactoryFromProto(proto_config, "prefix.", server_context);
+  auto cb_or =
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context);
   ASSERT_OK(cb_or);
   auto cb = std::move(cb_or.value());
 

--- a/test/extensions/filters/http/json_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/json_to_metadata/config_test.cc
@@ -93,9 +93,12 @@ request_rules:
   TestUtility::loadFromYaml(yaml_request, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   auto callback =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, server_context, extra_context)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/local_ratelimit/config_test.cc
+++ b/test/extensions/filters/http/local_ratelimit/config_test.cc
@@ -418,8 +418,11 @@ stat_prefix: test
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
-  auto callback = factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
+  auto callback =
+      factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -62,8 +62,10 @@ TEST(LuaFilterConfigTest, LuaFilterWithDefaultSourceCodeWithServerContext) {
   TestUtility::loadFromYaml(yaml_string, proto_config);
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   LuaFilterConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/mcp/config_test.cc
+++ b/test/extensions/filters/http/mcp/config_test.cc
@@ -57,9 +57,12 @@ TEST_F(McpFilterConfigTest, CreateRouteSpecificConfig) {
 TEST_F(McpFilterConfigTest, CreateFilterWithServerContext) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory_->createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+      factory_->createHttpFilterFactoryFromProto(proto_config, server_context, extra_context)
+          .value();
 
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));

--- a/test/extensions/filters/http/mcp_json_rest_bridge/config_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/config_test.cc
@@ -41,8 +41,10 @@ TEST(McpJsonRestBridgeFilterConfigFactoryTest, CreateFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
 
   McpJsonRestBridgeFilterConfigFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context).value();
 
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter);

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -185,9 +185,12 @@ config:
   ON_CALL(secret_manager, findStaticGenericSecretProvider(_))
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, server_context, extra_context)
+          .value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/on_demand/config_test.cc
+++ b/test/extensions/filters/http/on_demand/config_test.cc
@@ -29,9 +29,11 @@ TEST(OnDemandFilterConfigTest, OnDemandFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   OnDemandFilterFactory factory;
   envoy::extensions::filters::http::on_demand::v3::OnDemand config;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamDecoderFilter(_));
   cb(filter_callback);

--- a/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
+++ b/test/extensions/filters/http/original_src/original_src_config_factory_test.cc
@@ -56,9 +56,12 @@ TEST(OriginalSrcHttpConfigFactoryTest, CreateFilterWithServerContext) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), ""};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(*proto_config, "", server_context).value();
+      factory.createHttpFilterFactoryFromProto(*proto_config, server_context, extra_context)
+          .value();
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   Http::StreamDecoderFilterSharedPtr added_filter;

--- a/test/extensions/filters/http/proto_api_scrubber/filter_config_test.cc
+++ b/test/extensions/filters/http/proto_api_scrubber/filter_config_test.cc
@@ -621,8 +621,11 @@ TEST_F(ProtoApiScrubberFilterConfigTest, StatsInitialization) {
 // used for route/vhost level factory support.
 TEST_F(ProtoApiScrubberFilterConfigTest, CreateFilterWithServerContext) {
   FilterFactoryCreator factory;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_factory_context_.messageValidationVisitor(), "stats"};
   Envoy::Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config_, "stats", server_factory_context_)
+      factory
+          .createHttpFilterFactoryFromProto(proto_config_, server_factory_context_, extra_context)
           .value();
   NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(testing::_));

--- a/test/extensions/filters/http/proto_message_extraction/filter_config_test.cc
+++ b/test/extensions/filters/http/proto_message_extraction/filter_config_test.cc
@@ -512,9 +512,11 @@ TEST(FilterFactoryCreatorTest, CreateFilterFactoryFromProtoWithServerContext) {
       api->fileSystem()
           .fileReadToEnd(Envoy::TestEnvironment::runfilesPath("test/proto/apikeys.descriptor"))
           .value();
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   testing::NiceMock<Http::MockFilterChainFactoryCallbacks> filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(testing::_));
   cb(filter_callback);

--- a/test/extensions/filters/http/rbac/config_test.cc
+++ b/test/extensions/filters/http/rbac/config_test.cc
@@ -132,8 +132,10 @@ TEST(RoleBasedAccessControlFilterConfigFactoryTest, ValidProtoWithServerContext)
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
   RoleBasedAccessControlFilterConfigFactory factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/set_filter_state/integration_test.cc
+++ b/test/extensions/filters/http/set_filter_state/integration_test.cc
@@ -47,10 +47,12 @@ public:
     {
       SetFilterStateConfig factory;
       auto cb_1 = factory.createFilterFactoryFromProto(proto_config, "", context_);
-      auto cb_2 =
-          factory
-              .createHttpFilterFactoryFromProto(proto_config, "", context_.server_factory_context_)
-              .value();
+      Server::Configuration::ExtraFactoryContext extra_context{
+          context_.server_factory_context_.messageValidationVisitor(), ""};
+      auto cb_2 = factory
+                      .createHttpFilterFactoryFromProto(
+                          proto_config, context_.server_factory_context_, extra_context)
+                      .value();
 
       NiceMock<Http::MockFilterChainFactoryCallbacks> filter_chain_factory_callbacks;
 

--- a/test/extensions/filters/http/set_metadata/config_test.cc
+++ b/test/extensions/filters/http/set_metadata/config_test.cc
@@ -76,9 +76,11 @@ metadata:
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   SetMetadataConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamDecoderFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/sse_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/sse_to_metadata/config_test.cc
@@ -71,8 +71,10 @@ TEST(SseToMetadataConfigTest, CreateFilterWithServerContext) {
   NiceMock<Server::Configuration::MockServerFactoryContext> server_context;
 
   SseToMetadataConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "stats"};
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", server_context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, server_context, extra_context).value();
 
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamEncoderFilter(_));

--- a/test/extensions/filters/http/stateful_session/config_test.cc
+++ b/test/extensions/filters/http/stateful_session/config_test.cc
@@ -100,9 +100,11 @@ TEST(StatefulSessionFactoryConfigTest, SimpleConfigTestWithServerContext) {
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
   StatefulSessionFactoryConfig factory;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
   Http::FilterFactoryCb cb =
-      factory.createHttpFilterFactoryFromProto(proto_config, "stats", context).value();
+      factory.createHttpFilterFactoryFromProto(proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/thrift_to_metadata/config_test.cc
+++ b/test/extensions/filters/http/thrift_to_metadata/config_test.cc
@@ -188,8 +188,11 @@ request_rules:
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
+                                                           "stats"};
 
-  auto callback = factory.createHttpFilterFactoryFromProto(*proto_config, "stats", context).value();
+  auto callback =
+      factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   callback(filter_callback);

--- a/test/extensions/filters/http/transform/config_test.cc
+++ b/test/extensions/filters/http/transform/config_test.cc
@@ -130,8 +130,11 @@ clear_route_cache: true
 
   ProtoConfig proto_config;
   TestUtility::loadFromYaml(config, proto_config);
+  Server::Configuration::ExtraFactoryContext extra_context{
+      server_context.messageValidationVisitor(), "test"};
 
-  auto cb = factory->createHttpFilterFactoryFromProto(proto_config, "test", server_context).value();
+  auto cb = factory->createHttpFilterFactoryFromProto(proto_config, server_context, extra_context)
+                .value();
   Http::MockFilterChainFactoryCallbacks filter_callbacks;
   EXPECT_CALL(filter_callbacks, addStreamFilter(_));
   cb(filter_callbacks);

--- a/test/extensions/filters/http/wasm/config_test.cc
+++ b/test/extensions/filters/http/wasm/config_test.cc
@@ -187,14 +187,18 @@ TEST_P(WasmFilterConfigTest, CreateFilterFactoryFromProtoWithServerContext) {
   WasmFilterConfig factory;
   Http::FilterFactoryCb cb;
   if (std::get<2>(GetParam())) {
+    Server::Configuration::ExtraFactoryContext extra_context{
+        context_.server_factory_context_.messageValidationVisitor(), "stats"};
     cb = factory
-             .createHttpFilterFactoryFromProto(proto_config, "stats",
-                                               context_.server_factory_context_)
+             .createHttpFilterFactoryFromProto(proto_config, context_.server_factory_context_,
+                                               extra_context)
              .value();
   } else {
+    Server::Configuration::ExtraFactoryContext extra_context{
+        upstream_factory_context_.server_factory_context_.messageValidationVisitor(), "stats"};
     cb = factory
-             .createHttpFilterFactoryFromProto(proto_config, "stats",
-                                               upstream_factory_context_.server_factory_context_)
+             .createHttpFilterFactoryFromProto(
+                 proto_config, upstream_factory_context_.server_factory_context_, extra_context)
              .value();
   }
 

--- a/test/integration/filters/server_factory_context_filter.cc
+++ b/test/integration/filters/server_factory_context_filter.cc
@@ -138,7 +138,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::ServerFactoryContextFilterConfig& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext& server_context) override {
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext&) override {
     FilterConfigSharedPtr filter_config =
         std::make_shared<test::integration::filters::ServerFactoryContextFilterConfig>(
             proto_config);
@@ -177,7 +178,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::ServerFactoryContextFilterConfigDual& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext& server_context) override {
+      Server::Configuration::ServerFactoryContext& server_context,
+      Server::Configuration::ExtraFactoryContext&) override {
     auto filter_config =
         std::make_shared<test::integration::filters::ServerFactoryContextFilterConfigDual>(
             proto_config);

--- a/test/integration/filters/set_response_code_filter.cc
+++ b/test/integration/filters/set_response_code_filter.cc
@@ -97,7 +97,8 @@ private:
   }
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::SetResponseCodeFilterConfig& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext& context) override {
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext&) override {
     auto filter_config = std::make_shared<SetResponseCodeFilterConfig>(
         proto_config.prefix(), proto_config.code(), proto_config.body(), context);
     return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
@@ -138,7 +139,8 @@ private:
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const test::integration::filters::SetResponseCodeFilterConfigDual& proto_config,
-      const std::string&, Server::Configuration::ServerFactoryContext& context) override {
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext&) override {
     auto filter_config = std::make_shared<SetResponseCodeFilterConfig>(
         proto_config.prefix(), proto_config.code(), proto_config.body(), context);
     return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {


### PR DESCRIPTION
Commit Message: http: refactor multiple interfaces to support extra context
Additional Description:

This PR added a new interface `createHttpFilterRouteConfig` to gradually replace the `createRouteSpecificFilterConfig`, the  `createHttpFilterRouteConfig` will take an `ExtraFactoryContext`.

And we also refactored the `createHttpFilterFactoryFromProto` to take the `ExtraFactoryContext`.

With this new simple structure of `ExtraFactoryContext`, it's would be pretty simple to add more features support there without change the signature. And it's possible to merge upstream, downstream, route FilterFactory to single interface to help jump out from current mud.

You may also found I fold the `stats_prefix` of `createHttpFilterFactoryFromProto` to the `ExtraFactoryContext`. This is because rather than a plain string, it would be better to propagate a prefixed scope into the factory in the future and deprecate teh plain string, esp we have plan to migrate our stats system to regex-extraction-less one. (see https://github.com/envoyproxy/envoy/issues/20289)


Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.