### PR TITLE
adaptive concurrency: add min concurrency limit knob

### DIFF
--- a/api/envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.proto
+++ b/api/envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.proto
@@ -49,8 +49,7 @@ message GradientControllerConfig {
     // :ref:`min_concurrency
     // <envoy_v3_api_field_extensions.filters.http.adaptive_concurrency.v3.GradientControllerConfig.MinimumRTTCalculationParams.min_concurrency>`
     // to preserve the existing behavior where the same value controls both the minimum calculated
-    // limit and the limit used while measuring minRTT. When this value is configured separately,
-    // minRTT measurements do not change the current concurrency limit.
+    // limit and the limit used while measuring minRTT.
     google.protobuf.UInt32Value min_concurrency_limit = 4 [(validate.rules).uint32 = {gt: 0}];
   }
 

--- a/api/envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.proto
+++ b/api/envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.proto
@@ -49,7 +49,8 @@ message GradientControllerConfig {
     // :ref:`min_concurrency
     // <envoy_v3_api_field_extensions.filters.http.adaptive_concurrency.v3.GradientControllerConfig.MinimumRTTCalculationParams.min_concurrency>`
     // to preserve the existing behavior where the same value controls both the minimum calculated
-    // limit and the limit used while measuring minRTT.
+    // limit and the limit used while measuring minRTT. When this value is configured separately,
+    // minRTT measurements do not change the current concurrency limit.
     google.protobuf.UInt32Value min_concurrency_limit = 4 [(validate.rules).uint32 = {gt: 0}];
   }
 

--- a/api/envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.proto
+++ b/api/envoy/extensions/filters/http/adaptive_concurrency/v3/adaptive_concurrency.proto
@@ -44,6 +44,13 @@ message GradientControllerConfig {
       required: true
       gt {}
     }];
+
+    // The allowed lower-bound on the calculated concurrency limit. If unset, this defaults to
+    // :ref:`min_concurrency
+    // <envoy_v3_api_field_extensions.filters.http.adaptive_concurrency.v3.GradientControllerConfig.MinimumRTTCalculationParams.min_concurrency>`
+    // to preserve the existing behavior where the same value controls both the minimum calculated
+    // limit and the limit used while measuring minRTT.
+    google.protobuf.UInt32Value min_concurrency_limit = 4 [(validate.rules).uint32 = {gt: 0}];
   }
 
   // Parameters controlling the periodic minRTT recalculation.

--- a/changelogs/current/new_features/http__adaptive_concurrency_min_concurrency_limit.rst
+++ b/changelogs/current/new_features/http__adaptive_concurrency_min_concurrency_limit.rst
@@ -1,0 +1,1 @@
+Added ``min_concurrency_limit`` to the adaptive concurrency gradient controller to allow the minimum calculated concurrency limit to be configured separately from the concurrency used during minRTT recalculation.

--- a/changelogs/current/new_features/http__adaptive_concurrency_min_concurrency_limit.rst
+++ b/changelogs/current/new_features/http__adaptive_concurrency_min_concurrency_limit.rst
@@ -1,1 +1,3 @@
-Added ``min_concurrency_limit`` to the adaptive concurrency gradient controller to allow the minimum calculated concurrency limit to be configured separately from the concurrency used during minRTT recalculation.
+Added ``min_concurrency_limit`` to the adaptive concurrency gradient controller to allow the
+minimum calculated concurrency limit to be configured separately from the concurrency used during
+minRTT recalculation.

--- a/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
+++ b/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
@@ -28,10 +28,8 @@ time (minRTT) for an upstream.
 Calculating the minRTT
 ^^^^^^^^^^^^^^^^^^^^^^
 
-By default, the minRTT is periodically measured by pinning the concurrency limit to the configured
-``min_concurrency`` and measuring the latency under these ideal conditions. If
-``min_concurrency_limit`` is configured separately, the minRTT measurement does not change the
-current concurrency limit and only records latency samples from live traffic. The calculation is also
+The minRTT is periodically measured by pinning the concurrency limit to the configured
+``min_concurrency`` and measuring the latency under these ideal conditions. The calculation is also
 triggered in scenarios where the concurrency limit is determined to be the minimum configured value
 for 5 consecutive sampling windows. The length of this minRTT calculation window is variable
 depending on the number of requests the filter is configured to aggregate to represent the expected
@@ -45,9 +43,9 @@ calculation on the downstream success rate if retries are enabled.
 
 It is possible that there is a noticeable increase in request 503s during the minRTT measurement
 window because of the potentially significant drop in the concurrency limit. This is expected and it
-is recommended to enable retries for resets/503s. To avoid changing the concurrency limit during
-minRTT measurements while still allowing the controller to clamp more aggressively during overload,
-configure ``min_concurrency_limit`` separately from ``min_concurrency``.
+is recommended to enable retries for resets/503s. To reduce the impact of minRTT measurements while
+still allowing the controller to clamp more aggressively during overload, configure
+``min_concurrency_limit`` separately from ``min_concurrency``.
 
 .. note::
 
@@ -65,10 +63,11 @@ The calculated concurrency limit will not be reduced below the configured minimu
 If ``min_concurrency_limit`` is not configured, this lower bound defaults to the minRTT calculation
 concurrency to preserve the historical behavior where ``min_concurrency`` controlled both values.
 
