### PR TITLE
APM: add utilities to define and validate JSON schema. add the first schema - OpenAI chat completion schema

### DIFF
--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -65,19 +65,24 @@ message AiProtocolManagerPerRoute {
   // The schema the request payload on this route follows.
   //
   // Setting this hands the payload to the filter to hold and validate: a body
-  // that is not well-formed JSON or does not conform to the declared schema is
-  // rejected with a 400 rather than forwarded for the upstream to interpret
-  // differently.
+  // that is not well-formed is rejected with a 400 rather than forwarded for the
+  // upstream to interpret differently.
+  //
+  // The schemas themselves are not part of this API yet; a later change adds
+  // them along with validation and transcoding against them. Until then the
+  // choice is recorded and carried, but the payload is not checked against it.
   Schema schema = 1 [(validate.rules).enum = {defined_only: true not_in: 0}];
 
   // Whether to normalize the payload from :ref:`schema
   // <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.AiProtocolManagerPerRoute.schema>`
   // into the canonical schema.
   //
-  // Normalization / transcoding is not implemented yet; a later change adds it.
-  // When normalization is implemented, setting this will transcode the payload
-  // into the canonical schema. Until then this field is accepted and has no effect;
-  // all declared routes operate as pass-through endpoints (validated in their own
-  // schema and forwarded in that same schema).
+  // When unset the route is a pass-through endpoint: the payload is validated in
+  // its own schema and forwarded upstream in that same schema. When set, it is
+  // additionally transcoded into the canonical schema, which is what lets one set
+  // of policies apply to payloads from different providers.
+  //
+  // Transcoding is not implemented yet; a later change adds it. Until then this
+  // field is accepted and has no effect.
   bool normalize = 2;
 }

--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -65,24 +65,19 @@ message AiProtocolManagerPerRoute {
   // The schema the request payload on this route follows.
   //
   // Setting this hands the payload to the filter to hold and validate: a body
-  // that is not well-formed is rejected with a 400 rather than forwarded for the
-  // upstream to interpret differently.
-  //
-  // The schemas themselves are not part of this API yet; a later change adds
-  // them along with validation and transcoding against them. Until then the
-  // choice is recorded and carried, but the payload is not checked against it.
+  // that is not well-formed JSON or does not conform to the declared schema is
+  // rejected with a 400 rather than forwarded for the upstream to interpret
+  // differently.
   Schema schema = 1 [(validate.rules).enum = {defined_only: true not_in: 0}];
 
   // Whether to normalize the payload from :ref:`schema
   // <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.AiProtocolManagerPerRoute.schema>`
   // into the canonical schema.
   //
-  // When unset the route is a pass-through endpoint: the payload is validated in
-  // its own schema and forwarded upstream in that same schema. When set, it is
-  // additionally transcoded into the canonical schema, which is what lets one set
-  // of policies apply to payloads from different providers.
-  //
-  // Transcoding is not implemented yet; a later change adds it. Until then this
-  // field is accepted and has no effect.
+  // Normalization / transcoding is not implemented yet; a later change adds it.
+  // When normalization is implemented, setting this will transcode the payload
+  // into the canonical schema. Until then this field is accepted and has no effect;
+  // all declared routes operate as pass-through endpoints (validated in their own
+  // schema and forwarded in that same schema).
   bool normalize = 2;
 }

--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -35,11 +35,19 @@ than after the whole upload. Oversized string values are left in the external
 buffer and referenced by offset, so a large prompt does not reappear in
 per-stream memory.
 
+Upon stream completion, the parsed document is validated against the route's declared
+:ref:`schema <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.AiProtocolManagerPerRoute.schema>`
+(such as ``OPENAI_CHAT_COMPLETIONS``). Validation checks required fields, data types, enum values,
+and offload rules -- ensuring metadata fields (like ``model`` and ``role``) remain inline in the DOM
+while permitting large message content to reside in external buffers. Any schema validation failure
+triggers an immediate HTTP 400 response.
+
 .. note::
 
   Only the request (decode) path is wired today, and the body is offloaded to an
-  in-memory store. Schema validation and transcoding are not implemented yet;
-  the parsed payload is not consumed by anything downstream so far.
+  in-memory store. Request schema validation is supported for declared schemas
+  (such as OpenAI Chat Completions). Response path handling and schema transcoding
+  are not implemented yet.
 
 The filter is a dual filter: besides the downstream HTTP filter chain shown
 below, it can also be placed in a cluster's upstream HTTP filter chain via
