### PR TITLE
composite cluster: add optional per-request order from dynamic metadata

### DIFF
--- a/api/envoy/extensions/clusters/composite/v3/BUILD
+++ b/api/envoy/extensions/clusters/composite/v3/BUILD
@@ -5,5 +5,8 @@ load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
 licenses(["notice"])  # Apache 2
 
 api_proto_package(
-    deps = ["@xds//udpa/annotations:pkg"],
+    deps = [
+        "//envoy/type/metadata/v3:pkg",
+        "@xds//udpa/annotations:pkg",
+    ],
 )

--- a/api/envoy/extensions/clusters/composite/v3/cluster.proto
+++ b/api/envoy/extensions/clusters/composite/v3/cluster.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.clusters.composite.v3;
 
+import "envoy/type/metadata/v3/metadata.proto";
+
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
@@ -20,8 +22,12 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // health-based selection, the composite cluster uses the retry attempt count to
 // deterministically select which sub-cluster to route to.
 //
-// When retry attempts exceed the number of configured clusters, requests will fail with no
-// host available.
+// When retry attempts exceed the length of the order in effect for the request, requests will
+// fail with no host available.
+//
+// The order may optionally be chosen per request by a filter, by configuring
+// :ref:`order_metadata_key
+// <envoy_v3_api_field_extensions.clusters.composite.v3.ClusterConfig.order_metadata_key>`.
 //
 // Example configuration:
 //
@@ -49,7 +55,52 @@ message ClusterConfig {
 
   // List of clusters to use for request routing. The first cluster is used for the
   // initial request (attempt 1), the second cluster for the first retry (attempt 2),
-  // and so on. Must contain at least one cluster. When retry attempts exceed the number
-  // of configured clusters, requests will fail with no host available.
+  // and so on. Must contain at least one cluster. When retry attempts exceed the length of the
+  // order in effect for the request, requests will fail with no host available. A cluster must
+  // not name the composite cluster that contains it.
+  //
+  // This list is also the allowlist for :ref:`order_metadata_key
+  // <envoy_v3_api_field_extensions.clusters.composite.v3.ClusterConfig.order_metadata_key>`.
   repeated ClusterEntry clusters = 1 [(validate.rules).repeated = {min_items: 1}];
+
+  // Optional dynamic metadata key holding a per-request cluster order that replaces
+  // :ref:`clusters <envoy_v3_api_field_extensions.clusters.composite.v3.ClusterConfig.clusters>`
+  // for that request.
+  //
+  // The key is resolved against the request's dynamic metadata and must hold a list of strings,
+  // each naming a cluster. Entries that do not name a cluster present in ``clusters`` are
+  // ignored, so ``clusters`` acts as an allowlist and a request can never reach a cluster the
+  // configuration did not authorize. Entries may repeat, in which case the same cluster is used
+  // for more than one attempt. Attempt 1 uses the first surviving entry, attempt 2 the second,
+  // and so on; when attempts exceed the length of the surviving list, requests fail with no host
+  // available, just as they do with the static order.
+  //
+  // If the key is absent, does not hold a list, or no entry names a configured cluster, the
+  // statically configured ``clusters`` order is used. Malformed metadata never fails a request.
+  // Selection remains deterministic and does not consider sub-cluster health: an entry naming a
+  // cluster with no healthy hosts still consumes its attempt.
+  //
+  // The list is read again on each attempt and indexed by that attempt's number, so a filter that
+  // modifies it between retries must leave the already-consumed prefix in place and only append
+  // or replace later entries. Removing consumed entries shifts every remaining entry forward and
+  // will end the retry sequence early.
+  //
+  // The metadata namespace must not be ``envoy.lb``, which the router reserves: every field the
+  // request carries there is merged into the load balancer's
+  // :ref:`metadata match criteria <envoy_v3_api_field_config.route.v3.RouteAction.metadata_match>`,
+  // so an order list stored under it becomes a match criterion no host can satisfy.
+  //
+  // For example, given ``clusters`` of ``[primary, secondary, fallback]`` and:
+  //
+  // .. code-block:: yaml
+  //
+  //     order_metadata_key:
+  //       key: envoy.clusters.composite
+  //       path:
+  //       - key: order
+  //
+  // a request whose ``envoy.clusters.composite`` dynamic metadata contains
+  // ``order: ["fallback", "primary"]`` is routed to ``fallback`` on attempt 1 and ``primary`` on
+  // attempt 2, and fails on attempt 3.
+  type.metadata.v3.MetadataKey order_metadata_key = 2;
 }

--- a/changelogs/current/new_features/composite_cluster__per-request-order-metadata.rst
+++ b/changelogs/current/new_features/composite_cluster__per-request-order-metadata.rst
@@ -1,0 +1,7 @@
+Added :ref:`order_metadata_key
+<envoy_v3_api_field_extensions.clusters.composite.v3.ClusterConfig.order_metadata_key>` to the
+composite cluster, allowing the sub-cluster order for a single request to be supplied by a filter
+as a list of strings in request dynamic metadata. Names that are not present in :ref:`clusters
+<envoy_v3_api_field_extensions.clusters.composite.v3.ClusterConfig.clusters>` are ignored, so the
+configured list remains the allowlist, and absent or malformed metadata falls back to the
+configured order without failing the request.

--- a/docs/root/intro/arch_overview/upstream/composite_cluster.rst
+++ b/docs/root/intro/arch_overview/upstream/composite_cluster.rst
@@ -59,8 +59,74 @@ The composite cluster uses a sequential selection strategy based on retry attemp
 * **Second retry** (attempt 3): Uses the third cluster.
 * **Further retries**: Fail with no host available.
 
-When retry attempts exceed the number of configured clusters, requests fail with no host available.
-Configure the number of retries in your retry policy to match your cluster configuration.
+When retry attempts exceed the length of the order in effect for the request, requests fail with
+no host available. With no per-request order that length is the number of configured clusters, so
+configure the number of retries in your retry policy to match your cluster configuration.
+
+Dynamic order
+-------------
+
+The order above is fixed at configuration time and is the same for every request. Setting
+:ref:`order_metadata_key
+<envoy_v3_api_field_extensions.clusters.composite.v3.ClusterConfig.order_metadata_key>` additionally
+lets a filter choose the order for a single request, while configuration keeps ownership of the set
+of clusters a request may reach:
+
+.. code-block:: yaml
+
+  cluster_type:
+    name: envoy.clusters.composite
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+      clusters:
+      - name: primary_cluster
+      - name: secondary_cluster
+      - name: fallback_cluster
+      order_metadata_key:
+        key: envoy.clusters.composite
+        path:
+        - key: order
+
+A filter earlier in the chain, such as :ref:`ext_proc <config_http_filters_ext_proc>` or
+:ref:`set_metadata <config_http_filters_set_metadata>`, writes a list of cluster names at that key:
+
+.. code-block:: yaml
+
+  envoy.clusters.composite:
+    order: ["fallback_cluster", "primary_cluster"]
+
+.. warning::
+
+  Do not store the order in the ``envoy.lb`` metadata namespace. The router reserves it: every
+  field a request carries under ``envoy.lb`` is merged into the load balancer's
+  :ref:`metadata match criteria <envoy_v3_api_field_config.route.v3.RouteAction.metadata_match>`,
+  so an order list stored there becomes a match criterion that no host can satisfy, and requests
+  to sub-clusters using the :ref:`subset load balancer <arch_overview_load_balancer_subsets>`
+  fail with no healthy upstream.
+
+The effective order for the request is that list with any entry that does not name a configured
+cluster removed. In the example above, attempt 1 goes to ``fallback_cluster`` and attempt 2 to
+``primary_cluster``; attempt 3 fails with no host available, because the effective order has only
+two entries. A cluster may be named more than once, in which case it is used for more than one
+attempt.
+
+The rules are:
+
+* **Configuration is the allowlist**: entries naming a cluster that is not in ``clusters`` are
+  ignored, so a request can never reach a cluster the configuration did not authorize.
+* **Fallback is the configured order**: if the key is absent, does not hold a list, or no entry
+  names a configured cluster, the configured ``clusters`` order is used. Malformed metadata never
+  fails a request.
+* **Overflow is unchanged**: attempts past the end of the effective order fail with no host
+  available, exactly as they do past the end of the configured order. The supplied order replaces
+  the configured one rather than prefixing it. Note that a list containing repeated names can be
+  longer than ``clusters``, and then permits more attempts than there are configured clusters.
+* **Indexed by attempt number**: the list is read again on each attempt and indexed by that
+  attempt's number, not consumed entry by entry. A filter that modifies the list between retries
+  must leave the already-consumed prefix in place and only append or replace later entries;
+  removing consumed entries shifts every remaining entry forward and ends the sequence early.
+* **Still health-blind**: as with the configured order, selection does not consider sub-cluster
+  health. An entry naming a cluster with no healthy hosts still consumes its attempt.
 
 Retry policy coordination
 -------------------------
