### PR TITLE
reverse_tunnel: add tunnel setup latency stats

### DIFF
--- a/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
+++ b/api/envoy/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/v3/downstream_reverse_connection_socket_interface.proto
@@ -23,7 +23,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Configuration for the downstream reverse connection socket interface.
 // This interface initiates reverse connections to upstream Envoys and provides
 // them as socket connections for downstream requests.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message DownstreamReverseConnectionSocketInterface {
   // HTTP handshake settings for initiator envoy initiated reverse tunnels.
   message HttpHandshakeConfig {
@@ -69,5 +69,11 @@ message DownstreamReverseConnectionSocketInterface {
   // deterministic exponential schedule (1s, 2s, 4s, ...) with small upward jitter; this value caps
   // that schedule.
   google.protobuf.Duration max_reconnect_backoff = 5
+      [(validate.rules).duration = {gte {seconds: 1}}];
+
+  // The maximum time for tunnels to a host to finish setup (reach the configured per-host
+  // connection count). Attempts continue after this deadline; it only drives
+  // ``tunnel_setup_time`` / ``tunnel_setup_time_exceeded`` stats. Defaults to 30s.
+  google.protobuf.Duration max_tunnel_setup_time = 6
       [(validate.rules).duration = {gte {seconds: 1}}];
 }

--- a/changelogs/current/new_features/reverse_tunnel__tunnel-setup-latency.rst
+++ b/changelogs/current/new_features/reverse_tunnel__tunnel-setup-latency.rst
@@ -1,0 +1,8 @@
+Added
+:ref:`max_tunnel_setup_time <envoy_v3_api_field_extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3.DownstreamReverseConnectionSocketInterface.max_tunnel_setup_time>`
+to the downstream reverse-tunnel initiator
+(``envoy.bootstrap.reverse_tunnel.downstream_socket_interface``). The initiator now records how long
+it takes for tunnels to a host to reach the configured per-host connection count via the
+``tunnel_setup_time`` histogram. If that budget is exceeded, ``tunnel_setup_time_exceeded`` is
+incremented and a late completion is not recorded as a setup-time sample. Connection attempts
+continue after the deadline; the setting is stats-only and defaults to 30s.

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -384,6 +384,8 @@ private:
                                              const ListenerImpl& existing_listener);
 
   ApiListenerPtr api_listener_;
+  // Listeners can hold timers etc. so we need them to die first.
+  std::vector<WorkerPtr> workers_;
   // Active listeners are listeners that are currently accepting new connections on the workers.
   ListenerList active_listeners_;
   // Warming listeners are listeners that may need further initialization via the listener's init
@@ -397,7 +399,6 @@ private:
   std::list<DrainingListener> draining_listeners_;
   std::list<DrainingFilterChainsManager> draining_filter_chains_manager_;
 