@@ -72,7 +80,7 @@ Which routes are AI endpoints is declared per route, with
 <envoy_v3_api_msg_extensions.filters.http.ai_protocol_manager.v3.AiProtocolManagerPerRoute>`.
 A route that carries one names the :ref:`schema
 <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.AiProtocolManagerPerRoute.schema>`
-its payload follows, and its payload is parsed strictly: a malformed body is
+its payload follows, and its payload is parsed and validated strictly: a malformed or invalid body is
 rejected with a 400. This is normally attached to a route matching the
 provider's REST path, such as ``/chat/completions``:
 

--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -85,6 +85,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "schema_lib",
+    srcs = ["schema.cc"],
+    hdrs = ["schema.h"],
+    deps = [
+        ":json_with_ext_buf_lib",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/strings",
+        "@nlohmann_json//:json",
+    ],
+)
+
+envoy_cc_library(
     name = "filter_lib",
     srcs = ["filter.cc"],
     hdrs = ["filter.h"],
@@ -94,10 +106,12 @@ envoy_cc_library(
         ":filter_chain_bridge_lib",
         ":json_with_ext_buf_lib",
         ":json_with_ext_buf_parser_lib",
+        ":schema_lib",
         "//envoy/http:codes_interface",
         "//envoy/router:router_interface",
         "//source/common/common:logger_lib",
         "//source/common/http:utility_lib",
+        "//source/extensions/filters/http/ai_protocol_manager/schema:schema_registry_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@abseil-cpp//absl/status",
         "@envoy_api//envoy/extensions/filters/http/ai_protocol_manager/v3:pkg_cc_proto",

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -7,6 +7,7 @@
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/http/utility.h"
 #include "source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.h"
+#include "source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -113,6 +114,17 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
   if (end_stream) {
     request_json_ = request_parser_->takeDocument();
     request_parser_.reset();
+
+    if (isAiEndpoint()) {
+      if (const PayloadSchema* payload_schema = SchemaRegistry::getSchema(schema_);
+          payload_schema != nullptr) {
+        const absl::Status validation_status = payload_schema->validateRequest(request_json_);
+        if (!validation_status.ok()) {
+          rejectInvalidPayload(validation_status);
+          return false;
+        }
+      }
+    }
   }
   return true;
 }
@@ -121,7 +133,7 @@ void AiProtocolManagerFilter::rejectInvalidPayload(const absl::Status& status) {
   ENVOY_LOG(debug, "ai_protocol_manager: rejecting request: {}", status.message());
   payload_rejected_ = true;
   request_parser_.reset();
-  decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, "invalid JSON payload", nullptr,
+  decoder_callbacks_->sendLocalReply(Http::Code::BadRequest, status.message(), nullptr,
                                      std::nullopt, "ai_protocol_manager_invalid_json");
 }
 

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -116,6 +116,8 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
     request_parser_.reset();
 
     if (isAiEndpoint()) {
+      // TODO(penguingao): Support validating payload schema on the fly as the Wuffs parser
+      // streams and parses chunks, rejecting invalid fields early before end_stream.
       if (const PayloadSchema* payload_schema = SchemaRegistry::getSchema(schema_);
           payload_schema != nullptr) {
         const absl::Status validation_status = payload_schema->validateRequest(request_json_);

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -11,6 +11,7 @@
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer.h"
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf_parser.h"
+#include "source/extensions/filters/http/ai_protocol_manager/schema.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include "absl/status/status.h"
@@ -24,7 +25,7 @@ using PerRouteProto =
     envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManagerPerRoute;
 // The schema a route declares its payload follows. UNSPECIFIED means the route
 // declared nothing, i.e. it is not an AI endpoint.
-using Schema = PerRouteProto::Schema;
+using RouteSchema = PerRouteProto::Schema;
 
 // Filter-level configuration, shared by every stream on the chain.
 class FilterConfig {
@@ -41,18 +42,18 @@ private:
 using FilterConfigSharedPtr = std::shared_ptr<const FilterConfig>;
 
 // Per-route configuration. Its presence declares the route an AI endpoint: the
-// payload is parsed strictly and, once schemas land, validated against schema()
-// and transcoded to the canonical schema when normalize() is set.
+// payload is parsed strictly, validated against schema(), and transcoded to the
+// canonical schema when normalize() is set.
 class RouteConfig : public Router::RouteSpecificFilterConfig {
 public:
   explicit RouteConfig(const PerRouteProto& proto)
       : schema_(proto.schema()), normalize_(proto.normalize()) {}
 
-  Schema schema() const { return schema_; }
+  RouteSchema schema() const { return schema_; }
   bool normalize() const { return normalize_; }
 
 private:
-  const Schema schema_;
+  const RouteSchema schema_;
   const bool normalize_;
 };
 
@@ -139,7 +140,7 @@ private:
   // Copied out of the route configuration rather than held by pointer: the route
   // can be re-resolved mid-stream, which would leave a cached pointer dangling,
   // and these are two scalars.
-  Schema schema_{PerRouteProto::UNSPECIFIED};
+  RouteSchema schema_{PerRouteProto::UNSPECIFIED};
   bool normalize_{false};
 
   // The parsed payload. Populated once the body has been fully received and

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.pb.h"
 #include "envoy/router/router.h"
@@ -11,7 +12,6 @@
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer.h"
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf_parser.h"
-#include "source/extensions/filters/http/ai_protocol_manager/schema.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include "absl/status/status.h"
@@ -23,9 +23,6 @@ namespace AiProtocolManager {
 
 using PerRouteProto =
     envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManagerPerRoute;
-// The schema a route declares its payload follows. UNSPECIFIED means the route
-// declared nothing, i.e. it is not an AI endpoint.
-using RouteSchema = PerRouteProto::Schema;
 
 // Filter-level configuration, shared by every stream on the chain.
 class FilterConfig {
@@ -49,11 +46,11 @@ public:
   explicit RouteConfig(const PerRouteProto& proto)
       : schema_(proto.schema()), normalize_(proto.normalize()) {}
 
-  RouteSchema schema() const { return schema_; }
+  PerRouteProto::Schema schema() const { return schema_; }
   bool normalize() const { return normalize_; }
 
 private:
-  const RouteSchema schema_;
+  const PerRouteProto::Schema schema_;
   const bool normalize_;
 };
 
@@ -140,7 +137,7 @@ private:
   // Copied out of the route configuration rather than held by pointer: the route
   // can be re-resolved mid-stream, which would leave a cached pointer dangling,
   // and these are two scalars.
-  RouteSchema schema_{PerRouteProto::UNSPECIFIED};
+  PerRouteProto::Schema schema_{PerRouteProto::UNSPECIFIED};
   bool normalize_{false};
 
   // The parsed payload. Populated once the body has been fully received and

--- a/source/extensions/filters/http/ai_protocol_manager/schema.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.cc
@@ -298,6 +298,10 @@ absl::Status Schema::validateOneOf(const nlohmann::json& json, absl::string_view
 }
 
 absl::Status Schema::validate(const nlohmann::json& json, absl::string_view path) const {
+  if (is_nullable_ && json.is_null()) {
+    return absl::OkStatus();
+  }
+
   absl::Status status = absl::OkStatus();
   switch (type_) {
   case Type::String:

--- a/source/extensions/filters/http/ai_protocol_manager/schema.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.cc
@@ -114,164 +114,229 @@ Schema Schema::oneOf(std::vector<Schema> candidates) {
   return s;
 }
 
-absl::Status Schema::validate(const nlohmann::json& json, absl::string_view path) const {
+std::vector<std::string> Schema::offloadableFieldPaths(absl::string_view current_path) const {
+  std::vector<std::string> paths;
+  if (is_offloadable_) {
+    paths.push_back(std::string(current_path));
+  }
   switch (type_) {
-  case Type::String: {
-    if (JsonWithExtBuf::isExternalRef(json)) {
-      if (!is_offloadable_) {
-        return absl::InvalidArgumentError(
-            absl::StrCat("field '", path, "' cannot be offloaded to external buffer"));
-      }
-      break;
-    }
-    if (!json.is_string()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected string, got ", jsonTypeName(json)));
-    }
-    if (!allowed_values_.empty()) {
-      const std::string val = json.get<std::string>();
-      if (std::find(allowed_values_.begin(), allowed_values_.end(), val) == allowed_values_.end()) {
-        return absl::InvalidArgumentError(
-            absl::StrCat("field '", path, "' has invalid value: '", val, "'"));
+  case Type::Object:
+    for (const auto& prop : properties_) {
+      if (prop.schema != nullptr) {
+        std::string child_path = makeChildPath(current_path, prop.name);
+        auto sub_paths = prop.schema->offloadableFieldPaths(child_path);
+        paths.insert(paths.end(), sub_paths.begin(), sub_paths.end());
       }
     }
     break;
-  }
-  case Type::Number: {
-    if (!json.is_number()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected number, got ", jsonTypeName(json)));
-    }
-    const double val =
-        json.is_number_float() ? json.get<double>() : static_cast<double>(json.get<int64_t>());
-    if (min_number_.has_value() && val < *min_number_) {
-      return absl::InvalidArgumentError(
-          absl::StrCat("field '", path, "' value ", val, " is less than minimum ", *min_number_));
-    }
-    if (max_number_.has_value() && val > *max_number_) {
-      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' value ", val,
-                                                     " is greater than maximum ", *max_number_));
-    }
-    break;
-  }
-  case Type::Integer: {
-    if (!json.is_number_integer() && !json.is_number_unsigned()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected integer, got ", jsonTypeName(json)));
-    }
-    const int64_t val = json.get<int64_t>();
-    if (min_integer_.has_value() && val < *min_integer_) {
-      return absl::InvalidArgumentError(
-          absl::StrCat("field '", path, "' value ", val, " is less than minimum ", *min_integer_));
-    }
-    if (max_integer_.has_value() && val > *max_integer_) {
-      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' value ", val,
-                                                     " is greater than maximum ", *max_integer_));
-    }
-    break;
-  }
-  case Type::Boolean: {
-    if (!json.is_boolean()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected boolean, got ", jsonTypeName(json)));
-    }
-    break;
-  }
-  case Type::Null: {
-    if (!json.is_null()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected null, got ", jsonTypeName(json)));
-    }
-    break;
-  }
-  case Type::Any: {
-    break;
-  }
-  case Type::Object: {
-    if (!json.is_object()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected object, got ", jsonTypeName(json)));
-    }
-    for (const Property& prop : properties_) {
-      auto it = json.find(prop.name);
-      const std::string child_path = makeChildPath(path, prop.name);
-      if (it == json.end()) {
-        if (prop.schema != nullptr && prop.schema->isRequired()) {
-          return absl::InvalidArgumentError(absl::StrCat("missing required field: ", child_path));
-        }
-      } else if (prop.schema != nullptr) {
-        auto status = prop.schema->validate(it.value(), child_path);
-        if (!status.ok()) {
-          return status;
-        }
-      }
-    }
-    if (!allow_unknown_fields_) {
-      for (auto it = json.begin(); it != json.end(); ++it) {
-        bool found = false;
-        for (const Property& prop : properties_) {
-          if (prop.name == it.key()) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          return absl::InvalidArgumentError(
-              absl::StrCat("unknown field: ", makeChildPath(path, it.key())));
-        }
-      }
-    }
-    break;
-  }
-  case Type::Array: {
-    if (!json.is_array()) {
-      return absl::InvalidArgumentError(absl::StrCat(
-          "field '", path, "' has invalid type: expected array, got ", jsonTypeName(json)));
-    }
-    if (min_integer_.has_value() && static_cast<int64_t>(json.size()) < *min_integer_) {
-      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' array size ", json.size(),
-                                                     " is less than minimum ", *min_integer_));
-    }
-    if (max_integer_.has_value() && static_cast<int64_t>(json.size()) > *max_integer_) {
-      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' array size ", json.size(),
-                                                     " is greater than maximum ", *max_integer_));
-    }
+  case Type::Array:
     if (element_schema_ != nullptr) {
-      for (size_t i = 0; i < json.size(); ++i) {
-        const std::string child_path = makeArrayChildPath(path, i);
-        auto status = element_schema_->validate(json[i], child_path);
-        if (!status.ok()) {
-          return status;
+      std::string child_path = current_path.empty() ? "[]" : absl::StrCat(current_path, "[]");
+      auto sub_paths = element_schema_->offloadableFieldPaths(child_path);
+      paths.insert(paths.end(), sub_paths.begin(), sub_paths.end());
+    }
+    break;
+  case Type::OneOf:
+    for (const auto& candidate : one_of_candidates_) {
+      auto sub_paths = candidate.offloadableFieldPaths(current_path);
+      paths.insert(paths.end(), sub_paths.begin(), sub_paths.end());
+    }
+    break;
+  default:
+    break;
+  }
+  return paths;
+}
+
+absl::Status Schema::validateString(const nlohmann::json& json, absl::string_view path) const {
+  if (JsonWithExtBuf::isExternalRef(json)) {
+    if (!is_offloadable_) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("field '", path, "' cannot be offloaded to external buffer"));
+    }
+    return absl::OkStatus();
+  }
+  if (!json.is_string()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected string, got ", jsonTypeName(json)));
+  }
+  if (!allowed_values_.empty()) {
+    const std::string val = json.get<std::string>();
+    if (std::find(allowed_values_.begin(), allowed_values_.end(), val) == allowed_values_.end()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("field '", path, "' has invalid value: '", val, "'"));
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateNumber(const nlohmann::json& json, absl::string_view path) const {
+  if (!json.is_number()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected number, got ", jsonTypeName(json)));
+  }
+  const double val =
+      json.is_number_float() ? json.get<double>() : static_cast<double>(json.get<int64_t>());
+  if (min_number_.has_value() && val < *min_number_) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("field '", path, "' value ", val, " is less than minimum ", *min_number_));
+  }
+  if (max_number_.has_value() && val > *max_number_) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("field '", path, "' value ", val, " is greater than maximum ", *max_number_));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateInteger(const nlohmann::json& json, absl::string_view path) const {
+  if (!json.is_number_integer() && !json.is_number_unsigned()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected integer, got ", jsonTypeName(json)));
+  }
+  const int64_t val = json.get<int64_t>();
+  if (min_integer_.has_value() && val < *min_integer_) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("field '", path, "' value ", val, " is less than minimum ", *min_integer_));
+  }
+  if (max_integer_.has_value() && val > *max_integer_) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("field '", path, "' value ", val, " is greater than maximum ", *max_integer_));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateBoolean(const nlohmann::json& json, absl::string_view path) const {
+  if (!json.is_boolean()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected boolean, got ", jsonTypeName(json)));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateNull(const nlohmann::json& json, absl::string_view path) const {
+  if (!json.is_null()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected null, got ", jsonTypeName(json)));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateObject(const nlohmann::json& json, absl::string_view path) const {
+  if (!json.is_object()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected object, got ", jsonTypeName(json)));
+  }
+  for (const Property& prop : properties_) {
+    auto it = json.find(prop.name);
+    const std::string child_path = makeChildPath(path, prop.name);
+    if (it == json.end()) {
+      if (prop.schema != nullptr && prop.schema->isRequired()) {
+        return absl::InvalidArgumentError(absl::StrCat("missing required field: ", child_path));
+      }
+    } else if (prop.schema != nullptr) {
+      auto status = prop.schema->validate(it.value(), child_path);
+      if (!status.ok()) {
+        return status;
+      }
+    }
+  }
+  if (!allow_unknown_fields_) {
+    for (auto it = json.begin(); it != json.end(); ++it) {
+      bool found = false;
+      for (const Property& prop : properties_) {
+        if (prop.name == it.key()) {
+          found = true;
+          break;
         }
       }
-    }
-    break;
-  }
-  case Type::OneOf: {
-    bool matched = false;
-    std::vector<std::string> failure_reasons;
-    for (const Schema& candidate : one_of_candidates_) {
-      auto status = candidate.validate(json, path);
-      if (status.ok()) {
-        matched = true;
-        break;
+      if (!found) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("unknown field: ", makeChildPath(path, it.key())));
       }
-      failure_reasons.push_back(std::string(status.message()));
     }
-    if (!matched) {
-      return absl::InvalidArgumentError(absl::StrCat("field '", path,
-                                                     "' did not match any allowed oneof schemas: [",
-                                                     absl::StrJoin(failure_reasons, "; "), "]"));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateArray(const nlohmann::json& json, absl::string_view path) const {
+  if (!json.is_array()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "field '", path, "' has invalid type: expected array, got ", jsonTypeName(json)));
+  }
+  if (min_integer_.has_value() && static_cast<int64_t>(json.size()) < *min_integer_) {
+    return absl::InvalidArgumentError(absl::StrCat("field '", path, "' array size ", json.size(),
+                                                   " is less than minimum ", *min_integer_));
+  }
+  if (max_integer_.has_value() && static_cast<int64_t>(json.size()) > *max_integer_) {
+    return absl::InvalidArgumentError(absl::StrCat("field '", path, "' array size ", json.size(),
+                                                   " is greater than maximum ", *max_integer_));
+  }
+  if (element_schema_ != nullptr) {
+    for (size_t i = 0; i < json.size(); ++i) {
+      const std::string child_path = makeArrayChildPath(path, i);
+      auto status = element_schema_->validate(json[i], child_path);
+      if (!status.ok()) {
+        return status;
+      }
     }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Schema::validateOneOf(const nlohmann::json& json, absl::string_view path) const {
+  std::vector<std::string> failure_reasons;
+  for (const Schema& candidate : one_of_candidates_) {
+    auto status = candidate.validate(json, path);
+    if (status.ok()) {
+      return absl::OkStatus();
+    }
+    failure_reasons.push_back(std::string(status.message()));
+  }
+  return absl::InvalidArgumentError(absl::StrCat("field '", path,
+                                                 "' did not match any allowed oneof schemas: [",
+                                                 absl::StrJoin(failure_reasons, "; "), "]"));
+}
+
+absl::Status Schema::validate(const nlohmann::json& json, absl::string_view path) const {
+  absl::Status status = absl::OkStatus();
+  switch (type_) {
+  case Type::String:
+    status = validateString(json, path);
+    break;
+  case Type::Number:
+    status = validateNumber(json, path);
+    break;
+  case Type::Integer:
+    status = validateInteger(json, path);
+    break;
+  case Type::Boolean:
+    status = validateBoolean(json, path);
+    break;
+  case Type::Null:
+    status = validateNull(json, path);
+    break;
+  case Type::Any:
+    break;
+  case Type::Object:
+    status = validateObject(json, path);
+    break;
+  case Type::Array:
+    status = validateArray(json, path);
+    break;
+  case Type::OneOf:
+    status = validateOneOf(json, path);
     break;
   }
+
+  if (!status.ok()) {
+    return status;
   }
 
   if (custom_validator_) {
-    auto status = custom_validator_(json);
-    if (!status.ok()) {
+    auto custom_status = custom_validator_(json);
+    if (!custom_status.ok()) {
       return absl::InvalidArgumentError(
-          absl::StrCat("field '", path, "' failed validation: ", status.message()));
+          absl::StrCat("field '", path, "' failed validation: ", custom_status.message()));
     }
   }
 

--- a/source/extensions/filters/http/ai_protocol_manager/schema.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.cc
@@ -45,10 +45,17 @@ std::string jsonTypeName(const nlohmann::json& json) {
 }
 
 std::string makeChildPath(absl::string_view parent_path, absl::string_view child_key) {
-  if (parent_path == "/") {
-    return absl::StrCat("/", child_key);
+  if (parent_path.empty()) {
+    return std::string(child_key);
   }
-  return absl::StrCat(parent_path, "/", child_key);
+  return absl::StrCat(parent_path, ".", child_key);
+}
+
+std::string makeArrayChildPath(absl::string_view parent_path, size_t index) {
+  if (parent_path.empty()) {
+    return absl::StrCat("[", index, "]");
+  }
+  return absl::StrCat(parent_path, "[", index, "]");
 }
 
 } // namespace
@@ -231,7 +238,7 @@ absl::Status Schema::validate(const nlohmann::json& json, absl::string_view path
     }
     if (element_schema_ != nullptr) {
       for (size_t i = 0; i < json.size(); ++i) {
-        const std::string child_path = makeChildPath(path, absl::StrCat(i));
+        const std::string child_path = makeArrayChildPath(path, i);
         auto status = element_schema_->validate(json[i], child_path);
         if (!status.ok()) {
           return status;

--- a/source/extensions/filters/http/ai_protocol_manager/schema.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.cc
@@ -1,0 +1,277 @@
+#include "source/extensions/filters/http/ai_protocol_manager/schema.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+namespace {
+
+std::string jsonTypeName(const nlohmann::json& json) {
+  if (JsonWithExtBuf::isExternalRef(json)) {
+    return "external_ref_string";
+  }
+  switch (json.type()) {
+  case nlohmann::json::value_t::null:
+    return "null";
+  case nlohmann::json::value_t::object:
+    return "object";
+  case nlohmann::json::value_t::array:
+    return "array";
+  case nlohmann::json::value_t::string:
+    return "string";
+  case nlohmann::json::value_t::boolean:
+    return "boolean";
+  case nlohmann::json::value_t::number_integer:
+  case nlohmann::json::value_t::number_unsigned:
+    return "integer";
+  case nlohmann::json::value_t::number_float:
+    return "number";
+  case nlohmann::json::value_t::binary:
+    return "binary";
+  case nlohmann::json::value_t::discarded:
+    return "discarded";
+  }
+  return "unknown";
+}
+
+std::string makeChildPath(absl::string_view parent_path, absl::string_view child_key) {
+  if (parent_path == "/") {
+    return absl::StrCat("/", child_key);
+  }
+  return absl::StrCat(parent_path, "/", child_key);
+}
+
+} // namespace
+
+Schema::Property::Property(std::string n, Schema s)
+    : name(std::move(n)), schema(std::make_shared<Schema>(std::move(s))) {}
+
+Schema::Property::Property(const char* n, Schema s)
+    : name(n), schema(std::make_shared<Schema>(std::move(s))) {}
+
+Schema Schema::string() { return Schema(Type::String); }
+
+Schema Schema::enumString(std::vector<std::string> allowed_values) {
+  Schema s(Type::String);
+  s.allowed_values_ = std::move(allowed_values);
+  return s;
+}
+
+Schema Schema::number() { return Schema(Type::Number); }
+
+Schema Schema::integer() { return Schema(Type::Integer); }
+
+Schema Schema::boolean() { return Schema(Type::Boolean); }
+
+Schema Schema::null() { return Schema(Type::Null); }
+
+Schema Schema::any() { return Schema(Type::Any); }
+
+Schema Schema::object(std::initializer_list<Property> properties) {
+  Schema s(Type::Object);
+  s.properties_ = std::vector<Property>(properties);
+  return s;
+}
+
+Schema Schema::object(std::vector<Property> properties) {
+  Schema s(Type::Object);
+  s.properties_ = std::move(properties);
+  return s;
+}
+
+Schema Schema::array(Schema element_schema) {
+  Schema s(Type::Array);
+  s.element_schema_ = std::make_shared<Schema>(std::move(element_schema));
+  return s;
+}
+
+Schema Schema::oneOf(std::initializer_list<Schema> candidates) {
+  Schema s(Type::OneOf);
+  s.one_of_candidates_ = std::vector<Schema>(candidates);
+  return s;
+}
+
+Schema Schema::oneOf(std::vector<Schema> candidates) {
+  Schema s(Type::OneOf);
+  s.one_of_candidates_ = std::move(candidates);
+  return s;
+}
+
+absl::Status Schema::validate(const nlohmann::json& json, absl::string_view path) const {
+  switch (type_) {
+  case Type::String: {
+    if (JsonWithExtBuf::isExternalRef(json)) {
+      if (!is_offloadable_) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("field '", path, "' cannot be offloaded to external buffer"));
+      }
+      break;
+    }
+    if (!json.is_string()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected string, got ", jsonTypeName(json)));
+    }
+    if (!allowed_values_.empty()) {
+      const std::string val = json.get<std::string>();
+      if (std::find(allowed_values_.begin(), allowed_values_.end(), val) == allowed_values_.end()) {
+        return absl::InvalidArgumentError(
+            absl::StrCat("field '", path, "' has invalid value: '", val, "'"));
+      }
+    }
+    break;
+  }
+  case Type::Number: {
+    if (!json.is_number()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected number, got ", jsonTypeName(json)));
+    }
+    const double val =
+        json.is_number_float() ? json.get<double>() : static_cast<double>(json.get<int64_t>());
+    if (min_number_.has_value() && val < *min_number_) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("field '", path, "' value ", val, " is less than minimum ", *min_number_));
+    }
+    if (max_number_.has_value() && val > *max_number_) {
+      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' value ", val,
+                                                     " is greater than maximum ", *max_number_));
+    }
+    break;
+  }
+  case Type::Integer: {
+    if (!json.is_number_integer() && !json.is_number_unsigned()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected integer, got ", jsonTypeName(json)));
+    }
+    const int64_t val = json.get<int64_t>();
+    if (min_integer_.has_value() && val < *min_integer_) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("field '", path, "' value ", val, " is less than minimum ", *min_integer_));
+    }
+    if (max_integer_.has_value() && val > *max_integer_) {
+      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' value ", val,
+                                                     " is greater than maximum ", *max_integer_));
+    }
+    break;
+  }
+  case Type::Boolean: {
+    if (!json.is_boolean()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected boolean, got ", jsonTypeName(json)));
+    }
+    break;
+  }
+  case Type::Null: {
+    if (!json.is_null()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected null, got ", jsonTypeName(json)));
+    }
+    break;
+  }
+  case Type::Any: {
+    break;
+  }
+  case Type::Object: {
+    if (!json.is_object()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected object, got ", jsonTypeName(json)));
+    }
+    for (const Property& prop : properties_) {
+      auto it = json.find(prop.name);
+      const std::string child_path = makeChildPath(path, prop.name);
+      if (it == json.end()) {
+        if (prop.schema != nullptr && prop.schema->isRequired()) {
+          return absl::InvalidArgumentError(absl::StrCat("missing required field: ", child_path));
+        }
+      } else if (prop.schema != nullptr) {
+        auto status = prop.schema->validate(it.value(), child_path);
+        if (!status.ok()) {
+          return status;
+        }
+      }
+    }
+    if (!allow_unknown_fields_) {
+      for (auto it = json.begin(); it != json.end(); ++it) {
+        bool found = false;
+        for (const Property& prop : properties_) {
+          if (prop.name == it.key()) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          return absl::InvalidArgumentError(
+              absl::StrCat("unknown field: ", makeChildPath(path, it.key())));
+        }
+      }
+    }
+    break;
+  }
+  case Type::Array: {
+    if (!json.is_array()) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "field '", path, "' has invalid type: expected array, got ", jsonTypeName(json)));
+    }
+    if (min_integer_.has_value() && static_cast<int64_t>(json.size()) < *min_integer_) {
+      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' array size ", json.size(),
+                                                     " is less than minimum ", *min_integer_));
+    }
+    if (max_integer_.has_value() && static_cast<int64_t>(json.size()) > *max_integer_) {
+      return absl::InvalidArgumentError(absl::StrCat("field '", path, "' array size ", json.size(),
+                                                     " is greater than maximum ", *max_integer_));
+    }
+    if (element_schema_ != nullptr) {
+      for (size_t i = 0; i < json.size(); ++i) {
+        const std::string child_path = makeChildPath(path, absl::StrCat(i));
+        auto status = element_schema_->validate(json[i], child_path);
+        if (!status.ok()) {
+          return status;
+        }
+      }
+    }
+    break;
+  }
+  case Type::OneOf: {
+    bool matched = false;
+    std::vector<std::string> failure_reasons;
+    for (const Schema& candidate : one_of_candidates_) {
+      auto status = candidate.validate(json, path);
+      if (status.ok()) {
+        matched = true;
+        break;
+      }
+      failure_reasons.push_back(std::string(status.message()));
+    }
+    if (!matched) {
+      return absl::InvalidArgumentError(absl::StrCat("field '", path,
+                                                     "' did not match any allowed oneof schemas: [",
+                                                     absl::StrJoin(failure_reasons, "; "), "]"));
+    }
+    break;
+  }
+  }
+
+  if (custom_validator_) {
+    auto status = custom_validator_(json);
+    if (!status.ok()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("field '", path, "' failed validation: ", status.message()));
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/schema.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "nlohmann/json.hpp"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+// Declarative, type-safe, and recursive JSON schema definition.
+//
+// Supports primitive types (String, Number, Integer, Boolean, Null, Any), composite types
+// (Object, Array), and polymorphic union types (OneOf).
+//
+// Allows explicit marking of `.offloadable()` string fields that accept buffer-offloaded
+// `ExternalRef` nodes from `JsonWithExtBuf`, while rejecting offload nodes on non-offloadable
+// metadata fields (e.g. `model`, `role`, `type`).
+class Schema {
+public:
+  enum class Type {
+    String,
+    Number,
+    Integer,
+    Boolean,
+    Object,
+    Array,
+    Null,
+    Any,
+    OneOf,
+  };
+
+  struct Property {
+    Property(std::string n, Schema s);
+    Property(const char* n, Schema s);
+
+    std::string name;
+    std::shared_ptr<Schema> schema;
+  };
+
+  using CustomValidator = std::function<absl::Status(const nlohmann::json&)>;
+
+  Schema(const Schema&) = default;
+  Schema(Schema&&) noexcept = default;
+  Schema& operator=(const Schema&) = default;
+  Schema& operator=(Schema&&) noexcept = default;
+
+  // Static factory methods for declarative schema construction:
+  static Schema string();
+  static Schema enumString(std::vector<std::string> allowed_values);
+  static Schema number();
+  static Schema integer();
+  static Schema boolean();
+  static Schema null();
+  static Schema any();
+  static Schema object(std::initializer_list<Property> properties);
+  static Schema object(std::vector<Property> properties);
+  static Schema array(Schema element_schema);
+  static Schema oneOf(std::initializer_list<Schema> candidates);
+  static Schema oneOf(std::vector<Schema> candidates);
+
+  // Fluent modifiers:
+  Schema& required(bool req = true) {
+    is_required_ = req;
+    return *this;
+  }
+  Schema& optional() {
+    is_required_ = false;
+    return *this;
+  }
+  bool isRequired() const { return is_required_; }
+
+  Schema& offloadable(bool off = true) {
+    is_offloadable_ = off;
+    return *this;
+  }
+  bool isOffloadable() const { return is_offloadable_; }
+
+  Schema& range(double min_val, double max_val) {
+    min_number_ = min_val;
+    max_number_ = max_val;
+    return *this;
+  }
+  Schema& min(int64_t min_val) {
+    min_integer_ = min_val;
+    return *this;
+  }
+  Schema& max(int64_t max_val) {
+    max_integer_ = max_val;
+    return *this;
+  }
+
+  Schema& allowUnknownFields(bool allow = true) {
+    allow_unknown_fields_ = allow;
+    return *this;
+  }
+  bool allowsUnknownFields() const { return allow_unknown_fields_; }
+
+  Schema& customValidator(CustomValidator validator) {
+    custom_validator_ = std::move(validator);
+    return *this;
+  }
+
+  // Validation:
+  absl::Status validate(const nlohmann::json& json, absl::string_view path = "/") const;
+  absl::Status validate(const JsonWithExtBuf& payload) const {
+    return validate(payload.json(), "/");
+  }
+
+  // Introspection & Reflection accessors:
+  Type type() const { return type_; }
+  const std::vector<Property>& properties() const { return properties_; }
+  const Schema* elementSchema() const { return element_schema_.get(); }
+  const std::vector<Schema>& oneOfCandidates() const { return one_of_candidates_; }
+  const std::vector<std::string>& allowedValues() const { return allowed_values_; }
+
+private:
+  explicit Schema(Type type) : type_(type) {}
+
+  Type type_{Type::Any};
+  bool is_required_{false};
+  bool is_offloadable_{false};
+  bool allow_unknown_fields_{true};
+
+  std::vector<std::string> allowed_values_;
+  std::optional<double> min_number_;
+  std::optional<double> max_number_;
+  std::optional<int64_t> min_integer_;
+  std::optional<int64_t> max_integer_;
+
+  std::vector<Property> properties_;
+  std::shared_ptr<Schema> element_schema_;
+  std::vector<Schema> one_of_candidates_;
+  CustomValidator custom_validator_;
+};
+
+// Request schema wrapper around the root Schema.
+class RequestSchema {
+public:
+  RequestSchema() : root_schema_(Schema::object({}).allowUnknownFields(true)) {}
+  explicit RequestSchema(Schema root_schema) : root_schema_(std::move(root_schema)) {}
+
+  const Schema& rootSchema() const { return root_schema_; }
+
+  absl::Status validate(const JsonWithExtBuf& payload) const {
+    return root_schema_.validate(payload);
+  }
+  absl::Status validate(const nlohmann::json& json) const {
+    return root_schema_.validate(json, "/");
+  }
+
+private:
+  Schema root_schema_;
+};
+
+// Response schema definition. Left empty / placeholder for now as response
+// schema parsing and validation will be added in a later change.
+class ResponseSchema {
+public:
+  ResponseSchema() = default;
+  explicit ResponseSchema(Schema root_schema) : root_schema_(std::move(root_schema)) {}
+
+  const std::optional<Schema>& rootSchema() const { return root_schema_; }
+
+private:
+  std::optional<Schema> root_schema_;
+};
+
+// Container holding the pair of request and response schemas for an AI endpoint protocol.
+class PayloadSchema {
+public:
+  explicit PayloadSchema(RequestSchema request_schema,
+                         ResponseSchema response_schema = ResponseSchema())
+      : request_schema_(std::move(request_schema)), response_schema_(std::move(response_schema)) {}
+
+  const RequestSchema& requestSchema() const { return request_schema_; }
+  const ResponseSchema& responseSchema() const { return response_schema_; }
+
+  absl::Status validateRequest(const JsonWithExtBuf& payload) const {
+    return request_schema_.validate(payload);
+  }
+  absl::Status validateRequest(const nlohmann::json& json) const {
+    return request_schema_.validate(json);
+  }
+
+private:
+  RequestSchema request_schema_;
+  ResponseSchema response_schema_;
+};
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/schema.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.h
@@ -124,8 +124,20 @@ public:
   const std::vector<Schema>& oneOfCandidates() const { return one_of_candidates_; }
   const std::vector<std::string>& allowedValues() const { return allowed_values_; }
 
+  // Recursively walks schema definition and returns all declared offloadable field paths.
+  std::vector<std::string> offloadableFieldPaths(absl::string_view current_path = "") const;
+
 private:
   explicit Schema(Type type) : type_(type) {}
+
+  absl::Status validateString(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateNumber(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateInteger(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateBoolean(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateNull(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateObject(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateArray(const nlohmann::json& json, absl::string_view path) const;
+  absl::Status validateOneOf(const nlohmann::json& json, absl::string_view path) const;
 
   Type type_{Type::Any};
   bool is_required_{false};
@@ -157,6 +169,11 @@ public:
   // Returns the declared canonical ordering of streamable / offloadable field paths.
   const std::vector<std::string>& streamableFieldOrder() const { return streamable_field_order_; }
 
+  // Returns all offloadable field paths declared in the request schema.
+  std::vector<std::string> offloadableFieldPaths() const {
+    return root_schema_.offloadableFieldPaths();
+  }
+
   absl::Status validate(const JsonWithExtBuf& payload) const {
     return root_schema_.validate(payload);
   }
@@ -181,6 +198,12 @@ public:
   const std::optional<Schema>& rootSchema() const { return root_schema_; }
   const std::vector<std::string>& streamableFieldOrder() const { return streamable_field_order_; }
 
+  // Returns all offloadable field paths declared in the response schema.
+  std::vector<std::string> offloadableFieldPaths() const {
+    return root_schema_.has_value() ? root_schema_->offloadableFieldPaths()
+                                    : std::vector<std::string>{};
+  }
+
 private:
   std::optional<Schema> root_schema_;
   std::vector<std::string> streamable_field_order_;
@@ -199,6 +222,11 @@ public:
   // Canonical ordering of streamable / offloadable field paths for request payloads.
   const std::vector<std::string>& requestStreamableFieldOrder() const {
     return request_schema_.streamableFieldOrder();
+  }
+
+  // Returns all offloadable field paths declared in the request schema.
+  std::vector<std::string> requestOffloadableFieldPaths() const {
+    return request_schema_.offloadableFieldPaths();
   }
 
   absl::Status validateRequest(const JsonWithExtBuf& payload) const {

--- a/source/extensions/filters/http/ai_protocol_manager/schema.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.h
@@ -25,6 +25,8 @@ namespace AiProtocolManager {
 // Supports primitive types (String, Number, Integer, Boolean, Null, Any), composite types
 // (Object, Array), and polymorphic union types (OneOf).
 //
+// Fields default to optional unless explicitly marked `.required()`.
+//
 // Allows explicit marking of `.offloadable()` string fields that accept buffer-offloaded
 // `ExternalRef` nodes from `JsonWithExtBuf`, while rejecting offload nodes on non-offloadable
 // metadata fields (e.g. `model`, `role`, `type`).
@@ -76,10 +78,6 @@ public:
     is_required_ = req;
     return *this;
   }
-  Schema& optional() {
-    is_required_ = false;
-    return *this;
-  }
   bool isRequired() const { return is_required_; }
 
   Schema& offloadable(bool off = true) {
@@ -114,9 +112,9 @@ public:
   }
 
   // Validation:
-  absl::Status validate(const nlohmann::json& json, absl::string_view path = "/") const;
+  absl::Status validate(const nlohmann::json& json, absl::string_view path = "") const;
   absl::Status validate(const JsonWithExtBuf& payload) const {
-    return validate(payload.json(), "/");
+    return validate(payload.json(), "");
   }
 
   // Introspection & Reflection accessors:
@@ -150,19 +148,25 @@ private:
 class RequestSchema {
 public:
   RequestSchema() : root_schema_(Schema::object({}).allowUnknownFields(true)) {}
-  explicit RequestSchema(Schema root_schema) : root_schema_(std::move(root_schema)) {}
+  explicit RequestSchema(Schema root_schema, std::vector<std::string> streamable_field_order = {})
+      : root_schema_(std::move(root_schema)),
+        streamable_field_order_(std::move(streamable_field_order)) {}
 
   const Schema& rootSchema() const { return root_schema_; }
+
+  // Returns the declared canonical ordering of streamable / offloadable field paths.
+  const std::vector<std::string>& streamableFieldOrder() const { return streamable_field_order_; }
 
   absl::Status validate(const JsonWithExtBuf& payload) const {
     return root_schema_.validate(payload);
   }
   absl::Status validate(const nlohmann::json& json) const {
-    return root_schema_.validate(json, "/");
+    return root_schema_.validate(json, "");
   }
 
 private:
   Schema root_schema_;
+  std::vector<std::string> streamable_field_order_;
 };
 
 // Response schema definition. Left empty / placeholder for now as response
@@ -170,12 +174,16 @@ private:
 class ResponseSchema {
 public:
   ResponseSchema() = default;
-  explicit ResponseSchema(Schema root_schema) : root_schema_(std::move(root_schema)) {}
+  explicit ResponseSchema(Schema root_schema, std::vector<std::string> streamable_field_order = {})
+      : root_schema_(std::move(root_schema)),
+        streamable_field_order_(std::move(streamable_field_order)) {}
 
   const std::optional<Schema>& rootSchema() const { return root_schema_; }
+  const std::vector<std::string>& streamableFieldOrder() const { return streamable_field_order_; }
 
 private:
   std::optional<Schema> root_schema_;
+  std::vector<std::string> streamable_field_order_;
 };
 
 // Container holding the pair of request and response schemas for an AI endpoint protocol.
@@ -187,6 +195,11 @@ public:
 
   const RequestSchema& requestSchema() const { return request_schema_; }
   const ResponseSchema& responseSchema() const { return response_schema_; }
+
+  // Canonical ordering of streamable / offloadable field paths for request payloads.
+  const std::vector<std::string>& requestStreamableFieldOrder() const {
+    return request_schema_.streamableFieldOrder();
+  }
 
   absl::Status validateRequest(const JsonWithExtBuf& payload) const {
     return request_schema_.validate(payload);

--- a/source/extensions/filters/http/ai_protocol_manager/schema.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.h
@@ -80,6 +80,12 @@ public:
   }
   bool isRequired() const { return is_required_; }
 
+  Schema& nullable(bool is_nullable = true) {
+    is_nullable_ = is_nullable;
+    return *this;
+  }
+  bool isNullable() const { return is_nullable_; }
+
   Schema& offloadable(bool off = true) {
     is_offloadable_ = off;
     return *this;
@@ -141,6 +147,7 @@ private:
 
   Type type_{Type::Any};
   bool is_required_{false};
+  bool is_nullable_{false};
   bool is_offloadable_{false};
   bool allow_unknown_fields_{true};
 

--- a/source/extensions/filters/http/ai_protocol_manager/schema/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/BUILD
@@ -1,0 +1,29 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_extension_package",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_cc_library(
+    name = "openai_chat_completions_lib",
+    srcs = ["openai_chat_completions.cc"],
+    hdrs = ["openai_chat_completions.h"],
+    deps = [
+        "//source/extensions/filters/http/ai_protocol_manager:schema_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "schema_registry_lib",
+    srcs = ["schema_registry.cc"],
+    hdrs = ["schema_registry.h"],
+    deps = [
+        ":openai_chat_completions_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:schema_lib",
+        "@envoy_api//envoy/extensions/filters/http/ai_protocol_manager/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
@@ -4,7 +4,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
-namespace OpenAi {
+namespace OpenAI {
 
 const Schema& toolCallSchema() {
   static const Schema schema = Schema::object({
@@ -111,7 +111,7 @@ PayloadSchema createPayloadSchema() {
       /*response_schema=*/ResponseSchema{}};
 }
 
-} // namespace OpenAi
+} // namespace OpenAI
 } // namespace AiProtocolManager
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
@@ -24,22 +24,23 @@ const Schema& chatMessageSchema() {
   static const Schema schema = Schema::object({
       {"role", Schema::enumString({"system", "user", "assistant", "tool", "function", "developer"})
                    .required()},
-      {"content", Schema::oneOf({
-                      Schema::string().offloadable(),
-                      Schema::array(Schema::object({
-                          {"type", Schema::string().required()},
-                          {"text", Schema::string().offloadable()},
-                          {"image_url", Schema::object({
-                                                           {"url", Schema::string().required()},
-                                                           {"detail", Schema::string()},
-                                                       })
-                                            .allowUnknownFields(true)},
-                      })),
-                      Schema::null(),
-                  })},
-      {"name", Schema::string()},
-      {"tool_call_id", Schema::string()},
-      {"tool_calls", Schema::array(toolCallSchema())},
+      {"content",
+       Schema::oneOf({
+           Schema::string().offloadable(),
+           Schema::array(Schema::object({
+               {"type", Schema::string().required()},
+               {"text", Schema::string().offloadable()},
+               {"image_url", Schema::object({
+                                                {"url", Schema::string().offloadable().required()},
+                                                {"detail", Schema::string().nullable()},
+                                            })
+                                 .allowUnknownFields(true)},
+           })),
+           Schema::null(),
+       })},
+      {"name", Schema::string().nullable()},
+      {"tool_call_id", Schema::string().nullable()},
+      {"tool_calls", Schema::array(toolCallSchema()).nullable()},
   });
   return schema;
 }
@@ -49,9 +50,9 @@ const Schema& toolSchema() {
       {"type", Schema::enumString({"function"}).required()},
       {"function", Schema::object({
                                       {"name", Schema::string().required()},
-                                      {"description", Schema::string().offloadable()},
+                                      {"description", Schema::string().offloadable().nullable()},
                                       {"parameters", Schema::object({}).allowUnknownFields(true)},
-                                      {"strict", Schema::boolean()},
+                                      {"strict", Schema::boolean().nullable()},
                                   })
                        .allowUnknownFields(true)
                        .required()},
@@ -65,21 +66,21 @@ PayloadSchema createPayloadSchema() {
           Schema::object({
               {"model", Schema::string().required()},
               {"messages", Schema::array(chatMessageSchema()).min(1).required()},
-              {"temperature", Schema::number().range(0.0, 2.0)},
-              {"top_p", Schema::number().range(0.0, 1.0)},
-              {"n", Schema::integer().min(1)},
-              {"stream", Schema::boolean()},
+              {"temperature", Schema::number().range(0.0, 2.0).nullable()},
+              {"top_p", Schema::number().range(0.0, 1.0).nullable()},
+              {"n", Schema::integer().min(1).nullable()},
+              {"stream", Schema::boolean().nullable()},
               {"stop", Schema::oneOf({
                            Schema::string(),
                            Schema::array(Schema::string()),
-                       })},
-              {"max_tokens", Schema::integer().min(0)},
-              {"max_completion_tokens", Schema::integer().min(0)},
-              {"presence_penalty", Schema::number().range(-2.0, 2.0)},
-              {"frequency_penalty", Schema::number().range(-2.0, 2.0)},
-              {"logit_bias", Schema::object({}).allowUnknownFields(true)},
-              {"user", Schema::string()},
-              {"tools", Schema::array(toolSchema())},
+                       }).nullable()},
+              {"max_tokens", Schema::integer().min(0).nullable()},
+              {"max_completion_tokens", Schema::integer().min(0).nullable()},
+              {"presence_penalty", Schema::number().range(-2.0, 2.0).nullable()},
+              {"frequency_penalty", Schema::number().range(-2.0, 2.0).nullable()},
+              {"logit_bias", Schema::object({}).allowUnknownFields(true).nullable()},
+              {"user", Schema::string().nullable()},
+              {"tools", Schema::array(toolSchema()).nullable()},
               {"tool_choice", Schema::oneOf({
                                   Schema::string(),
                                   Schema::object({
@@ -90,21 +91,23 @@ PayloadSchema createPayloadSchema() {
                                                        .allowUnknownFields(true)
                                                        .required()},
                                   }),
-                              })},
+                              }).nullable()},
               {"response_format", Schema::object({
                                       {"type", Schema::enumString(
                                                    {"text", "json_object", "json_schema"})
                                                    .required()},
                                       {"json_schema", Schema::object({}).allowUnknownFields(true)},
                                   })
-                                      .allowUnknownFields(true)},
-              {"seed", Schema::integer()},
-              {"service_tier", Schema::string()},
+                                      .allowUnknownFields(true)
+                                      .nullable()},
+              {"seed", Schema::integer().nullable()},
+              {"service_tier", Schema::string().nullable()},
           })
               .allowUnknownFields(true),
           /*streamable_field_order=*/{
               "messages[].content",
               "messages[].content[].text",
+              "messages[].content[].image_url.url",
               "messages[].tool_calls[].function.arguments",
               "tools[].function.description",
           }},

--- a/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
@@ -1,0 +1,123 @@
+#include "source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace OpenAi {
+
+const Schema& toolCallSchema() {
+  static const Schema schema = Schema::object({
+      {"id", Schema::string().required()},
+      {"type", Schema::enumString({"function"}).required()},
+      {"function", Schema::object({
+                                      {"name", Schema::string().required()},
+                                      {"arguments", Schema::string().offloadable().required()},
+                                  })
+                       .allowUnknownFields(true)
+                       .required()},
+  });
+  return schema;
+}
+
+const Schema& chatMessageSchema() {
+  static const Schema schema = Schema::object({
+      {"role", Schema::enumString({"system", "user", "assistant", "tool", "function", "developer"})
+                   .required()},
+      {"content", Schema::oneOf({
+                                    Schema::string().offloadable(),
+                                    Schema::array(Schema::object({
+                                        {"type", Schema::string().required()},
+                                        {"text", Schema::string().offloadable().optional()},
+                                        {"image_url",
+                                         Schema::object({
+                                                            {"url", Schema::string().required()},
+                                                            {"detail", Schema::string().optional()},
+                                                        })
+                                             .allowUnknownFields(true)
+                                             .optional()},
+                                    })),
+                                    Schema::null(),
+                                })
+                      .optional()},
+      {"name", Schema::string().optional()},
+      {"tool_call_id", Schema::string().optional()},
+      {"tool_calls", Schema::array(toolCallSchema()).optional()},
+  });
+  return schema;
+}
+
+const Schema& toolSchema() {
+  static const Schema schema = Schema::object({
+      {"type", Schema::enumString({"function"}).required()},
+      {"function",
+       Schema::object({
+                          {"name", Schema::string().required()},
+                          {"description", Schema::string().offloadable().optional()},
+                          {"parameters", Schema::object({}).allowUnknownFields(true).optional()},
+                          {"strict", Schema::boolean().optional()},
+                      })
+           .allowUnknownFields(true)
+           .required()},
+  });
+  return schema;
+}
+
+PayloadSchema createPayloadSchema() {
+  return PayloadSchema{
+      /*request_schema=*/RequestSchema{
+          Schema::object(
+              {
+                  {"model", Schema::string().required()},
+                  {"messages", Schema::array(chatMessageSchema()).min(1).required()},
+                  {"temperature", Schema::number().range(0.0, 2.0).optional()},
+                  {"top_p", Schema::number().range(0.0, 1.0).optional()},
+                  {"n", Schema::integer().min(1).optional()},
+                  {"stream", Schema::boolean().optional()},
+                  {"stop", Schema::oneOf({
+                                             Schema::string(),
+                                             Schema::array(Schema::string()),
+                                         })
+                               .optional()},
+                  {"max_tokens", Schema::integer().min(0).optional()},
+                  {"max_completion_tokens", Schema::integer().min(0).optional()},
+                  {"presence_penalty", Schema::number().range(-2.0, 2.0).optional()},
+                  {"frequency_penalty", Schema::number().range(-2.0, 2.0).optional()},
+                  {"logit_bias", Schema::object({}).allowUnknownFields(true).optional()},
+                  {"user", Schema::string().optional()},
+                  {"tools", Schema::array(toolSchema()).optional()},
+                  {"tool_choice",
+                   Schema::oneOf({
+                                     Schema::string(),
+                                     Schema::object({
+                                         {"type", Schema::enumString({"function"}).required()},
+                                         {"function",
+                                          Schema::object({
+                                                             {"name", Schema::string().required()},
+                                                         })
+                                              .allowUnknownFields(true)
+                                              .required()},
+                                     }),
+                                 })
+                       .optional()},
+                  {"response_format",
+                   Schema::object(
+                       {
+                           {"type",
+                            Schema::enumString({"text", "json_object", "json_schema"}).required()},
+                           {"json_schema", Schema::object({}).allowUnknownFields(true).optional()},
+                       })
+                       .allowUnknownFields(true)
+                       .optional()},
+                  {"seed", Schema::integer().optional()},
+                  {"service_tier", Schema::string().optional()},
+              })
+              .allowUnknownFields(true)},
+      /*response_schema=*/ResponseSchema{}};
+}
+
+} // namespace OpenAi
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.cc
@@ -25,24 +25,21 @@ const Schema& chatMessageSchema() {
       {"role", Schema::enumString({"system", "user", "assistant", "tool", "function", "developer"})
                    .required()},
       {"content", Schema::oneOf({
-                                    Schema::string().offloadable(),
-                                    Schema::array(Schema::object({
-                                        {"type", Schema::string().required()},
-                                        {"text", Schema::string().offloadable().optional()},
-                                        {"image_url",
-                                         Schema::object({
-                                                            {"url", Schema::string().required()},
-                                                            {"detail", Schema::string().optional()},
-                                                        })
-                                             .allowUnknownFields(true)
-                                             .optional()},
-                                    })),
-                                    Schema::null(),
-                                })
-                      .optional()},
-      {"name", Schema::string().optional()},
-      {"tool_call_id", Schema::string().optional()},
-      {"tool_calls", Schema::array(toolCallSchema()).optional()},
+                      Schema::string().offloadable(),
+                      Schema::array(Schema::object({
+                          {"type", Schema::string().required()},
+                          {"text", Schema::string().offloadable()},
+                          {"image_url", Schema::object({
+                                                           {"url", Schema::string().required()},
+                                                           {"detail", Schema::string()},
+                                                       })
+                                            .allowUnknownFields(true)},
+                      })),
+                      Schema::null(),
+                  })},
+      {"name", Schema::string()},
+      {"tool_call_id", Schema::string()},
+      {"tool_calls", Schema::array(toolCallSchema())},
   });
   return schema;
 }
@@ -50,15 +47,14 @@ const Schema& chatMessageSchema() {
 const Schema& toolSchema() {
   static const Schema schema = Schema::object({
       {"type", Schema::enumString({"function"}).required()},
-      {"function",
-       Schema::object({
-                          {"name", Schema::string().required()},
-                          {"description", Schema::string().offloadable().optional()},
-                          {"parameters", Schema::object({}).allowUnknownFields(true).optional()},
-                          {"strict", Schema::boolean().optional()},
-                      })
-           .allowUnknownFields(true)
-           .required()},
+      {"function", Schema::object({
+                                      {"name", Schema::string().required()},
+                                      {"description", Schema::string().offloadable()},
+                                      {"parameters", Schema::object({}).allowUnknownFields(true)},
+                                      {"strict", Schema::boolean()},
+                                  })
+                       .allowUnknownFields(true)
+                       .required()},
   });
   return schema;
 }
@@ -66,53 +62,52 @@ const Schema& toolSchema() {
 PayloadSchema createPayloadSchema() {
   return PayloadSchema{
       /*request_schema=*/RequestSchema{
-          Schema::object(
-              {
-                  {"model", Schema::string().required()},
-                  {"messages", Schema::array(chatMessageSchema()).min(1).required()},
-                  {"temperature", Schema::number().range(0.0, 2.0).optional()},
-                  {"top_p", Schema::number().range(0.0, 1.0).optional()},
-                  {"n", Schema::integer().min(1).optional()},
-                  {"stream", Schema::boolean().optional()},
-                  {"stop", Schema::oneOf({
-                                             Schema::string(),
-                                             Schema::array(Schema::string()),
-                                         })
-                               .optional()},
-                  {"max_tokens", Schema::integer().min(0).optional()},
-                  {"max_completion_tokens", Schema::integer().min(0).optional()},
-                  {"presence_penalty", Schema::number().range(-2.0, 2.0).optional()},
-                  {"frequency_penalty", Schema::number().range(-2.0, 2.0).optional()},
-                  {"logit_bias", Schema::object({}).allowUnknownFields(true).optional()},
-                  {"user", Schema::string().optional()},
-                  {"tools", Schema::array(toolSchema()).optional()},
-                  {"tool_choice",
-                   Schema::oneOf({
-                                     Schema::string(),
-                                     Schema::object({
-                                         {"type", Schema::enumString({"function"}).required()},
-                                         {"function",
-                                          Schema::object({
-                                                             {"name", Schema::string().required()},
-                                                         })
-                                              .allowUnknownFields(true)
-                                              .required()},
-                                     }),
-                                 })
-                       .optional()},
-                  {"response_format",
-                   Schema::object(
-                       {
-                           {"type",
-                            Schema::enumString({"text", "json_object", "json_schema"}).required()},
-                           {"json_schema", Schema::object({}).allowUnknownFields(true).optional()},
-                       })
-                       .allowUnknownFields(true)
-                       .optional()},
-                  {"seed", Schema::integer().optional()},
-                  {"service_tier", Schema::string().optional()},
-              })
-              .allowUnknownFields(true)},
+          Schema::object({
+              {"model", Schema::string().required()},
+              {"messages", Schema::array(chatMessageSchema()).min(1).required()},
+              {"temperature", Schema::number().range(0.0, 2.0)},
+              {"top_p", Schema::number().range(0.0, 1.0)},
+              {"n", Schema::integer().min(1)},
+              {"stream", Schema::boolean()},
+              {"stop", Schema::oneOf({
+                           Schema::string(),
+                           Schema::array(Schema::string()),
+                       })},
+              {"max_tokens", Schema::integer().min(0)},
+              {"max_completion_tokens", Schema::integer().min(0)},
+              {"presence_penalty", Schema::number().range(-2.0, 2.0)},
+              {"frequency_penalty", Schema::number().range(-2.0, 2.0)},
+              {"logit_bias", Schema::object({}).allowUnknownFields(true)},
+              {"user", Schema::string()},
+              {"tools", Schema::array(toolSchema())},
+              {"tool_choice", Schema::oneOf({
+                                  Schema::string(),
+                                  Schema::object({
+                                      {"type", Schema::enumString({"function"}).required()},
+                                      {"function", Schema::object({
+                                                       {"name", Schema::string().required()},
+                                                   })
+                                                       .allowUnknownFields(true)
+                                                       .required()},
+                                  }),
+                              })},
+              {"response_format", Schema::object({
+                                      {"type", Schema::enumString(
+                                                   {"text", "json_object", "json_schema"})
+                                                   .required()},
+                                      {"json_schema", Schema::object({}).allowUnknownFields(true)},
+                                  })
+                                      .allowUnknownFields(true)},
+              {"seed", Schema::integer()},
+              {"service_tier", Schema::string()},
+          })
+              .allowUnknownFields(true),
+          /*streamable_field_order=*/{
+              "messages[].content",
+              "messages[].content[].text",
+              "messages[].tool_calls[].function.arguments",
+              "tools[].function.description",
+          }},
       /*response_schema=*/ResponseSchema{}};
 }
 

--- a/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "source/extensions/filters/http/ai_protocol_manager/schema.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace OpenAi {
+
+// Reusable sub-schemas and complete payload schema definition for OpenAI Chat Completions.
+const Schema& toolCallSchema();
+const Schema& chatMessageSchema();
+const Schema& toolSchema();
+
+// Returns the full OpenAI Chat Completions PayloadSchema.
+PayloadSchema createPayloadSchema();
+
+} // namespace OpenAi
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h
@@ -6,7 +6,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
-namespace OpenAi {
+namespace OpenAI {
 
 // Reusable sub-schemas and complete payload schema definition for OpenAI Chat Completions.
 const Schema& toolCallSchema();
@@ -16,7 +16,7 @@ const Schema& toolSchema();
 // Returns the full OpenAI Chat Completions PayloadSchema.
 PayloadSchema createPayloadSchema();
 
-} // namespace OpenAi
+} // namespace OpenAI
 } // namespace AiProtocolManager
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.cc
@@ -1,0 +1,25 @@
+#include "source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h"
+
+#include "source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+const PayloadSchema* SchemaRegistry::getSchema(PerRouteProto::Schema schema) {
+  switch (schema) {
+  case PerRouteProto::OPENAI_CHAT_COMPLETIONS: {
+    static const PayloadSchema openai_schema = OpenAi::createPayloadSchema();
+    return &openai_schema;
+  }
+  case PerRouteProto::UNSPECIFIED:
+  default:
+    return nullptr;
+  }
+}
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.cc
@@ -10,7 +10,7 @@ namespace AiProtocolManager {
 const PayloadSchema* SchemaRegistry::getSchema(PerRouteProto::Schema schema) {
   switch (schema) {
   case PerRouteProto::OPENAI_CHAT_COMPLETIONS: {
-    static const PayloadSchema openai_schema = OpenAi::createPayloadSchema();
+    static const PayloadSchema openai_schema = OpenAI::createPayloadSchema();
     return &openai_schema;
   }
   case PerRouteProto::UNSPECIFIED:

--- a/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.cc
@@ -8,11 +8,10 @@ namespace HttpFilters {
 namespace AiProtocolManager {
 
 const PayloadSchema* SchemaRegistry::getSchema(PerRouteProto::Schema schema) {
+  static const PayloadSchema openai_schema = OpenAI::createPayloadSchema();
   switch (schema) {
-  case PerRouteProto::OPENAI_CHAT_COMPLETIONS: {
-    static const PayloadSchema openai_schema = OpenAI::createPayloadSchema();
+  case PerRouteProto::OPENAI_CHAT_COMPLETIONS:
     return &openai_schema;
-  }
   case PerRouteProto::UNSPECIFIED:
   default:
     return nullptr;

--- a/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.pb.h"
+
+#include "source/extensions/filters/http/ai_protocol_manager/schema.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+using PerRouteProto =
+    envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManagerPerRoute;
+
+// Registry mapping route schema configurations to their corresponding PayloadSchema.
+class SchemaRegistry {
+public:
+  static const PayloadSchema* getSchema(PerRouteProto::Schema schema);
+};
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/BUILD
@@ -35,6 +35,17 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "schema_test",
+    srcs = ["schema_test.cc"],
+    extension_names = ["envoy.filters.http.ai_protocol_manager"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/extensions/filters/http/ai_protocol_manager:schema_lib",
+        "//test/test_common:status_utility_lib",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "json_with_ext_buf_parser_test",
     srcs = ["json_with_ext_buf_parser_test.cc"],
     extension_names = ["envoy.filters.http.ai_protocol_manager"],

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -724,6 +724,21 @@ TEST_F(AiProtocolManagerFilterTest, PassThroughEndpointIsParsedAndForwarded) {
             R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
 }
 
+// A payload with valid JSON syntax but violating the route's schema is rejected with 400.
+TEST_F(AiProtocolManagerFilterTest, SchemaValidationRejectsInvalidPayload) {
+  setRouteConfig(/*normalize=*/false);
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  // Missing required "messages" array.
+  Buffer::OwnedImpl body(R"({"model":"gpt-4"})");
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 1);
+  EXPECT_EQ(local_reply_code_, Http::Code::BadRequest);
+  EXPECT_EQ(inject_calls_, 0);
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -384,7 +384,8 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
   setRouteConfig();
   EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
 
-  const std::string payload = R"({"model":"gpt-4","stream":true,"max_tokens":256})";
+  const std::string payload =
+      R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":256})";
   Buffer::OwnedImpl body(payload);
   EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
   drain();
@@ -493,22 +494,56 @@ TEST_F(AiProtocolManagerFilterTest, RejectsMalformedJsonMidUpload) {
   EXPECT_EQ(inject_calls_, 0);
 }
 
+// A payload that is valid JSON syntax but fails schema validation is answered
+// with a 400 and never reaches the upstream.
+TEST_F(AiProtocolManagerFilterTest, RejectsPayloadFailingSchemaValidation) {
+  setRouteConfig();
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  // Missing required "messages" field.
+  Buffer::OwnedImpl body(R"({"model":"gpt-4"})");
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 1);
+  EXPECT_EQ(local_reply_code_, Http::Code::BadRequest);
+  EXPECT_EQ(local_reply_details_, "ai_protocol_manager_invalid_json");
+  EXPECT_EQ(inject_calls_, 0);
+}
+
+// Unknown fields are permitted and pass through untouched.
+TEST_F(AiProtocolManagerFilterTest, PassesThroughUnknownFields) {
+  setRouteConfig();
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  const std::string payload =
+      R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"custom_tag":"blue"})";
+  Buffer::OwnedImpl body(payload);
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 0);
+  EXPECT_EQ(injected_.toString(), payload);
+  EXPECT_TRUE(injected_end_stream_);
+}
+
 // A body ending on an empty terminal frame still gets its document closed, so a
 // complete payload split that way is not mistaken for a truncated one.
 TEST_F(AiProtocolManagerFilterTest, ChunkedBodyWithEmptyTerminalFrame) {
   setRouteConfig();
   EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
 
-  Buffer::OwnedImpl chunk1(R"({"model":"gpt)");
+  Buffer::OwnedImpl chunk1(R"({"model":"gpt-4","messages":[{"role":")");
   EXPECT_EQ(filter_->decodeData(chunk1, false), Http::FilterDataStatus::StopIterationNoBuffer);
-  Buffer::OwnedImpl chunk2(R"(-4"})");
+  Buffer::OwnedImpl chunk2(R"(user","content":"hi"}]})");
   EXPECT_EQ(filter_->decodeData(chunk2, false), Http::FilterDataStatus::StopIterationNoBuffer);
   Buffer::OwnedImpl terminal;
   EXPECT_EQ(filter_->decodeData(terminal, true), Http::FilterDataStatus::StopIterationNoBuffer);
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(), R"({"model":"gpt-4"})");
+  EXPECT_EQ(injected_.toString(),
+            R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
 }
 
 // With trailers, no data frame carries end_stream, so the trailers close it.
@@ -516,14 +551,15 @@ TEST_F(AiProtocolManagerFilterTest, TrailerTerminatedJsonIsParsed) {
   setRouteConfig();
   EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
 
-  Buffer::OwnedImpl body(R"({"model":"gpt-4"})");
+  Buffer::OwnedImpl body(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
   EXPECT_EQ(filter_->decodeData(body, false), Http::FilterDataStatus::StopIterationNoBuffer);
   Http::TestRequestTrailerMapImpl trailers{{"x-trailer", "1"}};
   EXPECT_EQ(filter_->decodeTrailers(trailers), Http::FilterTrailersStatus::StopIteration);
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(), R"({"model":"gpt-4"})");
+  EXPECT_EQ(injected_.toString(),
+            R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
   EXPECT_EQ(continue_calls_, 1);
 }
 
@@ -673,18 +709,19 @@ TEST_F(AiProtocolManagerFilterTest, RouteConfigIsStrictEvenWithBestEffortConfigu
   EXPECT_EQ(inject_calls_, 0);
 }
 
-// A pass-through endpoint (no normalization) is parsed and forwarded just the
-// same; normalization only governs the transcoding a later change adds.
+// A pass-through endpoint (no normalization) is parsed, validated, and forwarded
+// just the same; normalization only governs the transcoding a later change adds.
 TEST_F(AiProtocolManagerFilterTest, PassThroughEndpointIsParsedAndForwarded) {
   setRouteConfig(/*normalize=*/false);
   EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
 
-  Buffer::OwnedImpl body(R"({"model":"gpt-4"})");
+  Buffer::OwnedImpl body(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
   EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(), R"({"model":"gpt-4"})");
+  EXPECT_EQ(injected_.toString(),
+            R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -709,8 +709,8 @@ TEST_F(AiProtocolManagerFilterTest, RouteConfigIsStrictEvenWithBestEffortConfigu
   EXPECT_EQ(inject_calls_, 0);
 }
 
-// A pass-through endpoint (no normalization) is parsed, validated, and forwarded
-// just the same; normalization only governs the transcoding a later change adds.
+// A pass-through endpoint (normalization is not yet supported) is parsed,
+// validated against its schema, and forwarded upstream.
 TEST_F(AiProtocolManagerFilterTest, PassThroughEndpointIsParsedAndForwarded) {
   setRouteConfig(/*normalize=*/false);
   EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -739,6 +739,20 @@ TEST_F(AiProtocolManagerFilterTest, SchemaValidationRejectsInvalidPayload) {
   EXPECT_EQ(inject_calls_, 0);
 }
 
+// Trailers arriving after a stream was rejected are dropped with StopIteration.
+TEST_F(AiProtocolManagerFilterTest, TrailersDroppedAfterPayloadRejection) {
+  setRouteConfig(/*normalize=*/false);
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  // Send malformed payload chunk that fails the stream.
+  Buffer::OwnedImpl bad_chunk(R"({"model" "gpt-4"})");
+  EXPECT_EQ(filter_->decodeData(bad_chunk, false), Http::FilterDataStatus::StopIterationNoBuffer);
+
+  // Send trailers on the dying stream.
+  Http::TestRequestTrailerMapImpl trailers;
+  EXPECT_EQ(filter_->decodeTrailers(trailers), Http::FilterTrailersStatus::StopIteration);
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/schema/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/BUILD
@@ -19,8 +19,18 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/ai_protocol_manager:json_with_ext_buf_lib",
         "//source/extensions/filters/http/ai_protocol_manager/schema:openai_chat_completions_lib",
-        "//source/extensions/filters/http/ai_protocol_manager/schema:schema_registry_lib",
         "//test/test_common:status_utility_lib",
         "@nlohmann_json//:json",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "schema_registry_test",
+    srcs = ["schema_registry_test.cc"],
+    extension_names = ["envoy.filters.http.ai_protocol_manager"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/extensions/filters/http/ai_protocol_manager/schema:schema_registry_lib",
+        "//test/test_common:status_utility_lib",
     ],
 )

--- a/test/extensions/filters/http/ai_protocol_manager/schema/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/BUILD
@@ -1,0 +1,26 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "openai_chat_completions_test",
+    srcs = ["openai_chat_completions_test.cc"],
+    extension_names = ["envoy.filters.http.ai_protocol_manager"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/extensions/filters/http/ai_protocol_manager:json_with_ext_buf_lib",
+        "//source/extensions/filters/http/ai_protocol_manager/schema:openai_chat_completions_lib",
+        "//source/extensions/filters/http/ai_protocol_manager/schema:schema_registry_lib",
+        "//test/test_common:status_utility_lib",
+        "@nlohmann_json//:json",
+    ],
+)

--- a/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
@@ -54,10 +54,19 @@ TEST(OpenAiChatCompletionsTest, MultimodalContentParts) {
       {"messages",
        nlohmann::json::array(
            {{{"role", "user"},
-             {"content", nlohmann::json::array(
-                             {{{"type", "text"}, {"text", "What is in this image?"}},
-                              {{"type", "image_url"},
-                               {"image_url", {{"url", "https://example.com/image.png"}}}}})}}})},
+             {"content",
+              nlohmann::json::array(
+                  {{{"type", "text"}, {"text", "What is in this image?"}},
+                   {{"type", "image_url"},
+                    {"image_url", {{"url", "https://example.com/image.png"}}}},
+                   {{"type", "image_url"},
+                    {"image_url",
+                     {{"url", "data:image/jpeg;base64,/9j/4AAQSkZJRg..."}, {"detail", "high"}}}},
+                   {{"type", "image_url"},
+                    {"image_url",
+                     {{"url",
+                       JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{100, 50000})},
+                      {"detail", "auto"}}}}})}}})},
   };
   EXPECT_THAT(payload_schema.validateRequest(multimodal_req), IsOk());
 }
@@ -143,6 +152,22 @@ TEST(OpenAiChatCompletionsTest, MissingRequiredFields) {
   auto role_err = payload_schema.validateRequest(missing_role);
   EXPECT_THAT(role_err, StatusCodeIs(absl::StatusCode::kInvalidArgument));
   EXPECT_EQ(role_err.message(), "missing required field: messages[0].role");
+
+  // Missing required url in image_url part.
+  nlohmann::json missing_image_url = {
+      {"model", "gpt-4o"},
+      {"messages",
+       nlohmann::json::array({
+           {{"role", "user"},
+            {"content", nlohmann::json::array({
+                            {{"type", "image_url"}, {"image_url", {{"detail", "high"}}}},
+                        })}},
+       })},
+  };
+  auto img_err = payload_schema.validateRequest(missing_image_url);
+  EXPECT_THAT(img_err, StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(img_err.message(),
+              testing::HasSubstr("missing required field: messages[0].content[0].image_url.url"));
 }
 
 TEST(OpenAiChatCompletionsTest, CanonicalStreamableFieldOrder) {
@@ -150,10 +175,12 @@ TEST(OpenAiChatCompletionsTest, CanonicalStreamableFieldOrder) {
   const std::vector<std::string> expected_order = {
       "messages[].content",
       "messages[].content[].text",
+      "messages[].content[].image_url.url",
       "messages[].tool_calls[].function.arguments",
       "tools[].function.description",
   };
   EXPECT_EQ(payload_schema.requestStreamableFieldOrder(), expected_order);
+  EXPECT_EQ(payload_schema.requestOffloadableFieldPaths(), expected_order);
 }
 
 TEST(OpenAiChatCompletionsTest, InvalidFieldValuesAndTypes) {
@@ -189,6 +216,39 @@ TEST(OpenAiChatCompletionsTest, InvalidFieldValuesAndTypes) {
   };
   EXPECT_THAT(payload_schema.validateRequest(high_temp),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Invalid image_url.url type (e.g., integer instead of string or ExternalRef).
+  nlohmann::json invalid_image_url_type = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"},
+                        {"content", nlohmann::json::array({
+                                        {{"type", "image_url"}, {"image_url", {{"url", 12345}}}},
+                                    })}},
+                   })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(invalid_image_url_type),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Non-offloadable field in image_url (e.g. detail) cannot be an ExternalRef.
+  nlohmann::json offloaded_detail = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"},
+                        {"content", nlohmann::json::array({
+                                        {{"type", "image_url"},
+                                         {"image_url",
+                                          {{"url", "https://example.com/image.png"},
+                                           {"detail", JsonWithExtBuf::makeExternalRef(
+                                                          JsonWithExtBuf::ExternalRef{0, 10})}}}},
+                                    })}},
+                   })},
+  };
+  auto detail_err = payload_schema.validateRequest(offloaded_detail);
+  EXPECT_THAT(detail_err, StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(detail_err.message(),
+              testing::HasSubstr("field 'messages[0].content[0].image_url.detail' cannot be "
+                                 "offloaded to external buffer"));
 }
 
 TEST(OpenAiChatCompletionsTest, SubSchemasDirectValidation) {
@@ -218,6 +278,18 @@ TEST(OpenAiChatCompletionsTest, SubSchemasDirectValidation) {
   };
   EXPECT_THAT(chat_message_schema.validate(valid_msg), IsOk());
 
+  // Direct validation of chatMessageSchema with offloaded image_url.
+  nlohmann::json multimodal_msg = {
+      {"role", "user"},
+      {"content",
+       nlohmann::json::array({
+           {{"type", "image_url"},
+            {"image_url",
+             {{"url", JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{100, 5000})}}}},
+       })},
+  };
+  EXPECT_THAT(chat_message_schema.validate(multimodal_msg), IsOk());
+
   nlohmann::json msg_invalid_role = {
       {"role", "superadmin"},
   };
@@ -238,6 +310,72 @@ TEST(OpenAiChatCompletionsTest, SubSchemasDirectValidation) {
       {"type", "not_a_function"},
   };
   EXPECT_THAT(tool_schema.validate(invalid_tool), StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Test toolSchema with nullable optional fields.
+  nlohmann::json null_fields_tool = {
+      {"type", "function"},
+      {"function", {{"name", "fetch_info"}, {"description", nullptr}, {"strict", nullptr}}},
+  };
+  EXPECT_THAT(tool_schema.validate(null_fields_tool), IsOk());
+}
+
+TEST(OpenAiChatCompletionsTest, NullableFieldsValidation) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  // Full request payload with all optional fields explicitly set to null.
+  nlohmann::json null_fields_req = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"},
+                        {"content", nullptr},
+                        {"name", nullptr},
+                        {"tool_call_id", nullptr},
+                        {"tool_calls", nullptr}},
+                   })},
+      {"temperature", nullptr},
+      {"top_p", nullptr},
+      {"n", nullptr},
+      {"stream", nullptr},
+      {"stop", nullptr},
+      {"max_tokens", nullptr},
+      {"max_completion_tokens", nullptr},
+      {"presence_penalty", nullptr},
+      {"frequency_penalty", nullptr},
+      {"logit_bias", nullptr},
+      {"user", nullptr},
+      {"tools", nullptr},
+      {"tool_choice", nullptr},
+      {"response_format", nullptr},
+      {"seed", nullptr},
+      {"service_tier", nullptr},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(null_fields_req), IsOk());
+
+  // Non-nullable fields set to null must be rejected.
+  nlohmann::json null_model = {
+      {"model", nullptr},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Hi"}},
+                   })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(null_model),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  nlohmann::json null_messages = {
+      {"model", "gpt-4o"},
+      {"messages", nullptr},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(null_messages),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  nlohmann::json null_role = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", nullptr}, {"content", "Hi"}},
+                   })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(null_role),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
@@ -10,7 +10,7 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
-namespace OpenAi {
+namespace OpenAI {
 namespace {
 
 using StatusHelpers::IsOk;
@@ -191,8 +191,57 @@ TEST(OpenAiChatCompletionsTest, InvalidFieldValuesAndTypes) {
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
 }
 
+TEST(OpenAiChatCompletionsTest, SubSchemasDirectValidation) {
+  // Test toolCallSchema directly.
+  const Schema& tool_call_schema = toolCallSchema();
+  nlohmann::json valid_tool_call = {
+      {"id", "call_1"},
+      {"type", "function"},
+      {"function",
+       {{"name", "search"},
+        {"arguments", JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{0, 100})}}},
+  };
+  EXPECT_THAT(tool_call_schema.validate(valid_tool_call), IsOk());
+
+  nlohmann::json invalid_tool_call = {
+      {"id", "call_1"},
+      {"type", "unknown_type"},
+  };
+  EXPECT_THAT(tool_call_schema.validate(invalid_tool_call),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Test chatMessageSchema directly.
+  const Schema& chat_message_schema = chatMessageSchema();
+  nlohmann::json valid_msg = {
+      {"role", "assistant"}, {"content", "Hello"},       {"refusal", "Cannot comply"},
+      {"name", "bot"},       {"tool_call_id", "call_1"},
+  };
+  EXPECT_THAT(chat_message_schema.validate(valid_msg), IsOk());
+
+  nlohmann::json msg_invalid_role = {
+      {"role", "superadmin"},
+  };
+  EXPECT_THAT(chat_message_schema.validate(msg_invalid_role),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Test toolSchema directly.
+  const Schema& tool_schema = toolSchema();
+  nlohmann::json valid_tool = {
+      {"type", "function"},
+      {"function",
+       {{"name", "fetch_info"},
+        {"description", JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{0, 50})}}},
+  };
+  EXPECT_THAT(tool_schema.validate(valid_tool), IsOk());
+
+  nlohmann::json invalid_tool = {
+      {"type", "not_a_function"},
+  };
+  EXPECT_THAT(tool_schema.validate(invalid_tool), StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
 } // namespace
-} // namespace OpenAi
+} // namespace OpenAI
 } // namespace AiProtocolManager
 } // namespace HttpFilters
 } // namespace Extensions

--- a/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
@@ -143,7 +143,18 @@ TEST(OpenAiChatCompletionsTest, MissingRequiredFields) {
   };
   auto role_err = payload_schema.validateRequest(missing_role);
   EXPECT_THAT(role_err, StatusCodeIs(absl::StatusCode::kInvalidArgument));
-  EXPECT_EQ(role_err.message(), "missing required field: /messages/0/role");
+  EXPECT_EQ(role_err.message(), "missing required field: messages[0].role");
+}
+
+TEST(OpenAiChatCompletionsTest, CanonicalStreamableFieldOrder) {
+  PayloadSchema payload_schema = createPayloadSchema();
+  const std::vector<std::string> expected_order = {
+      "messages[].content",
+      "messages[].content[].text",
+      "messages[].tool_calls[].function.arguments",
+      "tools[].function.description",
+  };
+  EXPECT_EQ(payload_schema.requestStreamableFieldOrder(), expected_order);
 }
 
 TEST(OpenAiChatCompletionsTest, InvalidFieldValuesAndTypes) {

--- a/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
@@ -1,6 +1,5 @@
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
 #include "source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h"
-#include "source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h"
 
 #include "test/test_common/status_utility.h"
 
@@ -190,14 +189,6 @@ TEST(OpenAiChatCompletionsTest, InvalidFieldValuesAndTypes) {
   };
   EXPECT_THAT(payload_schema.validateRequest(high_temp),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
-}
-
-TEST(OpenAiChatCompletionsTest, SchemaRegistryLookup) {
-  const PayloadSchema* schema = SchemaRegistry::getSchema(PerRouteProto::OPENAI_CHAT_COMPLETIONS);
-  ASSERT_NE(schema, nullptr);
-
-  const PayloadSchema* unspec_schema = SchemaRegistry::getSchema(PerRouteProto::UNSPECIFIED);
-  EXPECT_EQ(unspec_schema, nullptr);
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions_test.cc
@@ -1,0 +1,197 @@
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+#include "source/extensions/filters/http/ai_protocol_manager/schema/openai_chat_completions.h"
+#include "source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h"
+
+#include "test/test_common/status_utility.h"
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace OpenAi {
+namespace {
+
+using StatusHelpers::IsOk;
+using StatusHelpers::StatusCodeIs;
+
+TEST(OpenAiChatCompletionsTest, StandardValidPayload) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  nlohmann::json valid_req = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "system"}, {"content", "You are a helpful assistant."}},
+                       {{"role", "user"}, {"content", "Hello!"}},
+                   })},
+      {"temperature", 0.7},
+      {"max_tokens", 100},
+      {"stream", false},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(valid_req), IsOk());
+}
+
+TEST(OpenAiChatCompletionsTest, OffloadedMessageContent) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  nlohmann::json offloaded_req = {
+      {"model", "gpt-4o"},
+      {"messages",
+       nlohmann::json::array({
+           {{"role", "user"},
+            {"content", JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{100, 50000})}},
+       })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(offloaded_req), IsOk());
+}
+
+TEST(OpenAiChatCompletionsTest, MultimodalContentParts) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  nlohmann::json multimodal_req = {
+      {"model", "gpt-4o"},
+      {"messages",
+       nlohmann::json::array(
+           {{{"role", "user"},
+             {"content", nlohmann::json::array(
+                             {{{"type", "text"}, {"text", "What is in this image?"}},
+                              {{"type", "image_url"},
+                               {"image_url", {{"url", "https://example.com/image.png"}}}}})}}})},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(multimodal_req), IsOk());
+}
+
+TEST(OpenAiChatCompletionsTest, ToolsAndToolCalls) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  nlohmann::json tools_req = {
+      {"model", "gpt-4o"},
+      {"messages",
+       nlohmann::json::array({
+           {{"role", "assistant"},
+            {"tool_calls", nlohmann::json::array({
+                               {{"id", "call_123"},
+                                {"type", "function"},
+                                {"function",
+                                 {{"name", "get_weather"},
+                                  {"arguments", JsonWithExtBuf::makeExternalRef(
+                                                    JsonWithExtBuf::ExternalRef{500, 200})}}}},
+                           })}},
+       })},
+      {"tools",
+       nlohmann::json::array({
+           {{"type", "function"},
+            {"function",
+             {{"name", "get_weather"},
+              {"description", "Get current weather"},
+              {"parameters", {{"type", "object"}, {"properties", {{"location", "string"}}}}}}}},
+       })},
+      {"tool_choice", "auto"},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(tools_req), IsOk());
+}
+
+TEST(OpenAiChatCompletionsTest, UnknownFieldsPassThrough) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  nlohmann::json custom_fields_req = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Hi"}},
+                   })},
+      {"custom_routing_tag", "blue"},
+      {"user_tracking_id", 9999},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(custom_fields_req), IsOk());
+}
+
+TEST(OpenAiChatCompletionsTest, MissingRequiredFields) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  // Missing required model.
+  nlohmann::json missing_model = {
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Hi"}},
+                   })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(missing_model),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Missing required messages.
+  nlohmann::json missing_messages = {
+      {"model", "gpt-4o"},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(missing_messages),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Empty messages array (min size is 1).
+  nlohmann::json empty_messages = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array()},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(empty_messages),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Missing required role in message.
+  nlohmann::json missing_role = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"content", "Hi"}},
+                   })},
+  };
+  auto role_err = payload_schema.validateRequest(missing_role);
+  EXPECT_THAT(role_err, StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_EQ(role_err.message(), "missing required field: /messages/0/role");
+}
+
+TEST(OpenAiChatCompletionsTest, InvalidFieldValuesAndTypes) {
+  PayloadSchema payload_schema = createPayloadSchema();
+
+  // Invalid role enum value.
+  nlohmann::json invalid_role = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "admin"}, {"content", "Hi"}},
+                   })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(invalid_role),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Invalid model offload (model cannot be an ExternalRef).
+  nlohmann::json offloaded_model = {
+      {"model", JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{0, 100})},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Hi"}},
+                   })},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(offloaded_model),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Temperature out of bounds.
+  nlohmann::json high_temp = {
+      {"model", "gpt-4o"},
+      {"messages", nlohmann::json::array({
+                       {{"role", "user"}, {"content", "Hi"}},
+                   })},
+      {"temperature", 2.5},
+  };
+  EXPECT_THAT(payload_schema.validateRequest(high_temp),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(OpenAiChatCompletionsTest, SchemaRegistryLookup) {
+  const PayloadSchema* schema = SchemaRegistry::getSchema(PerRouteProto::OPENAI_CHAT_COMPLETIONS);
+  ASSERT_NE(schema, nullptr);
+
+  const PayloadSchema* unspec_schema = SchemaRegistry::getSchema(PerRouteProto::UNSPECIFIED);
+  EXPECT_EQ(unspec_schema, nullptr);
+}
+
+} // namespace
+} // namespace OpenAi
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/schema/schema_registry_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/schema_registry_test.cc
@@ -19,6 +19,10 @@ TEST(SchemaRegistryTest, SchemaRegistryLookup) {
 
   const PayloadSchema* unspec_schema = SchemaRegistry::getSchema(PerRouteProto::UNSPECIFIED);
   EXPECT_EQ(unspec_schema, nullptr);
+
+  const PayloadSchema* unknown_schema =
+      SchemaRegistry::getSchema(static_cast<PerRouteProto::Schema>(999));
+  EXPECT_EQ(unknown_schema, nullptr);
 }
 
 TEST(SchemaRegistryTest, AllDeclaredOffloadableFieldsInStreamOrder) {

--- a/test/extensions/filters/http/ai_protocol_manager/schema/schema_registry_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema/schema_registry_test.cc
@@ -1,0 +1,58 @@
+#include <algorithm>
+#include <vector>
+
+#include "source/extensions/filters/http/ai_protocol_manager/schema/schema_registry.h"
+
+#include "test/test_common/status_utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace {
+
+TEST(SchemaRegistryTest, SchemaRegistryLookup) {
+  const PayloadSchema* schema = SchemaRegistry::getSchema(PerRouteProto::OPENAI_CHAT_COMPLETIONS);
+  ASSERT_NE(schema, nullptr);
+
+  const PayloadSchema* unspec_schema = SchemaRegistry::getSchema(PerRouteProto::UNSPECIFIED);
+  EXPECT_EQ(unspec_schema, nullptr);
+}
+
+TEST(SchemaRegistryTest, AllDeclaredOffloadableFieldsInStreamOrder) {
+  const auto* descriptor = PerRouteProto::Schema_descriptor();
+  ASSERT_NE(descriptor, nullptr);
+
+  for (int i = 0; i < descriptor->value_count(); ++i) {
+    const auto* value_descriptor = descriptor->value(i);
+    ASSERT_NE(value_descriptor, nullptr);
+    const auto schema_enum = static_cast<PerRouteProto::Schema>(value_descriptor->number());
+    if (schema_enum == PerRouteProto::UNSPECIFIED) {
+      continue;
+    }
+
+    const PayloadSchema* schema = SchemaRegistry::getSchema(schema_enum);
+    ASSERT_NE(schema, nullptr) << "SchemaRegistry missing registered schema for enum "
+                               << value_descriptor->name();
+
+    const std::vector<std::string> offloadable_paths = schema->requestOffloadableFieldPaths();
+    const std::vector<std::string>& stream_order = schema->requestStreamableFieldOrder();
+
+    EXPECT_FALSE(offloadable_paths.empty());
+    for (const std::string& offloadable_path : offloadable_paths) {
+      EXPECT_NE(std::find(stream_order.begin(), stream_order.end(), offloadable_path),
+                stream_order.end())
+          << "Declared offloadable field path '" << offloadable_path
+          << "' is missing from the streamable field order list in schema "
+          << value_descriptor->name();
+    }
+  }
+}
+
+} // namespace
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -1,0 +1,175 @@
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+#include "source/extensions/filters/http/ai_protocol_manager/schema.h"
+
+#include "test/test_common/status_utility.h"
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace {
+
+using StatusHelpers::IsOk;
+using StatusHelpers::StatusCodeIs;
+
+TEST(SchemaTest, PrimitiveTypesValidation) {
+  EXPECT_THAT(Schema::string().validate(nlohmann::json("hello")), IsOk());
+  EXPECT_THAT(Schema::string().validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  EXPECT_THAT(Schema::number().validate(nlohmann::json(3.14)), IsOk());
+  EXPECT_THAT(Schema::number().validate(nlohmann::json(42)), IsOk());
+  EXPECT_THAT(Schema::number().validate(nlohmann::json("not a number")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  EXPECT_THAT(Schema::integer().validate(nlohmann::json(42)), IsOk());
+  EXPECT_THAT(Schema::integer().validate(nlohmann::json(3.14)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  EXPECT_THAT(Schema::boolean().validate(nlohmann::json(true)), IsOk());
+  EXPECT_THAT(Schema::boolean().validate(nlohmann::json(false)), IsOk());
+  EXPECT_THAT(Schema::boolean().validate(nlohmann::json("true")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  EXPECT_THAT(Schema::null().validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(Schema::null().validate(nlohmann::json("null")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  EXPECT_THAT(Schema::any().validate(nlohmann::json("anything")), IsOk());
+  EXPECT_THAT(Schema::any().validate(nlohmann::json(123)), IsOk());
+  EXPECT_THAT(Schema::any().validate(nlohmann::json(nlohmann::json::object())), IsOk());
+}
+
+TEST(SchemaTest, NumericRangeConstraints) {
+  Schema temp_schema = Schema::number().range(0.0, 2.0);
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(0.0)), IsOk());
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(1.5)), IsOk());
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(2.0)), IsOk());
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(-0.1)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(2.1)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  Schema int_schema = Schema::integer().min(0).max(100);
+  EXPECT_THAT(int_schema.validate(nlohmann::json(0)), IsOk());
+  EXPECT_THAT(int_schema.validate(nlohmann::json(50)), IsOk());
+  EXPECT_THAT(int_schema.validate(nlohmann::json(100)), IsOk());
+  EXPECT_THAT(int_schema.validate(nlohmann::json(-1)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(int_schema.validate(nlohmann::json(101)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SchemaTest, EnumStringValidation) {
+  Schema role_schema =
+      Schema::enumString({"system", "user", "assistant", "tool", "function", "developer"});
+
+  EXPECT_THAT(role_schema.validate(nlohmann::json("user")), IsOk());
+  EXPECT_THAT(role_schema.validate(nlohmann::json("assistant")), IsOk());
+  EXPECT_THAT(role_schema.validate(nlohmann::json("invalid_role")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SchemaTest, OffloadableStringValidation) {
+  Schema inline_only = Schema::string().offloadable(false);
+  Schema offloadable = Schema::string().offloadable(true);
+
+  nlohmann::json regular_str = "simple inline string";
+  nlohmann::json offloaded_ref =
+      JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{0, 2048});
+
+  EXPECT_THAT(inline_only.validate(regular_str), IsOk());
+  EXPECT_THAT(offloadable.validate(regular_str), IsOk());
+
+  EXPECT_THAT(offloadable.validate(offloaded_ref), IsOk());
+  EXPECT_THAT(inline_only.validate(offloaded_ref),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SchemaTest, ObjectValidation) {
+  Schema schema = Schema::object({
+      {"model", Schema::string().required()},
+      {"temperature", Schema::number().optional()},
+  });
+
+  // Valid object with required field.
+  nlohmann::json valid_obj = {{"model", "gpt-4"}};
+  EXPECT_THAT(schema.validate(valid_obj), IsOk());
+
+  // Valid object with both required and optional fields.
+  nlohmann::json full_obj = {{"model", "gpt-4"}, {"temperature", 0.7}};
+  EXPECT_THAT(schema.validate(full_obj), IsOk());
+
+  // Missing required field.
+  nlohmann::json missing_req = {{"temperature", 0.7}};
+  auto status = schema.validate(missing_req);
+  EXPECT_THAT(status, StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_EQ(status.message(), "missing required field: /model");
+
+  // Invalid type for property.
+  nlohmann::json bad_type = {{"model", 123}};
+  EXPECT_THAT(schema.validate(bad_type), StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Unknown fields allowed by default.
+  nlohmann::json with_extra = {{"model", "gpt-4"}, {"extra_field", "permitted"}};
+  EXPECT_THAT(schema.validate(with_extra), IsOk());
+
+  // Strict unknown fields rejection.
+  Schema strict_schema = Schema::object({
+                                            {"model", Schema::string().required()},
+                                        })
+                             .allowUnknownFields(false);
+  EXPECT_THAT(strict_schema.validate(valid_obj), IsOk());
+  EXPECT_THAT(strict_schema.validate(with_extra), StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SchemaTest, ArrayValidation) {
+  Schema schema = Schema::array(Schema::string()).min(1);
+
+  nlohmann::json valid_arr = {"alpha", "beta"};
+  EXPECT_THAT(schema.validate(valid_arr), IsOk());
+
+  nlohmann::json empty_arr = nlohmann::json::array();
+  EXPECT_THAT(schema.validate(empty_arr), StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  nlohmann::json bad_arr = {"alpha", 42};
+  auto status = schema.validate(bad_arr);
+  EXPECT_THAT(status, StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_EQ(status.message(), "field '/1' has invalid type: expected string, got integer");
+}
+
+TEST(SchemaTest, OneOfPolymorphicValidation) {
+  Schema stop_schema = Schema::oneOf({
+      Schema::string(),
+      Schema::array(Schema::string()),
+  });
+
+  EXPECT_THAT(stop_schema.validate(nlohmann::json("STOP")), IsOk());
+  EXPECT_THAT(stop_schema.validate(nlohmann::json({"STOP", "END"})), IsOk());
+  EXPECT_THAT(stop_schema.validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(stop_schema.validate(nlohmann::json({123, 456})),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SchemaTest, CustomValidator) {
+  Schema schema = Schema::string().customValidator([](const nlohmann::json& val) -> absl::Status {
+    if (val.get<std::string>().rfind("prefix_", 0) == 0) {
+      return absl::OkStatus();
+    }
+    return absl::InvalidArgumentError("string must start with 'prefix_'");
+  });
+
+  EXPECT_THAT(schema.validate(nlohmann::json("prefix_foo")), IsOk());
+  EXPECT_THAT(schema.validate(nlohmann::json("other_foo")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+} // namespace
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -289,29 +289,49 @@ TEST(SchemaTest, TypeMismatchRejections) {
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(Schema::string().validate(nlohmann::json::object()),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::string().validate(nlohmann::json(nullptr)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::string().validate(nlohmann::json::binary({})),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::string().validate(nlohmann::json(nlohmann::json::value_t::discarded)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   // Number schema given non-number.
   EXPECT_THAT(Schema::number().validate(nlohmann::json("abc")),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::number().validate(nlohmann::json(nullptr)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  nlohmann::json ext_ref = JsonWithExtBuf::makeExternalRef(JsonWithExtBuf::ExternalRef{0, 10});
+  EXPECT_THAT(Schema::number().validate(ext_ref), StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   // Integer schema given non-integer.
   EXPECT_THAT(Schema::integer().validate(nlohmann::json(true)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::integer().validate(nlohmann::json(nullptr)),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   // Boolean schema given non-boolean.
   EXPECT_THAT(Schema::boolean().validate(nlohmann::json(0)),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::boolean().validate(nlohmann::json(nullptr)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   // Null schema given non-null.
   EXPECT_THAT(Schema::null().validate(nlohmann::json(false)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::null().validate(nlohmann::json("text")),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   // Object schema given non-object.
   EXPECT_THAT(Schema::object({}).validate(nlohmann::json("not_an_object")),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::object({}).validate(nlohmann::json(nullptr)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   // Array schema given non-array.
   EXPECT_THAT(Schema::array(Schema::string()).validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::array(Schema::string()).validate(nlohmann::json(nullptr)),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
 }
 

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -92,7 +92,7 @@ TEST(SchemaTest, OffloadableStringValidation) {
 TEST(SchemaTest, ObjectValidation) {
   Schema schema = Schema::object({
       {"model", Schema::string().required()},
-      {"temperature", Schema::number().optional()},
+      {"temperature", Schema::number()},
   });
 
   // Valid object with required field.
@@ -107,7 +107,7 @@ TEST(SchemaTest, ObjectValidation) {
   nlohmann::json missing_req = {{"temperature", 0.7}};
   auto status = schema.validate(missing_req);
   EXPECT_THAT(status, StatusCodeIs(absl::StatusCode::kInvalidArgument));
-  EXPECT_EQ(status.message(), "missing required field: /model");
+  EXPECT_EQ(status.message(), "missing required field: model");
 
   // Invalid type for property.
   nlohmann::json bad_type = {{"model", 123}};
@@ -138,7 +138,7 @@ TEST(SchemaTest, ArrayValidation) {
   nlohmann::json bad_arr = {"alpha", 42};
   auto status = schema.validate(bad_arr);
   EXPECT_THAT(status, StatusCodeIs(absl::StatusCode::kInvalidArgument));
-  EXPECT_EQ(status.message(), "field '/1' has invalid type: expected string, got integer");
+  EXPECT_EQ(status.message(), "field '[1]' has invalid type: expected string, got integer");
 }
 
 TEST(SchemaTest, OneOfPolymorphicValidation) {

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -168,6 +168,20 @@ TEST(SchemaTest, CustomValidator) {
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
 }
 
+TEST(SchemaTest, OffloadableFieldPathsDiscovery) {
+  Schema schema = Schema::object({
+      {"model", Schema::string()},
+      {"prompt", Schema::string().offloadable()},
+      {"messages", Schema::array(Schema::object({
+                       {"role", Schema::string()},
+                       {"content", Schema::string().offloadable()},
+                   }))},
+  });
+
+  const std::vector<std::string> expected = {"prompt", "messages[].content"};
+  EXPECT_EQ(schema.offloadableFieldPaths(), expected);
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -229,11 +229,18 @@ TEST(SchemaTest, OffloadableFieldPathsDiscovery) {
 }
 
 TEST(SchemaTest, SchemaReflectionAndAccessors) {
-  Schema enum_schema = Schema::enumString({"a", "b"}).required(true).offloadable(true);
+  Schema enum_schema =
+      Schema::enumString({"a", "b"}).required(true).offloadable(true).nullable(true);
   EXPECT_EQ(enum_schema.type(), Schema::Type::String);
   EXPECT_TRUE(enum_schema.isRequired());
   EXPECT_TRUE(enum_schema.isOffloadable());
+  EXPECT_TRUE(enum_schema.isNullable());
   EXPECT_EQ(enum_schema.allowedValues(), (std::vector<std::string>{"a", "b"}));
+
+  Schema non_nullable_schema = Schema::string();
+  EXPECT_FALSE(non_nullable_schema.isNullable());
+  non_nullable_schema.nullable(false);
+  EXPECT_FALSE(non_nullable_schema.isNullable());
 
   Schema arr_schema = Schema::array(Schema::number());
   ASSERT_NE(arr_schema.elementSchema(), nullptr);
@@ -241,6 +248,83 @@ TEST(SchemaTest, SchemaReflectionAndAccessors) {
 
   Schema obj_schema = Schema::object({}).allowUnknownFields(false);
   EXPECT_FALSE(obj_schema.allowsUnknownFields());
+}
+
+TEST(SchemaTest, NullableValidation) {
+  // Nullable string.
+  Schema non_null_str = Schema::string();
+  Schema null_str = Schema::string().nullable();
+  EXPECT_THAT(non_null_str.validate(nlohmann::json("hello")), IsOk());
+  EXPECT_THAT(non_null_str.validate(nlohmann::json(nullptr)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(null_str.validate(nlohmann::json("hello")), IsOk());
+  EXPECT_THAT(null_str.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_str.validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Nullable number with range constraint.
+  Schema null_num = Schema::number().range(0.0, 2.0).nullable();
+  EXPECT_THAT(null_num.validate(nlohmann::json(1.0)), IsOk());
+  EXPECT_THAT(null_num.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_num.validate(nlohmann::json(3.0)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(null_num.validate(nlohmann::json("text")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Nullable integer with min/max constraint.
+  Schema null_int = Schema::integer().min(0).max(10).nullable();
+  EXPECT_THAT(null_int.validate(nlohmann::json(5)), IsOk());
+  EXPECT_THAT(null_int.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_int.validate(nlohmann::json(-1)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(null_int.validate(nlohmann::json(15)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Nullable boolean.
+  Schema null_bool = Schema::boolean().nullable();
+  EXPECT_THAT(null_bool.validate(nlohmann::json(true)), IsOk());
+  EXPECT_THAT(null_bool.validate(nlohmann::json(false)), IsOk());
+  EXPECT_THAT(null_bool.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_bool.validate(nlohmann::json("true")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Nullable object.
+  Schema null_obj = Schema::object({{"key", Schema::string()}}).nullable();
+  EXPECT_THAT(null_obj.validate(nlohmann::json{{"key", "val"}}), IsOk());
+  EXPECT_THAT(null_obj.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_obj.validate(nlohmann::json("not_an_object")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Nullable array and array with nullable elements.
+  Schema null_arr = Schema::array(Schema::string()).nullable();
+  EXPECT_THAT(null_arr.validate(nlohmann::json{"a", "b"}), IsOk());
+  EXPECT_THAT(null_arr.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_arr.validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  Schema arr_with_null_elems = Schema::array(Schema::string().nullable());
+  EXPECT_THAT(arr_with_null_elems.validate(nlohmann::json{"a", nullptr, "b"}), IsOk());
+  EXPECT_THAT(arr_with_null_elems.validate(nlohmann::json{"a", 123}),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Nullable oneOf.
+  Schema null_one_of = Schema::oneOf({Schema::string(), Schema::integer()}).nullable();
+  EXPECT_THAT(null_one_of.validate(nlohmann::json("hello")), IsOk());
+  EXPECT_THAT(null_one_of.validate(nlohmann::json(42)), IsOk());
+  EXPECT_THAT(null_one_of.validate(nlohmann::json(nullptr)), IsOk());
+  EXPECT_THAT(null_one_of.validate(nlohmann::json(true)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Required and nullable property in object.
+  Schema req_null_obj = Schema::object({
+      {"req_null", Schema::string().required().nullable()},
+  });
+  EXPECT_THAT(req_null_obj.validate(nlohmann::json{{"req_null", "val"}}), IsOk());
+  EXPECT_THAT(req_null_obj.validate(nlohmann::json{{"req_null", nullptr}}), IsOk());
+  EXPECT_THAT(req_null_obj.validate(nlohmann::json::object()),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(req_null_obj.validate(nlohmann::json{{"req_null", 123}}),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
 }
 
 TEST(SchemaTest, RequestResponseAndPayloadSchema) {

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
 #include "source/extensions/filters/http/ai_protocol_manager/schema.h"
 
@@ -51,6 +53,13 @@ TEST(SchemaTest, NumericRangeConstraints) {
   EXPECT_THAT(temp_schema.validate(nlohmann::json(-0.1)),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(temp_schema.validate(nlohmann::json(2.1)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Integer value checked against number range constraints.
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(1)), IsOk());
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(-1)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(temp_schema.validate(nlohmann::json(3)),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   Schema int_schema = Schema::integer().min(0).max(100);
@@ -127,13 +136,16 @@ TEST(SchemaTest, ObjectValidation) {
 }
 
 TEST(SchemaTest, ArrayValidation) {
-  Schema schema = Schema::array(Schema::string()).min(1);
+  Schema schema = Schema::array(Schema::string()).min(1).max(2);
 
   nlohmann::json valid_arr = {"alpha", "beta"};
   EXPECT_THAT(schema.validate(valid_arr), IsOk());
 
   nlohmann::json empty_arr = nlohmann::json::array();
   EXPECT_THAT(schema.validate(empty_arr), StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  nlohmann::json too_large_arr = {"alpha", "beta", "gamma"};
+  EXPECT_THAT(schema.validate(too_large_arr), StatusCodeIs(absl::StatusCode::kInvalidArgument));
 
   nlohmann::json bad_arr = {"alpha", 42};
   auto status = schema.validate(bad_arr);
@@ -153,6 +165,25 @@ TEST(SchemaTest, OneOfPolymorphicValidation) {
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
   EXPECT_THAT(stop_schema.validate(nlohmann::json({123, 456})),
               StatusCodeIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SchemaTest, VectorOverloadsAndConstructors) {
+  // Test std::vector<Property> overload for Schema::object.
+  std::vector<Schema::Property> props;
+  std::string prop_name = "key";
+  props.emplace_back(prop_name, Schema::string());
+  props.emplace_back("literal_key", Schema::integer());
+  Schema obj_schema = Schema::object(std::move(props));
+  EXPECT_EQ(obj_schema.type(), Schema::Type::Object);
+  EXPECT_EQ(obj_schema.properties().size(), 2);
+
+  // Test std::vector<Schema> overload for Schema::oneOf.
+  std::vector<Schema> candidates;
+  candidates.push_back(Schema::string());
+  candidates.push_back(Schema::number());
+  Schema one_of_schema = Schema::oneOf(std::move(candidates));
+  EXPECT_EQ(one_of_schema.type(), Schema::Type::OneOf);
+  EXPECT_EQ(one_of_schema.oneOfCandidates().size(), 2);
 }
 
 TEST(SchemaTest, CustomValidator) {
@@ -180,6 +211,108 @@ TEST(SchemaTest, OffloadableFieldPathsDiscovery) {
 
   const std::vector<std::string> expected = {"prompt", "messages[].content"};
   EXPECT_EQ(schema.offloadableFieldPaths(), expected);
+
+  // Root offloadable string and array.
+  Schema root_str = Schema::string().offloadable();
+  EXPECT_EQ(root_str.offloadableFieldPaths(), std::vector<std::string>{""});
+
+  Schema root_arr = Schema::array(Schema::string().offloadable());
+  EXPECT_EQ(root_arr.offloadableFieldPaths(), std::vector<std::string>{"[]"});
+
+  // OneOf candidate offloadable field path.
+  Schema one_of = Schema::oneOf({
+      Schema::string().offloadable(),
+      Schema::array(Schema::string().offloadable()),
+  });
+  const std::vector<std::string> expected_one_of = {"", "[]"};
+  EXPECT_EQ(one_of.offloadableFieldPaths(), expected_one_of);
+}
+
+TEST(SchemaTest, SchemaReflectionAndAccessors) {
+  Schema enum_schema = Schema::enumString({"a", "b"}).required(true).offloadable(true);
+  EXPECT_EQ(enum_schema.type(), Schema::Type::String);
+  EXPECT_TRUE(enum_schema.isRequired());
+  EXPECT_TRUE(enum_schema.isOffloadable());
+  EXPECT_EQ(enum_schema.allowedValues(), (std::vector<std::string>{"a", "b"}));
+
+  Schema arr_schema = Schema::array(Schema::number());
+  ASSERT_NE(arr_schema.elementSchema(), nullptr);
+  EXPECT_EQ(arr_schema.elementSchema()->type(), Schema::Type::Number);
+
+  Schema obj_schema = Schema::object({}).allowUnknownFields(false);
+  EXPECT_FALSE(obj_schema.allowsUnknownFields());
+}
+
+TEST(SchemaTest, RequestResponseAndPayloadSchema) {
+  // Default RequestSchema.
+  RequestSchema default_req;
+  EXPECT_TRUE(default_req.streamableFieldOrder().empty());
+  EXPECT_TRUE(default_req.offloadableFieldPaths().empty());
+  EXPECT_THAT(default_req.validate(nlohmann::json::object()), IsOk());
+
+  // Default ResponseSchema.
+  ResponseSchema default_resp;
+  EXPECT_FALSE(default_resp.rootSchema().has_value());
+  EXPECT_TRUE(default_resp.streamableFieldOrder().empty());
+  EXPECT_TRUE(default_resp.offloadableFieldPaths().empty());
+
+  // Parameterized ResponseSchema.
+  ResponseSchema custom_resp(Schema::object({{"data", Schema::string().offloadable()}}), {"data"});
+  EXPECT_TRUE(custom_resp.rootSchema().has_value());
+  EXPECT_EQ(custom_resp.streamableFieldOrder(), std::vector<std::string>{"data"});
+  EXPECT_EQ(custom_resp.offloadableFieldPaths(), std::vector<std::string>{"data"});
+
+  // PayloadSchema.
+  RequestSchema req(Schema::object({{"prompt", Schema::string().offloadable()}}), {"prompt"});
+  PayloadSchema payload_schema(req, custom_resp);
+
+  EXPECT_EQ(payload_schema.requestStreamableFieldOrder(), std::vector<std::string>{"prompt"});
+  EXPECT_EQ(payload_schema.requestOffloadableFieldPaths(), std::vector<std::string>{"prompt"});
+  EXPECT_EQ(payload_schema.requestSchema().streamableFieldOrder(),
+            std::vector<std::string>{"prompt"});
+  EXPECT_EQ(payload_schema.responseSchema().streamableFieldOrder(),
+            std::vector<std::string>{"data"});
+
+  // Validate request via JsonWithExtBuf and nlohmann::json.
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"prompt", "test"}});
+  EXPECT_THAT(payload_schema.validateRequest(doc), IsOk());
+  EXPECT_THAT(payload_schema.validateRequest(nlohmann::json{{"prompt", "test"}}), IsOk());
+  EXPECT_THAT(payload_schema.requestSchema().validate(doc), IsOk());
+  EXPECT_THAT(payload_schema.requestSchema().validate(nlohmann::json{{"prompt", "test"}}), IsOk());
+  EXPECT_THAT(req.rootSchema().validate(doc), IsOk());
+}
+
+TEST(SchemaTest, TypeMismatchRejections) {
+  // String schema given non-string.
+  EXPECT_THAT(Schema::string().validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(Schema::string().validate(nlohmann::json::object()),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Number schema given non-number.
+  EXPECT_THAT(Schema::number().validate(nlohmann::json("abc")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Integer schema given non-integer.
+  EXPECT_THAT(Schema::integer().validate(nlohmann::json(true)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Boolean schema given non-boolean.
+  EXPECT_THAT(Schema::boolean().validate(nlohmann::json(0)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Null schema given non-null.
+  EXPECT_THAT(Schema::null().validate(nlohmann::json(false)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Object schema given non-object.
+  EXPECT_THAT(Schema::object({}).validate(nlohmann::json("not_an_object")),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
+
+  // Array schema given non-array.
+  EXPECT_THAT(Schema::array(Schema::string()).validate(nlohmann::json(123)),
+              StatusCodeIs(absl::StatusCode::kInvalidArgument));
 }
 
 } // namespace

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -1190,6 +1190,7 @@ oauth
 observability
 observations
 ocagent
+offloadable
 offsetof
 oneof
 oneway


### PR DESCRIPTION
Commit Message:
add utilities to define and validate JSON schema. add the first schema - OpenAI chat completion schema

This allows us to structurally define a JSON payload schema for AI requests. It is useful for validation, and
later transcoding.

This is part of #44681.

I used AI to generate this PR. I have read and fully understand this PR.

Additional Description: https://github.com/penguingao/thoughts/blob/main/20260727_AI_FILTER.md
Risk Level: Medium
Testing: unit tests
Docs Changes: updated the extension docs, but this is still an alpha filter under development
Release Notes: N/A - WIP alpha filter
Platform Specific Features: no