@@ -82,8 +148,8 @@ Important considerations
   fail according to that sub-cluster's load balancing behavior, potentially triggering another retry
   attempt if configured.
 * **Deterministic routing**: The same retry attempt will always target the same cluster given
-  identical configuration. Cluster selection is based solely on retry attempt count, not on the
-  health status of sub-clusters.
+  identical configuration and, where used, identical order metadata. Cluster selection is based
+  solely on retry attempt count, not on the health status of sub-clusters.
 * **Thread-local clustering**: Cluster selection occurs at the thread-local level for optimal
   performance.
 * **Sub-cluster health**: Unlike the aggregate cluster, the composite cluster does not consider
@@ -93,16 +159,19 @@ Important considerations
 Comparison with aggregate cluster
 ---------------------------------
 
-+------------------+---------------------------+-------------------------------+
-| Feature          | Aggregate Cluster         | Composite Cluster             |
-+==================+===========================+===============================+
-| Selection basis  | Health status             | Retry attempt count           |
-+------------------+---------------------------+-------------------------------+
-| Primary use case | Health-based failover     | Retry progression             |
-+------------------+---------------------------+-------------------------------+
-| Overflow handling| Health-dependent          | Fails request                 |
-+------------------+---------------------------+-------------------------------+
-| Predictability   | Health-dependent          | Fully deterministic           |
-+------------------+---------------------------+-------------------------------+
++------------------+---------------------------+-----------------------------------------+
+| Feature          | Aggregate Cluster         | Composite Cluster                       |
++==================+===========================+=========================================+
+| Selection basis  | Health status             | Retry attempt count                     |
++------------------+---------------------------+-----------------------------------------+
+| Primary use case | Health-based failover     | Retry progression                       |
++------------------+---------------------------+-----------------------------------------+
+| Order source     | Configuration             | Configuration, optionally overridden    |
+|                  |                           | per request via dynamic metadata        |
++------------------+---------------------------+-----------------------------------------+
+| Overflow handling| Health-dependent          | Fails request                           |
++------------------+---------------------------+-----------------------------------------+
+| Predictability   | Health-dependent          | Fully deterministic                     |
++------------------+---------------------------+-----------------------------------------+
 
 