-When configured separately, ``min_concurrency_limit`` controls how far the controller can clamp the
-calculated concurrency limit during normal operation, and minRTT measurements no longer pin the
-concurrency limit to ``min_concurrency``. This lets deployments measure minRTT from live traffic
-without periodically shedding otherwise healthy requests only to calculate a new baseline.
+When configured separately, ``min_concurrency`` controls the concurrency used while measuring
+minRTT, and ``min_concurrency_limit`` controls how far the controller can clamp the calculated
+concurrency limit during normal operation. If the current concurrency limit is already lower than
+the minRTT calculation concurrency when a minRTT measurement starts, the controller will keep the
+lower current limit rather than raising it for the measurement window.
 
 The Gradient
 ^^^^^^^^^^^^
@@ -153,9 +152,8 @@ The above configuration can be understood as follows:
 * The calculated concurrency limit will not be reduced below 25.
 * Recalculate the minRTT every 60s and add a jitter (random delay) of 0s-6s to the start of the
   minRTT recalculation. The delay is dictated by the jitter value.
-* Because ``min_concurrency_limit`` is configured separately, do not pin concurrency while
-  calculating minRTT. Collect 50 request samples from live traffic and use the p90 to summarize
-  them.
+* Pin concurrency to 50 while calculating minRTT, collect 50 request samples, and use the p90 to
+  summarize them.
 * The filter is enabled by default.
 
 .. note::
@@ -200,13 +198,13 @@ adaptive_concurrency.gradient_controller.sample_aggregate_percentile
     clamped to the range [0,100].
 
 adaptive_concurrency.gradient_controller.min_concurrency
-    Overrides the concurrency that is pinned while measuring the minRTT. This only applies when
-    ``min_concurrency_limit`` is not configured. If ``min_concurrency_limit`` is not configured,
-    this value is also used as the minimum calculated concurrency limit.
+    Overrides the concurrency that is pinned while measuring the minRTT. If
+    ``min_concurrency_limit`` is not configured, this value is also used as the minimum calculated
+    concurrency limit.
 
 adaptive_concurrency.gradient_controller.min_concurrency_limit
-    Overrides the minimum calculated concurrency limit. When configured, minRTT measurements do not
-    change the current concurrency limit.
+    Overrides the minimum calculated concurrency limit. This does not affect the concurrency that is
+    pinned while measuring the minRTT.
 
 Statistics
 ----------

--- a/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
+++ b/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
@@ -28,8 +28,10 @@ time (minRTT) for an upstream.
 Calculating the minRTT
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The minRTT is periodically measured by pinning the concurrency limit to the configured
-``min_concurrency`` and measuring the latency under these ideal conditions. The calculation is also
+By default, the minRTT is periodically measured by pinning the concurrency limit to the configured
+``min_concurrency`` and measuring the latency under these ideal conditions. If
+``min_concurrency_limit`` is configured separately, the minRTT measurement does not change the
+current concurrency limit and only records latency samples from live traffic. The calculation is also
 triggered in scenarios where the concurrency limit is determined to be the minimum configured value
 for 5 consecutive sampling windows. The length of this minRTT calculation window is variable
 depending on the number of requests the filter is configured to aggregate to represent the expected
@@ -43,9 +45,9 @@ calculation on the downstream success rate if retries are enabled.
 
 It is possible that there is a noticeable increase in request 503s during the minRTT measurement
 window because of the potentially significant drop in the concurrency limit. This is expected and it
-is recommended to enable retries for resets/503s. To reduce the impact of minRTT measurements while
-still allowing the controller to clamp more aggressively during overload, configure
-``min_concurrency_limit`` separately from ``min_concurrency``.
+is recommended to enable retries for resets/503s. To avoid changing the concurrency limit during
+minRTT measurements while still allowing the controller to clamp more aggressively during overload,
+configure ``min_concurrency_limit`` separately from ``min_concurrency``.
 
 .. note::
 
@@ -63,11 +65,10 @@ The calculated concurrency limit will not be reduced below the configured minimu
 If ``min_concurrency_limit`` is not configured, this lower bound defaults to the minRTT calculation
 concurrency to preserve the historical behavior where ``min_concurrency`` controlled both values.
 
-When configured separately, ``min_concurrency`` controls the concurrency used while measuring
-minRTT, and ``min_concurrency_limit`` controls how far the controller can clamp the calculated
-concurrency limit during normal operation. If the current concurrency limit is already lower than
-the minRTT calculation concurrency when a minRTT measurement starts, the controller will keep the
-lower current limit rather than raising it for the measurement window.
+When configured separately, ``min_concurrency_limit`` controls how far the controller can clamp the
+calculated concurrency limit during normal operation, and minRTT measurements no longer pin the
+concurrency limit to ``min_concurrency``. This lets deployments measure minRTT from live traffic
+without periodically shedding otherwise healthy requests only to calculate a new baseline.
 
 The Gradient
 ^^^^^^^^^^^^
@@ -152,8 +153,9 @@ The above configuration can be understood as follows:
 * The calculated concurrency limit will not be reduced below 25.
 * Recalculate the minRTT every 60s and add a jitter (random delay) of 0s-6s to the start of the
   minRTT recalculation. The delay is dictated by the jitter value.
-* Pin concurrency to 50 while calculating minRTT, collect 50 request samples, and use the p90 to
-  summarize them.
+* Because ``min_concurrency_limit`` is configured separately, do not pin concurrency while
+  calculating minRTT. Collect 50 request samples from live traffic and use the p90 to summarize
+  them.
 * The filter is enabled by default.
 
 .. note::
@@ -198,13 +200,13 @@ adaptive_concurrency.gradient_controller.sample_aggregate_percentile
     clamped to the range [0,100].
 
 adaptive_concurrency.gradient_controller.min_concurrency
