### PR TITLE
Replace C++ exception with Status in BuiltInStreamInfoCommandParser

### DIFF
--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -2664,7 +2664,7 @@ public:
       return nullptr;
     }
     // Check flags for the command.
-    THROW_IF_NOT_OK(Envoy::Formatter::CommandSyntaxChecker::verifySyntax(
+    RETURN_IF_NOT_OK(Envoy::Formatter::CommandSyntaxChecker::verifySyntax(
         (*it).second.first, command, sub_command, max_length));
 
     StreamInfoFormatterResult result = (*it).second.second(sub_command, max_length);

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -5653,8 +5653,8 @@ TEST(SubstitutionFormatterTest, PercentEscapingEdgeCase) {
 
 TEST(SubstitutionFormatterTest, EnvironmentFormatterTest) {
   {
-    EXPECT_THROW_WITH_MESSAGE(SubstitutionFormatParser::parse("%ENVIRONMENT()%").IgnoreError(),
-                              EnvoyException, "ENVIRONMENT requires parameters");
+    EXPECT_THAT(SubstitutionFormatParser::parse("%ENVIRONMENT()%"),
+                HasStatus(absl::StatusCode::kInvalidArgument, "ENVIRONMENT requires parameters"));
   }
 
   {

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -112,7 +112,6 @@ paths:
     - source/common/network/io_socket_handle_base_impl.cc
     - source/common/network/address_impl.cc
     - source/common/formatter/http_specific_formatter.cc
-    - source/common/formatter/stream_info_formatter.cc
     - source/common/formatter/substitution_formatter.cc
     - source/common/stats/tag_extractor_impl.cc
     - source/common/protobuf/yaml_utility.cc


### PR DESCRIPTION
All callers already have Status checks.

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
