### PR TITLE
extensions: use C++20 container contains()

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -455,7 +455,7 @@ void ReverseConnectionIOHandle::maybeUpdateHostsMappingsAndConnections(
     removed_hosts = cluster_to_resolved_hosts_itr->second;
   }
   for (const std::string& host : hosts) {
-    if (removed_hosts.find(host) != removed_hosts.end()) {
+    if (removed_hosts.contains(host)) {
       // Since the host still exists, we will remove it from removed_hosts.
       removed_hosts.erase(host);
     }
@@ -843,7 +843,7 @@ ReverseConnectionIOHandle::dropTunnelFromTracking(const std::string& connection_
   std::string host_address;
   std::string cluster_name;
   for (const auto& [host, host_info] : host_to_conn_info_map_) {
-    if (host_info.connection_keys.find(connection_key) != host_info.connection_keys.end()) {
+    if (host_info.connection_keys.contains(connection_key)) {
       host_address = host;
       cluster_name = host_info.cluster_name;
       break;

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -514,7 +514,7 @@ void UpstreamSocketManager::markSocketDead(const int fd) {
 
 void UpstreamSocketManager::cleanStaleNodeEntry(const std::string& node_id) {
   // Clean the given node ID if there are no active sockets.
-  if (accepted_reverse_connections_.find(node_id) != accepted_reverse_connections_.end() &&
+  if (accepted_reverse_connections_.contains(node_id) &&
       !accepted_reverse_connections_[node_id].empty()) {
     ENVOY_LOG(trace, "reverse_tunnel: found {} active sockets for node {}.",
               accepted_reverse_connections_[node_id].size(), node_id);

--- a/source/extensions/clusters/redis/redis_cluster.cc
+++ b/source/extensions/clusters/redis/redis_cluster.cc
@@ -166,7 +166,7 @@ void RedisCluster::onClusterSlotUpdate(ClusterSlotsSharedPtr&& slots,
 
   for (const ClusterSlot& slot : *slots) {
     const std::string primary_address = slot.primary()->asString();
-    if (all_new_hosts.count(primary_address) == 0) {
+    if (!all_new_hosts.contains(primary_address)) {
       // Pass zone from map to set host's locality.zone
       new_hosts.emplace_back(THROW_OR_RETURN_VALUE(
           RedisHost::create(info(), "", slot.primary(), *this, true, get_zone(primary_address)),
@@ -174,7 +174,7 @@ void RedisCluster::onClusterSlotUpdate(ClusterSlotsSharedPtr&& slots,
       all_new_hosts.emplace(primary_address);
     }
     for (auto const& replica : slot.replicas()) {
-      if (all_new_hosts.count(replica.first) == 0) {
+      if (!all_new_hosts.contains(replica.first)) {
         // Pass zone from map to set host's locality.zone
         new_hosts.emplace_back(THROW_OR_RETURN_VALUE(
             RedisHost::create(info(), "", replica.second, *this, false, get_zone(replica.first)),

--- a/source/extensions/common/tap/admin.cc
+++ b/source/extensions/common/tap/admin.cc
@@ -91,7 +91,7 @@ Http::Code AdminHandler::badRequest(Buffer::Instance& response, absl::string_vie
 
 void AdminHandler::registerConfig(ExtensionConfig& config, const std::string& config_id) {
   ASSERT(!config_id.empty());
-  ASSERT(config_id_map_[config_id].count(&config) == 0);
+  ASSERT(!config_id_map_[config_id].contains(&config));
   config_id_map_[config_id].insert(&config);
   if (attached_request_ != nullptr && attached_request_->id() == config_id) {
     config.newTapConfig(attached_request_->config(), this);

--- a/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
+++ b/source/extensions/config_subscription/grpc/grpc_mux_impl.cc
@@ -366,7 +366,7 @@ void GrpcMuxImpl::onDiscoveryResponse(
   const std::string type_url = message->type_url();
   ENVOY_LOG(debug, "Received gRPC message for {} at version {}", type_url, message->version_info());
 
-  if (api_state_.count(type_url) == 0) {
+  if (!api_state_.contains(type_url)) {
     // TODO(yuval-k): This should never happen. consider dropping the stream as this is a
     // protocol violation
     ENVOY_LOG(warn, "Ignoring the message for type URL {} as it has no current subscribers.",
@@ -631,7 +631,7 @@ void GrpcMuxImpl::expiryCallback(absl::string_view type_url,
     Protobuf::RepeatedPtrField<std::string> found_resources_for_watch;
 
     for (const auto& resource : expired) {
-      if (all_expired.find(resource) != all_expired.end()) {
+      if (all_expired.contains(resource)) {
         found_resources_for_watch.Add(std::string(resource));
       }
     }

--- a/source/extensions/filters/http/compressor/compressor_filter.cc
+++ b/source/extensions/filters/http/compressor/compressor_filter.cc
@@ -715,7 +715,7 @@ bool CompressorFilterConfig::DirectionConfig::isContentTypeAllowed(
   if (content_type != nullptr && !content_type_values_.empty()) {
     const absl::string_view value =
         StringUtil::trim(StringUtil::cropRight(content_type->value().getStringView(), ";"));
-    return content_type_values_.find(value) != content_type_values_.end();
+    return content_type_values_.contains(value);
   }
 
   return true;

--- a/source/extensions/filters/http/jwt_authn/extractor.cc
+++ b/source/extensions/filters/http/jwt_authn/extractor.cc
@@ -43,7 +43,7 @@ public:
     if (allow_all_) {
       return true;
     }
-    return specified_issuers_.find(jwt_issuer) != specified_issuers_.end();
+    return specified_issuers_.contains(jwt_issuer);
   }
 
 private:

--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -657,7 +657,7 @@ bool McpFieldExtractor::requiredFieldsCollected() const {
     if (!has_method_ && (has_result_ || has_error_) && field == "method") {
       continue;
     }
-    if (collected_fields_.count(field) == 0) {
+    if (!collected_fields_.contains(field)) {
       return false;
     }
   }
@@ -668,7 +668,7 @@ bool McpFieldExtractor::requiredFieldsCollected() const {
   }
 
   for (const auto& field : required_fields_) {
-    if (collected_fields_.count(field) == 0) {
+    if (!collected_fields_.contains(field)) {
       return false;
     }
   }
@@ -789,7 +789,7 @@ void McpFieldExtractor::copyFieldByPath(absl::string_view path) {
 void McpFieldExtractor::validateRequiredFields() {
   updateFieldRequirements();
   for (const auto& field : required_fields_) {
-    if (extracted_fields_.count(field) == 0) {
+    if (!extracted_fields_.contains(field)) {
       missing_required_fields_.push_back(field);
       ENVOY_LOG(debug, "missing required field for {}: {}", method_, field);
     }

--- a/source/extensions/filters/network/common/redis/fault_impl.cc
+++ b/source/extensions/filters/network/common/redis/fault_impl.cc
@@ -129,7 +129,7 @@ const Fault* FaultManagerImpl::getFaultForCommandInternal(const std::string& com
 
 const Fault* FaultManagerImpl::getFaultForCommand(const std::string& command) const {
   if (!fault_map_.empty()) {
-    if (fault_map_.count(command) > 0) {
+    if (fault_map_.contains(command)) {
       return getFaultForCommandInternal(command);
     } else {
       return getFaultForCommandInternal(FaultManagerKeyNames::get().AllKey);

--- a/source/extensions/filters/network/common/redis/supported_commands.cc
+++ b/source/extensions/filters/network/common/redis/supported_commands.cc
@@ -40,7 +40,7 @@ bool SupportedCommands::validateCommandSubcommands(const std::string& command,
   // Validate the subcommand against the allowlist
   const auto& allowed_subcommands = it->second;
 
-  return allowed_subcommands.find(subcommand) != allowed_subcommands.end();
+  return allowed_subcommands.contains(subcommand);
 }
 
 } // namespace Redis

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -914,10 +914,10 @@ TransactionRequest::create(Router& router, Common::Redis::RespValuePtr&& incomin
   // So if this is not a transaction command, a simple command or a custom command, it is an error.
   // We also support multi-key commands, but will leave it to the client to handle the case where
   // the keys provided are not from the same shard.
-  if (Common::Redis::SupportedCommands::transactionCommands().count(command_name) == 0 &&
-      Common::Redis::SupportedCommands::simpleCommands().count(command_name) == 0 &&
-      Common::Redis::SupportedCommands::multiKeyCommands().count(command_name) == 0 &&
-      custom_commands.count(command_name) == 0) {
+  if (!Common::Redis::SupportedCommands::transactionCommands().contains(command_name) &&
+      !Common::Redis::SupportedCommands::simpleCommands().contains(command_name) &&
+      !Common::Redis::SupportedCommands::multiKeyCommands().contains(command_name) &&
+      !custom_commands.contains(command_name)) {
     callbacks.onResponse(Common::Redis::Utility::makeError(
         fmt::format("'{}' command is not supported within transaction",
                     incoming_request->asArray()[0].asString())));

--- a/source/extensions/load_balancing_policies/round_robin/round_robin_lb.h
+++ b/source/extensions/load_balancing_policies/round_robin/round_robin_lb.h
@@ -74,7 +74,7 @@ private:
     // To avoid storing the RR index in the base class, we end up using a second map here with
     // host source as the key. This means that each LB decision will require two map lookups in
     // the unweighted case. We might consider trying to optimize this in the future.
-    ASSERT(rr_indexes_.find(source) != rr_indexes_.end());
+    ASSERT(rr_indexes_.contains(source));
     return hosts_to_use[rr_indexes_[source]++ % hosts_to_use.size()];
   }
 

--- a/source/extensions/load_balancing_policies/subset/subset_lb.cc
+++ b/source/extensions/load_balancing_policies/subset/subset_lb.cc
@@ -878,13 +878,13 @@ void SubsetLoadBalancer::PriorityLbSubset::finalize(uint32_t priority) {
   HostVector removed;
 
   for (const auto& host : old_hosts) {
-    if (new_hosts.count(host) == 0) {
+    if (!new_hosts.contains(host)) {
       removed.emplace_back(host);
     }
   }
 
   for (const auto& host : new_hosts) {
-    if (old_hosts.count(host) == 0) {
+    if (!old_hosts.contains(host)) {
       added.emplace_back(host);
     }
   }

--- a/source/extensions/tracers/xray/tracer.h
+++ b/source/extensions/tracers/xray/tracer.h
@@ -130,7 +130,7 @@ public:
    * Check if key is set in http request annotation field of a Span.
    */
   bool hasKeyInHttpRequestAnnotations(absl::string_view key) {
-    return http_request_annotations_.find(key) != http_request_annotations_.end();
+    return http_request_annotations_.contains(key);
   }
 
   /*

--- a/source/extensions/transport_sockets/alts/config.cc
+++ b/source/extensions/transport_sockets/alts/config.cc
@@ -55,7 +55,7 @@ SINGLETON_MANAGER_REGISTRATION(alts_shared_state);
 // returns false and fills out err with an error message.
 bool doValidate(const absl::node_hash_set<std::string>& peers, TsiInfo& tsi_info,
                 std::string& err) {
-  if (peers.find(tsi_info.peer_identity_) != peers.end()) {
+  if (peers.contains(tsi_info.peer_identity_)) {
     return true;
   }
   err =

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -697,8 +697,8 @@ TEST_F(ReverseConnectionIOHandleTest, MaybeUpdateHostsMappingsValidHosts) {
   // Verify that hosts were added to the mapping.
   const auto& host_to_conn_info_map = getHostToConnInfoMap();
   EXPECT_EQ(host_to_conn_info_map.size(), 2);
-  EXPECT_NE(host_to_conn_info_map.find("192.168.1.1"), host_to_conn_info_map.end());
-  EXPECT_NE(host_to_conn_info_map.find("192.168.1.2"), host_to_conn_info_map.end());
+  EXPECT_TRUE(host_to_conn_info_map.contains("192.168.1.1"));
+  EXPECT_TRUE(host_to_conn_info_map.contains("192.168.1.2"));
 }
 
 // Test maybeUpdateHostsMappingsAndConnections with no new hosts.
@@ -739,9 +739,9 @@ TEST_F(ReverseConnectionIOHandleTest, MaybeUpdateHostsMappingsNoNewHosts) {
   // Verify that all three host entries exist after maintainClusterConnections.
   const auto& host_to_conn_info_map = getHostToConnInfoMap();
   EXPECT_EQ(host_to_conn_info_map.size(), 3);
-  EXPECT_NE(host_to_conn_info_map.find("192.168.1.1"), host_to_conn_info_map.end());
-  EXPECT_NE(host_to_conn_info_map.find("192.168.1.2"), host_to_conn_info_map.end());
-  EXPECT_NE(host_to_conn_info_map.find("192.168.1.3"), host_to_conn_info_map.end());
+  EXPECT_TRUE(host_to_conn_info_map.contains("192.168.1.1"));
+  EXPECT_TRUE(host_to_conn_info_map.contains("192.168.1.2"));
+  EXPECT_TRUE(host_to_conn_info_map.contains("192.168.1.3"));
 
   // Now test partial host removal by calling maybeUpdateHostsMappingsAndConnections with fewer.
   // hosts
@@ -751,10 +751,10 @@ TEST_F(ReverseConnectionIOHandleTest, MaybeUpdateHostsMappingsNoNewHosts) {
   // Verify that the removed host was cleaned up but others remain.
   const auto& updated_host_to_conn_info_map = getHostToConnInfoMap();
   EXPECT_EQ(updated_host_to_conn_info_map.size(), 2);
-  EXPECT_NE(updated_host_to_conn_info_map.find("192.168.1.1"), updated_host_to_conn_info_map.end());
+  EXPECT_TRUE(updated_host_to_conn_info_map.contains("192.168.1.1"));
   EXPECT_EQ(updated_host_to_conn_info_map.find("192.168.1.2"),
             updated_host_to_conn_info_map.end()); // Should be removed
-  EXPECT_NE(updated_host_to_conn_info_map.find("192.168.1.3"), updated_host_to_conn_info_map.end());
+  EXPECT_TRUE(updated_host_to_conn_info_map.contains("192.168.1.3"));
 }
 
 // Test shouldAttemptConnectionToHost with valid host and no existing connections.
@@ -1151,11 +1151,11 @@ TEST_F(ReverseConnectionIOHandleTest, HostMappingAndBackoffIntegration) {
   const auto& host_to_conn_info_map_initial = getHostToConnInfoMap();
   EXPECT_EQ(host_to_conn_info_map_initial.size(),
             5); // 192.168.1.1, 192.168.1.2, 192.168.1.3, 192.168.2.1, 192.168.2.2
-  EXPECT_NE(host_to_conn_info_map_initial.find("192.168.1.1"), host_to_conn_info_map_initial.end());
-  EXPECT_NE(host_to_conn_info_map_initial.find("192.168.1.2"), host_to_conn_info_map_initial.end());
-  EXPECT_NE(host_to_conn_info_map_initial.find("192.168.1.3"), host_to_conn_info_map_initial.end());
-  EXPECT_NE(host_to_conn_info_map_initial.find("192.168.2.1"), host_to_conn_info_map_initial.end());
-  EXPECT_NE(host_to_conn_info_map_initial.find("192.168.2.2"), host_to_conn_info_map_initial.end());
+  EXPECT_TRUE(host_to_conn_info_map_initial.contains("192.168.1.1"));
+  EXPECT_TRUE(host_to_conn_info_map_initial.contains("192.168.1.2"));
+  EXPECT_TRUE(host_to_conn_info_map_initial.contains("192.168.1.3"));
+  EXPECT_TRUE(host_to_conn_info_map_initial.contains("192.168.2.1"));
+  EXPECT_TRUE(host_to_conn_info_map_initial.contains("192.168.2.2"));
 
   // Step 3: Put some hosts in backoff.
   trackConnectionFailure("192.168.1.1", "cluster-A"); // 192.168.1.1 in backoff
@@ -1672,10 +1672,10 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateMultipleConnectionsMixedResults) {
   for (const auto& [wrapper, host] : wrapper_to_host_map) {
     mapped_hosts.insert(host);
   }
-  EXPECT_EQ(mapped_hosts.size(), 2);                               // Should have 2 successful hosts
-  EXPECT_NE(mapped_hosts.find("192.168.1.1"), mapped_hosts.end()); // Success
-  EXPECT_EQ(mapped_hosts.find("192.168.1.2"), mapped_hosts.end()); // Failed - not in map
-  EXPECT_NE(mapped_hosts.find("192.168.1.3"), mapped_hosts.end()); // Success
+  EXPECT_EQ(mapped_hosts.size(), 2);                  // Should have 2 successful hosts
+  EXPECT_TRUE(mapped_hosts.contains("192.168.1.1"));  // Success
+  EXPECT_FALSE(mapped_hosts.contains("192.168.1.2")); // Failed - not in map
+  EXPECT_TRUE(mapped_hosts.contains("192.168.1.3"));  // Success
 }
 
 // Test removeStaleHostAndCloseConnections removes host and closes connections.
@@ -1751,8 +1751,8 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
 
   // Verify both hosts are initially present.
   EXPECT_EQ(getHostToConnInfoMap().size(), 2);
-  EXPECT_NE(getHostToConnInfoMap().find("192.168.1.1"), getHostToConnInfoMap().end());
-  EXPECT_NE(getHostToConnInfoMap().find("192.168.1.2"), getHostToConnInfoMap().end());
+  EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.1"));
+  EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.2"));
 
   // Verify that connection wrappers were created by maintainClusterConnections.
   const auto& connection_wrappers = getConnectionWrappers();
@@ -1765,8 +1765,8 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
   // Verify that host 192.168.1.1 is still in host_to_conn_info_map_
   // (removeStaleHostAndCloseConnections doesn't remove it)
   EXPECT_EQ(getHostToConnInfoMap().size(), 2);
-  EXPECT_NE(getHostToConnInfoMap().find("192.168.1.1"), getHostToConnInfoMap().end());
-  EXPECT_NE(getHostToConnInfoMap().find("192.168.1.2"), getHostToConnInfoMap().end());
+  EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.1"));
+  EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.2"));
 
   // Verify that connection wrappers for the removed host are removed.
   EXPECT_EQ(getConnectionWrappers().size(), 1);   // Only host 192.168.1.2's wrapper remains
@@ -2246,7 +2246,7 @@ TEST_F(ReverseConnectionIOHandleTest, OnConnectionDoneFailureAndRecovery) {
   // Verify host info is still present (should not be removed)
   const auto& host_to_conn_info_map = getHostToConnInfoMap();
   EXPECT_EQ(host_to_conn_info_map.size(), 1);
-  EXPECT_NE(host_to_conn_info_map.find("192.168.1.1"), host_to_conn_info_map.end());
+  EXPECT_TRUE(host_to_conn_info_map.contains("192.168.1.1"));
 }
 
 // Test downstream connection closure and re-initiation.
@@ -2353,7 +2353,7 @@ TEST_F(ReverseConnectionIOHandleTest, OnDownstreamConnectionClosedTriggersReInit
   // Verify connection key is removed from host tracking.
   host_it = getHostToConnInfoMap().find("192.168.1.1");
   EXPECT_NE(host_it, getHostToConnInfoMap().end());
-  EXPECT_EQ(host_it->second.connection_keys.count(connection_key), 0);
+  EXPECT_FALSE(host_it->second.connection_keys.contains(connection_key));
 
   // Step 5: Set up expectation for new connection attempts.
   auto mock_connection2 = setupMockConnection();
@@ -2699,7 +2699,7 @@ TEST_F(ReverseConnectionIOHandleTest, ShouldAttemptConnectionCreatesHostEntry) {
 
   EXPECT_TRUE(shouldAttemptConnectionToHost("10.0.0.5", "cluster-x"));
   const auto& map = getHostToConnInfoMap();
-  EXPECT_NE(map.find("10.0.0.5"), map.end());
+  EXPECT_TRUE(map.contains("10.0.0.5"));
 }
 
 // Test maybeUpdateHostsMappingsAndConnections removes stale hosts.
@@ -2717,8 +2717,8 @@ TEST_F(ReverseConnectionIOHandleTest, MaybeUpdateHostsRemovesStaleHosts) {
   // Updated set: only a → b should be removed.
   maybeUpdateHostsMappingsAndConnections("c1", std::vector<std::string>{"a"});
   const auto& map = getHostToConnInfoMap();
-  EXPECT_NE(map.find("a"), map.end());
-  EXPECT_EQ(map.find("b"), map.end());
+  EXPECT_TRUE(map.contains("a"));
+  EXPECT_FALSE(map.contains("b"));
 }
 
 // Lightly exercise read/write/connect wrappers for coverage.
@@ -3392,7 +3392,7 @@ TEST_F(ReverseConnectionIOHandleTest, MarkTunnelDrainingDropsKeyAndDialsReplacem
   io_handle_->markTunnelDrainingAndDialReplacement(connection_key);
 
   // The draining tunnel is no longer tracked, leaving a deficit for the maintenance loop to fill.
-  EXPECT_EQ(getHostConnectionInfo(host).connection_keys.count(connection_key), 0);
+  EXPECT_FALSE(getHostConnectionInfo(host).connection_keys.contains(connection_key));
 }
 
 // Draining an unknown connection key is a benign no-op: nothing is dropped and no immediate

--- a/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager_test.cc
@@ -83,22 +83,13 @@ protected:
     EXPECT_EQ(socket_manager_->cluster_to_node_info_map_.size(), 0);
   }
 
-  bool verifyFDToNodeMap(int fd) {
-    return socket_manager_->fd_to_node_map_.find(fd) != socket_manager_->fd_to_node_map_.end();
-  }
+  bool verifyFDToNodeMap(int fd) { return socket_manager_->fd_to_node_map_.contains(fd); }
 
-  bool verifyFDToClusterMap(int fd) {
-    return socket_manager_->fd_to_cluster_map_.find(fd) !=
-           socket_manager_->fd_to_cluster_map_.end();
-  }
+  bool verifyFDToClusterMap(int fd) { return socket_manager_->fd_to_cluster_map_.contains(fd); }
 
-  bool verifyFDToEventMap(int fd) {
-    return socket_manager_->fd_to_event_map_.find(fd) != socket_manager_->fd_to_event_map_.end();
-  }
+  bool verifyFDToEventMap(int fd) { return socket_manager_->fd_to_event_map_.contains(fd); }
 
-  bool verifyFDToTimerMap(int fd) {
-    return socket_manager_->fd_to_timer_map_.find(fd) != socket_manager_->fd_to_timer_map_.end();
-  }
+  bool verifyFDToTimerMap(int fd) { return socket_manager_->fd_to_timer_map_.contains(fd); }
 
   size_t getFDToEventMapSize() { return socket_manager_->fd_to_event_map_.size(); }
   size_t getFDToTimerMapSize() { return socket_manager_->fd_to_timer_map_.size(); }

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -1105,8 +1105,8 @@ TEST_F(RedisConnPoolImplTest, HostsAddedAndRemovedWithDraining) {
   EXPECT_EQ(host_address_map[host1->address()->asString()], host1);
   EXPECT_EQ(host_address_map[host2->address()->asString()], host2);
   EXPECT_EQ(clientMap().size(), 2);
-  EXPECT_NE(clientMap().find(host1), clientMap().end());
-  EXPECT_NE(clientMap().find(host2), clientMap().end());
+  EXPECT_TRUE(clientMap().contains(host1));
+  EXPECT_TRUE(clientMap().contains(host2));
   void* host1_active_client = clientMap(host1);
   EXPECT_EQ(createdViaRedirectHosts().size(), 2);
   EXPECT_EQ(clientsToDrain().size(), 0);
@@ -1204,8 +1204,8 @@ TEST_F(RedisConnPoolImplTest, HostsAddedAndEndWithNoDraining) {
   EXPECT_EQ(host_address_map[host1->address()->asString()], host1);
   EXPECT_EQ(host_address_map[host2->address()->asString()], host2);
   EXPECT_EQ(clientMap().size(), 2);
-  EXPECT_NE(clientMap().find(host1), clientMap().end());
-  EXPECT_NE(clientMap().find(host2), clientMap().end());
+  EXPECT_TRUE(clientMap().contains(host1));
+  EXPECT_TRUE(clientMap().contains(host2));
   EXPECT_EQ(createdViaRedirectHosts().size(), 2);
   EXPECT_EQ(clientsToDrain().size(), 0);
   EXPECT_EQ(drainTimer()->enabled(), false);
@@ -1282,8 +1282,8 @@ TEST_F(RedisConnPoolImplTest, HostsAddedAndEndWithClusterRemoval) {
   EXPECT_EQ(host_address_map[host1->address()->asString()], host1);
   EXPECT_EQ(host_address_map[host2->address()->asString()], host2);
   EXPECT_EQ(clientMap().size(), 2);
-  EXPECT_NE(clientMap().find(host1), clientMap().end());
-  EXPECT_NE(clientMap().find(host2), clientMap().end());
+  EXPECT_TRUE(clientMap().contains(host1));
+  EXPECT_TRUE(clientMap().contains(host2));
   EXPECT_EQ(createdViaRedirectHosts().size(), 2);
   EXPECT_EQ(clientsToDrain().size(), 0);
   EXPECT_EQ(drainTimer()->enabled(), false);

--- a/test/extensions/load_balancing_policies/subset/subset_test.cc
+++ b/test/extensions/load_balancing_policies/subset/subset_test.cc
@@ -146,7 +146,7 @@ public:
   filterMatchCriteria(const std::set<std::string>& names) const override {
     auto new_criteria = std::make_unique<TestMetadataMatchCriteria>(*this);
     for (auto it = new_criteria->matches_.begin(); it != new_criteria->matches_.end();) {
-      if (names.count(it->get()->name()) == 0) {
+      if (!names.contains(it->get()->name())) {
         it = new_criteria->matches_.erase(it);
       } else {
         it++;


### PR DESCRIPTION
Replace `count(key)`/`find(key) != end()` membership checks with the C++20 `contains()` member across `source/extensions` and the mirrored tests.

This is a readability cleanup with no behavior change: `contains()` states membership intent directly and avoids constructing an unused iterator. It applies equally to the abseil and `std::` associative containers used at these sites.