-  std::vector<WorkerPtr> workers_;
   // The per-worker CPU assignment, lazily computed and cached by workerCpus(). worker_cpus_[i] is
   // the CPU that worker i is pinned to; the vector is empty when no worker is pinned.
   std::optional<std::vector<uint32_t>> worker_cpus_;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -98,6 +98,7 @@ envoy_cc_library(
         "//source/common/network:connection_socket_lib",
         "//source/common/network:default_socket_interface_lib",
         "//source/common/network:filter_lib",
+        "//source/common/stats:timespan_lib",
         "//source/common/stream_info:stream_info_lib",
         "//source/common/tls:ssl_handshaker_lib",
         "//source/common/upstream:load_balancer_context_base_lib",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -386,6 +386,7 @@ Api::IoCallUint64Result ReverseConnectionIOHandle::close() {
   if (rev_conn_retry_timer_) {
     rev_conn_retry_timer_.reset();
   }
+  host_to_conn_info_map_.clear();
 
   return IoSocketHandleImpl::close();
 }
@@ -446,7 +447,8 @@ ReverseTunnelInitiatorExtension* ReverseConnectionIOHandle::getDownstreamExtensi
 }
 
 void ReverseConnectionIOHandle::maybeUpdateHostsMappingsAndConnections(
-    const std::string& cluster_id, const std::vector<std::string>& hosts) {
+    const std::string& cluster_id, const std::vector<std::string>& hosts,
+    const RemoteClusterConnectionConfig& cluster_config) {
   absl::flat_hash_set<std::string> new_hosts(hosts.begin(), hosts.end());
   absl::flat_hash_set<std::string> removed_hosts;
   const auto& cluster_to_resolved_hosts_itr = cluster_to_resolved_hosts_map_.find(cluster_id);
@@ -469,16 +471,9 @@ void ReverseConnectionIOHandle::maybeUpdateHostsMappingsAndConnections(
           debug,
           "Creating HostConnectionInfo on-demand during host update for host {} in cluster {}",
           host, cluster_id);
-      host_to_conn_info_map_[host] = HostConnectionInfo{
-          host,
-          cluster_id,
-          {},                              // connection_keys - empty set initially
-          1,                               // default target_connection_count
-          0,                               // failure_count
-          getTimeSource().monotonicTime(), // last_failure_time
-          getTimeSource().monotonicTime(), // backoff_until (no backoff initially)
-          {}                               // connection_states - empty map initially
-      };
+      host_to_conn_info_map_.emplace(
+          host, HostConnectionInfo(host, cluster_id, cluster_config.reverse_connection_count,
+                                   getThreadLocalDispatcher(), extension_));
     } else {
       // Update cluster name if host moved to different cluster.
       host_it->second.cluster_name = cluster_id;
@@ -564,7 +559,7 @@ void ReverseConnectionIOHandle::maintainClusterConnections(
     const std::string& resolved = host_itr.first;
     resolved_hosts.emplace_back(resolved);
   }
-  maybeUpdateHostsMappingsAndConnections(cluster_name, std::move(resolved_hosts));
+  maybeUpdateHostsMappingsAndConnections(cluster_name, std::move(resolved_hosts), cluster_config);
   // Track successful connections for this cluster.
   uint32_t total_successful_connections = 0;
   uint32_t total_required_connections =
@@ -580,31 +575,22 @@ void ReverseConnectionIOHandle::maintainClusterConnections(
     auto host_it = host_to_conn_info_map_.find(key);
     if (host_it == host_to_conn_info_map_.end()) {
       ENVOY_LOG(debug, "Creating HostConnectionInfo for host {} in cluster {}", key, cluster_name);
-      host_to_conn_info_map_[key] = HostConnectionInfo{
-          key,
-          cluster_name,
-          {},                                      // connection_keys - empty set initially
-          cluster_config.reverse_connection_count, // target_connection_count from config
-          0,                                       // failure_count
-          // last_failure_time
-          worker_dispatcher_->timeSource().monotonicTime(),
-          // backoff_until
-          worker_dispatcher_->timeSource().monotonicTime(),
-          {} // connection_states
-      };
+      host_it = host_to_conn_info_map_
+                    .emplace(key, HostConnectionInfo(host_address, cluster_name,
+                                                     cluster_config.reverse_connection_count,
+                                                     getThreadLocalDispatcher(), extension_))
+                    .first;
     }
 
-    host_to_conn_info_map_[key].target_connection_count = cluster_config.reverse_connection_count;
-
     // Check if we should attempt connection to this host (backoff logic).
-    if (!shouldAttemptConnectionToHost(host_address, cluster_name)) {
+    if (!shouldAttemptConnectionToHost(host_address, cluster_name, cluster_config)) {
       ENVOY_LOG(debug, "reverse_tunnel: Skipping connection attempt to host {} due to backoff",
                 host_address);
       continue;
     }
     // Get current number of successful connections to this host.
-    uint32_t current_connections = host_to_conn_info_map_[key].connection_keys.size();
-    uint32_t pending_connections = host_to_conn_info_map_[key].connecting_count;
+    uint32_t current_connections = host_it->second.connection_keys.size();
+    uint32_t pending_connections = host_it->second.connecting_count;
 
     ENVOY_LOG(info,
               "reverse_tunnel: Number of reverse connections to host {} of cluster {} from source "
@@ -660,8 +646,9 @@ void ReverseConnectionIOHandle::maintainClusterConnections(
   }
 }
 
-bool ReverseConnectionIOHandle::shouldAttemptConnectionToHost(const std::string& host_address,
-                                                              const std::string& cluster_name) {
+bool ReverseConnectionIOHandle::shouldAttemptConnectionToHost(
+    const std::string& host_address, const std::string& cluster_name,
+    const RemoteClusterConnectionConfig& cluster_config) {
   if (!config_.enable_circuit_breaker) {
     return true;
   }
@@ -670,17 +657,11 @@ bool ReverseConnectionIOHandle::shouldAttemptConnectionToHost(const std::string&
     // Create host entry on-demand to avoid race conditions during initialization.
     ENVOY_LOG(debug, "Creating HostConnectionInfo on-demand for host {} in cluster {}",
               host_address, cluster_name);
-    host_to_conn_info_map_[host_address] = HostConnectionInfo{
-        host_address,
-        cluster_name,
-        {},                              // connection_keys - empty set initially
-        1,                               // default target_connection_count
-        0,                               // failure_count
-        getTimeSource().monotonicTime(), // last_failure_time
-        getTimeSource().monotonicTime(), // backoff_until (no backoff initially)
-        {}                               // connection_states - empty map initially
-    };
-    host_it = host_to_conn_info_map_.find(host_address);
+    host_it = host_to_conn_info_map_
+                  .emplace(host_address, HostConnectionInfo(host_address, cluster_name,
+                                                            cluster_config.reverse_connection_count,
+                                                            getThreadLocalDispatcher(), extension_))
+                  .first;
   }
   auto& host_info = host_it->second;
   auto now = getTimeSource().monotonicTime();
@@ -1025,12 +1006,6 @@ bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& 
   ENVOY_LOG(debug, "reverse_tunnel: Cluster '{}' found with type {} and {} hosts", cluster_name,
             static_cast<int>(cluster_info->type()), host_count);
 
-  // Normalize host key for internal addresses to ensure consistent map lookups.
-  std::string normalized_host_key = host_address;
-  if (absl::StartsWith(host_address, "envoy://")) {
-    normalized_host_key = host_address; // already canonical for internal addresses
-  }
-
   // Validate that we have hosts available for internal addresses.
   if (absl::StartsWith(host_address, "envoy://") && host_count == 0) {
     ENVOY_LOG(error, "reverse_tunnel: No hosts available in cluster '{}' for internal address '{}'",
@@ -1040,10 +1015,29 @@ bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& 
     return false;
   }
 
+  // Stamp the episode on the first dial: initiation time, setup-time span, and setup deadline
+  // timer. Reused for handshake retries until the host reaches target connection count. Deadline
+  // expiry only increments the exceeded counter; late completions skip the histogram. A redial
+  // after capacity drops begins a fresh episode.
+  auto host_info_it = host_to_conn_info_map_.find(host_address);
+  RELEASE_ASSERT(host_info_it != host_to_conn_info_map_.end(),
+                 "HostConnectionInfo must exist before initiating a reverse connection");
+  auto& host_info = host_info_it->second;
+  if (!host_info.episode_initiation_time_ms.has_value()) {
+    host_info.episode_initiation_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                               getTimeSource().systemTime().time_since_epoch())
+                                               .count();
+    if (extension_) {
+      host_info.setup_time_span = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+          extension_->tunnel_setup_time_, getTimeSource());
+      host_info.setup_time_timer_->enableTimer(
+          std::chrono::milliseconds(extension_->maxTunnelSetupTimeMs()));
+    }
+  }
+
   // Create load balancer context and validate it.
-  ReverseConnectionLoadBalancerContext lb_context(normalized_host_key);
-  ENVOY_LOG(debug, "reverse_tunnel: Created load balancer context for host key: {}",
-            normalized_host_key);
+  ReverseConnectionLoadBalancerContext lb_context(host_address);
+  ENVOY_LOG(debug, "reverse_tunnel: Created load balancer context for host key: {}", host_address);
 
   // Get connection from cluster manager with defensive error handling.
   Upstream::Host::CreateConnectionData conn_data;
@@ -1068,16 +1062,6 @@ bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& 
   auto wrapper = std::make_unique<RCConnectionWrapper>(*this, std::move(conn_data.connection_),
                                                        conn_data.host_description_, cluster_name);
 
-  // Stamp the episode initiation time on the first dial of an establishment episode, and reuse it
-  // for subsequent handshake retries. It is cleared on handshake success (see onConnectionDone()),
-  // so a redial after a live connection drops begins a fresh episode with a new timestamp.
-  auto& host_info = host_to_conn_info_map_[normalized_host_key];
-  if (!host_info.episode_initiation_time_ms.has_value()) {
-    host_info.episode_initiation_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                               getTimeSource().systemTime().time_since_epoch())
-                                               .count();
-  }
-
   // Send the reverse connection handshake over the TCP connection.
   const std::string connection_key =
       wrapper->connect(config_.src_tenant_id, config_.src_cluster_id, config_.src_node_id,
@@ -1087,7 +1071,7 @@ bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& 
 
   // Mark as Connecting after handshake is initiated. Use the actual connection key so that it can
   // be marked as failed in onConnectionDone().
-  conn_wrapper_to_host_map_[wrapper.get()] = normalized_host_key;
+  conn_wrapper_to_host_map_[wrapper.get()] = host_address;
   connection_wrappers_.push_back(std::move(wrapper));
 
   {
@@ -1111,8 +1095,8 @@ bool ReverseConnectionIOHandle::initiateOneReverseConnection(const std::string& 
     }
   }
   // Reset backoff for successful connection.
-  resetHostBackoff(normalized_host_key);
-  updateConnectionState(normalized_host_key, cluster_name, connection_key,
+  resetHostBackoff(host_address);
+  updateConnectionState(host_address, cluster_name, connection_key,
                         ReverseConnectionState::Connecting);
   return true;
 }
@@ -1257,6 +1241,14 @@ void ReverseConnectionIOHandle::onConnectionDone(
       // future redial after a connection drops then begins a fresh episode with a new timestamp.
       if (host_it->second.connection_keys.size() >= host_it->second.target_connection_count) {
         host_it->second.episode_initiation_time_ms.reset();
+        // Record the span only if the deadline hasn't already fired.
+        if (host_it->second.setup_time_timer_->enabled()) {
+          host_it->second.setup_time_timer_->disableTimer();
+          RELEASE_ASSERT(host_it->second.setup_time_span != nullptr,
+                         "Setup time span should not be null");
+          host_it->second.setup_time_span->complete();
+        }
+        host_it->second.setup_time_span.reset();
       }
     }
 
@@ -1298,6 +1290,22 @@ void ReverseConnectionIOHandle::onConnectionDone(
     connection_wrappers_.erase(wrapper_vector_it);
     getThreadLocalDispatcher().deferredDelete(std::move(wrapper_to_delete));
   }
+}
+
+ReverseConnectionIOHandle::HostConnectionInfo::HostConnectionInfo(
+    absl::string_view host_address, absl::string_view cluster_name,
+    uint32_t target_connection_count, Event::Dispatcher& dispatcher,
+    ReverseTunnelInitiatorExtension* extension)
+    : host_address(host_address), cluster_name(cluster_name),
+      target_connection_count(target_connection_count) {
+  last_failure_time = dispatcher.timeSource().monotonicTime();
+  backoff_until = dispatcher.timeSource().monotonicTime();
+
+  setup_time_timer_ = dispatcher.createTimer([extension] {
+    if (extension) {
+      extension->tunnel_setup_time_exceeded_.inc();
+    }
+  });
 }
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -19,6 +19,7 @@
 #include "source/common/network/filter_impl.h"
 #include "source/common/network/io_socket_handle_impl.h"
 #include "source/common/network/socket_interface.h"
+#include "source/common/stats/timespan_impl.h"
 #include "source/common/upstream/load_balancer_context_base.h"
 #include "source/extensions/bootstrap/reverse_tunnel/common/reverse_connection_utility.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/downstream_reverse_connection_io_handle.h"
@@ -249,7 +250,8 @@ public:
    * @return true if connection attempt should be made, false if in backoff.
    */
   bool shouldAttemptConnectionToHost(const std::string& host_address,
-                                     const std::string& cluster_name);
+                                     const std::string& cluster_name,
+                                     const RemoteClusterConnectionConfig& cluster_config);
 
   /**
    * Track a connection failure for a specific host and cluster and trigger backoff logic.
@@ -464,7 +466,8 @@ private:
    * @param hosts the list of hosts in the cluster
    */
   void maybeUpdateHostsMappingsAndConnections(const std::string& cluster_id,
-                                              const std::vector<std::string>& hosts);
+                                              const std::vector<std::string>& hosts,
+                                              const RemoteClusterConnectionConfig& cluster_config);
 
   /**
    * Remove stale host entries and close associated connections.
@@ -479,20 +482,25 @@ private:
   struct HostConnectionInfo {
     std::string host_address;                                // Host address
     std::string cluster_name;                                // Cluster to which host belongs
-    absl::flat_hash_set<std::string> connection_keys;        // Connection keys for stats tracking
+    absl::flat_hash_set<std::string> connection_keys{};      // Connection keys for stats tracking
     uint32_t target_connection_count;                        // Target connection count for the host
     uint32_t failure_count{0};                               // Number of consecutive failures
     std::chrono::steady_clock::time_point last_failure_time; // NO_CHECK_FORMAT(real_time)
     std::chrono::steady_clock::time_point backoff_until;     // NO_CHECK_FORMAT(real_time)
     absl::flat_hash_map<std::string, ReverseConnectionState>
-        connection_states;        // State tracking per connection
+        connection_states{};      // State tracking per connection
     uint32_t connecting_count{0}; // Number of pending connections.
     // Wall-clock epoch millis of the first dial in the current establishment episode. Set on the
-    // first dial made while the host has no live connection, carried unchanged across handshake
-    // retries, and cleared on handshake success. This makes retries during initial establishment
-    // report the original intent time, while a redial after a previously-established connection
-    // drops starts a fresh episode.
-    std::optional<int64_t> episode_initiation_time_ms;
+    // first dial while the host is below target capacity, carried across handshake retries, and
+    // cleared when the host reaches target connection count (or when a new episode starts after
+    // capacity drops). Setup-time span/timer are armed with this stamp.
+    std::optional<int64_t> episode_initiation_time_ms{};
+    std::unique_ptr<Stats::HistogramCompletableTimespanImpl> setup_time_span{};
+    Event::TimerPtr setup_time_timer_;
+
+    HostConnectionInfo(absl::string_view host_address, absl::string_view cluster_name,
+                       uint32_t target_connection_count, Event::Dispatcher& dispatcher,
+                       ReverseTunnelInitiatorExtension* extension);
   };
 
   // Map from host address to connection info.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.cc
@@ -26,18 +26,24 @@ static bool reverse_tunnel_detailed_stats_warning_logged = false;
 namespace {
 // Default cap on the per-host reconnect backoff when ``max_reconnect_backoff`` is unset.
 constexpr uint64_t kDefaultMaxReconnectBackoffMs = 30000;
+// Something like 3 attempts since we loop every 10s by default.
+constexpr uint64_t kDefaultMaxTunnelSetupTimeMs = 30000;
 } // namespace
 
 ReverseTunnelInitiatorExtension::ReverseTunnelInitiatorExtension(
     Server::Configuration::ServerFactoryContext& context,
     const envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
         DownstreamReverseConnectionSocketInterface& config)
-    : context_(context), config_(config) {
-  stat_prefix_ = PROTOBUF_GET_STRING_OR_DEFAULT(config, stat_prefix, "reverse_tunnel_initiator");
+    : context_(context), config_(config),
+      stat_prefix_(PROTOBUF_GET_STRING_OR_DEFAULT(config, stat_prefix, "reverse_tunnel_initiator")),
+      tunnel_setup_time_(getHistogram("tunnel_setup_time", context_.scope())),
+      tunnel_setup_time_exceeded_(getCounter("tunnel_setup_time_exceeded", context_.scope())) {
   // Configure detailed stats flag (defaults to false).
   enable_detailed_stats_ = config.enable_detailed_stats();
   max_reconnect_backoff_ms_ =
       PROTOBUF_GET_MS_OR_DEFAULT(config, max_reconnect_backoff, kDefaultMaxReconnectBackoffMs);
+  max_tunnel_setup_time_ms_ =
+      PROTOBUF_GET_MS_OR_DEFAULT(config, max_tunnel_setup_time, kDefaultMaxTunnelSetupTimeMs);
   if (config.has_http_handshake() && !config.http_handshake().request_path().empty()) {
     handshake_request_path_ = config.http_handshake().request_path();
   } else {
@@ -458,6 +464,21 @@ void ReverseTunnelInitiatorExtension::incrementHandshakeStats(const std::string&
             "reverse_tunnel: incremented handshake stat {} with tags worker={}, cluster={}, "
             "result={}, failure_reason={}",
             base_stat_name, dispatcher_name, cluster_id, result_value, failure_reason);
+}
+
+Stats::Histogram& ReverseTunnelInitiatorExtension::getHistogram(absl::string_view name,
+                                                                Stats::Scope& stats_store) {
+  std::string stat_name = fmt::format("{}.{}", stat_prefix_, name);
+  Stats::StatNameManagedStorage stat_name_storage(stat_name, stats_store.symbolTable());
+  return stats_store.histogramFromStatName(stat_name_storage.statName(),
+                                           Stats::Histogram::Unit::Milliseconds);
+}
+
+Stats::Counter& ReverseTunnelInitiatorExtension::getCounter(absl::string_view name,
+                                                            Stats::Scope& stats_store) {
+  std::string stat_name = fmt::format("{}.{}", stat_prefix_, name);
+  Stats::StatNameManagedStorage stat_name_storage(stat_name, stats_store.symbolTable());
+  return stats_store.counterFromStatName(stat_name_storage.statName());
 }
 
 } // namespace ReverseConnection

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h
@@ -112,6 +112,11 @@ public:
   uint64_t maxReconnectBackoffMs() const { return max_reconnect_backoff_ms_; }
 
   /**
+   * @return the configured maximum time for tunnels to a host to finish setup, in milliseconds.
+   */
+  uint64_t maxTunnelSetupTimeMs() const { return max_tunnel_setup_time_ms_; }
+
+  /**
    * @return reference to the configured HTTP handshake request path.
    */
   const std::string& handshakeRequestPath() const { return handshake_request_path_; }
@@ -191,11 +196,16 @@ private:
   std::string stat_prefix_; // Reverse connection stats prefix
   bool enable_detailed_stats_{false};
   uint64_t max_reconnect_backoff_ms_{};
+  uint64_t max_tunnel_setup_time_ms_{};
   std::string handshake_request_path_;
   std::vector<envoy::config::core::v3::HeaderValueOption> additional_headers_;
   bool use_http_upgrade_{false};
   HandshakeHeadersConstSharedPtr handshake_headers_;
   AccessLog::InstanceSharedPtrVector access_logs_;
+
+  // Makes a histogram with the given name and stats store.
+  Stats::Histogram& getHistogram(absl::string_view name, Stats::Scope& stats_store);
+  Stats::Counter& getCounter(absl::string_view name, Stats::Scope& stats_store);
 
   /**
    * Update per-worker connection stats for debugging purposes.
@@ -208,6 +218,11 @@ private:
    */
   void updatePerWorkerConnectionStats(const std::string& node_id, const std::string& cluster_id,
                                       const std::string& state_suffix, bool increment);
+
+public:
+  // Keep at the end as it depends on stat prefix.
+  Stats::Histogram& tunnel_setup_time_;
+  Stats::Counter& tunnel_setup_time_exceeded_;
 };
 
 /**

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -68,6 +68,7 @@ envoy_cc_test(
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_tunnel_extension_lib",
         "//source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_tunnel_initiator_lib",
+        "//test/common/stats:stat_test_utility_lib",
         "//test/common/tls:mock_ssl_handshaker_lib",
         "//test/mocks/api:api_mocks",
         "//test/mocks/event:event_mocks",

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -21,6 +21,7 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/simulated_time_system.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -56,7 +57,7 @@ makeHandshakeHeader(absl::string_view key, absl::string_view value,
                          Formatter::FormatterImpl::create(value, true, command_parsers).value()};
 }
 
-class RCConnectionWrapperTest : public testing::Test {
+class RCConnectionWrapperTest : public Event::TestUsingSimulatedTime, public testing::Test {
 protected:
   void SetUp() override {
     stats_scope_ = Stats::ScopeSharedPtr(stats_store_.createScope("test_scope."));
@@ -129,19 +130,9 @@ protected:
 
   void addHostConnectionInfo(const std::string& host_address, const std::string& cluster_name,
                              uint32_t target_count) {
-    io_handle_->host_to_conn_info_map_[host_address] =
-        ReverseConnectionIOHandle::HostConnectionInfo{
-            host_address,
-            cluster_name,
-            {},           // connection_keys - empty set initially
-            target_count, // target_connection_count
-            0,            // failure_count
-            // last_failure_time
-            std::chrono::steady_clock::now(), // NO_CHECK_FORMAT(real_time)
-            // backoff_until
-            std::chrono::steady_clock::now(), // NO_CHECK_FORMAT(real_time)
-            {}                                // connection_states
-        };
+    io_handle_->host_to_conn_info_map_.emplace(
+        host_address, ReverseConnectionIOHandle::HostConnectionInfo(
+                          host_address, cluster_name, target_count, dispatcher_, extension_.get()));
   }
 
   // Helper to create a mock host.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -14,6 +14,7 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator.h"
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension.h"
 
+#include "test/common/stats/stat_test_utility.h"
 #include "test/common/tls/mock_ssl_handshaker.h"
 #include "test/mocks/api/mocks.h"
 #include "test/mocks/event/mocks.h"
@@ -21,6 +22,7 @@
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/simulated_time_system.h"
 #include "test/test_common/threadsafe_singleton_injector.h"
 
 #include "gmock/gmock.h"
@@ -41,9 +43,16 @@ namespace ReverseConnection {
 
 using TransportSockets::Tls::MockSslHandshakerImpl;
 
+// Fully-qualified name of the setup-latency histogram: the fixture's scope prefix followed by the
+// stat prefix configured on the extension.
+constexpr char kTunnelSetupTimeHistogram[] = "test_scope.reverse_connections.tunnel_setup_time";
+
+// Deadline the extension arms when max_tunnel_setup_time is left unset in config.
+constexpr std::chrono::milliseconds kDefaultSetupDeadline{30000};
+
 // ReverseConnectionIOHandle Test Class.
 
-class ReverseConnectionIOHandleTest : public testing::Test {
+class ReverseConnectionIOHandleTest : public Event::TestUsingSimulatedTime, public testing::Test {
 protected:
   ReverseConnectionIOHandleTest() {
     // Set up the stats scope.
@@ -117,7 +126,8 @@ protected:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context_;
   NiceMock<ThreadLocal::MockInstance> thread_local_;
-  Stats::IsolatedStoreImpl stats_store_;
+  // TestStore (rather than IsolatedStoreImpl) so tests can read back recorded histogram samples.
+  Stats::TestUtil::TestStore stats_store_;
   Stats::ScopeSharedPtr stats_scope_;
   NiceMock<Event::MockDispatcher> dispatcher_{"worker_0"};
 
@@ -214,13 +224,17 @@ protected:
   // Host Management Helpers.
 
   void maybeUpdateHostsMappingsAndConnections(const std::string& cluster_id,
-                                              const std::vector<std::string>& hosts) {
-    io_handle_->maybeUpdateHostsMappingsAndConnections(cluster_id, hosts);
+                                              const std::vector<std::string>& hosts,
+                                              uint32_t reverse_connection_count = 1) {
+    RemoteClusterConnectionConfig cluster_config(cluster_id, reverse_connection_count);
+    io_handle_->maybeUpdateHostsMappingsAndConnections(cluster_id, hosts, cluster_config);
   }
 
   bool shouldAttemptConnectionToHost(const std::string& host_address,
-                                     const std::string& cluster_name) {
-    return io_handle_->shouldAttemptConnectionToHost(host_address, cluster_name);
+                                     const std::string& cluster_name,
+                                     uint32_t reverse_connection_count = 1) {
+    RemoteClusterConnectionConfig cluster_config(cluster_name, reverse_connection_count);
+    return io_handle_->shouldAttemptConnectionToHost(host_address, cluster_name, cluster_config);
   }
 
   void trackConnectionFailure(const std::string& host_address, const std::string& cluster_name) {
@@ -282,20 +296,37 @@ protected:
 
   void addHostConnectionInfo(const std::string& host_address, const std::string& cluster_name,
                              uint32_t target_count) {
-    io_handle_->host_to_conn_info_map_[host_address] =
-        ReverseConnectionIOHandle::HostConnectionInfo{
-            host_address,
-            cluster_name,
-            {},           // connection_keys - empty set initially
-            target_count, // target_connection_count
-            0,            // failure_count
-            // last_failure_time
-            std::chrono::steady_clock::now(), // NO_CHECK_FORMAT(real_time)
-            // backoff_until - set to epoch start so host is not in backoff initially
-            std::chrono::steady_clock::time_point{}, // NO_CHECK_FORMAT(real_time)
-            {}                                       // connection_states
-        };
+    io_handle_->host_to_conn_info_map_.emplace(
+        host_address, ReverseConnectionIOHandle::HostConnectionInfo(
+                          host_address, cluster_name, target_count, dispatcher_, extension_.get()));
   }
+
+  void addHostConnectionInfo(const std::string& host_address, const std::string& cluster_name,
+                             uint32_t target_count, ReverseTunnelInitiatorExtension* extension) {
+    io_handle_->host_to_conn_info_map_.emplace(
+        host_address, ReverseConnectionIOHandle::HostConnectionInfo(
+                          host_address, cluster_name, target_count, dispatcher_, extension));
+  }
+
+  // Captures the setup-deadline timer created by the next HostConnectionInfo construction.
+  Event::MockTimer* expectNextSetupTimer() {
+    auto timer = new NiceMock<Event::MockTimer>();
+    EXPECT_CALL(dispatcher_, createTimer_(_))
+        .WillOnce(Invoke([timer](std::function<void()> callback) {
+          timer->callback_ = callback;
+          return timer;
+        }));
+    return timer;
+  }
+
+  std::vector<uint64_t> setupTimeSamples() {
+    if (!stats_store_.histogramRecordedValues(kTunnelSetupTimeHistogram)) {
+      return {};
+    }
+    return stats_store_.histogramValues(kTunnelSetupTimeHistogram, /*clear=*/false);
+  }
+
+  void clearExtensionForTest() { io_handle_->extension_ = nullptr; }
 
   // Helper to create a mock host.
   Upstream::HostConstSharedPtr createMockHost(const std::string& address) {
@@ -816,7 +847,8 @@ TEST_F(ReverseConnectionIOHandleTest, ShouldAttemptConnectionToHostValidHost) {
   io_handle_disabled->trackConnectionFailure("192.168.1.1", "test-cluster");
 
   // With circuit breaker disabled, shouldAttemptConnectionToHost should always return true.
-  EXPECT_TRUE(io_handle_disabled->shouldAttemptConnectionToHost("192.168.1.1", "test-cluster"));
+  EXPECT_TRUE(io_handle_disabled->shouldAttemptConnectionToHost("192.168.1.1", "test-cluster",
+                                                                cluster_config));
 }
 
 // Test trackConnectionFailure puts host in backoff.
@@ -2078,6 +2110,7 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateOneReverseConnectionLogsWithoutPor
   EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
 
   auto mock_host = createMockPipeHost("/tmp/rev.sock");
+  addHostConnectionInfo("10.0.0.9", "test-cluster", 1);
   auto mock_connection = setupMockConnection();
   Upstream::MockHost::MockCreateConnectionData success_conn_data;
   success_conn_data.connection_ = mock_connection.get();
@@ -3372,8 +3405,11 @@ TEST_F(ReverseConnectionIOHandleTest, MarkTunnelDrainingDropsKeyAndDialsReplacem
   ASSERT_NE(io_handle_, nullptr);
 
   // Capture the retry timer created during initializeFileEvent so we can assert it is re-armed.
+  // HostConnectionInfo construction also creates a setup-deadline timer afterward.
   auto* mock_timer = new NiceMock<Event::MockTimer>();
-  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(dispatcher_, createTimer_(_))
+      .WillOnce(Return(mock_timer))
+      .WillRepeatedly(testing::ReturnNew<NiceMock<Event::MockTimer>>());
   EXPECT_CALL(*mock_timer, enableTimer(_, _)).Times(testing::AnyNumber());
 
   Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
@@ -3428,6 +3464,370 @@ TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedUnknownKeyIsNo
 
   io_handle_->onDownstreamConnectionClosed("203.0.113.9:9999", /*connection_id=*/0);
   EXPECT_TRUE(getHostToConnInfoMap().empty());
+}
+
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeCompletesWithinDeadline) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+  createTriggerPipe();
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  auto mock_connection = setupMockConnection();
+  Upstream::MockHost::MockCreateConnectionData conn_data;
+  conn_data.connection_ = mock_connection.get();
+  conn_data.host_description_ = mock_host;
+  EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+  mock_connection.release();
+
+  EXPECT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+  EXPECT_TRUE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_NE(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_TRUE(setup_timer->enabled());
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 0);
+  EXPECT_THAT(setupTimeSamples(), testing::IsEmpty())
+      << "no sample must be taken before the host reaches capacity";
+
+  // Elapse a known amount of simulated time so the recorded sample is exact rather than 0ms.
+  constexpr std::chrono::milliseconds setup_latency{250};
+  simTime().advanceTimeWait(setup_latency);
+
+  RCConnectionWrapper* wrapper = getConnectionWrappers()[0].get();
+  io_handle_->onConnectionDone("reverse connection accepted", wrapper, false);
+
+  EXPECT_FALSE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_FALSE(setup_timer->enabled());
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 0);
+  EXPECT_THAT(setupTimeSamples(), testing::ElementsAre(setup_latency.count()))
+      << "reaching capacity within the deadline must record exactly one setup-time sample";
+}
+
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeExceededSkipsHistogramOnLateSuccess) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+  createTriggerPipe();
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  auto mock_connection = setupMockConnection();
+  Upstream::MockHost::MockCreateConnectionData conn_data;
+  conn_data.connection_ = mock_connection.get();
+  conn_data.host_description_ = mock_host;
+  EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+  mock_connection.release();
+
+  EXPECT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+  ASSERT_TRUE(setup_timer->enabled());
+  setup_timer->invokeCallback();
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 1);
+  EXPECT_FALSE(setup_timer->enabled());
+
+  RCConnectionWrapper* wrapper = getConnectionWrappers()[0].get();
+  io_handle_->onConnectionDone("reverse connection accepted", wrapper, false);
+
+  // Late completion after the deadline must not complete the span as a setup-time sample.
+  EXPECT_FALSE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 1);
+  EXPECT_THAT(setupTimeSamples(), testing::IsEmpty())
+      << "a host that finished after the deadline must not skew the setup-time histogram";
+}
+
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeWaitsForFullCapacity) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+  createTriggerPipe();
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 2);
+
+  auto mock_connection = setupMockConnection();
+  Upstream::MockHost::MockCreateConnectionData conn_data;
+  conn_data.connection_ = mock_connection.get();
+  conn_data.host_description_ = mock_host;
+  EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+  mock_connection.release();
+
+  EXPECT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+  ASSERT_TRUE(setup_timer->enabled());
+
+  RCConnectionWrapper* wrapper = getConnectionWrappers()[0].get();
+  io_handle_->onConnectionDone("reverse connection accepted", wrapper, false);
+  EXPECT_TRUE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_NE(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_TRUE(setup_timer->enabled());
+  EXPECT_THAT(setupTimeSamples(), testing::IsEmpty())
+      << "the first of two tunnels must not record a setup-time sample";
+
+  auto mock_connection2 = setupMockConnection();
+  auto local = std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1", 22222);
+  auto remote = std::make_shared<Network::Address::Ipv4Instance>("192.168.1.1", 8080);
+  auto provider = std::make_unique<Network::ConnectionInfoSetterImpl>(local, remote);
+  EXPECT_CALL(*mock_connection2, connectionInfoProvider())
+      .WillRepeatedly(
+          Invoke([&provider]() -> const Network::ConnectionInfoProvider& { return *provider; }));
+
+  auto wrapper2 = std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection2),
+                                                        mock_host, "test-cluster");
+  RCConnectionWrapper* wrapper2_ptr = wrapper2.get();
+  addWrapperToHostMap(wrapper2_ptr, "192.168.1.1");
+  pushConnectionWrapper(std::move(wrapper2));
+  io_handle_->onConnectionDone("reverse connection accepted", wrapper2_ptr, false);
+
+  EXPECT_FALSE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_FALSE(setup_timer->enabled());
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 0);
+  EXPECT_EQ(setupTimeSamples().size(), 1)
+      << "reaching full capacity must record exactly one sample for the whole episode";
+}
+
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeNotRearmedOnRetry) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  // The deadline is armed once per episode, with the configured (here defaulted) budget.
+  EXPECT_CALL(*setup_timer, enableTimer(kDefaultSetupDeadline, _));
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 2);
+
+  auto dial_once = [&]() {
+    auto mock_connection = setupMockConnection();
+    Upstream::MockHost::MockCreateConnectionData conn_data;
+    conn_data.connection_ = mock_connection.get();
+    conn_data.host_description_ = mock_host;
+    EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+    mock_connection.release();
+    EXPECT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+  };
+
+  dial_once();
+  const int64_t episode_stamp = *getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms;
+  dial_once();
+  EXPECT_EQ(*getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms, episode_stamp);
+  EXPECT_EQ(getConnectionWrappers().size(), 2);
+}
+
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeIncludesFailedAttemptBeforeRetry) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+  createTriggerPipe();
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  EXPECT_CALL(*setup_timer, enableTimer(kDefaultSetupDeadline, _));
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  auto dial_once = [&](std::unique_ptr<NiceMock<Network::MockClientConnection>>&& mock_connection) {
+    bool success = mock_connection != nullptr;
+    Upstream::MockHost::MockCreateConnectionData conn_data;
+    conn_data.connection_ = mock_connection.get();
+    conn_data.host_description_ = mock_host;
+    EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+    mock_connection.release();
+    EXPECT_EQ(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host), success);
+  };
+
+  dial_once(setupMockConnection());
+  ASSERT_EQ(getConnectionWrappers().size(), 1);
+  const int64_t episode_stamp = *getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms;
+  auto* const setup_span = getHostConnectionInfo("192.168.1.1").setup_time_span.get();
+
+  constexpr std::chrono::milliseconds failed_attempt_latency{100};
+  simTime().advanceTimeWait(failed_attempt_latency);
+  io_handle_->onConnectionDone("connection timeout", getConnectionWrappers()[0].get(), true);
+
+  EXPECT_TRUE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(*getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms, episode_stamp);
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").setup_time_span.get(), setup_span);
+  EXPECT_TRUE(setup_timer->enabled());
+  EXPECT_THAT(setupTimeSamples(), testing::IsEmpty())
+      << "a failed attempt must keep the establishment episode open";
+  EXPECT_THAT(getConnectionWrappers(), testing::IsEmpty());
+
+  // Return a null connection to simulate a failed conn attempt.
+  dial_once(nullptr);
+  constexpr std::chrono::milliseconds failed_conn_attempt_latency{100};
+  simTime().advanceTimeWait(failed_conn_attempt_latency);
+  EXPECT_TRUE(setup_timer->enabled());
+  EXPECT_THAT(setupTimeSamples(), testing::IsEmpty())
+      << "a failed attempt must keep the establishment episode open";
+  EXPECT_THAT(getConnectionWrappers(), testing::IsEmpty());
+
+  dial_once(setupMockConnection());
+  ASSERT_EQ(getConnectionWrappers().size(), 1);
+  EXPECT_EQ(*getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms, episode_stamp);
+
+  constexpr std::chrono::milliseconds successful_attempt_latency{400};
+  simTime().advanceTimeWait(successful_attempt_latency);
+  io_handle_->onConnectionDone("reverse connection accepted", getConnectionWrappers()[0].get(),
+                               false);
+
+  EXPECT_THAT(setupTimeSamples(),
+              testing::ElementsAre((failed_attempt_latency + failed_conn_attempt_latency +
+                                    successful_attempt_latency)
+                                       .count()))
+      << "the sample must cover the complete episode, including the failed attempt";
+  EXPECT_FALSE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_FALSE(setup_timer->enabled());
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 0);
+}
+
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeSkippedWithNullExtension) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+  // Drop the extension after worker_dispatcher_ is set so getTimeSource() still works.
+  clearExtensionForTest();
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1, nullptr);
+
+  // Null-extension timer callback is a no-op.
+  setup_timer->enableTimer(std::chrono::milliseconds(1), nullptr);
+  setup_timer->invokeCallback();
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 0);
+
+  auto mock_connection = setupMockConnection();
+  Upstream::MockHost::MockCreateConnectionData conn_data;
+  conn_data.connection_ = mock_connection.get();
+  conn_data.host_description_ = mock_host;
+  EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+  mock_connection.release();
+
+  EXPECT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+  EXPECT_TRUE(getHostConnectionInfo("192.168.1.1").episode_initiation_time_ms.has_value());
+  EXPECT_EQ(getHostConnectionInfo("192.168.1.1").setup_time_span, nullptr);
+  EXPECT_FALSE(setup_timer->enabled());
+}
+
+// Once a host has dropped below its target connection count, the redial starts a fresh
+// establishment episode: a new timestamp, a re-armed deadline, and a second histogram sample.
+TEST_F(ReverseConnectionIOHandleTest, TunnelSetupTimeStartsNewEpisodeAfterCapacityDrops) {
+  setupThreadLocalSlot();
+  io_handle_ = createTestIOHandle(createDefaultTestConfig());
+  createTriggerPipe();
+
+  auto mock_thread_local_cluster = std::make_shared<NiceMock<Upstream::MockThreadLocalCluster>>();
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster("test-cluster"))
+      .WillRepeatedly(Return(mock_thread_local_cluster.get()));
+  auto mock_priority_set = std::make_shared<NiceMock<Upstream::MockPrioritySet>>();
+  EXPECT_CALL(*mock_thread_local_cluster, prioritySet())
+      .WillRepeatedly(ReturnRef(*mock_priority_set));
+  auto host_map = std::make_shared<Upstream::HostMap>();
+  auto mock_host = createMockHost("192.168.1.1");
+  (*host_map)["192.168.1.1"] = std::const_pointer_cast<Upstream::Host>(mock_host);
+  EXPECT_CALL(*mock_priority_set, crossPriorityHostMap()).WillRepeatedly(Return(host_map));
+
+  auto* setup_timer = expectNextSetupTimer();
+  // The same timer instance is reused across episodes, so it must be armed once per episode.
+  EXPECT_CALL(*setup_timer, enableTimer(kDefaultSetupDeadline, _)).Times(2);
+  addHostConnectionInfo("192.168.1.1", "test-cluster", 1);
+
+  // Dials one tunnel and drives its handshake to success.
+  auto complete_one_episode = [&](std::chrono::milliseconds setup_latency) {
+    auto mock_connection = setupMockConnection();
+    Upstream::MockHost::MockCreateConnectionData conn_data;
+    conn_data.connection_ = mock_connection.get();
+    conn_data.host_description_ = mock_host;
+    EXPECT_CALL(*mock_thread_local_cluster, tcpConn_(_)).WillOnce(Return(conn_data));
+    mock_connection.release();
+
+    ASSERT_TRUE(initiateOneReverseConnection("test-cluster", "192.168.1.1", mock_host));
+    simTime().advanceTimeWait(setup_latency);
+    io_handle_->onConnectionDone("reverse connection accepted", getConnectionWrappers()[0].get(),
+                                 false);
+  };
+
+  constexpr std::chrono::milliseconds first_latency{100};
+  complete_one_episode(first_latency);
+  ASSERT_THAT(setupTimeSamples(), testing::ElementsAre(first_latency.count()));
+
+  // Drop the established tunnel, leaving the host below its target count.
+  ASSERT_EQ(getHostConnectionInfo("192.168.1.1").connection_keys.size(), 1);
+  const std::string connection_key = *getHostConnectionInfo("192.168.1.1").connection_keys.begin();
+  io_handle_->onDownstreamConnectionClosed(connection_key, /*connection_id=*/0);
+  ASSERT_THAT(getHostConnectionInfo("192.168.1.1").connection_keys, testing::IsEmpty());
+
+  constexpr std::chrono::milliseconds second_latency{400};
+  complete_one_episode(second_latency);
+
+  EXPECT_THAT(setupTimeSamples(),
+              testing::ElementsAre(first_latency.count(), second_latency.count()))
+      << "the redial must be timed as a new episode rather than reusing the first timestamp";
+  EXPECT_FALSE(setup_timer->enabled());
+  EXPECT_EQ(extension_->tunnel_setup_time_exceeded_.value(), 0);
 }
 
 } // namespace ReverseConnection

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -176,6 +176,26 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, MaxReconnectBackoffOverride) {
   EXPECT_EQ(custom_extension->maxReconnectBackoffMs(), 5000);
 }
 