-    Overrides the concurrency that is pinned while measuring the minRTT. If
-    ``min_concurrency_limit`` is not configured, this value is also used as the minimum calculated
-    concurrency limit.
+    Overrides the concurrency that is pinned while measuring the minRTT. This only applies when
+    ``min_concurrency_limit`` is not configured. If ``min_concurrency_limit`` is not configured,
+    this value is also used as the minimum calculated concurrency limit.
 
 adaptive_concurrency.gradient_controller.min_concurrency_limit
-    Overrides the minimum calculated concurrency limit. This does not affect the concurrency that is
-    pinned while measuring the minRTT.
+    Overrides the minimum calculated concurrency limit. When configured, minRTT measurements do not
+    change the current concurrency limit.
 
 Statistics
 ----------

--- a/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
+++ b/docs/root/configuration/http/http_filters/adaptive_concurrency_filter.rst
@@ -28,9 +28,9 @@ time (minRTT) for an upstream.
 Calculating the minRTT
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The minRTT is periodically measured by only allowing a very low outstanding request count to an
-upstream cluster and measuring the latency under these ideal conditions. The calculation is also
-triggered in scenarios where the concurrency limit is determined to be the minimum possible value
+The minRTT is periodically measured by pinning the concurrency limit to the configured
+``min_concurrency`` and measuring the latency under these ideal conditions. The calculation is also
+triggered in scenarios where the concurrency limit is determined to be the minimum configured value
 for 5 consecutive sampling windows. The length of this minRTT calculation window is variable
 depending on the number of requests the filter is configured to aggregate to represent the expected
 latency of an upstream.
@@ -43,7 +43,9 @@ calculation on the downstream success rate if retries are enabled.
 
 It is possible that there is a noticeable increase in request 503s during the minRTT measurement
 window because of the potentially significant drop in the concurrency limit. This is expected and it
-is recommended to enable retries for resets/503s.
+is recommended to enable retries for resets/503s. To reduce the impact of minRTT measurements while
+still allowing the controller to clamp more aggressively during overload, configure
+``min_concurrency_limit`` separately from ``min_concurrency``.
 
 .. note::
 
@@ -54,6 +56,18 @@ is recommended to enable retries for resets/503s.
 
 Once calculated, the minRTT is then used in the calculation of a value referred to as the
 *gradient*.
+
+Minimum Concurrency Limit
+^^^^^^^^^^^^^^^^^^^^^^^^^
+The calculated concurrency limit will not be reduced below the configured minimum concurrency limit.
+If ``min_concurrency_limit`` is not configured, this lower bound defaults to the minRTT calculation
+concurrency to preserve the historical behavior where ``min_concurrency`` controlled both values.
+
+When configured separately, ``min_concurrency`` controls the concurrency used while measuring
+minRTT, and ``min_concurrency_limit`` controls how far the controller can clamp the calculated
+concurrency limit during normal operation. If the current concurrency limit is already lower than
+the minRTT calculation concurrency when a minRTT measurement starts, the controller will keep the
+lower current limit rather than raising it for the measurement window.
 
 The Gradient
 ^^^^^^^^^^^^
@@ -119,7 +133,9 @@ fields can be overridden via runtime settings.
         value: 90
       concurrency_limit_params:
         concurrency_update_interval: 0.1s
+        min_concurrency_limit: 25
       min_rtt_calc_params:
+        min_concurrency: 50
         jitter:
           value: 10
         interval: 60s
@@ -131,11 +147,13 @@ fields can be overridden via runtime settings.
 The above configuration can be understood as follows:
 
 * Gather latency samples for a time window of 100ms. When entering a new window, summarize the
-  requests (sampleRTT) and and update the concurrency limit using this sampleRTT.
+  requests (sampleRTT) and update the concurrency limit using this sampleRTT.
 * When calculating the sampleRTT, use the p90 of all sampled latencies for that window.
+* The calculated concurrency limit will not be reduced below 25.
 * Recalculate the minRTT every 60s and add a jitter (random delay) of 0s-6s to the start of the
   minRTT recalculation. The delay is dictated by the jitter value.
-* Collect 50 request samples to calculate the minRTT and use the p90 to summarize them.
+* Pin concurrency to 50 while calculating minRTT, collect 50 request samples, and use the p90 to
+  summarize them.
 * The filter is enabled by default.
 
 .. note::
@@ -180,7 +198,13 @@ adaptive_concurrency.gradient_controller.sample_aggregate_percentile
     clamped to the range [0,100].
 
 adaptive_concurrency.gradient_controller.min_concurrency
-    Overrides the concurrency that is pinned while measuring the minRTT.
+    Overrides the concurrency that is pinned while measuring the minRTT. If
+    ``min_concurrency_limit`` is not configured, this value is also used as the minimum calculated
+    concurrency limit.
+
+adaptive_concurrency.gradient_controller.min_concurrency_limit
+    Overrides the minimum calculated concurrency limit. This does not affect the concurrency that is
+    pinned while measuring the minRTT.
 
 Statistics
 ----------

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -41,6 +41,10 @@ GradientControllerConfig::GradientControllerConfig(
           PROTOBUF_PERCENT_TO_DOUBLE_OR_DEFAULT(proto_config, sample_aggregate_percentile, 50)),
       min_concurrency_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(proto_config.min_rtt_calc_params(), min_concurrency, 3)),
