### PR TITLE
http: request body size limiting filter: fix parameter type

### DIFF
--- a/api/envoy/extensions/filters/http/body_size_limit/v3/body_size_limit.proto
+++ b/api/envoy/extensions/filters/http/body_size_limit/v3/body_size_limit.proto
@@ -20,5 +20,5 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message BodySizeLimit {
   // The maximum request body size allowed. If the request body exceeds this limit,
   // the filter will return a 413 response.
-  google.protobuf.UInt32Value max_request_bytes = 1 [(validate.rules).uint32 = {gt: 0}];
+  google.protobuf.UInt64Value max_request_bytes = 1 [(validate.rules).uint64 = {gt: 0}];
 }

--- a/test/extensions/filters/http/body_size_limit/body_size_limit_filter_test.cc
+++ b/test/extensions/filters/http/body_size_limit/body_size_limit_filter_test.cc
@@ -19,7 +19,7 @@ namespace BodySizeLimitFilter {
 
 class BodySizeLimitFilterTest : public testing::Test {
 public:
-  BodySizeLimitFilterConfigSharedPtr setupConfig(uint32_t max_request_bytes = 1024 * 1024) {
+  BodySizeLimitFilterConfigSharedPtr setupConfig(uint64_t max_request_bytes = 1024 * 1024) {
     envoy::extensions::filters::http::body_size_limit::v3::BodySizeLimit proto_config;
     proto_config.mutable_max_request_bytes()->set_value(max_request_bytes);
     return std::make_shared<BodySizeLimitFilterConfig>(proto_config);


### PR DESCRIPTION
Commit Message: Fix the parameter type of the request body size limiting HTTP filter
Additional Description: 

The parameter was defined as uint32, but it may be necessary to support larger
limits. As the code uses 64-bit unsigned integers elsewhere, it is enough to fix the
API definition.

Risk Level: Low
Testing: Manual test was performed, no extra automatic tests added
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A