+TEST_F(ReverseTunnelInitiatorExtensionTest, MaxTunnelSetupTimeDefaults) {
+  envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
+      DownstreamReverseConnectionSocketInterface empty_config;
+  auto extension_with_default =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, empty_config);
+  EXPECT_EQ(extension_with_default->maxTunnelSetupTimeMs(), 30000);
+}
+
+TEST_F(ReverseTunnelInitiatorExtensionTest, MaxTunnelSetupTimeOverride) {
+  auto custom_config = config_;
+  custom_config.mutable_max_tunnel_setup_time()->set_seconds(5);
+  auto custom_extension =
+      std::make_unique<ReverseTunnelInitiatorExtension>(context_, custom_config);
+  EXPECT_EQ(custom_extension->maxTunnelSetupTimeMs(), 5000);
+  EXPECT_EQ(custom_extension->tunnel_setup_time_.name(),
+            "test_scope.reverse_connections.tunnel_setup_time");
+  EXPECT_EQ(custom_extension->tunnel_setup_time_exceeded_.name(),
+            "test_scope.reverse_connections.tunnel_setup_time_exceeded");
+}
+
 TEST_F(ReverseTunnelInitiatorExtensionTest, AdditionalHeadersDefaults) {
   EXPECT_TRUE(extension_->handshakeAdditionalHeaders().empty());
 }