--- a/source/extensions/clusters/composite/BUILD
+++ b/source/extensions/clusters/composite/BUILD
@@ -16,6 +16,7 @@ envoy_cc_extension(
         "lb_context.h",
     ],
     deps = [
+        "//source/common/config:metadata_lib",
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
         "//source/extensions/load_balancing_policies/common:load_balancer_lib",

--- a/source/extensions/clusters/composite/cluster.cc
+++ b/source/extensions/clusters/composite/cluster.cc
@@ -7,28 +7,52 @@
 
 #include "source/common/common/assert.h"
 
+#include "absl/strings/str_cat.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Clusters {
 namespace Composite {
 
+CompositeClusterConfig::CompositeClusterConfig(
+    const envoy::extensions::clusters::composite::v3::ClusterConfig& config) {
+  clusters_.reserve(config.clusters_size());
+  for (const auto& entry : config.clusters()) {
+    clusters_.push_back(entry.name());
+  }
+
+  index_by_name_.reserve(clusters_.size());
+  for (size_t i = 0; i < clusters_.size(); ++i) {
+    // First occurrence wins if the same cluster is configured more than once.
+    index_by_name_.emplace(clusters_[i], i);
+  }
+
+  if (config.has_order_metadata_key()) {
+    order_metadata_key_.emplace(config.order_metadata_key());
+  }
+}
+
 Cluster::Cluster(const envoy::config::cluster::v3::Cluster& cluster,
                  const envoy::extensions::clusters::composite::v3::ClusterConfig& config,
                  Upstream::ClusterFactoryContext& context, absl::Status& creation_status)
     : Upstream::ClusterImplBase(cluster, context, creation_status),
-      cluster_manager_(context.serverFactoryContext().clusterManager()), clusters_([&config]() {
-        auto clusters = std::make_shared<ClusterSet>();
-        clusters->reserve(config.clusters_size());
-        for (const auto& entry : config.clusters()) {
-          clusters->push_back(entry.name());
-        }
-        return clusters;
-      }()) {}
+      cluster_manager_(context.serverFactoryContext().clusterManager()),
+      config_(std::make_shared<const CompositeClusterConfig>(config)) {
+  if (!creation_status.ok()) {
+    return;
+  }
+  // Selecting itself would re-enter this load balancer with an unchanged attempt count and
+  // recurse until the worker stack overflows.
+  if (config_->index_by_name_.contains(cluster.name())) {
+    creation_status = absl::InvalidArgumentError(
+        absl::StrCat("composite cluster '", cluster.name(), "' cannot list itself in 'clusters'"));
+  }
+}
 
 CompositeClusterLoadBalancer::CompositeClusterLoadBalancer(
     const Upstream::ClusterInfoConstSharedPtr& parent_info,
-    Upstream::ClusterManager& cluster_manager, const ClusterSetConstSharedPtr& clusters)
-    : parent_info_(parent_info), cluster_manager_(cluster_manager), clusters_(clusters) {
+    Upstream::ClusterManager& cluster_manager, const CompositeClusterConfigConstSharedPtr& config)
+    : parent_info_(parent_info), cluster_manager_(cluster_manager), config_(config) {
   handle_ = cluster_manager_.addThreadLocalClusterUpdateCallbacks(*this);
 }
 
@@ -47,53 +71,107 @@ CompositeClusterLoadBalancer::getAttemptCount(Upstream::LoadBalancerContext* con
   return 0;
 }
 
-std::optional<size_t>
-CompositeClusterLoadBalancer::mapAttemptToClusterIndex(uint32_t attempt_count) const {
+CompositeClusterLoadBalancer::SelectedCluster
+CompositeClusterLoadBalancer::clusterForAttempt(Upstream::LoadBalancerContext* context,
+                                                uint32_t attempt_count) const {
   // Attempt count is 1-based in Envoy router.
   // First attempt (count = 1) uses first cluster (index 0).
   if (attempt_count == 0) {
     ENVOY_LOG(warn, "invalid attempt count 0 in composite cluster '{}'", parent_info_->name());
-    return std::nullopt;
+    return {};
+  }
+  const size_t position = attempt_count - 1;
+
+  if (config_->order_metadata_key_.has_value() && context != nullptr) {
+    const StreamInfo::StreamInfo* stream_info = context->requestStreamInfo();
+    if (stream_info != nullptr) {
+      // metadataValue() returns the KIND_NOT_SET default instance for a missing namespace, a
+      // missing path segment, or a path running through a non-struct.
+      const Protobuf::Value& value = Envoy::Config::Metadata::metadataValue(
+          &stream_info->dynamicMetadata(), config_->order_metadata_key_.value());
+
+      if (value.kind_case() == Protobuf::Value::kListValue) {
+        // Take the entry at `position`, skipping anything that is not a string naming a
+        // configured cluster. Traversed rather than materialized, so this allocates nothing.
+        SelectedCluster selected;
+        size_t valid_entries = 0;
+        for (const Protobuf::Value& entry : value.list_value().values()) {
+          if (entry.kind_case() != Protobuf::Value::kStringValue) {
+            continue;
+          }
+          const auto it = config_->index_by_name_.find(entry.string_value());
+          if (it == config_->index_by_name_.end()) {
+            continue;
+          }
+          if (valid_entries == position) {
+            // Name the configuration's copy, so the view outlives the request.
+            selected = {config_->clusters_[it->second], it->second};
+            break;
+          }
+          ++valid_entries;
+        }
+
+        if (selected) {
+          return selected;
+        }
+        if (valid_entries > 0) {
+          // A usable override replaces the configured order wholesale, so an attempt past its end
+          // fails rather than falling back to the configured order's tail.
+          ENVOY_LOG(debug,
+                    "attempt {} exceeds the {} entry order override for composite cluster '{}'",
+                    attempt_count, valid_entries, parent_info_->name());
+          return {};
+        }
+        ENVOY_LOG(debug,
+                  "order override for composite cluster '{}' named no configured cluster; using "
+                  "the configured order",
+                  parent_info_->name());
+      }
+    }
   }
 
-  const size_t cluster_index = attempt_count - 1;
-
-  if (cluster_index < clusters_->size()) {
-    return cluster_index;
+  // Absent, wrong type, non-list or fully filtered out metadata: use the configured order.
+  if (position >= config_->clusters_.size()) {
+    return {};
   }
-
-  // Attempts exceed available clusters - fail the request.
-  return std::nullopt;
+  // Index by position, not by name: a name repeated in `clusters` would resolve to its first
+  // occurrence rather than the entry this attempt selected.
+  return {config_->clusters_[position], position};
 }
 
-Upstream::ThreadLocalCluster*
-CompositeClusterLoadBalancer::getClusterByIndex(size_t cluster_index) const {
-  if (cluster_index >= clusters_->size()) {
-    ENVOY_LOG(debug, "cluster index {} exceeds available clusters {} in composite cluster '{}'",
-              cluster_index, clusters_->size(), parent_info_->name());
-    return nullptr;
+CompositeClusterLoadBalancer::ResolvedCluster
+CompositeClusterLoadBalancer::resolveCluster(Upstream::LoadBalancerContext* context) const {
+  const uint32_t attempt_count = getAttemptCount(context);
+  const SelectedCluster selected = clusterForAttempt(context, attempt_count);
+  if (!selected) {
+    ENVOY_LOG(debug, "no cluster available for attempt {} in composite cluster '{}'", attempt_count,
+              parent_info_->name());
+    return {};
   }
 
-  const auto& cluster_name = (*clusters_)[cluster_index];
-  auto tlc = cluster_manager_.getThreadLocalCluster(cluster_name);
+  auto* tlc = cluster_manager_.getThreadLocalCluster(selected.name_);
   if (tlc == nullptr) {
-    ENVOY_LOG(debug, "cluster '{}' not found for composite cluster '{}'", cluster_name,
+    ENVOY_LOG(debug, "cluster '{}' not found for composite cluster '{}'", selected.name_,
               parent_info_->name());
+    return {};
   }
-  return tlc;
+
+  ENVOY_LOG(debug, "selecting cluster '{}' (index {}) for attempt {} in composite cluster '{}'",
+            selected.name_, selected.configured_index_, attempt_count, parent_info_->name());
+  return {tlc, selected.configured_index_};
 }
 
 void CompositeClusterLoadBalancer::onClusterAddOrUpdate(
     absl::string_view cluster_name, Upstream::ThreadLocalClusterCommand& get_cluster) {
   UNREFERENCED_PARAMETER(get_cluster);
-  if (std::find(clusters_->begin(), clusters_->end(), cluster_name) != clusters_->end()) {
+  if (config_->index_by_name_.contains(cluster_name)) {
     ENVOY_LOG(debug, "cluster '{}' added or updated for composite cluster '{}'", cluster_name,
               parent_info_->name());
   }
 }
 
 void CompositeClusterLoadBalancer::onClusterRemoval(absl::string_view cluster_name) {
-  if (std::find(clusters_->begin(), clusters_->end(), cluster_name) != clusters_->end()) {
+  if (config_->index_by_name_.contains(cluster_name)) {
     ENVOY_LOG(debug, "cluster '{}' removed from composite cluster '{}'", cluster_name,
               parent_info_->name());
   }
@@ -101,73 +179,41 @@ void CompositeClusterLoadBalancer::onClusterRemoval(absl::string_view cluster_na
 
 Upstream::HostSelectionResponse
 CompositeClusterLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
-  // Extract attempt count from context.
-  const uint32_t attempt_count = getAttemptCount(context);
-
-  // Map attempt count to cluster index.
-  const auto cluster_index_opt = mapAttemptToClusterIndex(attempt_count);
-  if (!cluster_index_opt.has_value()) {
-    ENVOY_LOG(debug, "no cluster available for attempt {} in composite cluster '{}'", attempt_count,
-              parent_info_->name());
+  const ResolvedCluster resolved = resolveCluster(context);
+  if (!resolved) {
     return {nullptr};
   }
-
-  const size_t cluster_index = cluster_index_opt.value();
-
-  // Get the target cluster.
-  auto* cluster = getClusterByIndex(cluster_index);
-  if (cluster == nullptr) {
-    ENVOY_LOG(debug, "cluster index {} not available for attempt {} in composite cluster '{}'",
-              cluster_index, attempt_count, parent_info_->name());
-    return {nullptr};
-  }
-
-  ENVOY_LOG(debug, "selecting cluster '{}' (index {}) for attempt {} in composite cluster '{}'",
-            cluster->info()->name(), cluster_index, attempt_count, parent_info_->name());
 
   // Create wrapped context with cluster information.
-  CompositeLoadBalancerContext composite_context(context, cluster_index);
+  CompositeLoadBalancerContext composite_context(context, resolved.configured_index_);
 
   // Delegate to selected cluster's load balancer.
-  return cluster->loadBalancer().chooseHost(&composite_context);
+  return resolved.cluster_->loadBalancer().chooseHost(&composite_context);
 }
 
 Upstream::HostConstSharedPtr
 CompositeClusterLoadBalancer::peekAnotherHost(Upstream::LoadBalancerContext* context) {
-  const uint32_t attempt_count = getAttemptCount(context);
-  const auto cluster_index_opt = mapAttemptToClusterIndex(attempt_count);
-  if (!cluster_index_opt.has_value()) {
+  const ResolvedCluster resolved = resolveCluster(context);
+  if (!resolved) {
     return nullptr;
   }
 
-  const size_t cluster_index = cluster_index_opt.value();
-  auto* cluster = getClusterByIndex(cluster_index);
-  if (cluster == nullptr) {
-    return nullptr;
-  }
-
-  CompositeLoadBalancerContext composite_context(context, cluster_index);
-  return cluster->loadBalancer().peekAnotherHost(&composite_context);
+  CompositeLoadBalancerContext composite_context(context, resolved.configured_index_);
+  return resolved.cluster_->loadBalancer().peekAnotherHost(&composite_context);
 }
 
 std::optional<Upstream::SelectedPoolAndConnection>
 CompositeClusterLoadBalancer::selectExistingConnection(Upstream::LoadBalancerContext* context,
                                                        const Upstream::Host& host,
                                                        std::vector<uint8_t>& hash_key) {
-  const uint32_t attempt_count = getAttemptCount(context);
-  const auto cluster_index_opt = mapAttemptToClusterIndex(attempt_count);
-  if (!cluster_index_opt.has_value()) {
+  const ResolvedCluster resolved = resolveCluster(context);
+  if (!resolved) {
     return std::nullopt;
   }
 
-  const size_t cluster_index = cluster_index_opt.value();
-  auto* cluster = getClusterByIndex(cluster_index);
-  if (cluster == nullptr) {
-    return std::nullopt;
-  }
-
-  CompositeLoadBalancerContext composite_context(context, cluster_index);
-  return cluster->loadBalancer().selectExistingConnection(&composite_context, host, hash_key);
+  CompositeLoadBalancerContext composite_context(context, resolved.configured_index_);
+  return resolved.cluster_->loadBalancer().selectExistingConnection(&composite_context, host,
+                                                                    hash_key);
 }
 
 OptRef<Envoy::Http::ConnectionPool::ConnectionLifetimeCallbacks>

--- a/source/extensions/clusters/composite/cluster.h
+++ b/source/extensions/clusters/composite/cluster.h
@@ -9,9 +9,12 @@
 #include "envoy/upstream/thread_local_cluster.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/config/metadata.h"
 #include "source/common/upstream/cluster_factory_impl.h"
 #include "source/common/upstream/upstream_impl.h"
 #include "source/extensions/clusters/composite/lb_context.h"
+
+#include "absl/container/flat_hash_map.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -20,7 +23,21 @@ namespace Composite {
 
 // Order matters so a vector must be used for rebuilds.
 using ClusterSet = std::vector<std::string>;
-using ClusterSetConstSharedPtr = std::shared_ptr<const ClusterSet>;
+
+// Immutable configuration built once on the main thread and shared by every worker load balancer.
+struct CompositeClusterConfig {
+  explicit CompositeClusterConfig(
+      const envoy::extensions::clusters::composite::v3::ClusterConfig& config);
+
+  // Configured cluster order, and the allowlist for metadata-supplied orders.
+  ClusterSet clusters_;
+  // Duplicate names map to their first index, so this resolves a name to an entry but cannot
+  // recover the index of an entry already located by position.
+  absl::flat_hash_map<std::string, size_t> index_by_name_;
+  // When set, the dynamic metadata key holding a per-request order override.
+  std::optional<Envoy::Config::MetadataKey> order_metadata_key_;
+};
+using CompositeClusterConfigConstSharedPtr = std::shared_ptr<const CompositeClusterConfig>;
 
 class Cluster : public Upstream::ClusterImplBase {
 public:
@@ -29,8 +46,11 @@ public:
     return Upstream::Cluster::InitializePhase::Secondary;
   }
 
+  // Statically configured cluster order.
+  const ClusterSet& clusters() const { return config_->clusters_; }
+
   Upstream::ClusterManager& cluster_manager_;
-  const ClusterSetConstSharedPtr clusters_;
+  const CompositeClusterConfigConstSharedPtr config_;
 
 protected:
   Cluster(const envoy::config::cluster::v3::Cluster& cluster,
@@ -52,7 +72,7 @@ class CompositeClusterLoadBalancer : public Upstream::LoadBalancer,
 public:
   CompositeClusterLoadBalancer(const Upstream::ClusterInfoConstSharedPtr& parent_info,
                                Upstream::ClusterManager& cluster_manager,
-                               const ClusterSetConstSharedPtr& clusters);
+                               const CompositeClusterConfigConstSharedPtr& config);
 
   // Upstream::ClusterUpdateCallbacks
   void onClusterAddOrUpdate(absl::string_view cluster_name,
@@ -70,17 +90,32 @@ public:
   // Extract retry attempt count from LoadBalancerContext.
   uint32_t getAttemptCount(Upstream::LoadBalancerContext* context) const;
 
-  // Map attempt count to cluster index.
-  // Returns nullopt when attempt count exceeds the number of available clusters.
-  std::optional<size_t> mapAttemptToClusterIndex(uint32_t attempt_count) const;
+  // `name_` points into this cluster's configuration, so it outlives the request.
+  struct SelectedCluster {
+    absl::string_view name_;
+    size_t configured_index_{0};
+    explicit operator bool() const { return !name_.empty(); }
+  };
 
-  // Get cluster by index.
-  Upstream::ThreadLocalCluster* getClusterByIndex(size_t cluster_index) const;
+  struct ResolvedCluster {
+    Upstream::ThreadLocalCluster* cluster_{nullptr};
+    size_t configured_index_{0};
+    explicit operator bool() const { return cluster_ != nullptr; }
+  };
+
+  // Cluster for `attempt_count`, which is 1-based: a per-request order override when
+  // `order_metadata_key_` is configured and the metadata supplies a usable one, otherwise the
+  // configured order. Falsy past the end of that order.
+  SelectedCluster clusterForAttempt(Upstream::LoadBalancerContext* context,
+                                    uint32_t attempt_count) const;
+
+  // Falsy when the attempt has no cluster, or the named cluster is absent on this worker.
+  ResolvedCluster resolveCluster(Upstream::LoadBalancerContext* context) const;
 
 private:
   Upstream::ClusterInfoConstSharedPtr parent_info_;
   Upstream::ClusterManager& cluster_manager_;
-  const ClusterSetConstSharedPtr clusters_;
+  const CompositeClusterConfigConstSharedPtr config_;
   Upstream::ClusterUpdateCallbacksHandlePtr handle_;
 };
 
@@ -93,7 +128,7 @@ public:
   // Upstream::LoadBalancerFactory
   Upstream::LoadBalancerPtr create(Upstream::LoadBalancerParams) override {
     return std::make_unique<CompositeClusterLoadBalancer>(
-        cluster_.info(), cluster_.cluster_manager_, cluster_.clusters_);
+        cluster_.info(), cluster_.cluster_manager_, cluster_.config_);
   }
   bool recreateOnHostChangeDeprecated() const override { return false; }
 

--- a/test/extensions/clusters/composite/BUILD
+++ b/test/extensions/clusters/composite/BUILD
@@ -49,6 +49,7 @@ envoy_extension_cc_test(
         "//source/common/config:protobuf_link_hacks",
         "//source/common/protobuf:utility_lib",
         "//source/extensions/clusters/composite:cluster",
+        "//source/extensions/filters/http/set_metadata:config",
         "//source/extensions/load_balancing_policies/cluster_provided:config",
         "//test/config:v2_link_hacks",
         "//test/integration:http_integration_lib",

--- a/test/extensions/clusters/composite/cluster_integration_test.cc
+++ b/test/extensions/clusters/composite/cluster_integration_test.cc
@@ -60,6 +60,12 @@ public:
       composite_config.add_clusters()->set_name("cluster_1");
       composite_config.add_clusters()->set_name("cluster_2");
 
+      if (order_metadata_key_enabled_) {
+        auto* order_key = composite_config.mutable_order_metadata_key();
+        order_key->set_key("envoy.clusters.composite");
+        order_key->add_path()->set_key("order");
+      }
+
       std::ignore = composite_cluster->mutable_cluster_type()->mutable_typed_config()->PackFrom(
           composite_config);
     });
@@ -84,6 +90,11 @@ public:
           }
         });
 
+    // Injects the per-request order as dynamic metadata ahead of routing.
+    if (!order_filter_config_.empty()) {
+      config_helper_.prependFilter(order_filter_config_);
+    }
+
     HttpIntegrationTest::initialize();
 
     // Verify clusters are created.
@@ -94,9 +105,84 @@ public:
 
   void setEnableAttemptCountHeaders(bool enable) { enable_attempt_count_headers_ = enable; }
 
+  // Reads the per-request order from envoy.clusters.composite:order.
+  void setOrderMetadataKeyEnabled(bool enabled) { order_metadata_key_enabled_ = enabled; }
+
+  // Installs a set_metadata filter writing `value_yaml` at envoy.clusters.composite:order.
+  void setOrderMetadata(absl::string_view value_yaml) {
+    order_filter_config_ = absl::StrCat(R"EOF(
+name: envoy.filters.http.set_metadata
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+  metadata:
+  - metadata_namespace: envoy.clusters.composite
+    allow_overwrite: true
+    value:
+      order: )EOF",
+                                        value_yaml, "\n");
+  }
+
+  // Drives one upstream attempt on `upstream_index`, responding with `status`. Returns rather
+  // than asserting, so an attempt landing on the wrong upstream names it instead of timing out
+  // and then crashing on a null connection.
+  ABSL_MUST_USE_RESULT testing::AssertionResult respondOnUpstream(size_t upstream_index,
+                                                                  absl::string_view status) {
+    if (!fake_upstreams_[upstream_index]->waitForHttpConnection(*dispatcher_,
+                                                                fake_upstream_connection_)) {
+      return testing::AssertionFailure()
+             << "timed out waiting for a connection on upstream " << upstream_index;
+    }
+    if (!fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_)) {
+      return testing::AssertionFailure()
+             << "timed out waiting for a stream on upstream " << upstream_index;
+    }
+    if (!upstream_request_->waitForEndStream(*dispatcher_)) {
+      return testing::AssertionFailure()
+             << "timed out waiting for end stream on upstream " << upstream_index;
+    }
+    upstream_request_->encodeHeaders(
+        Http::TestResponseHeaderMapImpl{{":status", std::string(status)}}, true);
+    return testing::AssertionSuccess();
+  }
+
+  // As above, then tears the connection down, so the next attempt cannot reuse a pooled one.
+  ABSL_MUST_USE_RESULT testing::AssertionResult
+  respondAndCloseOnUpstream(size_t upstream_index, absl::string_view status) {
+    const testing::AssertionResult result = respondOnUpstream(upstream_index, status);
+    if (!result) {
+      return result;
+    }
+    if (!fake_upstream_connection_->close()) {
+      return testing::AssertionFailure() << "failed to close upstream " << upstream_index;
+    }
+    if (!fake_upstream_connection_->waitForDisconnect()) {
+      return testing::AssertionFailure()
+             << "timed out waiting for upstream " << upstream_index << " to disconnect";
+    }
+    fake_upstream_connection_.reset();
+    return testing::AssertionSuccess();
+  }
+
+  IntegrationStreamDecoderPtr sendRequest() {
+    return codec_client_->makeRequestWithBody(
+        Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                       {":path", "/test"},
+                                       {":scheme", "http"},
+                                       {":authority", "test.example.com"}},
+        0);
+  }
+
+  void expectClusterRequestCounts(uint64_t cluster_0, uint64_t cluster_1, uint64_t cluster_2) {
+    EXPECT_EQ(cluster_0, test_server_->counter("cluster.cluster_0.upstream_rq_total")->value());
+    EXPECT_EQ(cluster_1, test_server_->counter("cluster.cluster_1.upstream_rq_total")->value());
+    EXPECT_EQ(cluster_2, test_server_->counter("cluster.cluster_2.upstream_rq_total")->value());
+  }
+
 private:
   uint32_t num_retries_{3};
   bool enable_attempt_count_headers_{false};
+  bool order_metadata_key_enabled_{false};
+  std::string order_filter_config_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, CompositeClusterIntegrationTest,
@@ -354,6 +440,167 @@ TEST_P(CompositeClusterIntegrationTest, RequestDetailsPreservedThroughRetries) {
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_0.upstream_rq_total")->value());
   EXPECT_EQ(1, test_server_->counter("cluster.cluster_1.upstream_rq_total")->value());
   EXPECT_EQ(0, test_server_->counter("cluster.cluster_2.upstream_rq_total")->value());
+}
+
+// A per-request order supplied as dynamic metadata replaces the configured order.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataReordersAttempts) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  setOrderMetadata(R"(["cluster_2", "cluster_0"])");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  // Attempt 1 follows the metadata's first entry rather than the configured first cluster.
+  ASSERT_TRUE(respondAndCloseOnUpstream(2, "503"));
+  // The retry follows the metadata's second entry.
+  ASSERT_TRUE(respondOnUpstream(0, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(1, 0, 1);
+}
+
+// Entries that do not name a configured cluster are ignored.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataUnknownNamesDropped) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  setOrderMetadata(R"(["not_a_cluster", "cluster_2", "also_missing", "cluster_1"])");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(2, "503"));
+  ASSERT_TRUE(respondOnUpstream(1, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(0, 1, 1);
+}
+
+// The same cluster may be named twice, consuming two attempts.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataDuplicateEntries) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  setOrderMetadata(R"(["cluster_1", "cluster_1", "cluster_0"])");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(1, "503"));
+  ASSERT_TRUE(respondAndCloseOnUpstream(1, "503"));
+  ASSERT_TRUE(respondOnUpstream(0, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(1, 2, 0);
+}
+
+// Attempts past the end of a supplied order fail rather than continuing into the configured order.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataShorterThanRetriesFails) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  setOrderMetadata(R"(["cluster_1"])");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(1, "503"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("503", response->headers().getStatusValue());
+
+  // No attempt spilled over into the configured order.
+  expectClusterRequestCounts(0, 1, 0);
+}
+
+// A list naming nothing configured falls back to the configured order.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataAllUnknownUsesConfiguredOrder) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  setOrderMetadata(R"(["nope_a", "nope_b"])");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(0, "503"));
+  ASSERT_TRUE(respondOnUpstream(1, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(1, 1, 0);
+}
+
+// Metadata that is not a list falls back to the configured order rather than failing.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataWrongTypeUsesConfiguredOrder) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  setOrderMetadata(R"("cluster_2")");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(0, "503"));
+  ASSERT_TRUE(respondOnUpstream(1, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(1, 1, 0);
+}
+
+// With the key configured but no metadata present, behavior is unchanged.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataAbsentUsesConfiguredOrder) {
+  setNumRetries(3);
+  setOrderMetadataKeyEnabled(true);
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(0, "503"));
+  ASSERT_TRUE(respondOnUpstream(1, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(1, 1, 0);
+}
+
+// The feature is opt-in: metadata is ignored when the cluster does not configure the key.
+TEST_P(CompositeClusterIntegrationTest, OrderMetadataIgnoredWhenKeyNotConfigured) {
+  setNumRetries(3);
+  setOrderMetadata(R"(["cluster_2", "cluster_0"])");
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequest();
+
+  ASSERT_TRUE(respondAndCloseOnUpstream(0, "503"));
+  ASSERT_TRUE(respondOnUpstream(1, "200"));
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  expectClusterRequestCounts(1, 1, 0);
 }
 
 } // namespace Composite

--- a/test/extensions/clusters/composite/cluster_test.cc
+++ b/test/extensions/clusters/composite/cluster_test.cc
@@ -39,6 +39,12 @@ public:
   CompositeClusterTest() = default;
 
   void initialize(const std::string& yaml_config) {
+    THROW_IF_NOT_OK_REF(initializeWithStatus(yaml_config));
+  }
+
+  // As above, but surfaces the construction status instead of throwing, for configs expected to
+  // be rejected at load time.
+  absl::Status initializeWithStatus(const std::string& yaml_config) {
     cluster_config_ = Upstream::parseClusterFromV3Yaml(yaml_config);
     THROW_IF_NOT_OK(Config::Utility::translateOpaqueConfig(
         cluster_config_.cluster_type().typed_config(),
@@ -50,7 +56,7 @@ public:
     absl::Status creation_status = absl::OkStatus();
     cluster_ = std::shared_ptr<Cluster>(
         new Cluster(cluster_config_, config_, factory_context, creation_status));
-    THROW_IF_NOT_OK_REF(creation_status);
+    return creation_status;
   }
 
   envoy::config::cluster::v3::Cluster cluster_config_;
@@ -75,9 +81,9 @@ cluster_type:
 )EOF";
 
   initialize(yaml);
-  EXPECT_EQ(2, cluster_->clusters_->size());
-  EXPECT_EQ("primary", (*cluster_->clusters_)[0]);
-  EXPECT_EQ("secondary", (*cluster_->clusters_)[1]);
+  EXPECT_EQ(2, cluster_->clusters().size());
+  EXPECT_EQ("primary", cluster_->clusters()[0]);
+  EXPECT_EQ("secondary", cluster_->clusters()[1]);
   EXPECT_EQ(Upstream::Cluster::InitializePhase::Secondary, cluster_->initializePhase());
 }
 
@@ -98,8 +104,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   // Test with null context.
   EXPECT_EQ(0, lb.getAttemptCount(nullptr));
@@ -123,8 +128,8 @@ cluster_type:
   EXPECT_EQ(0, lb.getAttemptCount(&context_null));
 }
 
-// Test cluster index mapping.
-TEST_F(CompositeClusterTest, ClusterIndexMapping) {
+// Test mapping of attempt count to cluster name using the configured order.
+TEST_F(CompositeClusterTest, ClusterNameForAttemptStaticOrder) {
   const std::string yaml = R"EOF(
 name: composite_cluster
 connect_timeout: 0.25s
@@ -140,23 +145,71 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   // Test invalid attempt 0.
-  EXPECT_FALSE(lb.mapAttemptToClusterIndex(0).has_value());
+  EXPECT_EQ("", lb.clusterForAttempt(nullptr, 0).name_);
 
   // Test normal mapping (1-based attempts).
-  EXPECT_EQ(0, lb.mapAttemptToClusterIndex(1).value()); // First attempt -> first cluster.
-  EXPECT_EQ(1, lb.mapAttemptToClusterIndex(2).value()); // Second attempt -> second cluster.
+  EXPECT_EQ("primary", lb.clusterForAttempt(nullptr, 1).name_);
+  EXPECT_EQ("secondary", lb.clusterForAttempt(nullptr, 2).name_);
 
   // Test overflow - should fail when attempts exceed available clusters.
-  EXPECT_FALSE(lb.mapAttemptToClusterIndex(3).has_value());
-  EXPECT_FALSE(lb.mapAttemptToClusterIndex(10).has_value());
+  EXPECT_EQ("", lb.clusterForAttempt(nullptr, 3).name_);
+  EXPECT_EQ("", lb.clusterForAttempt(nullptr, 10).name_);
 }
 
-// Test getClusterByIndex with bounds checking.
-TEST_F(CompositeClusterTest, GetClusterByIndexBoundsCheck) {
+// Selecting itself would recurse until the worker stack overflows.
+TEST_F(CompositeClusterTest, SelfReferenceRejected) {
+  const std::string yaml = R"EOF(
+name: composite_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cluster_type:
+  name: envoy.clusters.composite
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+    clusters:
+    - name: primary
+    - name: composite_cluster
+)EOF";
+
+  const absl::Status status = initializeWithStatus(yaml);
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(absl::StatusCode::kInvalidArgument, status.code());
+  EXPECT_THAT(std::string(status.message()), testing::HasSubstr("cannot list itself"));
+}
+
+// Each position reports its own index, not the index of the first occurrence of the name.
+TEST_F(CompositeClusterTest, DuplicateConfiguredNamesReportTheirOwnIndex) {
+  const std::string yaml = R"EOF(
+name: composite_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cluster_type:
+  name: envoy.clusters.composite
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+    clusters:
+    - name: primary
+    - name: secondary
+    - name: primary
+)EOF";
+
+  initialize(yaml);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  EXPECT_EQ("primary", lb.clusterForAttempt(nullptr, 1).name_);
+  EXPECT_EQ(0, lb.clusterForAttempt(nullptr, 1).configured_index_);
+  EXPECT_EQ("secondary", lb.clusterForAttempt(nullptr, 2).name_);
+  EXPECT_EQ(1, lb.clusterForAttempt(nullptr, 2).configured_index_);
+  // Attempt 3 is the second "primary" entry, at index 2 - not index 0.
+  EXPECT_EQ("primary", lb.clusterForAttempt(nullptr, 3).name_);
+  EXPECT_EQ(2, lb.clusterForAttempt(nullptr, 3).configured_index_);
+}
+
+// Test that resolveCluster returns nothing when the named cluster is unknown to the manager.
+TEST_F(CompositeClusterTest, ResolveClusterUnknownToClusterManager) {
   const std::string yaml = R"EOF(
 name: composite_cluster
 connect_timeout: 0.25s
@@ -172,16 +225,19 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
-  // Test out of bounds index.
-  EXPECT_EQ(nullptr, lb.getClusterByIndex(2));
-  EXPECT_EQ(nullptr, lb.getClusterByIndex(10));
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(context, requestStreamInfo()).WillRepeatedly(Return(&stream_info));
 
-  // Test that cluster manager returns nullptr for unknown cluster.
-  EXPECT_EQ(nullptr, lb.getClusterByIndex(0)); // primary doesn't exist in cluster manager.
-  EXPECT_EQ(nullptr, lb.getClusterByIndex(1)); // secondary doesn't exist in cluster manager.
+  // Neither configured cluster exists in the cluster manager.
+  EXPECT_CALL(stream_info, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(1)));
+  EXPECT_FALSE(static_cast<bool>(lb.resolveCluster(&context)));
+
+  // Attempts past the end of the configured order resolve to nothing as well.
+  EXPECT_CALL(stream_info, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(3)));
+  EXPECT_FALSE(static_cast<bool>(lb.resolveCluster(&context)));
 }
 
 // Test load balancer methods when no clusters are available.
@@ -200,8 +256,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -237,8 +292,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   // Test cluster removal for cluster in our list and unknown cluster.
   lb.onClusterRemoval("primary");
@@ -358,9 +412,9 @@ cluster_type:
 
   // This should still construct successfully even if clusters don't exist yet.
   initialize(yaml);
-  EXPECT_EQ(2, cluster_->clusters_->size());
-  EXPECT_EQ("missing_cluster", (*cluster_->clusters_)[0]);
-  EXPECT_EQ("another_missing_cluster", (*cluster_->clusters_)[1]);
+  EXPECT_EQ(2, cluster_->clusters().size());
+  EXPECT_EQ("missing_cluster", cluster_->clusters()[0]);
+  EXPECT_EQ("another_missing_cluster", cluster_->clusters()[1]);
 }
 
 // Test cluster update callbacks when clusters are added/updated.
@@ -380,8 +434,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   // Test onClusterAddOrUpdate for clusters in our list.
   NiceMock<Upstream::MockThreadLocalCluster> mock_cluster;
@@ -416,7 +469,7 @@ cluster_type:
 )EOF");
 
   CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
-                                  cluster_->clusters_);
+                                  cluster_->config_);
 
   // Set up mocks for successful delegation.
   NiceMock<Upstream::MockLoadBalancerContext> context;
@@ -453,7 +506,7 @@ cluster_type:
 )EOF");
 
   CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
