### PR TITLE
bazel: support platform-based Darwin architecture selection

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -683,6 +683,8 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
+# Match the target platform selected by --platforms. Legacy --cpu settings can otherwise fall
+# through to the default branch in platform-based builds.
 config_setting(
     name = "darwin_x86_64",
     constraint_values = [

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -683,8 +683,6 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
-# Match the target platform selected by --platforms. Legacy --cpu settings can otherwise fall
-# through to the default branch in platform-based builds.
 config_setting(
     name = "darwin_x86_64",
     constraint_values = [

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -683,46 +683,19 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
-# Preserve legacy --cpu matching while supporting platform-based builds.
 config_setting(
-    name = "darwin_x86_64_legacy",
-    values = {"cpu": "darwin_x86_64"},
-)
-
-config_setting(
-    name = "darwin_x86_64_platform",
+    name = "darwin_x86_64",
     constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:macos",
     ],
 )
 
-selects.config_setting_group(
-    name = "darwin_x86_64",
-    match_any = [
-        ":darwin_x86_64_legacy",
-        ":darwin_x86_64_platform",
-    ],
-)
-
 config_setting(
-    name = "darwin_arm64_legacy",
-    values = {"cpu": "darwin_arm64"},
-)
-
-config_setting(
-    name = "darwin_arm64_platform",
+    name = "darwin_arm64",
     constraint_values = [
         "@platforms//cpu:arm64",
         "@platforms//os:macos",
-    ],
-)
-
-selects.config_setting_group(
-    name = "darwin_arm64",
-    match_any = [
-        ":darwin_arm64_legacy",
-        ":darwin_arm64_platform",
     ],
 )
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -683,14 +683,47 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
+# Preserve legacy --cpu matching while supporting platform-based builds.
 config_setting(
-    name = "darwin_x86_64",
+    name = "darwin_x86_64_legacy",
     values = {"cpu": "darwin_x86_64"},
 )
 
 config_setting(
-    name = "darwin_arm64",
+    name = "darwin_x86_64_platform",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
+)
+
+selects.config_setting_group(
+    name = "darwin_x86_64",
+    match_any = [
+        ":darwin_x86_64_legacy",
+        ":darwin_x86_64_platform",
+    ],
+)
+
+config_setting(
+    name = "darwin_arm64_legacy",
     values = {"cpu": "darwin_arm64"},
+)
+
+config_setting(
+    name = "darwin_arm64_platform",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:macos",
+    ],
+)
+
+selects.config_setting_group(
+    name = "darwin_arm64",
+    match_any = [
+        ":darwin_arm64_legacy",
+        ":darwin_arm64_platform",
+    ],
 )
 
 config_setting(


### PR DESCRIPTION
Commit Message: bazel: support platform-based Darwin architecture selection

Additional Description: Fixes #46572. Migrates the existing `darwin_arm64` and `darwin_x86_64` settings from legacy `cpu` values to macOS platform constraints. The public labels and their consumers remain unchanged.

Why `constraint_values`:
- `values = {"cpu": ...}` matches Bazel's legacy `--cpu` option. A build that selects its target with `--platforms` does not necessarily set that legacy value, so a `select()` can miss the Darwin branch and silently use its default.
- `constraint_values` matches constraints on the Bazel target platform. Requiring both the macOS OS constraint and the appropriate CPU constraint makes the setting follow the platform selected by `--platforms`.
- Bazel does not consider the execution platform for this match. That is the intended behavior here because these settings describe the platform and architecture of the configured target, not the machine executing an action.
- This mirrors Envoy's existing `linux_x86_64` and `linux_aarch64` settings and the constraints already declared by `//bazel/platforms:macos_x86_64` and `//bazel/platforms:macos_arm64`.
- The existing `//bazel:darwin_x86_64` and `//bazel:darwin_arm64` labels remain stable. Their meaning moves from matching standalone legacy `--cpu` values to matching the configured target platform.

Homebrew compatibility: The current Homebrew Core formula builds Envoy with `--config=macos` and does not pass an explicit `--platforms` or legacy Darwin `--cpu` value. Bazel derives the native macOS host platform, which supplies the OS and CPU constraints matched by these settings. This command shape was validated on native GitHub-hosted ARM64 and Intel x86_64 runners.

Risk Level: Low

Testing:
- `tools/local_fix_format.sh`
- GitHub-hosted macOS ARM64 and Intel x86_64: [matrix validation run](https://github.com/dio/envoy/actions/runs/31554107533) passed on native `arm64` and `x86_64` runners
- On each architecture, `bazel cquery //tools/protoc:protoc` with its matching `--platforms` value, both without and with `--cpu=k8`, selected the matching prebuilt `protoc`
- On each architecture, built `//tools/protoc:protoc`, `//source/extensions/network/dns_resolver/apple:config`, and `//source/extensions/geoip_providers/maxmind:config` with its matching `--platforms` value, both without and with `--cpu=k8`
- On each architecture, the Homebrew-shaped `--config=macos` path, without an explicit `--platforms` or legacy Darwin `--cpu`, selected the matching prebuilt `protoc` and built the same targets

Docs Changes: N/A. Native macOS and Homebrew build commands are unchanged.

Release Notes: N/A

AI assistance: AI assisted with code exploration, the initial spike, and verification. I reviewed and understand the proposed change and remain responsible for the contribution.
