### PR TITLE
reverse_tunnel: fail closed on empty identifier validation renders

### DIFF
--- a/changelogs/current/minor_behavior_changes/reverse_tunnel__fail-closed-identifier-validation.rst
+++ b/changelogs/current/minor_behavior_changes/reverse_tunnel__fail-closed-identifier-validation.rst
@@ -1,0 +1,7 @@
+The ``reverse_tunnel`` network filter now fails closed when a configured identifier validation
+formatter (``node_id_format``, ``cluster_id_format``, ``tenant_id_format``) renders an empty string
+or the absent-value placeholder ``-``. Previously such a render silently skipped the identity
+binding and accepted the claimed identifier. A present-but-empty
+``x-envoy-reverse-tunnel-tenant-id`` header value is now rejected with a 400 error, matching the
+existing missing-header rejection and the empty-identifier guards already applied to node and
+cluster ids at socket registration.

--- a/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
+++ b/source/extensions/filters/network/reverse_tunnel/reverse_tunnel_filter.cc
@@ -215,10 +215,19 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
   // earlier in the handshake.
   const Formatter::Context context(&request_headers);
 
+  // Each check fails closed: an empty render, or the formatter's "-" placeholder for an absent
+  // value, means the configured binding could not be evaluated and must reject the handshake
+  // rather than skip the check. This mirrors the consumer side, where
+  // RevConCluster::LoadBalancer::chooseHost treats both values as underivable and returns
+  // nullptr.
+  auto binding_failed = [](const std::string& expected, absl::string_view actual) {
+    return expected.empty() || expected == "-" || expected != actual;
+  };
+
   // Validate node_id if formatter is configured.
   if (node_id_formatter_) {
     const std::string expected_node_id = node_id_formatter_->format(context, stream_info);
-    if (!expected_node_id.empty() && expected_node_id != node_id) {
+    if (binding_failed(expected_node_id, node_id)) {
       ENVOY_LOG(debug, "reverse_tunnel: node_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_node_id, node_id);
       return false;
@@ -228,7 +237,7 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
   // Validate cluster_id if formatter is configured.
   if (cluster_id_formatter_) {
     const std::string expected_cluster_id = cluster_id_formatter_->format(context, stream_info);
-    if (!expected_cluster_id.empty() && expected_cluster_id != cluster_id) {
+    if (binding_failed(expected_cluster_id, cluster_id)) {
       ENVOY_LOG(debug, "reverse_tunnel: cluster_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_cluster_id, cluster_id);
       return false;
@@ -238,7 +247,7 @@ bool ReverseTunnelFilterConfig::validateIdentifiers(
   // Validate tenant_id if formatter is configured.
   if (tenant_id_formatter_) {
     const std::string expected_tenant_id = tenant_id_formatter_->format(context, stream_info);
-    if (!expected_tenant_id.empty() && expected_tenant_id != tenant_id) {
+    if (binding_failed(expected_tenant_id, tenant_id)) {
       ENVOY_LOG(debug, "reverse_tunnel: tenant_id validation failed. Expected: '{}', Actual: '{}'",
                 expected_tenant_id, tenant_id);
       return false;
@@ -449,6 +458,21 @@ void ReverseTunnelFilter::RequestDecoderImpl::processIfComplete(bool end_stream)
   const absl::string_view node_id = node_vals[0]->value().getStringView();
   const absl::string_view cluster_id = cluster_vals[0]->value().getStringView();
   const absl::string_view tenant_id = tenant_vals[0]->value().getStringView();
+
+  // Reject a present-but-empty tenant id the same way as a missing header. An empty tenant
+  // silently disables tenant scoping when the socket is registered, since
+  // maybeBuildTenantScopedIdentifier returns the bare identifier for an empty tenant, while
+  // empty node and cluster ids are already rejected at registration by
+  // UpstreamSocketManager::addConnectionSocket.
+  if (tenant_id.empty()) {
+    parent_.stats_.parse_error_.inc();
+    ENVOY_CONN_LOG(debug, "reverse_tunnel: empty tenant-id header value",
+                   parent_.read_callbacks_->connection());
+    sendLocalReply(Http::Code::BadRequest, "Empty tenant-id header value", nullptr, std::nullopt,
+                   "reverse_tunnel_empty_tenant_id");
+    parent_.read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
+    return;
+  }
 
   // Get tenant isolation setting from socket manager (configured at bootstrap level).
   bool tenant_isolation_enabled = false;

--- a/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/filter_unit_test.cc
@@ -2771,6 +2771,60 @@ TEST_F(ReverseTunnelJwtTest, ValidationReqCommandMatchesRequestHeader) {
   EXPECT_EQ(1, counter("reverse_tunnel.handshake.validation_failed"));
 }
 
+// Fail-closed regression: when the configured formatter renders EMPTY (here a %REQ(...)% header
+// that is present with an empty value), the binding could not be evaluated and the handshake must
+// be rejected. Previously the empty render silently skipped the check and the handshake was
+// accepted with any node id.
+TEST_F(ReverseTunnelJwtTest, ValidationEmptyRenderFailsClosed) {
+  std::string req = "GET /reverse_connections/request HTTP/1.1\r\n";
+  req += "Host: localhost\r\n";
+  req += makeRtHeaders("node-b", "c", "t");
+  req += "x-expected-node-id:\r\n";
+  req += "Content-Length: 0\r\n\r\n";
+
+  envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
+  cfg.mutable_validation()->set_node_id_format("%REQ(x-expected-node-id)%");
+
+  EXPECT_THAT(runHandshake(cfg, req), testing::HasSubstr("403 Forbidden"));
+  EXPECT_EQ(1, counter("reverse_tunnel.handshake.validation_failed"));
+  EXPECT_EQ(0, counter("reverse_tunnel.handshake.accepted"));
+}
+
+// Fail-closed regression for the formatter's absent-value placeholder: with the referenced header
+// missing, %REQ(...)% renders "-", which must reject the handshake even if the claimed node id is
+// itself "-".
+TEST_F(ReverseTunnelJwtTest, ValidationPlaceholderRenderFailsClosed) {
+  std::string req = "GET /reverse_connections/request HTTP/1.1\r\n";
+  req += "Host: localhost\r\n";
+  req += makeRtHeaders("-", "c", "t");
+  req += "Content-Length: 0\r\n\r\n";
+
+  envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
+  cfg.mutable_validation()->set_node_id_format("%REQ(x-expected-node-id)%");
+
+  EXPECT_THAT(runHandshake(cfg, req), testing::HasSubstr("403 Forbidden"));
+  EXPECT_EQ(1, counter("reverse_tunnel.handshake.validation_failed"));
+  EXPECT_EQ(0, counter("reverse_tunnel.handshake.accepted"));
+}
+
+// A present-but-empty tenant-id header is rejected like a missing one: an empty tenant silently
+// disables tenant scoping when the socket is registered, while empty node and cluster ids are
+// already rejected at registration by addConnectionSocket.
+TEST_F(ReverseTunnelJwtTest, EmptyTenantIdRejected) {
+  std::string req = "GET /reverse_connections/request HTTP/1.1\r\n";
+  req += "Host: localhost\r\n";
+  req += "x-envoy-reverse-tunnel-node-id: n\r\n";
+  req += "x-envoy-reverse-tunnel-cluster-id: c\r\n";
+  req += "x-envoy-reverse-tunnel-tenant-id:\r\n";
+  req += "Content-Length: 0\r\n\r\n";
+
+  envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
+
+  EXPECT_THAT(runHandshake(cfg, req), testing::HasSubstr("400 Bad Request"));
+  EXPECT_EQ(1, counter("reverse_tunnel.handshake.parse_error"));
+  EXPECT_EQ(0, counter("reverse_tunnel.handshake.accepted"));
+}
+
 TEST_F(ReverseTunnelJwtTest, BareTokenWithoutBearerPrefixAccepted) {
   envoy::extensions::filters::network::reverse_tunnel::v3::ReverseTunnel cfg;
   setJwt(cfg, kIssuer);


### PR DESCRIPTION
Commit Message: reverse_tunnel: fail closed on empty identifier validation renders

Additional Description:

The three identity checks in `ReverseTunnelFilterConfig::validateIdentifiers` silently skipped validation whenever the configured formatter rendered an empty string, so a binding that could not be evaluated accepted any claimed node, cluster, or tenant id. This change makes the checks fail closed: an empty render, or the formatter's `-` placeholder for an absent value, now rejects the handshake. This mirrors the consumer side, where `RevConCluster::LoadBalancer::chooseHost` already treats both renders as underivable and fails closed.

The handshake also now rejects a present-but-empty `x-envoy-reverse-tunnel-tenant-id` header value with a 400 error, matching the existing missing-header rejection and the empty-identifier guards that `UpstreamSocketManager::addConnectionSocket` already applies to node and cluster ids. Previously an empty tenant value silently disabled tenant scoping when the socket was registered.

This is fail-closed hardening of an alpha extension; the empty-render skip condition it removes is the same class of condition that once caused a silent validation bypass on the consumer side.

Risk Level: low. The extension is alpha, and the behavior change only affects handshakes where a configured validation formatter renders empty or `-`, which previously let any claimed id through.

Testing: unit tests added in `filter_unit_test.cc` covering an empty formatter render, the absent-value placeholder, and an empty tenant-id header value. Not built locally: a cold envoy bazel build is impractical on this machine (no local bazel toolchain), so the change was verified by close code review of the touched targets; CI will exercise them.

Docs Changes: n/a

Release Notes: included as a `minor_behavior_changes` changelog fragment.

Platform Specific Features: n/a

Made with [Cursor](https://cursor.com)