-                                  cluster_->clusters_);
+                                  cluster_->config_);
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -488,8 +541,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -515,8 +567,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -542,7 +593,7 @@ cluster_type:
 )EOF");
 
   CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
-                                  cluster_->clusters_);
+                                  cluster_->config_);
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -648,8 +699,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   // Mock context for attempt 1 (should map to cluster index 0).
   NiceMock<Upstream::MockLoadBalancerContext> mock_context;
@@ -683,8 +733,7 @@ cluster_type:
 
   initialize(yaml);
 
-  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_,
-                                  cluster_->clusters_);
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
 
   NiceMock<Upstream::MockLoadBalancerContext> context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -696,6 +745,386 @@ cluster_type:
 
   auto result = lb.chooseHost(&context);
   EXPECT_EQ(nullptr, result.host);
+}
+
+// Fixture for the per-request order override supplied via request dynamic metadata.
+class CompositeClusterOrderMetadataTest : public CompositeClusterTest {
+public:
+  // Three configured clusters, with the order override key pointing at
+  // envoy.clusters.composite:order.
+  static constexpr absl::string_view ThreeClustersWithOrderKey = R"EOF(
+name: composite_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cluster_type:
+  name: envoy.clusters.composite
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+    clusters:
+    - name: cluster_0
+    - name: cluster_1
+    - name: cluster_2
+    order_metadata_key:
+      key: envoy.clusters.composite
+      path:
+      - key: order
+)EOF";
+
+  // The same three clusters with no order override configured.
+  static constexpr absl::string_view ThreeClustersNoOrderKey = R"EOF(
+name: composite_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cluster_type:
+  name: envoy.clusters.composite
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+    clusters:
+    - name: cluster_0
+    - name: cluster_1
+    - name: cluster_2
+)EOF";
+
+  void SetUp() override {
+    ON_CALL(context_, requestStreamInfo()).WillByDefault(Return(&stream_info_));
+  }
+
+  // MockStreamInfo returns its `metadata_` member by reference from dynamicMetadata(), so tests
+  // populate that member directly rather than adding an expectation.
+  void setOrder(const std::vector<std::string>& order) {
+    Protobuf::Value value;
+    // Unconditional, so an empty `order` stores an empty ListValue rather than KIND_NOT_SET.
+    auto* values = value.mutable_list_value();
+    for (const auto& name : order) {
+      values->add_values()->set_string_value(name);
+    }
+    setValue(value);
+  }
+
+  void setValue(const Protobuf::Value& value) {
+    (*(*stream_info_.metadata_.mutable_filter_metadata())["envoy.clusters.composite"]
+          .mutable_fields())["order"] = value;
+  }
+
+  // Name selected for `attempt`, which is 1-based.
+  absl::string_view nameForAttempt(CompositeClusterLoadBalancer& lb, uint32_t attempt) {
+    return lb.clusterForAttempt(&context_, attempt).name_;
+  }
+
+  NiceMock<Upstream::MockLoadBalancerContext> context_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
+};
+
+// The order override key is absent unless configured, and is parsed when it is.
+TEST_F(CompositeClusterOrderMetadataTest, OrderMetadataKeyParsing) {
+  initialize(std::string(ThreeClustersNoOrderKey));
+  EXPECT_FALSE(cluster_->config_->order_metadata_key_.has_value());
+
+  initialize(std::string(ThreeClustersWithOrderKey));
+  ASSERT_TRUE(cluster_->config_->order_metadata_key_.has_value());
+  EXPECT_EQ("envoy.clusters.composite", cluster_->config_->order_metadata_key_->key_);
+  EXPECT_THAT(cluster_->config_->order_metadata_key_->path_, testing::ElementsAre("order"));
+}
+
+// The allowlist is built from the configured clusters, and duplicates map to the first index.
+TEST_F(CompositeClusterOrderMetadataTest, AllowlistBuiltFromConfiguredClusters) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  EXPECT_EQ(3, cluster_->config_->index_by_name_.size());
+  EXPECT_EQ(0, cluster_->config_->index_by_name_.at("cluster_0"));
+  EXPECT_EQ(2, cluster_->config_->index_by_name_.at("cluster_2"));
+  EXPECT_FALSE(cluster_->config_->index_by_name_.contains("not_configured"));
+
+  initialize(R"EOF(
+name: composite_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cluster_type:
+  name: envoy.clusters.composite
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+    clusters:
+    - name: repeated_cluster
+    - name: other_cluster
+    - name: repeated_cluster
+)EOF");
+  EXPECT_EQ(3, cluster_->clusters().size());
+  EXPECT_EQ(2, cluster_->config_->index_by_name_.size());
+  EXPECT_EQ(0, cluster_->config_->index_by_name_.at("repeated_cluster"));
+}
+
+// A full reorder replaces the configured order for every attempt.
+TEST_F(CompositeClusterOrderMetadataTest, FullReorder) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  setOrder({"cluster_2", "cluster_0", "cluster_1"});
+  EXPECT_EQ("cluster_2", nameForAttempt(lb, 1));
+  EXPECT_EQ("cluster_0", nameForAttempt(lb, 2));
+  EXPECT_EQ("cluster_1", nameForAttempt(lb, 3));
+  EXPECT_EQ("", nameForAttempt(lb, 4));
+}
+
+// Attempts past the end of a subset fail rather than falling back to the configured tail.
+TEST_F(CompositeClusterOrderMetadataTest, OrderedSubsetOverflows) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  setOrder({"cluster_2", "cluster_0"});
+  EXPECT_EQ("cluster_2", nameForAttempt(lb, 1));
+  EXPECT_EQ("cluster_0", nameForAttempt(lb, 2));
+  EXPECT_EQ("", nameForAttempt(lb, 3));
+}
+
+// Names that are not configured are dropped, and the remaining entries keep their relative order.
+TEST_F(CompositeClusterOrderMetadataTest, UnknownNamesDropped) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  setOrder({"not_configured", "cluster_1", "also_not_configured", "cluster_0"});
+  EXPECT_EQ("cluster_1", nameForAttempt(lb, 1));
+  EXPECT_EQ("cluster_0", nameForAttempt(lb, 2));
+  EXPECT_EQ("", nameForAttempt(lb, 3));
+}
+
+// A cluster may legitimately be named more than once, consuming two attempts.
+TEST_F(CompositeClusterOrderMetadataTest, DuplicateEntriesConsumeSeparateAttempts) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  setOrder({"cluster_1", "cluster_1", "cluster_0"});
+  EXPECT_EQ("cluster_1", nameForAttempt(lb, 1));
+  EXPECT_EQ("cluster_1", nameForAttempt(lb, 2));
+  EXPECT_EQ("cluster_0", nameForAttempt(lb, 3));
+  EXPECT_EQ("", nameForAttempt(lb, 4));
+}
+
+// Non-string entries are skipped exactly like unknown names.
+TEST_F(CompositeClusterOrderMetadataTest, NonStringEntriesSkipped) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  Protobuf::Value value;
+  auto* values = value.mutable_list_value();
+  values->add_values()->set_number_value(42);
+  values->add_values()->set_string_value("cluster_2");
+  values->add_values()->set_bool_value(true);
+  values->add_values()->mutable_struct_value();
+  values->add_values()->set_string_value("cluster_0");
+  setValue(value);
+
+  EXPECT_EQ("cluster_2", nameForAttempt(lb, 1));
+  EXPECT_EQ("cluster_0", nameForAttempt(lb, 2));
+  EXPECT_EQ("", nameForAttempt(lb, 3));
+}
+
+// Every shape of unusable metadata falls back to the configured order rather than failing.
+TEST_F(CompositeClusterOrderMetadataTest, UnusableMetadataFallsBackToConfiguredOrder) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  const auto expectConfiguredOrder = [&]() {
+    EXPECT_EQ("cluster_0", nameForAttempt(lb, 1));
+    EXPECT_EQ("cluster_1", nameForAttempt(lb, 2));
+    EXPECT_EQ("cluster_2", nameForAttempt(lb, 3));
+    EXPECT_EQ("", nameForAttempt(lb, 4));
+  };
+
+  // No metadata at all.
+  expectConfiguredOrder();
+
+  // Wrong namespace.
+  (*(*stream_info_.metadata_.mutable_filter_metadata())["other.namespace"]
+        .mutable_fields())["order"]
+      .set_string_value("cluster_2");
+  expectConfiguredOrder();
+
+  // Right namespace, wrong key.
+  (*(*stream_info_.metadata_.mutable_filter_metadata())["envoy.clusters.composite"]
+        .mutable_fields())["other_key"]
+      .set_string_value("cluster_2");
+  expectConfiguredOrder();
+
+  // Value is a bare string rather than a list.
+  Protobuf::Value string_value;
+  string_value.set_string_value("cluster_2");
+  setValue(string_value);
+  expectConfiguredOrder();
+
+  // Value is a struct.
+  Protobuf::Value struct_value;
+  struct_value.mutable_struct_value();
+  setValue(struct_value);
+  expectConfiguredOrder();
+
+  // Value is a number.
+  Protobuf::Value number_value;
+  number_value.set_number_value(7);
+  setValue(number_value);
+  expectConfiguredOrder();
+
+  // Empty list.
+  setOrder({});
+  expectConfiguredOrder();
+
+  // A list in which nothing names a configured cluster.
+  setOrder({"not_configured", "also_not_configured"});
+  expectConfiguredOrder();
+}
+
+// Metadata is ignored entirely when the cluster does not configure the key.
+TEST_F(CompositeClusterOrderMetadataTest, IgnoredWhenKeyNotConfigured) {
+  initialize(std::string(ThreeClustersNoOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  setOrder({"cluster_2", "cluster_0"});
+  EXPECT_EQ("cluster_0", nameForAttempt(lb, 1));
+  EXPECT_EQ("cluster_1", nameForAttempt(lb, 2));
+}
+
+// A null context or absent stream info falls back to the configured order.
+TEST_F(CompositeClusterOrderMetadataTest, IgnoredWithoutRequestStreamInfo) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  setOrder({"cluster_2", "cluster_0"});
+
+  EXPECT_EQ("cluster_0", lb.clusterForAttempt(nullptr, 1).name_);
+
+  EXPECT_CALL(context_, requestStreamInfo()).WillRepeatedly(Return(nullptr));
+  EXPECT_EQ("cluster_0", lb.clusterForAttempt(&context_, 1).name_);
+}
+
+// A nested metadata path resolves through intermediate structs.
+TEST_F(CompositeClusterOrderMetadataTest, NestedMetadataPath) {
+  initialize(R"EOF(
+name: composite_cluster
+connect_timeout: 0.25s
+lb_policy: CLUSTER_PROVIDED
+cluster_type:
+  name: envoy.clusters.composite
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.clusters.composite.v3.ClusterConfig
+    clusters:
+    - name: cluster_0
+    - name: cluster_1
+    order_metadata_key:
+      key: envoy.clusters.composite
+      path:
+      - key: routing
+      - key: order
+)EOF");
+  CompositeClusterLoadBalancer lb(cluster_->info(), cluster_->cluster_manager_, cluster_->config_);
+
+  Protobuf::Value order;
+  order.mutable_list_value()->add_values()->set_string_value("cluster_1");
+  (*(*(*stream_info_.metadata_.mutable_filter_metadata())["envoy.clusters.composite"]
+          .mutable_fields())["routing"]
+        .mutable_struct_value()
+        ->mutable_fields())["order"] = order;
+
+  EXPECT_EQ("cluster_1", nameForAttempt(lb, 1));
+  EXPECT_EQ("", nameForAttempt(lb, 2));
+}
+
+// The reported index is the selected cluster's configured index, not its position in the order.
+TEST_F(CompositeClusterOrderMetadataTest, ChooseHostUsesOverrideAndReportsConfiguredIndex) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
+                                  cluster_->config_);
+
+  NiceMock<Upstream::MockThreadLocalCluster> mock_cluster;
+  NiceMock<Upstream::MockLoadBalancer> mock_lb;
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHost>>();
+
+  setOrder({"cluster_2", "cluster_0"});
+  EXPECT_CALL(context_, requestStreamInfo()).WillRepeatedly(Return(&stream_info_));
+  EXPECT_CALL(stream_info_, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(1)));
+
+  // Only the override's first entry is consulted; the configured first cluster is not.
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster("cluster_2"))
+      .WillRepeatedly(Return(&mock_cluster));
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster("cluster_0")).Times(0);
+  EXPECT_CALL(mock_cluster, loadBalancer()).WillRepeatedly(ReturnRef(mock_lb));
+
+  size_t reported_index = 0;
+  EXPECT_CALL(mock_lb, chooseHost(_)).WillOnce([&](Upstream::LoadBalancerContext* ctx) {
+    reported_index = static_cast<CompositeLoadBalancerContext*>(ctx)->selectedClusterIndex();
+    return Upstream::HostSelectionResponse{mock_host};
+  });
+
+  auto result = lb.chooseHost(&context_);
+  EXPECT_EQ(mock_host, result.host);
+  // cluster_2 is at index 2 of the configured list, not index 0 of the override.
+  EXPECT_EQ(2, reported_index);
+}
+
+// An attempt past the end of a usable override selects no host and consults no cluster.
+TEST_F(CompositeClusterOrderMetadataTest, ChooseHostFailsPastEndOfOverride) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
+                                  cluster_->config_);
+
+  setOrder({"cluster_2"});
+  EXPECT_CALL(context_, requestStreamInfo()).WillRepeatedly(Return(&stream_info_));
+  EXPECT_CALL(stream_info_, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(2)));
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster(_)).Times(0);
+
+  EXPECT_EQ(nullptr, lb.chooseHost(&context_).host);
+}
+
+// peekAnotherHost and selectExistingConnection honor the override as well.
+TEST_F(CompositeClusterOrderMetadataTest, PeekAndSelectExistingConnectionUseOverride) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
+                                  cluster_->config_);
+
+  NiceMock<Upstream::MockThreadLocalCluster> mock_cluster;
+  NiceMock<Upstream::MockLoadBalancer> mock_lb;
+  NiceMock<Upstream::MockHost> host;
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHost>>();
+  std::vector<uint8_t> hash_key;
+
+  setOrder({"cluster_2", "cluster_0"});
+  EXPECT_CALL(context_, requestStreamInfo()).WillRepeatedly(Return(&stream_info_));
+  EXPECT_CALL(stream_info_, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(1)));
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster("cluster_2"))
+      .WillRepeatedly(Return(&mock_cluster));
+  EXPECT_CALL(mock_cluster, loadBalancer()).WillRepeatedly(ReturnRef(mock_lb));
+
+  EXPECT_CALL(mock_lb, peekAnotherHost(_)).WillOnce(Return(mock_host));
+  EXPECT_EQ(mock_host, lb.peekAnotherHost(&context_));
+
+  EXPECT_CALL(mock_lb, selectExistingConnection(_, _, _)).WillOnce(Return(std::nullopt));
+  EXPECT_EQ(std::nullopt, lb.selectExistingConnection(&context_, host, hash_key));
+}
+
+// The load balancer holds no per-request state across successive attempts.
+TEST_F(CompositeClusterOrderMetadataTest, OverrideStableAcrossAttempts) {
+  initialize(std::string(ThreeClustersWithOrderKey));
+  CompositeClusterLoadBalancer lb(cluster_->info(), server_context_.cluster_manager_,
+                                  cluster_->config_);
+
+  NiceMock<Upstream::MockThreadLocalCluster> mock_cluster;
+  NiceMock<Upstream::MockLoadBalancer> mock_lb;
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHost>>();
+
+  setOrder({"cluster_2", "cluster_0"});
+  EXPECT_CALL(context_, requestStreamInfo()).WillRepeatedly(Return(&stream_info_));
+  EXPECT_CALL(mock_cluster, loadBalancer()).WillRepeatedly(ReturnRef(mock_lb));
+  // HostSelectionResponse is move-only, so build a fresh one per call rather than using Return().
+  EXPECT_CALL(mock_lb, chooseHost(_)).WillRepeatedly([mock_host](Upstream::LoadBalancerContext*) {
+    return Upstream::HostSelectionResponse{mock_host};
+  });
+
+  EXPECT_CALL(stream_info_, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(1)));
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster("cluster_2"))
+      .WillOnce(Return(&mock_cluster));
+  EXPECT_EQ(mock_host, lb.chooseHost(&context_).host);
+
+  EXPECT_CALL(stream_info_, attemptCount()).WillRepeatedly(Return(std::optional<uint32_t>(2)));
+  EXPECT_CALL(server_context_.cluster_manager_, getThreadLocalCluster("cluster_0"))
+      .WillOnce(Return(&mock_cluster));
+  EXPECT_EQ(mock_host, lb.chooseHost(&context_).host);
 }
 
 } // namespace Composite


