### PR TITLE
exe: include windows.h before win32 subsystem headers in service_base.h

### DIFF
--- a/source/exe/win32/service_base.h
+++ b/source/exe/win32/service_base.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// clang-format off
+#include <windows.h>
+// clang-format on
+
 #include <processenv.h>
 #include <shellapi.h>
 #include <winsvc.h>


### PR DESCRIPTION
Additional Description:
Includes `<windows.h>` before `<processenv.h>`, `<shellapi.h>`, and `<winsvc.h>` in `service_base.h`. Windows SDK headers require `windows.h` to precede subsystem headers to define core Win32 types and macros.
Risk Level: low (header inclusion fix for Windows build)
Testing: verified compilation
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Windows