--- a/test/extensions/filters/network/reverse_tunnel/integration_test.cc
+++ b/test/extensions/filters/network/reverse_tunnel/integration_test.cc
@@ -1,3 +1,4 @@
+#include <optional>
 #include <thread>
 
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
@@ -47,18 +48,34 @@ typed_config:
   enable_detailed_stats: true
 )EOF");
 
+    std::string max_tunnel_setup_time_yaml;
+    if (max_tunnel_setup_time_seconds_.has_value()) {
+      // Optional override for setup-latency deadline tests. Unset keeps the 30s default.
+      max_tunnel_setup_time_yaml =
+          fmt::format("\n  max_tunnel_setup_time: {}s", *max_tunnel_setup_time_seconds_);
+    }
     config_helper_.addBootstrapExtension(fmt::format(R"EOF(
 name: envoy.bootstrap.reverse_tunnel.downstream_socket_interface
 typed_config:
   "@type": type.googleapis.com/envoy.extensions.bootstrap.reverse_tunnel.downstream_socket_interface.v3.DownstreamReverseConnectionSocketInterface
   enable_detailed_stats: true
   http_handshake:
-    request_path: "{}"
+    request_path: "{}"{}
 )EOF",
-                                                     downstream_handshake_request_path_));
+                                                     downstream_handshake_request_path_,
+                                                     max_tunnel_setup_time_yaml));
 
     // Call parent initialize to complete setup.
     BaseIntegrationTest::initialize();
