### PR TITLE
quic: promote HTTP/3 API status from alpha to stable

### DIFF
--- a/api/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
+++ b/api/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
@@ -73,9 +73,6 @@ message HttpProtocolOptions {
 
       config.core.v3.Http2ProtocolOptions http2_protocol_options = 2;
 
-      // .. warning::
-      //   QUIC upstream support is currently not ready for internet use.
-      //   Please see :ref:`here <arch_overview_http3>` for details.
       config.core.v3.Http3ProtocolOptions http3_protocol_options = 3;
     }
   }
@@ -90,9 +87,6 @@ message HttpProtocolOptions {
 
     config.core.v3.Http2ProtocolOptions http2_protocol_options = 2;
 
-    // .. warning::
-    //   QUIC upstream support is currently not ready for internet use.
-    //   Please see :ref:`here <arch_overview_http3>` for details.
     config.core.v3.Http3ProtocolOptions http3_protocol_options = 3;
   }
 
@@ -111,14 +105,10 @@ message HttpProtocolOptions {
     config.core.v3.Http2ProtocolOptions http2_protocol_options = 2;
 
     // Unlike HTTP/1 and HTTP/2, HTTP/3 will not be configured unless it is
-    // present, and (soon) only if there is an indication of server side
+    // present, and only if there is an indication of server side
     // support.
     // See :ref:`here <arch_overview_http3_upstream>` for more information on
     // when HTTP/3 will be used, and when Envoy will fail over to TCP.
-    //
-    // .. warning::
-    //   QUIC upstream support is currently not ready for internet use.
-    //   Please see :ref:`here <arch_overview_http3>` for details.
     config.core.v3.Http3ProtocolOptions http3_protocol_options = 3;
 
     // The presence of alternate protocols cache options causes the use of the

--- a/api/envoy/type/v3/http.proto
+++ b/api/envoy/type/v3/http.proto
@@ -14,11 +14,6 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 
 enum CodecClientType {
   HTTP1 = 0;
-
   HTTP2 = 1;
-
-  // [#not-implemented-hide:] QUIC implementation is not production ready yet. Use this enum with
-  // caution to prevent accidental execution of QUIC code. I.e. `!= HTTP2` is no longer sufficient
-  // to distinguish HTTP1 and HTTP2 traffic.
   HTTP3 = 2;
 }

--- a/changelogs/current/minor_behavior_changes/quic__promote-http3-to-stable.rst
+++ b/changelogs/current/minor_behavior_changes/quic__promote-http3-to-stable.rst
@@ -1,0 +1,3 @@
+Promoted QUIC/HTTP3 from alpha to stable. This includes all QUIC extensions and upstream HTTP/3 support.
+HTTP/3 downstream was already considered production-ready, and HTTP/3 upstream is now also considered
+stable.

--- a/docs/root/intro/arch_overview/http/http3.rst
+++ b/docs/root/intro/arch_overview/http/http3.rst
@@ -3,13 +3,6 @@
 HTTP/3 overview
 ===============
 
-.. warning::
-
-  While HTTP/3 **downstream support is deemed ready for production use**, improvements are ongoing,
-  tracked in the `area-quic <https://github.com/envoyproxy/envoy/labels/area%2Fquic>`_ tag.
-
-  HTTP/3 upstream support is alpha - key features are implemented but have not been tested at scale.
-
 .. _arch_overview_http3_downstream:
 
 HTTP/3 downstream

--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1381,21 +1381,21 @@ envoy.quic.proof_source.filter_chain:
   categories:
   - envoy.quic.proof_source
   security_posture: robust_to_untrusted_downstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.proof_source.v3.ProofSourceConfig
 envoy.quic.server_preferred_address.fixed:
   categories:
   - envoy.quic.server_preferred_address
   security_posture: robust_to_untrusted_downstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.server_preferred_address.v3.FixedServerPreferredAddressConfig
 envoy.quic.server_preferred_address.datasource:
   categories:
   - envoy.quic.server_preferred_address
   security_posture: robust_to_untrusted_downstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.server_preferred_address.v3.DataSourceServerPreferredAddressConfig
 envoy.udp_packet_writer.default:
@@ -1416,21 +1416,21 @@ envoy.quic.deterministic_connection_id_generator:
   categories:
   - envoy.quic.connection_id_generator
   security_posture: robust_to_untrusted_downstream_and_upstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.connection_id_generator.v3.DeterministicConnectionIdGeneratorConfig
 envoy.quic.connection_id_generator.quic_lb:
   categories:
   - envoy.quic.connection_id_generator
   security_posture: unknown
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.connection_id_generator.quic_lb.v3.Config
 envoy.quic.crypto_stream.server.quiche:
   categories:
   - envoy.quic.server.crypto_stream
   security_posture: robust_to_untrusted_downstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.crypto_stream.v3.CryptoServerStreamConfig
 envoy.rate_limit_descriptors.expr:
@@ -2413,14 +2413,14 @@ envoy.quic.connection_debug_visitor.basic:
   categories:
   - envoy.quic.connection_debug_visitor
   security_posture: requires_trusted_downstream_and_upstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.connection_debug_visitor.v3.BasicConfig
 envoy.quic.connection_debug_visitor.quic_stats:
   categories:
   - envoy.quic.connection_debug_visitor
   security_posture: robust_to_untrusted_downstream_and_upstream
-  status: alpha
+  status: stable
   type_urls:
   - envoy.extensions.quic.connection_debug_visitor.quic_stats.v3.Config
 envoy.filters.network.generic_proxy:


### PR DESCRIPTION
QUIC/HTTP3 is well-supported both internally and externally in Envoy. CVEs in it are treated with the highest priority. It's long-overdue to take it out of alpha.

Changes:
- Remove 'QUIC upstream support is currently not ready for internet use' warnings from http_protocol_options.proto (ExplicitHttpConfig, UseDownstreamHttpConfig, AutoHttpConfig).
- Remove stale '(soon)' qualifier from AutoHttpConfig comment.
- Remove 'QUIC implementation is not production ready yet' comment from the HTTP3 CodecClientType enum in http.proto.
- Remove the alpha/not-production-ready warning from the HTTP/3 arch overview documentation.
- Promote all QUIC extensions from alpha to stable in extensions_metadata.yaml:
  - envoy.quic.proof_source.filter_chain
  - envoy.quic.server_preferred_address.fixed
  - envoy.quic.server_preferred_address.datasource
  - envoy.quic.deterministic_connection_id_generator
  - envoy.quic.connection_id_generator.quic_lb
  - envoy.quic.crypto_stream.server.quiche
  - envoy.quic.connection_debug_visitor.basic
  - envoy.quic.connection_debug_visitor.quic_stats

Risk Level: Low (documentation and metadata only)
Testing: N/A (no code changes)

Created with AI