+      min_concurrency_limit_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          proto_config.concurrency_limit_params(), min_concurrency_limit, min_concurrency_)),
+      min_concurrency_limit_configured_(
+          proto_config.concurrency_limit_params().has_min_concurrency_limit()),
       fixed_value_(std::chrono::milliseconds(
           DurationUtil::durationToMilliseconds(proto_config.min_rtt_calc_params().fixed_value()))),
       min_rtt_buffer_pct_(
@@ -60,7 +64,8 @@ GradientController::GradientController(GradientControllerConfig config,
     : config_(std::move(config)), dispatcher_(dispatcher), scope_(scope),
       stats_(generateStats(scope_, stats_prefix)), random_(random), time_source_(time_source),
       deferred_limit_value_(0), num_rq_outstanding_(0),
-      concurrency_limit_(config_.minConcurrency()),
+      concurrency_limit_(config_.isMinRTTSamplingEnabled() ? config_.minRTTCalcConcurrency()
+                                                           : config_.minConcurrencyLimit()),
       latency_sample_hist_(hist_fast_alloc(), hist_free) {
   min_rtt_calc_timer_ = dispatcher_.createTimer([this]() -> void { enterMinRTTSamplingWindow(); });
 
@@ -86,7 +91,7 @@ GradientController::GradientController(GradientControllerConfig config,
     min_rtt_ = config_.fixedValue();
     stats_.min_rtt_msecs_.set(
         std::chrono::duration_cast<std::chrono::milliseconds>(min_rtt_).count());
-    updateConcurrencyLimit(config_.minConcurrency());
+    updateConcurrencyLimit(config_.minConcurrencyLimit());
   }
   sample_reset_timer_->enableTimer(config_.sampleRTTCalcInterval());
   stats_.concurrency_limit_.set(concurrency_limit_.load());
@@ -117,7 +122,8 @@ void GradientController::enterMinRTTSamplingWindow() {
   // prevent the sample window from resetting until enough requests are gathered to complete the
   // recalculation.
   deferred_limit_value_.store(GradientController::concurrencyLimit());
-  updateConcurrencyLimit(config_.minConcurrency());
+  updateConcurrencyLimit(
+      std::min(GradientController::concurrencyLimit(), config_.minRTTCalcConcurrency()));
 
   // Throw away any latency samples from before the recalculation window as it may not represent
   // the minRTT.
@@ -203,7 +209,7 @@ uint32_t GradientController::calculateNewLimit() {
   // The final concurrency value factors in the burst headroom and must be clamped to keep the value
   // in the range [configured_min, configured_max].
   const uint32_t new_limit = limit + burst_headroom;
-  return std::max<uint32_t>(config_.minConcurrency(),
+  return std::max<uint32_t>(config_.minConcurrencyLimit(),
                             std::min<uint32_t>(config_.maxConcurrencyLimit(), new_limit));
 }
 
@@ -263,8 +269,8 @@ void GradientController::updateConcurrencyLimit(const uint32_t new_limit) {
   concurrency_limit_.store(new_limit);
   stats_.concurrency_limit_.set(concurrency_limit_.load());
 
-  if (!inMinRTTSamplingWindow() && old_limit == config_.minConcurrency() &&
-      new_limit == config_.minConcurrency()) {
+  if (!inMinRTTSamplingWindow() && old_limit == config_.minConcurrencyLimit() &&
+      new_limit == config_.minConcurrencyLimit()) {
     ++consecutive_min_concurrency_set_;
   } else {
     consecutive_min_concurrency_set_ = 0;

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -64,7 +64,8 @@ GradientController::GradientController(GradientControllerConfig config,
     : config_(std::move(config)), dispatcher_(dispatcher), scope_(scope),
       stats_(generateStats(scope_, stats_prefix)), random_(random), time_source_(time_source),
       deferred_limit_value_(0), num_rq_outstanding_(0),
-      concurrency_limit_(config_.minConcurrencyLimit()),
+      concurrency_limit_(config_.isMinRTTSamplingEnabled() ? config_.minRTTCalcConcurrency()
+                                                           : config_.minConcurrencyLimit()),
       latency_sample_hist_(hist_fast_alloc(), hist_free) {
   min_rtt_calc_timer_ = dispatcher_.createTimer([this]() -> void { enterMinRTTSamplingWindow(); });
 
@@ -121,9 +122,8 @@ void GradientController::enterMinRTTSamplingWindow() {
   // prevent the sample window from resetting until enough requests are gathered to complete the
   // recalculation.
   deferred_limit_value_.store(GradientController::concurrencyLimit());
-  if (config_.minRTTCalcAdjustsConcurrency()) {
-    updateConcurrencyLimit(config_.minRTTCalcConcurrency());
-  }
+  updateConcurrencyLimit(
+      std::min(GradientController::concurrencyLimit(), config_.minRTTCalcConcurrency()));
 
   // Throw away any latency samples from before the recalculation window as it may not represent
   // the minRTT.
@@ -147,9 +147,7 @@ void GradientController::updateMinRTT() {
   min_rtt_ = processLatencySamplesAndClear();
   stats_.min_rtt_msecs_.set(
       std::chrono::duration_cast<std::chrono::milliseconds>(min_rtt_).count());
-  if (config_.minRTTCalcAdjustsConcurrency()) {
-    updateConcurrencyLimit(deferred_limit_value_.load());
-  }
+  updateConcurrencyLimit(deferred_limit_value_.load());
   deferred_limit_value_.store(0);
   stats_.min_rtt_calculation_active_.set(0);
 

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.cc
@@ -64,8 +64,7 @@ GradientController::GradientController(GradientControllerConfig config,
     : config_(std::move(config)), dispatcher_(dispatcher), scope_(scope),
       stats_(generateStats(scope_, stats_prefix)), random_(random), time_source_(time_source),
       deferred_limit_value_(0), num_rq_outstanding_(0),
-      concurrency_limit_(config_.isMinRTTSamplingEnabled() ? config_.minRTTCalcConcurrency()
-                                                           : config_.minConcurrencyLimit()),
+      concurrency_limit_(config_.minConcurrencyLimit()),
       latency_sample_hist_(hist_fast_alloc(), hist_free) {
   min_rtt_calc_timer_ = dispatcher_.createTimer([this]() -> void { enterMinRTTSamplingWindow(); });
 
@@ -122,8 +121,9 @@ void GradientController::enterMinRTTSamplingWindow() {
   // prevent the sample window from resetting until enough requests are gathered to complete the
   // recalculation.
   deferred_limit_value_.store(GradientController::concurrencyLimit());
-  updateConcurrencyLimit(
-      std::min(GradientController::concurrencyLimit(), config_.minRTTCalcConcurrency()));
+  if (config_.minRTTCalcAdjustsConcurrency()) {
+    updateConcurrencyLimit(config_.minRTTCalcConcurrency());
+  }
 
   // Throw away any latency samples from before the recalculation window as it may not represent
   // the minRTT.
@@ -147,7 +147,9 @@ void GradientController::updateMinRTT() {
   min_rtt_ = processLatencySamplesAndClear();
   stats_.min_rtt_msecs_.set(
       std::chrono::duration_cast<std::chrono::milliseconds>(min_rtt_).count());
-  updateConcurrencyLimit(deferred_limit_value_.load());
+  if (config_.minRTTCalcAdjustsConcurrency()) {
+    updateConcurrencyLimit(deferred_limit_value_.load());
+  }
   deferred_limit_value_.store(0);
   stats_.min_rtt_calculation_active_.set(0);
 

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
@@ -101,9 +101,7 @@ public:
   std::chrono::milliseconds fixedValue() const { return fixed_value_; }
 
   // True if minRTT is sampled.
-  bool isMinRTTSamplingEnabled() const {
-    return fixedValue() <= std::chrono::milliseconds::zero();
-  }
+  bool isMinRTTSamplingEnabled() const { return fixedValue() <= std::chrono::milliseconds::zero(); }
 
   // The percentage is normalized to the range [0.0, 1.0].
   double minRTTBufferPercent() const {
@@ -160,10 +158,10 @@ private:
   const uint32_t min_concurrency_;
 
   // The minimum allowed concurrency limit.
-  const uint32_t min_concurrency_limit_;
+  const uint32_t min_concurrency_limit_ = 0;
 
   // True when min_concurrency_limit was explicitly configured.
-  const bool min_concurrency_limit_configured_;
+  const bool min_concurrency_limit_configured_ = false;
 
   // The fixed value of minRTT, if present.
   const std::chrono::milliseconds fixed_value_;

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
@@ -98,8 +98,6 @@ public:
                                           min_concurrency_limit_);
   }
 
-  bool minRTTCalcAdjustsConcurrency() const { return !min_concurrency_limit_configured_; }
-
   std::chrono::milliseconds fixedValue() const { return fixed_value_; }
 
   // True if minRTT is sampled.

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
@@ -86,11 +86,24 @@ public:
     return std::max(0.0, std::min(val, 100.0)) / 100.0;
   }
 
-  uint32_t minConcurrency() const {
+  uint32_t minRTTCalcConcurrency() const {
     return runtime_.snapshot().getInteger(RuntimeKeys::get().MinConcurrencyKey, min_concurrency_);
   }
 
+  uint32_t minConcurrencyLimit() const {
+    if (!min_concurrency_limit_configured_) {
+      return minRTTCalcConcurrency();
+    }
+    return runtime_.snapshot().getInteger(RuntimeKeys::get().MinConcurrencyLimitKey,
+                                          min_concurrency_limit_);
+  }
+
   std::chrono::milliseconds fixedValue() const { return fixed_value_; }
+
+  // True if minRTT is sampled.
+  bool isMinRTTSamplingEnabled() const {
+    return fixedValue() <= std::chrono::milliseconds::zero();
+  }
 
   // The percentage is normalized to the range [0.0, 1.0].
   double minRTTBufferPercent() const {
@@ -115,6 +128,8 @@ private:
     const std::string JitterPercentKey = "adaptive_concurrency.gradient_controller.jitter";
     const std::string MinConcurrencyKey =
         "adaptive_concurrency.gradient_controller.min_concurrency";
+    const std::string MinConcurrencyLimitKey =
+        "adaptive_concurrency.gradient_controller.min_concurrency_limit";
     const std::string MinRTTBufferPercentKey =
         "adaptive_concurrency.gradient_controller.min_rtt_buffer";
   };
@@ -143,6 +158,12 @@ private:
 
   // The concurrency limit set while measuring the minRTT.
   const uint32_t min_concurrency_;
+
+  // The minimum allowed concurrency limit.
+  const uint32_t min_concurrency_limit_;
+
+  // True when min_concurrency_limit was explicitly configured.
+  const bool min_concurrency_limit_configured_;
 
   // The fixed value of minRTT, if present.
   const std::chrono::milliseconds fixed_value_;
@@ -227,9 +248,7 @@ public:
   bool inMinRTTSamplingWindow() const { return deferred_limit_value_.load() > 0; }
 
   // True if minRTT is sampled.
-  bool isMinRTTSamplingEnabled() const {
-    return config_.fixedValue() <= std::chrono::milliseconds::zero();
-  }
+  bool isMinRTTSamplingEnabled() const { return config_.isMinRTTSamplingEnabled(); }
 
   // ConcurrencyController.
   RequestForwardingAction forwardingDecision() override;

--- a/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
+++ b/source/extensions/filters/http/adaptive_concurrency/controller/gradient_controller.h
@@ -98,6 +98,8 @@ public:
                                           min_concurrency_limit_);
   }
 
+  bool minRTTCalcAdjustsConcurrency() const { return !min_concurrency_limit_configured_; }
+
   std::chrono::milliseconds fixedValue() const { return fixed_value_; }
 
   // True if minRTT is sampled.

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -113,6 +113,18 @@ protected:
             .value());
   }
 
+  void driveSampleRTTWindows(const GradientControllerSharedPtr& controller,
+                             std::chrono::microseconds latency, int windows) {
+    for (int recalcs = 0; recalcs < windows; ++recalcs) {
+      for (int i = 0; i < 5; ++i) {
+        tryForward(controller, true);
+        sampleLatency(controller, latency);
+      }
+      time_system_.advanceTimeAndRun(std::chrono::milliseconds(101), *dispatcher_,
+                                     Event::Dispatcher::RunType::Block);
+    }
+  }
+
   Event::SimulatedTimeSystem time_system_;
   Stats::TestUtil::TestStore stats_;
   NiceMock<Runtime::MockLoader> runtime_;
@@ -128,6 +140,7 @@ sample_aggregate_percentile:
 concurrency_limit_params:
   max_concurrency_limit: 1337
   concurrency_update_interval: 0.123s
+  min_concurrency_limit: 6
 min_rtt_calc_params:
   jitter:
     value: 13.2
@@ -145,7 +158,8 @@ min_rtt_calc_params:
   EXPECT_EQ(config.minRTTAggregateRequestCount(), 52);
   EXPECT_EQ(config.sampleAggregatePercentile(), .425);
   EXPECT_EQ(config.jitterPercent(), .132);
-  EXPECT_EQ(config.minConcurrency(), 8);
+  EXPECT_EQ(config.minRTTCalcConcurrency(), 8);
+  EXPECT_EQ(config.minConcurrencyLimit(), 6);
   EXPECT_EQ(config.fixedValue(), std::chrono::seconds(42));
 }
 
@@ -244,7 +258,7 @@ min_rtt_calc_params:
   EXPECT_EQ(config.jitterPercent(), .155);
 
   EXPECT_CALL(runtime_.snapshot_, getInteger(_, 7)).WillOnce(Return(9));
-  EXPECT_EQ(config.minConcurrency(), 9);
+  EXPECT_EQ(config.minRTTCalcConcurrency(), 9);
 
   EXPECT_CALL(runtime_.snapshot_, getDouble(_, 33.0)).WillOnce(Return(77.0));
   EXPECT_EQ(config.minRTTBufferPercent(), .77);
@@ -266,8 +280,40 @@ min_rtt_calc_params:
   EXPECT_EQ(config.minRTTAggregateRequestCount(), 50);
   EXPECT_EQ(config.sampleAggregatePercentile(), .5);
   EXPECT_EQ(config.jitterPercent(), .15);
-  EXPECT_EQ(config.minConcurrency(), 3);
+  EXPECT_EQ(config.minRTTCalcConcurrency(), 3);
+  EXPECT_EQ(config.minConcurrencyLimit(), 3);
   EXPECT_EQ(config.minRTTBufferPercent(), 0.25);
+}
+
+TEST_F(GradientControllerConfigTest, MinConcurrencyLimitFallsBackToMinRTTCalcConcurrency) {
+  const std::string yaml = R"EOF(
+concurrency_limit_params:
+  concurrency_update_interval: 0.123s
+min_rtt_calc_params:
+  interval: 31s
+  min_concurrency: 8
+)EOF";
+
+  auto config = makeConfig(yaml, runtime_);
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger(_, 8)).WillOnce(Return(9));
+  EXPECT_EQ(config.minConcurrencyLimit(), 9);
+}
+
+TEST_F(GradientControllerConfigTest, MinConcurrencyLimitCanBeOverriddenSeparately) {
+  const std::string yaml = R"EOF(
+concurrency_limit_params:
+  concurrency_update_interval: 0.123s
+  min_concurrency_limit: 4
+min_rtt_calc_params:
+  interval: 31s
+  min_concurrency: 8
+)EOF";
+
+  auto config = makeConfig(yaml, runtime_);
+
+  EXPECT_CALL(runtime_.snapshot_, getInteger(_, 4)).WillOnce(Return(5));
+  EXPECT_EQ(config.minConcurrencyLimit(), 5);
 }
 
 // Verify that requests started in the previous minRTT window are not sampled in the next.
@@ -378,6 +424,69 @@ min_rtt_calc_params:
   // Verify the minRTT value measured is accurate.
   verifyMinRTTInactive();
   verifyMinRTTValue(std::chrono::milliseconds(13));
+}
+
+TEST_F(GradientControllerTest, MinRTTProbeConcurrencyCanBeHigherThanMinimumLimit) {
+  const std::string yaml = R"EOF(
+sample_aggregate_percentile:
+  value: 50
+concurrency_limit_params:
+  min_concurrency_limit: 2
+  concurrency_update_interval: 0.1s
+min_rtt_calc_params:
+  jitter:
+    value: 0.0
+  interval: 30s
+  request_count: 5
+  min_concurrency: 7
+)EOF";
+
+  auto controller = makeController(yaml);
+  const auto min_rtt = std::chrono::milliseconds(13);
+
+  verifyMinRTTActive();
+  EXPECT_EQ(controller->concurrencyLimit(), 7);
+  for (int i = 0; i < 7; ++i) {
+    tryForward(controller, true);
+  }
+  tryForward(controller, false);
+  time_system_.advanceTimeAndRun(min_rtt, *dispatcher_, Event::Dispatcher::RunType::Block);
+  for (int i = 0; i < 7; ++i) {
+    sampleLatency(controller, min_rtt);
+  }
+
+  driveSampleRTTWindows(controller, std::chrono::milliseconds(200), 10);
+
+  EXPECT_EQ(controller->concurrencyLimit(), 2);
+}
+
+TEST_F(GradientControllerTest, MinRTTProbeDoesNotIncreaseLimitWhenAlreadyBelowProbeConcurrency) {
+  const std::string yaml = R"EOF(
+sample_aggregate_percentile:
+  value: 50
+concurrency_limit_params:
+  min_concurrency_limit: 2
+  concurrency_update_interval: 0.1s
+min_rtt_calc_params:
+  jitter:
+    value: 0.0
+  interval: 30s
+  request_count: 5
+  min_concurrency: 7
+)EOF";
+
+  auto controller = makeController(yaml);
+  advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));
+
+  driveSampleRTTWindows(controller, std::chrono::milliseconds(200), 10);
+  EXPECT_EQ(controller->concurrencyLimit(), 2);
+
+  if (!controller->inMinRTTSamplingWindow()) {
+    time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
+                                   Event::Dispatcher::RunType::Block);
+  }
+  verifyMinRTTActive();
+  EXPECT_EQ(controller->concurrencyLimit(), 2);
 }
 
 TEST_F(GradientControllerTest, FixedMinRTT) {

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -426,12 +426,11 @@ min_rtt_calc_params:
   verifyMinRTTValue(std::chrono::milliseconds(13));
 }
 
