### PR TITLE
github/copilot: Unset ANDROID_HOME

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -83,3 +83,4 @@ jobs:
       run: |
         bazel shutdown
         bazel --version
+        echo "ANDROID_HOME=" >> "$GITHUB_ENV"


### PR DESCRIPTION
under bzlmod this being set causes the android toolchain to kick in and fail when it cant find the sdk