+  }
+
+  // Number of samples currently recorded in the initiator setup-latency histogram.
+  uint64_t tunnelSetupTimeSampleCount() {
+    auto histogram = test_server_->histogram("reverse_tunnel_initiator.tunnel_setup_time");
+    if (histogram == nullptr) {
+      return 0;
+    }
+    return TestUtility::readSampleCount(test_server_->server().dispatcher(), *histogram);
   }
 
 protected:
@@ -230,6 +247,8 @@ typed_config:
   std::string upstream_request_path_ =
       std::string(Extensions::Bootstrap::ReverseConnection::ReverseConnectionUtility::
                       DEFAULT_REVERSE_TUNNEL_REQUEST_PATH);
+  // When set, overrides DownstreamReverseConnectionSocketInterface.max_tunnel_setup_time.
+  std::optional<uint32_t> max_tunnel_setup_time_seconds_;
 
   // Set log level to debug for this test class.
   LogLevelSetter log_level_setter_ = LogLevelSetter(spdlog::level::trace);
@@ -452,6 +471,14 @@ void ReverseTunnelFilterIntegrationTest::runEndToEndReverseConnectionHandshakeSc
   test_server_->waitForGauge("reverse_tunnel_acceptor.clusters.e2e-cluster", Ge(1));
 
   test_server_->waitForCounter("reverse_tunnel.handshake.accepted", Ge(1));
