### PR TITLE
original_dst: remove unused redirectRecordsSize variable on windows

### DIFF
--- a/source/extensions/filters/listener/original_dst/original_dst.cc
+++ b/source/extensions/filters/listener/original_dst/original_dst.cc
@@ -36,7 +36,6 @@ Network::FilterStatus OriginalDstFilter::onAccept(Network::ListenerFilterCallbac
       if constexpr (Platform::win32SupportsOriginalDestination()) {
         if (traffic_direction_ == envoy::config::core::v3::OUTBOUND) {
           ENVOY_LOG(debug, "[Windows] Querying for redirect record for outbound listener");
-          unsigned long redirectRecordsSize = 0;
           auto redirect_records = std::make_shared<Network::Win32RedirectRecords>();
           auto status = socket.ioctl(SIO_QUERY_WFP_CONNECTION_REDIRECT_RECORDS, NULL, 0,
                                      redirect_records->buf_, sizeof(redirect_records->buf_),


### PR DESCRIPTION
Commit Message: original_dst: remove unused redirectRecordsSize variable on windows
Additional Description:
Removes unused local variable `redirectRecordsSize` in `original_dst.cc` when querying Windows WFP redirect records, eliminating a `-Wunused-variable` compiler warning.
Risk Level: low
Testing: CI compilation
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: Windows