### PR TITLE
custom_response: allow LocalResponsePolicy to preserve or set response_code_details

### DIFF
--- a/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
+++ b/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
@@ -24,6 +24,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 
 // Custom response policy to serve a locally stored response to the
 // downstream.
+// [#next-free-field: 7]
 message LocalResponsePolicy {
   // Optional new local reply body text. It will be used
   // in the ``%LOCAL_REPLY_BODY%`` command operator in the ``body_format``.
@@ -43,4 +44,20 @@ message LocalResponsePolicy {
   // remote body, before it is sent to a downstream client.
   repeated config.core.v3.HeaderValueOption response_headers_to_add = 4
       [(validate.rules).repeated = {max_items: 1000}];
+
+  // Controls what is written to ``stream_info.response_code_details`` when this
+  // policy sends its local reply.
+  //
+  // If unset, details are cleared (empty string), matching legacy behavior.
+  // Use ``preserve_response_code_details`` to keep the existing value (e.g.
+  // ``csrf_origin_mismatch``), or ``response_code_details`` to set an explicit
+  // replacement.
+  oneof response_code_details_action {
+    // If true, keep the existing ``response_code_details`` already present on
+    // StreamInfo. If false, clear details (same as leaving this oneof unset).
+    bool preserve_response_code_details = 5;
+
+    // Replace ``response_code_details`` with this value.
+    string response_code_details = 6 [(validate.rules).string = {min_len: 1}];
+  }
 }

--- a/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
+++ b/api/envoy/extensions/http/custom_response/local_response_policy/v3/local_response_policy.proto
@@ -53,9 +53,8 @@ message LocalResponsePolicy {
   // ``csrf_origin_mismatch``), or ``response_code_details`` to set an explicit
   // replacement.
   oneof response_code_details_action {
-    // If true, keep the existing ``response_code_details`` already present on
-    // StreamInfo. If false, clear details (same as leaving this oneof unset).
-    bool preserve_response_code_details = 5;
+    // If set, keep the existing ``response_code_details`` already present on StreamInfo.
+    bool preserve_response_code_details = 5 [(validate.rules).bool = {const: true}];
 
     // Replace ``response_code_details`` with this value.
     string response_code_details = 6 [(validate.rules).string = {min_len: 1}];

--- a/changelogs/current/new_features/http__local-response-policy-response-code-details.rst
+++ b/changelogs/current/new_features/http__local-response-policy-response-code-details.rst
@@ -1,0 +1,4 @@
+The :ref:`LocalResponsePolicy <envoy_v3_api_msg_extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy>`
+can now optionally preserve the existing ``response_code_details`` or set an explicit
+value via ``preserve_response_code_details`` / ``response_code_details``. Unset continues
+to clear details (legacy behavior).

--- a/changelogs/current/new_features/http__local-response-policy-response-code-details.rst
+++ b/changelogs/current/new_features/http__local-response-policy-response-code-details.rst
@@ -1,4 +1,3 @@
 The :ref:`LocalResponsePolicy <envoy_v3_api_msg_extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy>`
 can now optionally preserve the existing ``response_code_details`` or set an explicit
-value via ``preserve_response_code_details`` / ``response_code_details``. Unset continues
-to clear details (legacy behavior).
+value via ``preserve_response_code_details`` (must be ``true`` if set) / ``response_code_details``. Unset continues to clear details (legacy behavior).

--- a/docs/root/configuration/http/http_filters/custom_response_filter.rst
+++ b/docs/root/configuration/http/http_filters/custom_response_filter.rst
@@ -28,7 +28,7 @@ The redirect policy can be used to override the original response by internally 
 Local Response Policy
 #####################
 
-The local response policy can be used to override the original response with a locally stored response body. The policy config can be used to modify the response headers and the response status code.
+The local response policy can be used to override the original response with a locally stored response body. The policy config can be used to modify the response headers and the response status code. When the policy sends a local reply, Envoy's ``response_code_details`` is cleared by default. Set ``preserve_response_code_details`` to keep the reason that was already on the stream, or set ``response_code_details`` to replace it with a custom string.
 
 * This extension should be configued with the type URL ``type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy>`

--- a/docs/root/configuration/http/http_filters/custom_response_filter.rst
+++ b/docs/root/configuration/http/http_filters/custom_response_filter.rst
@@ -28,7 +28,7 @@ The redirect policy can be used to override the original response by internally 
 Local Response Policy
 #####################
 
-The local response policy can be used to override the original response with a locally stored response body. The policy config can be used to modify the response headers and the response status code. When the policy sends a local reply, Envoy's ``response_code_details`` is cleared by default. Set ``preserve_response_code_details`` to keep the reason that was already on the stream, or set ``response_code_details`` to replace it with a custom string.
+The local response policy can be used to override the original response with a locally stored response body. The policy config can be used to modify the response headers and the response status code. When the policy sends a local reply, :ref:`response code details <config_access_log_format_response_code_details>` are cleared by default. Set ``preserve_response_code_details: true`` to keep the reason that was already on the stream, or set ``response_code_details`` to replace it with a custom string. These options are mutually exclusive, omit both for legacy behavior.
 
 * This extension should be configued with the type URL ``type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy``.
 * :ref:`v3 API reference <envoy_v3_api_msg_extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy>`

--- a/source/extensions/http/custom_response/local_response_policy/BUILD
+++ b/source/extensions/http/custom_response/local_response_policy/BUILD
@@ -25,6 +25,7 @@ envoy_cc_extension(
         "//envoy/server:filter_config_interface",
         "//envoy/stream_info:stream_info_interface",
         "//envoy/tracing:trace_driver_interface",
+        "//source/common/common:empty_string",
         "//source/common/common:enum_to_int",
         "//source/common/config:datasource_lib",
         "//source/common/formatter:formatter_extension_lib",

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -17,6 +17,28 @@ namespace Envoy {
 namespace Extensions {
 namespace Http {
 namespace CustomResponse {
+
+namespace {
+
+using LocalResponsePolicyProto =
+    envoy::extensions::http::custom_response::local_response_policy::v3::LocalResponsePolicy;
+
+bool preserveResponseCodeDetails(const LocalResponsePolicyProto& config) {
+  return config.response_code_details_action_case() ==
+             LocalResponsePolicyProto::kPreserveResponseCodeDetails &&
+         config.preserve_response_code_details();
+}
+
+std::optional<std::string> overrideResponseCodeDetails(const LocalResponsePolicyProto& config) {
+  if (config.response_code_details_action_case() ==
+      LocalResponsePolicyProto::kResponseCodeDetails) {
+    return config.response_code_details();
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
 LocalResponsePolicy::LocalResponsePolicy(
     const envoy::extensions::http::custom_response::local_response_policy::v3::LocalResponsePolicy&
         config,
@@ -32,7 +54,9 @@ LocalResponsePolicy::LocalResponsePolicy(
                        : std::optional<Envoy::Http::Code>{}},
       header_parser_(THROW_OR_RETURN_VALUE(
           Envoy::Router::HeaderParser::configure(config.response_headers_to_add()),
-          Router::HeaderParserPtr)) {
+          Router::HeaderParserPtr)),
+      preserve_response_code_details_(preserveResponseCodeDetails(config)),
+      response_code_details_(overrideResponseCodeDetails(config)) {
 
   // TODO(wbpcode): these is a potential bug of message validation. The validation visitor
   // of server context should not be used here directly. But this is bug is not introduced
@@ -77,10 +101,18 @@ Envoy::Http::FilterHeadersStatus LocalResponsePolicy::encodeHeaders(
                  : *encoder_callbacks->streamInfo().getRequestHeaders(),
              headers, encoder_callbacks->streamInfo(), encoder_callbacks->activeSpan(), body);
 
+  // Resolve details before sendLocalReply, which overwrites response_code_details.
+  std::string details;
+  if (response_code_details_.has_value()) {
+    details = *response_code_details_;
+  } else if (preserve_response_code_details_) {
+    details = encoder_callbacks->streamInfo().responseCodeDetails().value_or("");
+  }
+
   const auto mutate_headers = [this, encoder_callbacks](Envoy::Http::ResponseHeaderMap& headers) {
     header_parser_->evaluateHeaders(headers, encoder_callbacks->streamInfo());
   };
-  encoder_callbacks->sendLocalReply(code, body, mutate_headers, std::nullopt, "");
+  encoder_callbacks->sendLocalReply(code, body, mutate_headers, std::nullopt, details);
   return Envoy::Http::FilterHeadersStatus::StopIteration;
 }
 

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/stream_info/filter_state.h"
 
+#include "source/common/common/empty_string.h"
 #include "source/common/common/enum_to_int.h"
 #include "source/common/config/datasource.h"
 #include "source/common/formatter/substitution_format_string.h"
@@ -102,11 +103,12 @@ Envoy::Http::FilterHeadersStatus LocalResponsePolicy::encodeHeaders(
              headers, encoder_callbacks->streamInfo(), encoder_callbacks->activeSpan(), body);
 
   // Resolve details before sendLocalReply, which overwrites response_code_details.
-  std::string details;
+  absl::string_view details;
   if (response_code_details_.has_value()) {
     details = *response_code_details_;
   } else if (preserve_response_code_details_) {
-    details = encoder_callbacks->streamInfo().responseCodeDetails().value_or("");
+    const auto& stream_details = encoder_callbacks->streamInfo().responseCodeDetails();
+    details = stream_details.has_value() ? *stream_details : EMPTY_STRING;
   }
 
   const auto mutate_headers = [this, encoder_callbacks](Envoy::Http::ResponseHeaderMap& headers) {

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.h
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.h
@@ -48,6 +48,12 @@ private:
 
   const std::optional<Envoy::Http::Code> status_code_;
   const std::unique_ptr<Envoy::Router::HeaderParser> header_parser_;
+
+  // When true, pass existing StreamInfo response_code_details into sendLocalReply.
+  // When false and response_code_details_ is unset, pass "" (legacy Clear behavior).
+  const bool preserve_response_code_details_;
+  // When set, pass this explicit value into sendLocalReply (Override).
+  const std::optional<std::string> response_code_details_;
 };
 } // namespace CustomResponse
 } // namespace Http

--- a/source/extensions/http/custom_response/local_response_policy/local_response_policy.h
+++ b/source/extensions/http/custom_response/local_response_policy/local_response_policy.h
@@ -51,7 +51,7 @@ private:
 
   // When true, pass existing StreamInfo response_code_details into sendLocalReply.
   // When false and response_code_details_ is unset, pass "" (legacy Clear behavior).
-  const bool preserve_response_code_details_;
+  const bool preserve_response_code_details_ = false;
   // When set, pass this explicit value into sendLocalReply (Override).
   const std::optional<std::string> response_code_details_;
 };

--- a/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
@@ -71,8 +71,10 @@ TEST_F(CustomResponseFilterTest, LocalData) {
   ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "401"}};
   EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
             ::Envoy::Http::FilterHeadersStatus::Continue);
+  // Default policy clears response_code_details (legacy behavior).
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
   EXPECT_CALL(encoder_callbacks_,
-              sendLocalReply(static_cast<::Envoy::Http::Code>(499), "not allowed", _, _, _));
+              sendLocalReply(static_cast<::Envoy::Http::Code>(499), "not allowed", _, _, ""));
   ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
       .WillByDefault(Return(&request_headers));
   EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
@@ -410,6 +412,119 @@ TEST_F(CustomResponseFilterTest, PathRewriteInvalid) {
             path_rewrite: "/new/%INVALID_COMMAND_WITH_NO_CLOSING"
 )EOF"),
                           EnvoyException, "Failed to create path_rewrite formatter");
+}
+
+TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetails) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          preserve_response_code_details: true
+)EOF");
+  setupFilterAndCallback();
+
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _,
+                             "csrf_origin_mismatch"));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetailsWhenAbsent) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          preserve_response_code_details: true
+)EOF");
+  setupFilterAndCallback();
+
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _, ""));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, ExplicitResponseCodeDetails) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          response_code_details: "custom_error_page"
+)EOF");
+  setupFilterAndCallback();
+
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _,
+                             "custom_error_page"));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
+}
+
+TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetailsFalseClears) {
+  createConfig(R"EOF(
+  custom_response_matcher:
+    on_no_match:
+      action:
+        name: action
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.http.custom_response.local_response_policy.v3.LocalResponsePolicy
+          status_code: 403
+          body:
+            inline_string: "forbidden"
+          preserve_response_code_details: false
+)EOF");
+  setupFilterAndCallback();
+
+  encoder_callbacks_.stream_info_.response_code_details_ = "csrf_origin_mismatch";
+  ::Envoy::Http::TestRequestHeaderMapImpl request_headers{};
+  ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
+            ::Envoy::Http::FilterHeadersStatus::Continue);
+  EXPECT_CALL(encoder_callbacks_,
+              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _, ""));
+  ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
+      .WillByDefault(Return(&request_headers));
+  EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
+            ::Envoy::Http::FilterHeadersStatus::StopIteration);
 }
 
 } // namespace

--- a/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_filter_test.cc
@@ -434,9 +434,8 @@ TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetails) {
   ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
   EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
             ::Envoy::Http::FilterHeadersStatus::Continue);
-  EXPECT_CALL(encoder_callbacks_,
-              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _,
-                             "csrf_origin_mismatch"));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden",
+                                                 _, _, "csrf_origin_mismatch"));
   ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
       .WillByDefault(Return(&request_headers));
   EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
@@ -490,16 +489,15 @@ TEST_F(CustomResponseFilterTest, ExplicitResponseCodeDetails) {
   ::Envoy::Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
   EXPECT_EQ(filter_->decodeHeaders(request_headers, false),
             ::Envoy::Http::FilterHeadersStatus::Continue);
-  EXPECT_CALL(encoder_callbacks_,
-              sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden", _, _,
-                             "custom_error_page"));
+  EXPECT_CALL(encoder_callbacks_, sendLocalReply(static_cast<::Envoy::Http::Code>(403), "forbidden",
+                                                 _, _, "custom_error_page"));
   ON_CALL(encoder_callbacks_.stream_info_, getRequestHeaders())
       .WillByDefault(Return(&request_headers));
   EXPECT_EQ(filter_->encodeHeaders(response_headers, true),
             ::Envoy::Http::FilterHeadersStatus::StopIteration);
 }
 
-TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetailsFalseClears) {
+TEST_F(CustomResponseFilterTest, UnsetResponseCodeDetailsActionClears) {
   createConfig(R"EOF(
   custom_response_matcher:
     on_no_match:
@@ -510,7 +508,6 @@ TEST_F(CustomResponseFilterTest, PreserveResponseCodeDetailsFalseClears) {
           status_code: 403
           body:
             inline_string: "forbidden"
-          preserve_response_code_details: false
 )EOF");
   setupFilterAndCallback();
 


### PR DESCRIPTION
Commit Message: custom_response: allow LocalResponsePolicy to preserve or set response_code_details

When LocalResponsePolicy calls sendLocalReply it was always passing empty details, so whatever was already on StreamInfo (e.g. csrf_origin_mismatch) got wiped. That made access logs / debugging less useful after a custom local reply.

This adds an optional oneof on LocalResponsePolicy:

unset : clear details (same as today)
preserve_response_code_details : keep the existing StreamInfo value
response_code_details : set an explicit string
I kept clear-as-default on purpose. Flipping the default to preserve would change behavior for existing configs that never opted into anything, and I didn't want a silent behavior change. 
Preserve/set are opt-in; Let me know if preserve should be the default behaviour here.

Additional Description: Happy to change the field names / oneof shape if reviewers prefer something else. Proto comments + filter docs updated. Used generative AI for help drafting docs/PR text and iterating on the change; I wrote and understand the code.

Risk Level: Low

Testing: Unit tests in custom_response_filter_test covering unset (legacy clear), preserve true, preserve false, and explicit response_code_details override.

Docs Changes: Proto field comments on LocalResponsePolicy; short note in docs/root/configuration/http/http_filters/custom_response_filter.rst.

Release Notes: changelogs/current/new_features/http__local-response-policy-response-code-details.rst

Platform Specific Features: N/A

Fixes #46514

[Optional Runtime guard:] N/A: config opt-in; default matches legacy clear behavior.

[Optional API Considerations:] Additive oneof only. Unset path unchanged. response_code_details has min_len: 1.