+
+  // Successful full-capacity setup must record a setup-latency sample and must not trip the
+  // deadline counter.
+  test_server_->waitUntilHistogramHasSamples("reverse_tunnel_initiator.tunnel_setup_time",
+                                             std::chrono::milliseconds(5000));
+  EXPECT_EQ(tunnelSetupTimeSampleCount(), 1);
+  EXPECT_EQ(test_server_->counter("reverse_tunnel_initiator.tunnel_setup_time_exceeded")->value(),
+            0);
 
   BufferingStreamDecoderPtr admin_response = IntegrationUtil::makeSingleRequest(
       lookupPort("admin"), "POST", "/drain_listeners", "", Http::CodecType::HTTP1, GetParam());
@@ -678,6 +705,34 @@ TEST_P(ReverseTunnelFilterIntegrationTest, EndToEndReverseConnectionHandshakeCus
   downstream_handshake_request_path_ = "/custom/reverse";
   upstream_request_path_ = downstream_handshake_request_path_;
   runEndToEndReverseConnectionHandshakeScenario();
+}
+
+// I2: when the handshake is held past max_tunnel_setup_time, the initiator increments
+// tunnel_setup_time_exceeded and does not record a setup-latency histogram sample even if the
+// handshake later succeeds.
+TEST_P(ReverseTunnelFilterIntegrationTest, TunnelSetupTimeExceededWhenHandshakeDelayed) {
+  max_tunnel_setup_time_seconds_ = 1;
+  addDrainingAwareReverseConnectionHcmListener(/*reverse_connection_count=*/1);
+  initialize();
+
+  FakeRawConnectionPtr reverse_conn;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(reverse_conn));
+
+  // The initiator has dialed and armed the setup deadline, but the handshake response is withheld
+  // until after the deadline fires.
+  test_server_->waitForCounter("reverse_tunnel_initiator.tunnel_setup_time_exceeded", Eq(1),
+                               std::chrono::milliseconds(5000));
+  EXPECT_EQ(tunnelSetupTimeSampleCount(), 0);
+
+  completeReverseTunnelHandshake(*reverse_conn);
+
+  // Late success after the deadline must not become a setup-time sample.
+  timeSystem().advanceTimeWait(std::chrono::milliseconds(200));
+  EXPECT_EQ(tunnelSetupTimeSampleCount(), 0);
+  EXPECT_EQ(test_server_->counter("reverse_tunnel_initiator.tunnel_setup_time_exceeded")->value(),
+            1);
+
+  EXPECT_TRUE(reverse_conn->close());
 }
 
 TEST_P(ReverseTunnelFilterIntegrationTest, DrainingAwareHcmSendsGoAwayOnReverseConnections) {


### PR DESCRIPTION
## Commit Message
reverse_tunnel: add tunnel setup latency stats

## Description
Adds max_tunnel_setup_time on the downstream reverse-tunnel initiator and emits tunnel_setup_time (histogram) / tunnel_setup_time_exceeded (counter) for how long it takes a host to reach its configured connection count.
Attempts continue after the deadline; late completions are not recorded as setup-time samples. 
Episode timing is reused across retries within an establishment episode and resets when capacity drops.

## Testing
Unit tests + integ tests for the counter and histogram added.
