### PR TITLE
Disable fmtlib Unicode support on Windows

### DIFF
--- a/bazel/external/fmtlib.BUILD
+++ b/bazel/external/fmtlib.BUILD
@@ -9,7 +9,7 @@ cc_library(
     ]),
     defines = [
         "FMT_HEADER_ONLY",
-        "FMT_UNICODE=0"
+        "FMT_UNICODE=0",
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],

--- a/bazel/external/fmtlib.BUILD
+++ b/bazel/external/fmtlib.BUILD
@@ -7,7 +7,10 @@ cc_library(
     hdrs = glob([
         "include/fmt/*.h",
     ]),
-    defines = ["FMT_HEADER_ONLY"],
+    defines = [
+        "FMT_HEADER_ONLY",
+        "FMT_UNICODE=0"
+    ],
     includes = ["include"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The FMT_UNICODE is a Windows MSVC specific option. It has not effect on Linux build.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: Windows specific