-TEST_F(GradientControllerTest, ExplicitMinConcurrencyLimitDisablesMinRTTProbeClamp) {
+TEST_F(GradientControllerTest, MinRTTProbeConcurrencyCanBeHigherThanMinimumLimit) {
   const std::string yaml = R"EOF(
 sample_aggregate_percentile:
   value: 50
 concurrency_limit_params:
-  max_concurrency_limit: 100
   min_concurrency_limit: 2
   concurrency_update_interval: 0.1s
 min_rtt_calc_params:
@@ -443,33 +442,30 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
+  const auto min_rtt = std::chrono::milliseconds(13);
 
   verifyMinRTTActive();
+  EXPECT_EQ(controller->concurrencyLimit(), 7);
+  for (int i = 0; i < 7; ++i) {
+    tryForward(controller, true);
+  }
+  tryForward(controller, false);
+  time_system_.advanceTimeAndRun(min_rtt, *dispatcher_, Event::Dispatcher::RunType::Block);
+  for (int i = 0; i < 7; ++i) {
+    sampleLatency(controller, min_rtt);
+  }
+
+  driveSampleRTTWindows(controller, std::chrono::milliseconds(200), 10);
+
   EXPECT_EQ(controller->concurrencyLimit(), 2);
-  advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(13));
-  verifyMinRTTInactive();
-
-  driveSampleRTTWindows(controller, std::chrono::milliseconds(5), 3);
-  const auto limit_before_probe = controller->concurrencyLimit();
-  EXPECT_GT(limit_before_probe, 2);
-
-  time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
-                                 Event::Dispatcher::RunType::Block);
-  verifyMinRTTActive();
-  EXPECT_EQ(controller->concurrencyLimit(), limit_before_probe);
-
-  time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
-                                 Event::Dispatcher::RunType::Block);
-  advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(13));
-  verifyMinRTTInactive();
-  EXPECT_EQ(controller->concurrencyLimit(), limit_before_probe);
 }
 
