### PR TITLE
custom_response: allow LocalResponsePolicy to preserve or set response_code_details

### DIFF
--- a/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
+++ b/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
@@ -24,6 +24,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // Custom response policy to serve a locally stored response to the
 // downstream.
+// [#next-free-field: 7]
 message LocalResponsePolicy {
   // Optional new local reply body text. It will be used
   // in the ``%LOCAL_REPLY_BODY%`` command operator in the ``body_format``.
@@ -43,4 +44,20 @@ message LocalResponsePolicy {
   // remote body, before it is sent to a downstream client.
   repeated config.core.v3.HeaderValueOption response_headers_to_add = 4
       [(validate.rules).repeated = {max_items: 1000}];
+
+  // Controls what is written to ``stream_info.response_code_details`` when this
+  // policy sends its local reply.
+  //
+  // If unset, details are cleared (empty string), matching legacy behavior.
+  // Use ``preserve_response_code_details`` to keep the existing value (e.g.
+  // ``csrf_origin_mismatch``), or ``response_code_details`` to set an explicit
+  // replacement.
+  oneof response_code_details_action {
+    // If true, keep the existing ``response_code_details`` already present on
+    // StreamInfo. If false, clear details (same as leaving this oneof unset).
+    bool preserve_response_code_details = 5;
+
+    // Replace ``response_code_details`` with this value.
+    string response_code_details = 6 [(validate.rules).string = {min_len: 1}];
+  }
 }

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -17,6 +17,28 @@ namespace Envoy {
 namespace Extensions {
 namespace Http {
 namespace CustomResponse {
+
+namespace {
+
+using LocalResponsePolicyProto =
+    envoy::extensions::http::custom_response::local_response_policy::v3::LocalResponsePolicy;
+
+bool preserveResponseCodeDetails(const LocalResponsePolicyProto& config) {
+  return config.response_code_details_action_case() ==
+             LocalResponsePolicyProto::kPreserveResponseCodeDetails &&
+         config.preserve_response_code_details();
+}
+
+std::optional<std::string> overrideResponseCodeDetails(const LocalResponsePolicyProto& config) {
+  if (config.response_code_details_action_case() ==
+      LocalResponsePolicyProto::kResponseCodeDetails) {
+    return config.response_code_details();
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
 LocalResponsePolicy::LocalResponsePolicy(
     const envoy::extensions::http::custom_response::local_response_policy::v3::LocalResponsePolicy&
         config,
@@ -32,7 +54,9 @@ LocalResponsePolicy::LocalResponsePolicy(
                        : std::optional<Envoy::Http::Code>{}},
       header_parser_(THROW_OR_RETURN_VALUE(
           Envoy::Router::HeaderParser::configure(config.response_headers_to_add()),
-          Router::HeaderParserPtr)) {
+          Router::HeaderParserPtr)),
+      preserve_response_code_details_(preserveResponseCodeDetails(config)),
+      response_code_details_(overrideResponseCodeDetails(config)) {
 
   // TODO(wbpcode): these is a potential bug of message validation. The validation visitor
   // of server context should not be used here directly. But this is bug is not introduced
@@ -77,10 +101,18 @@ Envoy::Http::FilterHeadersStatus LocalResponsePolicy::encodeHeaders(
                  : *encoder_callbacks->streamInfo().getRequestHeaders(),
              headers, encoder_callbacks->streamInfo(), encoder_callbacks->activeSpan(), body);
 
+  // Resolve details before sendLocalReply, which overwrites response_code_details.
+  std::string details;
+  if (response_code_details_.has_value()) {
+    details = *response_code_details_;
+  } else if (preserve_response_code_details_) {
+    details = encoder_callbacks->streamInfo().responseCodeDetails().value_or("");
+  }
+
   const auto mutate_headers = [this, encoder_callbacks](Envoy::Http::ResponseHeaderMap& headers) {
     header_parser_->evaluateHeaders(headers, encoder_callbacks->streamInfo());
   };
-  encoder_callbacks->sendLocalReply(code, body, mutate_headers, std::nullopt, "");
+  encoder_callbacks->sendLocalReply(code, body, mutate_headers, std::nullopt, details);
   return Envoy::Http::FilterHeadersStatus::StopIteration;
 }
 

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.h
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.h
@@ -48,6 +48,12 @@ private:
 
   const std::optional<Envoy::Http::Code> status_code_;
   const std::unique_ptr<Envoy::Router::HeaderParser> header_parser_;
+
+  // When true, pass existing StreamInfo response_code_details into sendLocalReply.
+  // When false and response_code_details_ is unset, pass "" (legacy Clear behavior).
+  const bool preserve_response_code_details_;
+  // When set, pass this explicit value into sendLocalReply (Override).
+  const std::optional<std::string> response_code_details_;
 };
 } // namespace CustomResponse
 } // namespace Http

--- a/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
@@ -71,8 +71,10 @@ TEST_F(CustomResponseFilterTest, LocalData) {
   ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
   EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
             ::Envoy::Http::FilterHeadersStatus::Continue);
+  // Default policy clears response_code_details (legacy behavior).
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
   EXPECT_CALL(encoder_callbacks_,
-              sendLocalReply(static_cast<::Envoy::Http::Code>(499), "not allowed", _, _, _));
+              sendLocalReply(static_cast<::Envoy::Http::Code>(499), "not allowed", _, _, ""));
   ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
       .WillByDefault(Return(&request_headers));
   EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
@@ -410,6 +412,119 @@ TEST_F(CustomResponseFilterTest, PathRewriteInvalid) {
             path_rewrite: "/new/%INVALID_COMMAND_WITH_NO_CLOSING"
 )EOF"),
                           EnvoyException, "Failed to create path_rewrite formatter");
+}
+
+TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetails) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          preserve_response_code_details: true
+)EOF");
+  setupFilterAndCallback();
+
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _,
+                             "csrf_origin_mismatch"));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetailsWhenAbsent) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          preserve_response_code_details: true
+)EOF");
+  setupFilterAndCallback();
+
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _, ""));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, ExplicitResponseCodeDetails) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          response_code_details: "custom_error_page"
+)EOF");
+  setupFilterAndCallback();
+
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _,
+                             "custom_error_page"));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetailsFalseClears) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          preserve_response_code_details: false
+)EOF");
+  setupFilterAndCallback();
+
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _, ""));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: Previously LocalResponsePolicy always passed an empty
response_code_details into sendLocalReply, which cleared any
existing value (e.g. csrf_origin_mismatch) from access logs. Add an
optional oneof on LocalResponsePolicy to either preserve the existing
StreamInfo details (preserve_response_code_details) or set an explicit
replacement (response_code_details). If unset, behavior is unchanged
(clear/empty)

Additional Description: Follows the earlier steer from #34465 that
always passing through original details may be wrong when the policy
overrides the response, so this is opt-in rather than flipping the
default. Visible to Envoy Gateway users of BackendTrafficPolicy
responseOverride, which compiles to LocalResponsePolicy.

Risk Level: Low
Testing: Unit tests added in
custom_response_filter_test.cc covering default clear, preserve,
preserve when absent, explicit override, and preserve:false.
Platform Specific Features: N/A
API Considerations: Additive optional oneof on an existing WIP API;
default (unset) preserves legacy clear behavior.