### PR TITLE
Avoid unnecesary renaming of watcher_target.yaml

### DIFF
--- a/test/extensions/filters/http/ip_tagging/ip_tagging_integration_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_integration_test.cc
@@ -88,10 +88,7 @@ ip_tags:
  )EOF",
       true);
 
-  // Update the symlink to point to the new file.
-  TestEnvironment::renameFile(
-      TestEnvironment::temporaryPath("ip_tagging_test/watcher_target.yaml"),
-      TestEnvironment::temporaryPath("ip_tagging_test/watcher_old_target.yaml"));
+  // Atomically rename the new file onto the watched target path.
   TestEnvironment::renameFile(
       TestEnvironment::temporaryPath("ip_tagging_test/watcher_new_target.yaml"),
       TestEnvironment::temporaryPath("ip_tagging_test/watcher_target.yaml"));
@@ -180,15 +177,12 @@ ip_tags:
  )EOF",
       true);
 
-  // Update the symlink to point to the new file.
-  TestEnvironment::renameFile(
-      TestEnvironment::temporaryPath("ip_tagging_test/watcher_target.yaml"),
-      TestEnvironment::temporaryPath("ip_tagging_test/watcher_old_target.yaml"));
+  // Atomically rename the new file onto the watched target path.
   TestEnvironment::renameFile(
       TestEnvironment::temporaryPath("ip_tagging_test/watcher_new_target.yaml"),
       TestEnvironment::temporaryPath("ip_tagging_test/watcher_target.yaml"));
 
-  test_server_->waitForCounter("http.config_test.ip_tagging.reload_success", testing::Ge(2));
+  test_server_->waitForCounter("http.config_test.ip_tagging.reload_success", testing::Ge(1));
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(


### PR DESCRIPTION
This avoids the race condition where watcher_target.yaml is not present

Change-Id: I7f8c67023ac31f3a9cac294caca5c0d18c30ee1d

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