-TEST_F(GradientControllerTest, MinRTTProbePinsConcurrencyWhenMinimumLimitUsesLegacyFallback) {
+TEST_F(GradientControllerTest, MinRTTProbeDoesNotIncreaseLimitWhenAlreadyBelowProbeConcurrency) {
   const std::string yaml = R"EOF(
 sample_aggregate_percentile:
   value: 50
 concurrency_limit_params:
+  min_concurrency_limit: 2
   concurrency_update_interval: 0.1s
 min_rtt_calc_params:
   jitter:
@@ -482,13 +478,15 @@ min_rtt_calc_params:
   auto controller = makeController(yaml);
   advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));
 
-  driveSampleRTTWindows(controller, std::chrono::milliseconds(2), 3);
-  EXPECT_GT(controller->concurrencyLimit(), 7);
+  driveSampleRTTWindows(controller, std::chrono::milliseconds(200), 10);
+  EXPECT_EQ(controller->concurrencyLimit(), 2);
 
-  time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
-                                 Event::Dispatcher::RunType::Block);
+  if (!controller->inMinRTTSamplingWindow()) {
+    time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
+                                   Event::Dispatcher::RunType::Block);
+  }
   verifyMinRTTActive();
-  EXPECT_EQ(controller->concurrencyLimit(), 7);
+  EXPECT_EQ(controller->concurrencyLimit(), 2);
 }
 
 TEST_F(GradientControllerTest, FixedMinRTT) {

--- a/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
+++ b/test/extensions/filters/http/adaptive_concurrency/controller/gradient_controller_test.cc
@@ -426,11 +426,12 @@ min_rtt_calc_params:
   verifyMinRTTValue(std::chrono::milliseconds(13));
 }
 
