### PR TITLE
c-ares: disable shared resolver by default

### DIFF
--- a/changelogs/current/bug_fixes/cares__disable_shared_resolver.rst
+++ b/changelogs/current/bug_fixes/cares__disable_shared_resolver.rst
@@ -1,0 +1,3 @@
+Changes the default value of ``envoy.restart_features.shared_cares_dns_resolver`` to ``false``. This disabled the shared dns resolver
+that can cause a race when createDnsResolver() is called from a workerthread in the DnsFilter. Do not turn this back on until this bug is
+fixed if DnsFilter is used.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -145,7 +145,6 @@ RUNTIME_GUARD(envoy_reloadable_features_websocket_enable_timeout_on_upgrade_resp
 RUNTIME_GUARD(envoy_reloadable_features_xds_failover_to_primary_enabled);
 RUNTIME_GUARD(envoy_reloadable_features_xds_legacy_delta_skip_subsequent_node);
 RUNTIME_GUARD(envoy_restart_features_raise_file_limits);
-RUNTIME_GUARD(envoy_restart_features_shared_cares_dns_resolver);
 RUNTIME_GUARD(envoy_restart_features_validate_http3_pseudo_headers);
 RUNTIME_GUARD(envoy_restart_features_worker_threads_watchdog_fix);
 // Begin false flags. Most of them should come with a TODO to flip true.
@@ -284,6 +283,10 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_record_histograms);
 // validated in production. When disabled, QUIC retains zlib-only compression while TCP TLS has
 // no certificate compression.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_tls_certificate_compression_brotli);
+
+// DnsFilter created resolver on the workerthread which could need to race when sharing resolvers
+// Do not turn this on if DnsFilter is used or until the race is fixed
+FALSE_RUNTIME_GUARD(envoy_restart_features_shared_cares_dns_resolver);
 
 // Block of non-boolean flags. Use of int flags is deprecated. Do not add more.
 ABSL_FLAG(uint64_t, re2_max_program_size_error_level, 100, ""); // NOLINT

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -284,7 +284,7 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_record_histograms);
 // no certificate compression.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_tls_certificate_compression_brotli);
 
-// DnsFilter created resolver on the workerthread which could need to race when sharing resolvers
+// DnsFilter created resolver on the workerthread which could lead to race when sharing resolvers
 // Do not turn this on if DnsFilter is used or until the race is fixed
 FALSE_RUNTIME_GUARD(envoy_restart_features_shared_cares_dns_resolver);
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -284,7 +284,7 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_record_histograms);
 // no certificate compression.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_tls_certificate_compression_brotli);
 
-// DnsFilter created resolver on the workerthread which could lead to race when sharing resolvers
+// DnsFilter created resolver on the worker thread which could lead to race when sharing resolvers
 // Do not turn this on if DnsFilter is used or until the race is fixed
 FALSE_RUNTIME_GUARD(envoy_restart_features_shared_cares_dns_resolver);
 

--- a/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
+++ b/test/extensions/network/dns_resolver/cares/dns_impl_test.cc
@@ -2296,6 +2296,9 @@ TEST_F(DnsImplConstructor, VerifyCustomQcacheMaxTtl) {
 }
 
 TEST_F(DnsImplConstructor, ReusesResolverForIdenticalConfig) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.restart_features.shared_cares_dns_resolver", "true"}});
+
   auto typed_dns_resolver_config = getCaresDnsResolverConfig(0);
   Network::DnsResolverFactory& dns_resolver_factory =
       createDnsResolverFactoryFromTypedConfig(typed_dns_resolver_config);
@@ -2329,6 +2332,9 @@ TEST_F(DnsImplConstructor, DoesNotReuseResolverForIdenticalConfigWhenFeatureDisa
 }
 
 TEST_F(DnsImplConstructor, DoesNotReuseResolverForDifferentConfig) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.restart_features.shared_cares_dns_resolver", "true"}});
+
   auto typed_dns_resolver_config1 = getCaresDnsResolverConfig(67);
   auto typed_dns_resolver_config2 = getCaresDnsResolverConfig(123);
 
@@ -2346,6 +2352,9 @@ TEST_F(DnsImplConstructor, DoesNotReuseResolverForDifferentConfig) {
 }
 
 TEST_F(DnsImplConstructor, CleansExpiredResolverBeforeReinsertingIdenticalConfig) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.restart_features.shared_cares_dns_resolver", "true"}});
+
   auto typed_dns_resolver_config = getCaresDnsResolverConfig(1234);
 
   Network::DnsResolverFactory& dns_resolver_factory =


### PR DESCRIPTION
Commit Message: c-ares: disable shared resolver by default
Additional Description:
DnsFilter would call createDnsResolver() from a workerthread that would cause a race when sharing dns resolvers.
Turn off this feature until the race is fixed. Relates to https://github.com/envoyproxy/envoy/pull/46577 and https://github.com/envoyproxy/envoy/pull/45073
Risk Level: low
Testing: 
Docs Changes:
Release Notes:
Platform Specific Features:
