### PR TITLE
memory: support win32 aligned allocation in aligned_allocator

### DIFF
--- a/source/common/memory/aligned_allocator.h
+++ b/source/common/memory/aligned_allocator.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#if defined(__ANDROID_API__) && __ANDROID_API__ < 28
+#if defined(_WIN32)
+#include <malloc.h>
+
+#define ALIGNED_ALLOCATOR_USE_WIN32_ALIGNED_MALLOC 1
+#elif defined(__ANDROID_API__) && __ANDROID_API__ < 28
 #include <stdlib.h>
 
 #define ALIGNED_ALLOCATOR_USE_POSIX_MEMALIGN 1
@@ -40,7 +44,9 @@ public:
       return nullptr;
     }
     std::size_t bytes = n * sizeof(T);
-#ifdef ALIGNED_ALLOCATOR_USE_POSIX_MEMALIGN
+#if defined(ALIGNED_ALLOCATOR_USE_WIN32_ALIGNED_MALLOC)
+    return static_cast<T*>(_aligned_malloc(bytes, Alignment));
+#elif defined(ALIGNED_ALLOCATOR_USE_POSIX_MEMALIGN)
     void* ptr = nullptr;
     if (posix_memalign(&ptr, Alignment, bytes) != 0) {
       return nullptr;
@@ -55,7 +61,9 @@ public:
 
   void deallocate(T* p, std::size_t) noexcept {
     if (p != nullptr) {
-#ifdef ALIGNED_ALLOCATOR_USE_POSIX_MEMALIGN
+#if defined(ALIGNED_ALLOCATOR_USE_WIN32_ALIGNED_MALLOC)
+      _aligned_free(p);
+#elif defined(ALIGNED_ALLOCATOR_USE_POSIX_MEMALIGN)
       free(p);
 #else
       std::free(p);


### PR DESCRIPTION
Additional Description:
Adds Win32 platform support to `AlignedAllocator` by using `_aligned_malloc` and `_aligned_free` from `<malloc.h>` when `_WIN32` is defined, avoiding fallback to standard `aligned_alloc` which is not available on MSVC.
Risk Level: low (Win32-only compilation branch)
Testing: verified build on Windows / local compilation
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Windows