-TEST_F(GradientControllerTest, MinRTTProbeConcurrencyCanBeHigherThanMinimumLimit) {
+TEST_F(GradientControllerTest, ExplicitMinConcurrencyLimitDisablesMinRTTProbeClamp) {
   const std::string yaml = R"EOF(
 sample_aggregate_percentile:
   value: 50
 concurrency_limit_params:
+  max_concurrency_limit: 100
   min_concurrency_limit: 2
   concurrency_update_interval: 0.1s
 min_rtt_calc_params:
@@ -442,30 +443,33 @@ min_rtt_calc_params:
 )EOF";
 
   auto controller = makeController(yaml);
-  const auto min_rtt = std::chrono::milliseconds(13);
 
   verifyMinRTTActive();
-  EXPECT_EQ(controller->concurrencyLimit(), 7);
-  for (int i = 0; i < 7; ++i) {
-    tryForward(controller, true);
-  }
-  tryForward(controller, false);
-  time_system_.advanceTimeAndRun(min_rtt, *dispatcher_, Event::Dispatcher::RunType::Block);
-  for (int i = 0; i < 7; ++i) {
-    sampleLatency(controller, min_rtt);
-  }
-
-  driveSampleRTTWindows(controller, std::chrono::milliseconds(200), 10);
-
   EXPECT_EQ(controller->concurrencyLimit(), 2);
+  advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(13));
+  verifyMinRTTInactive();
+
+  driveSampleRTTWindows(controller, std::chrono::milliseconds(5), 3);
+  const auto limit_before_probe = controller->concurrencyLimit();
+  EXPECT_GT(limit_before_probe, 2);
+
+  time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
+                                 Event::Dispatcher::RunType::Block);
+  verifyMinRTTActive();
+  EXPECT_EQ(controller->concurrencyLimit(), limit_before_probe);
+
+  time_system_.advanceTimeAndRun(std::chrono::seconds(1), *dispatcher_,
+                                 Event::Dispatcher::RunType::Block);
+  advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(13));
+  verifyMinRTTInactive();
+  EXPECT_EQ(controller->concurrencyLimit(), limit_before_probe);
 }
 