### PR DESCRIPTION
Commit Message: composite cluster: add optional per-request order from dynamic metadata

Additional Description:

The composite cluster picks a sub-cluster by retry attempt index, using an order that is fixed at config load and identical for every request.

This adds one optional field, `order_metadata_key`, pointing at a request dynamic metadata location that holds an ordered list of sub-cluster names. When a filter supplies that list, it becomes the order for that request alone:

```yaml
clusters:
- name: primary_cluster
- name: secondary_cluster
- name: fallback_cluster
order_metadata_key:
  key: envoy.clusters.composite
  path:
  - key: order
```

Resolution for attempt k, which is 1-based. Metadata entries that do not name a configured cluster are dropped first:

```mermaid
flowchart LR
    A["Attempt k"] --> B{"Any entry left?"}
    B -->|Yes| C["order[k-1]"]
    B -->|No| D["clusters[k-1]"]
    C --> E{"In range?"}
    D --> E
    E -->|Yes| F["Sub-cluster LB"]
    E -->|No| G["No host"]
```

Why: this enables per-request provider fallback ordering for AI gateways (envoyproxy/ai-gateway). A trusted ext_proc computes a provider order from the request and attaches it as dynamic metadata, and the composite cluster executes it. The decision logic stays outside Envoy, and configuration keeps defining the candidate set.

Risk Level: Low.
Testing: UT and integration test
Docs Changes: Added
Release Notes: Added
Platform Specific Features: N/A
API Considerations: No change in security posture.