### PR TITLE
Add missing BUILD dependency in AWS credential provider

### DIFF
--- a/source/extensions/common/aws/BUILD
+++ b/source/extensions/common/aws/BUILD
@@ -76,6 +76,7 @@ envoy_cc_library(
     ],
     deps = [
         "//envoy/common:pure_lib",
+        "//envoy/common:time_interface",
         "//source/common/common:cleanup_lib",
         "//source/common/common:lock_guard_lib",
         "//source/common/common:thread_lib",


### PR DESCRIPTION
Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