-TEST_F(GradientControllerTest, MinRTTProbeDoesNotIncreaseLimitWhenAlreadyBelowProbeConcurrency) {
+TEST_F(GradientControllerTest, MinRTTProbePinsConcurrencyWhenMinimumLimitUsesLegacyFallback) {
   const std::string yaml = R"EOF(
 sample_aggregate_percentile:
   value: 50
 concurrency_limit_params:
-  min_concurrency_limit: 2
   concurrency_update_interval: 0.1s
 min_rtt_calc_params:
   jitter:
@@ -478,15 +482,13 @@ min_rtt_calc_params:
   auto controller = makeController(yaml);
   advancePastMinRTTStage(controller, yaml, std::chrono::milliseconds(5));
 
-  driveSampleRTTWindows(controller, std::chrono::milliseconds(200), 10);
-  EXPECT_EQ(controller->concurrencyLimit(), 2);
+  driveSampleRTTWindows(controller, std::chrono::milliseconds(2), 3);
+  EXPECT_GT(controller->concurrencyLimit(), 7);
 
-  if (!controller->inMinRTTSamplingWindow()) {
-    time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
-                                   Event::Dispatcher::RunType::Block);
-  }
+  time_system_.advanceTimeAndRun(std::chrono::seconds(31), *dispatcher_,
+                                 Event::Dispatcher::RunType::Block);
   verifyMinRTTActive();
-  EXPECT_EQ(controller->concurrencyLimit(), 2);
+  EXPECT_EQ(controller->concurrencyLimit(), 7);
 }
 
 TEST_F(GradientControllerTest, FixedMinRTT) {


### PR DESCRIPTION
Commit Message:

adaptive concurrency: add min concurrency limit knob

Additional Description:

The adaptive concurrency gradient controller currently uses `min_rtt_calc_params.min_concurrency` for two related but distinct controls:

1. the temporary concurrency limit used while recalculating minRTT, and
2. the lower bound for the calculated concurrency limit under load.

That coupling can force operators into an awkward tradeoff. A value high enough to make periodic minRTT probes less disruptive may also prevent the controller from clamping aggressively enough during overload. A value low enough for overload protection can make periodic minRTT probes more disruptive than necessary during otherwise healthy traffic.

This change adds an optional `concurrency_limit_params.min_concurrency_limit` field. When unset, it falls back to `min_rtt_calc_params.min_concurrency`, preserving existing behavior. When set, minRTT probe concurrency and the actual minimum calculated concurrency limit can be tuned independently.

The minRTT probe path also now clamps to `min(current_limit, min_rtt_calc_params.min_concurrency)`, so entering a probe does not increase the current limit if the controller is already clamped below the probe concurrency.

Generative AI was used to help draft and validate this change; I reviewed and understand the code.

Risk Level:

Low. The new field is optional and the default behavior is intended to remain unchanged when it is omitted. Behavior changes only for configurations that explicitly set the new `min_concurrency_limit`.

Testing:

- `bazel query //test/extensions/filters/http/adaptive_concurrency/controller:gradient_controller_test`
- `bazel test //test/extensions/filters/http/adaptive_concurrency/controller:gradient_controller_test`
- `tools/proto_format/proto_format.sh check`
- `git diff --check upstream/main...HEAD`
- Attempted `bazel run --config=clang //tools/code_format:check_format -- check`, but it failed in the local Darwin environment while trying to execute `external/go_linux_arm64/bin/go` (`cannot execute binary file`) before running the formatter.

Docs Changes:

API proto comments and a changelog entry are included. Generated docs are not committed.

Release Notes:

Added `min_concurrency_limit` to the adaptive concurrency gradient controller to allow the minimum calculated concurrency limit to be configured separately from the concurrency used during minRTT recalculation.

Platform Specific Features:

N/A

[Optional Runtime guard:]

N/A

[Optional Fixes #Issue]

N/A

[Optional Fixes commit #PR or SHA]

N/A

[Optional Deprecated:]

N/A

[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]

This adds an optional field to an existing v3 API message. The field has a positive-value validation rule and preserves existing behavior when unset by falling back to the existing `min_rtt_calc_params.min_concurrency` value.
