### PR TITLE
[bp/v1.38] compat/openssl: Ensure OpenSSL uses tcmalloc functions

### DIFF
--- a/changelogs/current/bug_fixes/tls__ensure-openssl-uses-tcmalloc.rst
+++ b/changelogs/current/bug_fixes/tls__ensure-openssl-uses-tcmalloc.rst
@@ -1,0 +1,4 @@
+Fixed a bug where OpenSSL was using glibc's allocator instead of tcmalloc. This
+resulted in OpenSSL operating on a completely separate heap, defeating
+tcmalloc's performance benefits on the TLS hot path and making all OpenSSL
+allocations invisible to tcmalloc heap profiling and memory dumps.

--- a/compat/openssl/source/ossl_dlutil.c
+++ b/compat/openssl/source/ossl_dlutil.c
@@ -13,6 +13,25 @@ static void *libcrypto;
 static void *libssl;
 
 
+static void *ossl_malloc(size_t num, const char *file, int line) {
+  (void)file;
+  (void)line;
+  return malloc(num);
+}
+
+static void *ossl_realloc(void *addr, size_t num, const char *file, int line) {
+  (void)file;
+  (void)line;
+  return realloc(addr, num);
+}
+
+static void ossl_free(void *addr, const char *file, int line) {
+  (void)file;
+  (void)line;
+  free(addr);
+}
+
+
 void ossl_dlopen(int expected_major, int expected_minor) {
   // First, a sanity check to see if OpenSSL shared libs are already linked in.
   // They shouldn't be, but it can easily happen (and has) if there's a bazel
@@ -65,12 +84,6 @@ void ossl_dlopen(int expected_major, int expected_minor) {
     exit(ELIBACC);
   }
 
-  // Load libssl.so second, so that its dependency on libcrypto.so is resolved.
-  if ((libssl = dlopen(libssl_path, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)) == NULL) {
-    bssl_compat_error("dlopen(%s) : %s\n", libssl_path, dlerror());
-    exit(ELIBACC);
-  }
-
   // Now check the OpenSSL version of the loaded libraries to ensure they match
   // what we expect to load i.e. the version we were built against. We do this
   // by looking up and then invoking the OpenSSL_version_num() function from the
@@ -92,6 +105,35 @@ void ossl_dlopen(int expected_major, int expected_minor) {
   if ((loaded_major != expected_major) || (loaded_minor < expected_minor)) {
     bssl_compat_error("Expecting to load OpenSSL version at least %d.%d.x but got %d.%d.%d\n",
                       expected_major, expected_minor, loaded_major, loaded_minor, loaded_patch);
+    exit(ELIBACC);
+  }
+
+  // Tell OpenSSL to use the tcmalloc malloc/realloc/free functions from the
+  // main executable. Without this, RTLD_DEEPBIND causes OpenSSL's allocations
+  // to resolve to glibc's malloc/realloc/free instead, resulting in OpenSSL
+  // using a completely separate heap. This defeats tcmalloc's performance
+  // benefits on the TLS hot path, and also makes all OpenSSL allocations
+  // invisible to tcmalloc's heap dumps.
+  typedef int (*CRYPTO_set_mem_functions_fn)(
+      void *(*malloc_fn)(size_t, const char *, int),
+      void *(*realloc_fn)(void *, size_t, const char *, int),
+      void (*free_fn)(void *, const char *, int));
+
+  CRYPTO_set_mem_functions_fn set_mem_fn = dlsym(libcrypto, "CRYPTO_set_mem_functions");
+  if (set_mem_fn == NULL) {
+    bssl_compat_error("dlsym(libcrypto, \"CRYPTO_set_mem_functions\") : %s\n", dlerror());
+    exit(ELIBACC);
+  }
+
+  if (!set_mem_fn(ossl_malloc, ossl_realloc, ossl_free)) {
+    bssl_compat_error("CRYPTO_set_mem_functions() failed\n");
+    exit(ELIBACC);
+  }
+
+  // Load libssl.so *after* calling CRYPTO_set_mem_functions() just in case
+  // libssl.so has any library constructors that call OPENSSL_malloc().
+  if ((libssl = dlopen(libssl_path, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)) == NULL) {
+    bssl_compat_error("dlopen(%s) : %s\n", libssl_path, dlerror());
     exit(ELIBACC);
   }
 }

--- a/compat/openssl/test/test_crypto.cc
+++ b/compat/openssl/test/test_crypto.cc
@@ -2,3 +2,25 @@
 #include <openssl/crypto.h>
 
 TEST(TestCrypto, test_FIPS_mode) { ASSERT_EQ(0, FIPS_mode()); }
+
+#ifdef BSSL_COMPAT
+#include <dlfcn.h>
+#include <gmock/gmock.h>
+
+TEST(TestCrypto, test_openssl_uses_main_executable_allocator) {
+  ossl_CRYPTO_malloc_fn malloc_fn = nullptr;
+  ossl_CRYPTO_realloc_fn realloc_fn = nullptr;
+  ossl_CRYPTO_free_fn free_fn = nullptr;
+  ossl_CRYPTO_get_mem_functions(&malloc_fn, &realloc_fn, &free_fn);
+
+  Dl_info info;
+  ASSERT_NE(dladdr(reinterpret_cast<void *>(malloc_fn), &info), 0);
+  EXPECT_THAT(info.dli_fname, ::testing::Not(::testing::HasSubstr("libcrypto")));
+
+  ASSERT_NE(dladdr(reinterpret_cast<void *>(realloc_fn), &info), 0);
+  EXPECT_THAT(info.dli_fname, ::testing::Not(::testing::HasSubstr("libcrypto")));
+
+  ASSERT_NE(dladdr(reinterpret_cast<void *>(free_fn), &info), 0);
+  EXPECT_THAT(info.dli_fname, ::testing::Not(::testing::HasSubstr("libcrypto")));
+}
+#endif


### PR DESCRIPTION
When dynamically loading the OpenSSL shared libraries, we use the RTLD_DEEPBIND option so that the compatibility layer's wrapper symbols don't shadow the real OpenSSL ones. As an unintended consequence of this, it causes OpenSSL's calls to malloc/realloc/free to bind to glibc's allocator instead of the tcmalloc that is statically linked into Envoy.

The result is that OpenSSL operates on a completely separate heap, defeating tcmalloc's performance benefits on the TLS hot path and making all OpenSSL allocations invisible to tcmalloc heap profiling and memory dumps.

This is fixed by calling CRYPTO_set_mem_functions() immediately after loading libcrypto.so, thus redirecting OpenSSL's malloc/realloc/free calls to the main executable's tcmalloc functions.

Also added a test to verify that OpenSSL is using allocator functions that reside in the main executable (tcmalloc) rather than inside `libcrypto.so` (glibc via `RTLD_DEEPBIND`), preventing regressions.

Backport of #46562 & #46576