### PR TITLE
tidy: enforce and apply C++20 container `contains()`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,7 @@ Checks: >
   performance-type-promotion-in-math-fn,
   performance-unnecessary-copy-initialization,
   readability-braces-around-statements,
+  readability-container-contains,
   readability-container-size-empty,
   readability-identifier-naming,
   readability-redundant-control-flow,

--- a/contrib/client_ssl_auth/filters/network/source/client_ssl_auth.h
+++ b/contrib/client_ssl_auth/filters/network/source/client_ssl_auth.h
@@ -55,7 +55,7 @@ public:
     }
   }
   bool allowed(const std::string& sha256_digest) const {
-    return allowed_sha256_digests_.count(sha256_digest) != 0;
+    return allowed_sha256_digests_.contains(sha256_digest);
   }
   size_t size() const { return allowed_sha256_digests_.size(); }
 

--- a/contrib/exe/contrib_version_test.cc
+++ b/contrib/exe/contrib_version_test.cc
@@ -12,7 +12,7 @@ TEST(ContribVersionTest, VersionContainsSuffix) {
 TEST(ContribVersionTest, BuildVersionContainsSuffix) {
   auto build_version = VersionInfo::buildVersion();
   const auto& fields = build_version.metadata().fields();
-  ASSERT_NE(fields.find(BuildVersionMetadataKeys::get().BuildLabel), fields.end());
+  ASSERT_TRUE(fields.contains(BuildVersionMetadataKeys::get().BuildLabel));
   EXPECT_THAT(fields.at(BuildVersionMetadataKeys::get().BuildLabel).string_value(),
               testing::EndsWith("contrib"));
 }

--- a/contrib/kafka/filters/network/source/mesh/upstream_config.cc
+++ b/contrib/kafka/filters/network/source/mesh/upstream_config.cc
@@ -38,7 +38,7 @@ UpstreamKafkaConfigurationImpl::UpstreamKafkaConfigurationImpl(const KafkaMeshPr
     const std::string& cluster_name = upstream_cluster_definition.cluster_name();
 
     // No duplicates are allowed.
-    if (cluster_name_to_cluster_config.find(cluster_name) != cluster_name_to_cluster_config.end()) {
+    if (cluster_name_to_cluster_config.contains(cluster_name)) {
       throw EnvoyException(
           absl::StrCat("kafka-mesh filter has multiple Kafka clusters referenced by the same name",
                        cluster_name));

--- a/contrib/kafka/filters/network/test/broker/filter_unit_test.cc
+++ b/contrib/kafka/filters/network/test/broker/filter_unit_test.cc
@@ -279,7 +279,7 @@ TEST_F(KafkaMetricsFacadeImplUnitTest, ShouldRegisterResponse) {
 
   // then
   const auto& request_arrivals = testee_.getRequestArrivalsForTest();
-  ASSERT_EQ(request_arrivals.find(correlation_id), request_arrivals.end());
+  ASSERT_FALSE(request_arrivals.contains(correlation_id));
 }
 
 TEST_F(KafkaMetricsFacadeImplUnitTest, ShouldRegisterUnknownResponse) {

--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -553,8 +553,7 @@ void DecoderImpl::onStartup() {
   attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'), absl::SkipEmpty());
 
   // If "database" attribute is not found, default it to "user" attribute.
-  if ((attributes_.find("database") == attributes_.end()) &&
-      (attributes_.find("user") != attributes_.end())) {
+  if (!attributes_.contains("database") && attributes_.contains("user")) {
     attributes_["database"] = attributes_["user"];
   }
 }

--- a/contrib/rocketmq_proxy/filters/network/source/active_message.cc
+++ b/contrib/rocketmq_proxy/filters/network/source/active_message.cc
@@ -122,7 +122,7 @@ void ActiveMessage::fillBrokerData(std::vector<BrokerData>& list, const std::str
   for (auto& entry : list) {
     if (entry.cluster() == cluster && entry.brokerName() == broker_name) {
       found = true;
-      if (entry.brokerAddresses().find(broker_id) != entry.brokerAddresses().end()) {
+      if (entry.brokerAddresses().contains(broker_id)) {
         ENVOY_LOG(warn, "Duplicate broker_id found. Broker ID: {}, address: {}", broker_id,
                   address);
         continue;

--- a/contrib/sip_proxy/filters/network/source/conn_manager.cc
+++ b/contrib/sip_proxy/filters/network/source/conn_manager.cc
@@ -307,7 +307,7 @@ void ConnectionManager::sendLocalReply(MessageMetadata& metadata, const DirectRe
 }
 
 void ConnectionManager::setLocalResponseSent(absl::string_view transaction_id) {
-  if (transactions_.find(transaction_id) != transactions_.end()) {
+  if (transactions_.contains(transaction_id)) {
     transactions_[transaction_id]->setLocalResponseSent(true);
   }
 }
@@ -357,7 +357,7 @@ DecoderEventHandler& ConnectionManager::newDecoderEventHandler(MessageMetadataSh
 
   std::string&& k = std::string(metadata->transactionId().value());
   // if (metadata->methodType() == MethodType::Ack) {
-  if (transactions_.find(k) != transactions_.end()) {
+  if (transactions_.contains(k)) {
     // ACK_4XX metadata will updated later.
     return *transactions_.at(k);
   }

--- a/contrib/sip_proxy/filters/network/source/utility.h
+++ b/contrib/sip_proxy/filters/network/source/utility.h
@@ -200,7 +200,7 @@ public:
     }
   }
 
-  bool contains(const K& key) { return cache_.find(key) != cache_.end(); }
+  bool contains(const K& key) { return cache_.contains(key); }
 
   OptRef<V> at(const K& key) {
     auto it = cache_.find(key);

--- a/contrib/sxg/filters/http/source/encoder.cc
+++ b/contrib/sxg/filters/http/source/encoder.cc
@@ -51,7 +51,7 @@ bool EncoderImpl::loadHeaders(Http::ResponseHeaderMap* headers) {
       }
     }
     // filter out headers that are not allowed to be encoded in the SXG document
-    if (filtered_headers.find(header_key) != filtered_headers.end()) {
+    if (filtered_headers.contains(header_key)) {
       return Http::HeaderMap::Iterate::Continue;
     }
 

--- a/contrib/vcl/source/vcl_interface.cc
+++ b/contrib/vcl/source/vcl_interface.cc
@@ -111,7 +111,7 @@ void vclInterfaceRegisterEpollEvent(Envoy::Event::Dispatcher& dispatcher) {
   MqFileEventsMap& mq_fevts_map = mqFileEventsMap();
   const int wrk_index = vppcom_worker_index();
   RELEASE_ASSERT(wrk_index != -1, "");
-  if (mq_fevts_map.find(wrk_index) != mq_fevts_map.end()) {
+  if (mq_fevts_map.contains(wrk_index)) {
     return;
   }
   mq_fevts_map[wrk_index] = dispatcher.createFileEvent(

--- a/source/common/access_log/access_log_impl.cc
+++ b/source/common/access_log/access_log_impl.cc
@@ -274,7 +274,7 @@ bool GrpcStatusFilter::evaluate(const Formatter::Context& context,
     status = optional_status.value();
   }
 
-  const bool found = statuses_.find(status) != statuses_.end();
+  const bool found = statuses_.contains(status);
   return exclude_ ? !found : found;
 }
 

--- a/source/common/filesystem/win32/watcher_impl.cc
+++ b/source/common/filesystem/win32/watcher_impl.cc
@@ -75,7 +75,7 @@ absl::Status WatcherImpl::addWatch(absl::string_view path, uint32_t events, OnCh
   RELEASE_ASSERT(
       GetFileInformationByHandleEx(dir_handle, FileIdInfo, &fii_key[0], sizeof(FILE_ID_INFO)),
       fmt::format("unable to identify directory {}: {}", result.directory_, GetLastError()));
-  if (callback_map_.find(fii_key) != callback_map_.end()) {
+  if (callback_map_.contains(fii_key)) {
     CloseHandle(dir_handle);
   } else {
     callback_map_[fii_key] = std::make_unique<DirectoryWatch>();

--- a/source/common/grpc/async_client_manager_impl.cc
+++ b/source/common/grpc/async_client_manager_impl.cc
@@ -200,7 +200,7 @@ AsyncClientManagerImpl::RawAsyncClientCache::RawAsyncClientCache(
 void AsyncClientManagerImpl::RawAsyncClientCache::setCache(
     const GrpcServiceConfigWithHashKey& config_with_hash_key,
     const RawAsyncClientSharedPtr& client) {
-  ASSERT(lru_map_.find(config_with_hash_key) == lru_map_.end());
+  ASSERT(!lru_map_.contains(config_with_hash_key));
   // Create a new cache entry at the beginning of the list.
   lru_list_.emplace_front(config_with_hash_key, client, dispatcher_.timeSource().monotonicTime());
   lru_map_[config_with_hash_key] = lru_list_.begin();

--- a/source/common/grpc/buffered_async_client.h
+++ b/source/common/grpc/buffered_async_client.h
@@ -101,7 +101,7 @@ private:
   void erasePendingMessage(uint64_t message_id) {
     // This case will be considered if `onSuccess` had called with unknown message id that is not
     // received by envoy as response.
-    if (message_buffer_.find(message_id) == message_buffer_.end()) {
+    if (!message_buffer_.contains(message_id)) {
       return;
     }
     auto& buffer = message_buffer_.at(message_id);

--- a/source/common/grpc/google_async_client_impl.h
+++ b/source/common/grpc/google_async_client_impl.h
@@ -77,7 +77,7 @@ public:
   grpc::CompletionQueue& completionQueue() { return cq_; }
 
   void registerStream(GoogleAsyncStreamImpl* stream) {
-    ASSERT(streams_.find(stream) == streams_.end());
+    ASSERT(!streams_.contains(stream));
     streams_.insert(stream);
   }
 

--- a/source/common/http/async_client_utility.cc
+++ b/source/common/http/async_client_utility.cc
@@ -12,7 +12,7 @@ AsyncClientRequestTracker::~AsyncClientRequestTracker() {
 }
 
 void AsyncClientRequestTracker::add(AsyncClient::Request& request) {
-  ASSERT(active_requests_.find(&request) == active_requests_.end(), "request is already tracked.");
+  ASSERT(!active_requests_.contains(&request), "request is already tracked.");
   active_requests_.insert(&request);
 }
 

--- a/source/common/http/session_idle_list.cc
+++ b/source/common/http/session_idle_list.cc
@@ -55,7 +55,7 @@ absl::Duration SessionIdleList::MinTimeBeforeTerminationAllowed() const {
 
 void SessionIdleList::IdleSessions::AddSessionToList(MonotonicTime enqueue_time,
                                                      IdleSessionInterface& session) {
-  if (map_.find(&session) != map_.end()) {
+  if (map_.contains(&session)) {
     IS_ENVOY_BUG("Session is already on the idle list.");
     return;
   }

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -1249,7 +1249,7 @@ std::string Utility::PercentEncoding::encode(absl::string_view value,
     // We do checking for each char in the string. If the current char is included in the defined
     // escaping characters, we jump to "the slow path" (append the char [encoded or not encoded]
     // to the returned string one by one) started from the current index.
-    if (ch < ' ' || ch >= '~' || reserved_char_set.find(ch) != reserved_char_set.end()) {
+    if (ch < ' ' || ch >= '~' || reserved_char_set.contains(ch)) {
       return PercentEncoding::encode(value, i, reserved_char_set);
     }
   }
@@ -1265,7 +1265,7 @@ std::string Utility::PercentEncoding::encode(absl::string_view value, const size
 
   for (size_t i = index; i < value.size(); ++i) {
     const char& ch = value[i];
-    if (ch < ' ' || ch >= '~' || reserved_char_set.find(ch) != reserved_char_set.end()) {
+    if (ch < ' ' || ch >= '~' || reserved_char_set.contains(ch)) {
       // For consistency, URI producers should use uppercase hexadecimal digits for all
       // percent-encodings. https://tools.ietf.org/html/rfc3986#section-2.1.
       absl::StrAppend(&encoded, fmt::format("%{:02X}", static_cast<const unsigned char&>(ch)));

--- a/source/common/init/manager_impl.cc
+++ b/source/common/init/manager_impl.cc
@@ -83,7 +83,7 @@ void ManagerImpl::onTargetReady(absl::string_view target_name) {
          fmt::format("{} called back by target after initialization complete", target_name));
 
   // Decrease target_name count by 1.
-  ASSERT(target_names_count_.find(target_name) != target_names_count_.end());
+  ASSERT(target_names_count_.contains(target_name));
   if (--target_names_count_[target_name] == 0) {
     target_names_count_.erase(target_name);
   }

--- a/source/common/json/json_rpc_field_extractor.cc
+++ b/source/common/json/json_rpc_field_extractor.cc
@@ -341,14 +341,14 @@ void JsonRpcFieldExtractor::checkEarlyStop() {
     if (is_notification_ && field == "id") {
       continue;
     }
-    if (collected_fields_.count(field) == 0) {
+    if (!collected_fields_.contains(field)) {
       return;
     }
   }
 
   const auto& required_fields = config_.getFieldsForMethod(method_);
   for (const auto& field : required_fields) {
-    if (collected_fields_.count(field.path) == 0) {
+    if (!collected_fields_.contains(field.path)) {
       return;
     }
   }
@@ -451,7 +451,7 @@ void JsonRpcFieldExtractor::copyFieldByPath(const std::string& path) {
 void JsonRpcFieldExtractor::validateRequiredFields() {
   const auto& fields = config_.getFieldsForMethod(method_);
   for (const auto& field : fields) {
-    if (extracted_fields_.count(field.path) == 0) {
+    if (!extracted_fields_.contains(field.path)) {
       missing_required_fields_.push_back(field.path);
       ENVOY_LOG(debug, "missing required field for {}: {}", method_, field.path);
     }

--- a/source/common/jwt/jwt.cc
+++ b/source/common/jwt/jwt.cc
@@ -25,7 +25,7 @@ bool isImplemented(absl::string_view alg) {
       {"RS384"}, {"RS512"}, {"PS256"}, {"PS384"}, {"PS512"}, {"EdDSA"},
   };
 
-  return implemented_algs.find(alg) != implemented_algs.end();
+  return implemented_algs.contains(alg);
 }
 
 } // namespace

--- a/source/common/listener_manager/filter_chain_manager_impl.cc
+++ b/source/common/listener_manager/filter_chain_manager_impl.cc
@@ -205,7 +205,7 @@ absl::Status FilterChainManagerImpl::addFilterChains(
   const auto* origin = getOriginFilterChainManager();
   if (origin != nullptr) {
     for (const auto& message_and_filter_chain : origin->fc_contexts_) {
-      if (fc_contexts_.find(message_and_filter_chain.first) == fc_contexts_.end()) {
+      if (!fc_contexts_.contains(message_and_filter_chain.first)) {
         origin->draining_filter_chains_.push_back(message_and_filter_chain.second);
       }
     }
@@ -415,7 +415,7 @@ absl::Status FilterChainManagerImpl::addFilterChainForDestinationPorts(
     const std::vector<std::string>& source_ips,
     const absl::Span<const Protobuf::uint32> source_ports,
     const Network::FilterChainSharedPtr& filter_chain) {
-  if (destination_ports_map.find(destination_port) == destination_ports_map.end()) {
+  if (!destination_ports_map.contains(destination_port)) {
     destination_ports_map[destination_port] =
         std::make_pair<DestinationIPsMap, DestinationIPsTriePtr>(DestinationIPsMap{}, nullptr);
   }

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -1208,7 +1208,7 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
         // This prevents us from double incrementing if listeners are stopped twice.
         // This can happen if the admin endpoint is triggered for inbound_only and then
         // all. We perform the check in the callback to ensure it's done on the main thread
-        if (stopped_listener_tags_.find(listener_tag) == stopped_listener_tags_.end()) {
+        if (!stopped_listener_tags_.contains(listener_tag)) {
           stats_.listener_stopped_.inc();
           stopped_listener_tags_.insert(listener_tag);
           for (auto& listener : active_listeners_) {

--- a/source/common/quic/envoy_quic_dispatcher.cc
+++ b/source/common/quic/envoy_quic_dispatcher.cc
@@ -197,7 +197,7 @@ void EnvoyQuicDispatcher::closeConnectionsWithFilterChain(
       // from the map as well.
       connection.close(Network::ConnectionCloseType::NoFlush);
     }
-    ASSERT(connections_by_filter_chain_.find(filter_chain) == connections_by_filter_chain_.end());
+    ASSERT(!connections_by_filter_chain_.contains(filter_chain));
     if (num_connections > 0) {
       // Explicitly destroy closed sessions in the current call stack. Because upon
       // returning the filter chain configs will be destroyed, and no longer safe to be accessed.

--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -469,8 +469,8 @@ absl::Status ProtoLayer::walkProtoValue(const Protobuf::Value& v, const std::str
     break;
   case Protobuf::Value::kStructValue: {
     const Protobuf::Struct& s = v.struct_value();
-    if (s.fields().empty() || s.fields().find("numerator") != s.fields().end() ||
-        s.fields().find("denominator") != s.fields().end()) {
+    if (s.fields().empty() || s.fields().contains("numerator") ||
+        s.fields().contains("denominator")) {
       SnapshotImpl::addEntry(values_, prefix, v, "");
       break;
     }

--- a/source/common/stats/allocator.cc
+++ b/source/common/stats/allocator.cc
@@ -297,8 +297,8 @@ private:
 CounterSharedPtr Allocator::makeCounter(StatName name, StatName tag_extracted_name,
                                         StatNameTagSpan stat_name_tags) {
   Thread::LockGuard lock(mutex_);
-  ASSERT(gauges_.find(name) == gauges_.end());
-  ASSERT(text_readouts_.find(name) == text_readouts_.end());
+  ASSERT(!gauges_.contains(name));
+  ASSERT(!text_readouts_.contains(name));
   auto iter = counters_.find(name);
   if (iter != counters_.end()) {
     return {*iter};
@@ -316,8 +316,8 @@ CounterSharedPtr Allocator::makeCounter(StatName name, StatName tag_extracted_na
 GaugeSharedPtr Allocator::makeGauge(StatName name, StatName tag_extracted_name,
                                     StatNameTagSpan stat_name_tags, Gauge::ImportMode import_mode) {
   Thread::LockGuard lock(mutex_);
-  ASSERT(counters_.find(name) == counters_.end());
-  ASSERT(text_readouts_.find(name) == text_readouts_.end());
+  ASSERT(!counters_.contains(name));
+  ASSERT(!text_readouts_.contains(name));
   auto iter = gauges_.find(name);
   if (iter != gauges_.end()) {
     return {*iter};
@@ -336,8 +336,8 @@ GaugeSharedPtr Allocator::makeGauge(StatName name, StatName tag_extracted_name,
 TextReadoutSharedPtr Allocator::makeTextReadout(StatName name, StatName tag_extracted_name,
                                                 StatNameTagSpan stat_name_tags) {
   Thread::LockGuard lock(mutex_);
-  ASSERT(counters_.find(name) == counters_.end());
-  ASSERT(gauges_.find(name) == gauges_.end());
+  ASSERT(!counters_.contains(name));
+  ASSERT(!gauges_.contains(name));
   auto iter = text_readouts_.find(name);
   if (iter != text_readouts_.end()) {
     return {*iter};

--- a/source/common/stats/custom_stat_namespaces_impl.cc
+++ b/source/common/stats/custom_stat_namespaces_impl.cc
@@ -8,7 +8,7 @@ namespace Stats {
 
 bool CustomStatNamespacesImpl::registered(const absl::string_view name) const {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
-  return namespaces_.find(name) != namespaces_.end();
+  return namespaces_.contains(name);
 }
 
 void CustomStatNamespacesImpl::registerStatNamespace(const absl::string_view name) {

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -1554,7 +1554,7 @@ UpstreamDrainManager::~UpstreamDrainManager() {
 
       // cancelDrain() should cause that drainer to be removed from drainers_.
       // ASSERT so that we don't end up in an infinite loop.
-      ASSERT(drainers_.find(key) == drainers_.end());
+      ASSERT(!drainers_.contains(key));
     }
 
     // This destructor is run when shutting down `ThreadLocal`. The destructor of some objects use

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1939,7 +1939,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::removeHosts(
         parent_.deferred_cluster_creation_,
         fmt::format("Cannot find ThreadLocalCluster {}, but deferred cluster creation is disabled.",
                     name));
-    ASSERT(thread_local_deferred_clusters_.find(name) != thread_local_deferred_clusters_.end(),
+    ASSERT(thread_local_deferred_clusters_.contains(name),
            "Cluster with removed host is neither deferred or inflated!");
     return;
   }
@@ -1957,7 +1957,7 @@ void ClusterManagerImpl::ThreadLocalClusterManagerImpl::updateClusterMembership(
     LocalityWeightsConstSharedPtr locality_weights, const HostVector& hosts_added,
     const HostVector& hosts_removed, bool weighted_priority_health,
     uint64_t overprovisioning_factor, HostMapConstSharedPtr cross_priority_host_map) {
-  ASSERT(thread_local_clusters_.find(name) != thread_local_clusters_.end());
+  ASSERT(thread_local_clusters_.contains(name));
   const auto& cluster_entry = thread_local_clusters_[name];
   cluster_entry->updateHosts(name, priority, std::move(update_hosts_params),
                              std::move(locality_weights), hosts_added, hosts_removed,

--- a/source/common/upstream/outlier_detection_impl.cc
+++ b/source/common/upstream/outlier_detection_impl.cc
@@ -375,7 +375,7 @@ void DetectorImpl::initialize(Cluster& cluster) {
 }
 
 void DetectorImpl::addHostMonitor(HostSharedPtr host) {
-  ASSERT(host_monitors_.count(host) == 0);
+  ASSERT(!host_monitors_.contains(host));
   DetectorHostMonitorImpl* monitor = new DetectorHostMonitorImpl(shared_from_this(), host);
   host_monitors_[host] = monitor;
   host->setOutlierDetector(DetectorHostMonitorPtr{monitor});
@@ -663,7 +663,7 @@ void DetectorImpl::setHostDegradedMainThread(HostSharedPtr host) {
   // posting this degrade event and the main thread running it; if so, ignore it
   // (mirrors the guard in the eject path) so host_monitors_[host] does not
   // default-insert a null monitor that is then dereferenced.
-  if (host_monitors_.count(host) == 0) {
+  if (!host_monitors_.contains(host)) {
     return;
   }
   if (!host->healthFlagGet(Host::HealthFlag::DEGRADED_OUTLIER_DETECTION)) {
@@ -704,7 +704,7 @@ void DetectorImpl::onConsecutiveErrorWorker(HostSharedPtr host,
                                             envoy::data::cluster::v3::OutlierEjectionType type) {
   // Ejections come in cross thread. There is a chance that the host has already been removed from
   // the set. If so, just ignore it.
-  if (host_monitors_.count(host) == 0) {
+  if (!host_monitors_.contains(host)) {
     return;
   }
   if (host->healthFlagGet(Host::HealthFlag::FAILED_OUTLIER_CHECK)) {

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -192,7 +192,7 @@ HostVector filterHosts(const absl::node_hash_set<HostSharedPtr>& hosts,
   net_hosts.reserve(hosts.size());
 
   for (const auto& host : hosts) {
-    if (excluded_hosts.find(host) == excluded_hosts.end()) {
+    if (!excluded_hosts.contains(host)) {
       net_hosts.emplace_back(host);
     }
   }
@@ -988,7 +988,7 @@ void PrioritySetImpl::BatchUpdateScope::updateHosts(
     std::optional<uint32_t> overprovisioning_factor,
     HostMapConstSharedPtr cross_priority_host_map) {
   // We assume that each call updates a different priority.
-  ASSERT(priorities_.find(priority) == priorities_.end());
+  ASSERT(!priorities_.contains(priority));
   priorities_.insert(priority);
 
   for (const auto& host : hosts_added) {
@@ -2385,8 +2385,7 @@ void PriorityStateManager::updateClusterPrioritySet(
 
   // Do we have hosts for the local locality?
   const bool non_empty_local_locality =
-      local_info_node_.has_locality() &&
-      hosts_per_locality.find(local_locality) != hosts_per_locality.end();
+      local_info_node_.has_locality() && hosts_per_locality.contains(local_locality);
 
   // As per HostsPerLocality::get(), the per_locality vector must have the local locality hosts
   // first if non_empty_local_locality.

--- a/source/server/drain_manager_impl.cc
+++ b/source/server/drain_manager_impl.cc
@@ -157,7 +157,7 @@ void DrainManagerImpl::startDrainSequence(Network::DrainDirection direction,
     addDrainCompleteCallback(direction, drain_complete_cb);
     return;
   }
-  ASSERT(drain_tick_timers_.count(direction) == 0,
+  ASSERT(!drain_tick_timers_.contains(direction),
          "cannot run two drain sequences for the same direction.");
 
   const std::chrono::seconds drain_delay(server_.options().drainTime());

--- a/source/server/overload_manager_impl.cc
+++ b/source/server/overload_manager_impl.cc
@@ -533,7 +533,7 @@ OverloadManagerImpl::OverloadManagerImpl(Event::Dispatcher& dispatcher, Stats::S
       auto proactive_resource_it =
           OverloadProactiveResources::get().proactive_action_name_to_resource_.find(resource);
 
-      if (resources_.find(resource) == resources_.end() &&
+      if (!resources_.contains(resource) &&
           proactive_resource_it ==
               OverloadProactiveResources::get().proactive_action_name_to_resource_.end()) {
         creation_status = absl::InvalidArgumentError(
@@ -631,7 +631,7 @@ bool OverloadManagerImpl::registerForAction(const std::string& action,
   ASSERT(!started_);
   const auto symbol = action_symbol_table_.get(action);
 
-  if (actions_.find(symbol) == actions_.end()) {
+  if (!actions_.contains(symbol)) {
     ENVOY_LOG(debug, "No overload action is configured for {}.", action);
     return false;
   }

--- a/test/common/common/version_test.cc
+++ b/test/common/common/version_test.cc
@@ -66,7 +66,7 @@ TEST(VersionTest, MakeBuildVersionWithoutLabel) {
   EXPECT_EQ(2, build_version.version().minor_number());
   EXPECT_EQ(3, build_version.version().patch());
   const auto& fields = build_version.metadata().fields();
-  EXPECT_EQ(fields.find(BuildVersionMetadataKeys::get().BuildLabel), fields.end());
+  EXPECT_FALSE(fields.contains(BuildVersionMetadataKeys::get().BuildLabel));
   // Other metadata should still be present
   EXPECT_GE(fields.size(), 1);
 }
@@ -77,7 +77,7 @@ TEST(VersionTest, MakeBadBuildVersion) {
   EXPECT_EQ(0, build_version.version().minor_number());
   EXPECT_EQ(0, build_version.version().patch());
   const auto& fields = build_version.metadata().fields();
-  EXPECT_EQ(fields.find(BuildVersionMetadataKeys::get().BuildLabel), fields.end());
+  EXPECT_FALSE(fields.contains(BuildVersionMetadataKeys::get().BuildLabel));
   // Other metadata should still be present
   EXPECT_GE(fields.size(), 1);
 }

--- a/test/common/config/grpc_subscription_test_harness.h
+++ b/test/common/config/grpc_subscription_test_harness.h
@@ -203,7 +203,7 @@ public:
       // is no longer internally used by GrpcSubscriptionImpl.
       std::set<std::string> both;
       for (const auto& n : cluster_names) {
-        if (last_cluster_names_.find(n) != last_cluster_names_.end()) {
+        if (last_cluster_names_.contains(n)) {
           both.insert(n);
         }
       }

--- a/test/common/config/metadata_test.cc
+++ b/test/common/config/metadata_test.cc
@@ -143,7 +143,7 @@ public:
   public:
     // Throws EnvoyException (conversion failure) if d is empty.
     std::unique_ptr<const TypedMetadata::Object> parse(const Protobuf::Struct& d) const override {
-      if (d.fields().find("name") != d.fields().end()) {
+      if (d.fields().contains("name")) {
         return std::make_unique<Foo>(d.fields().at("name").string_value());
       }
       throw EnvoyException("Cannot create a Foo when Struct metadata is empty.");

--- a/test/common/config/registry_test.cc
+++ b/test/common/config/registry_test.cc
@@ -65,7 +65,7 @@ TEST(RegistryTest, DefaultFactoryPublished) {
   const auto& factories = Envoy::Registry::FactoryCategoryRegistry::registeredFactories();
 
   // Expect that the category is present.
-  ASSERT_NE(factories.find("testing.published"), factories.end());
+  ASSERT_TRUE(factories.contains("testing.published"));
 
   // Expect that the factory is listed in the right category.
   const auto& names = factories.find("testing.published")->second->registeredNames();
@@ -94,7 +94,7 @@ TEST(RegistryTest, VersionedFactory) {
   const auto& factories = Envoy::Registry::FactoryCategoryRegistry::registeredFactories();
 
   // Expect that the category is present.
-  ASSERT_NE(factories.find("testing.published"), factories.end());
+  ASSERT_TRUE(factories.contains("testing.published"));
 
   // Expect that the factory is listed in the right category.
   const auto& names = factories.find("testing.published")->second->registeredNames();

--- a/test/common/http/filter_chain_helper_test.cc
+++ b/test/common/http/filter_chain_helper_test.cc
@@ -47,8 +47,8 @@ TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabled) {
 
     // 'filter_1' and 'filter_2' should be added.
     FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories);
-    EXPECT_TRUE(added_filters.find("filter_1") != added_filters.end());
-    EXPECT_TRUE(added_filters.find("filter_2") != added_filters.end());
+    EXPECT_TRUE(added_filters.contains("filter_1"));
+    EXPECT_TRUE(added_filters.contains("filter_2"));
     EXPECT_EQ(added_filters.size(), 2);
   }
 }
@@ -84,7 +84,7 @@ TEST(FilterChainUtilityTest, CreateFilterChainForFactoriesWithRouteDisabledAndDe
 
     // Only filter_1 should be added.
     FilterChainUtility::createFilterChainForFactories(callbacks, filter_factories);
-    EXPECT_TRUE(added_filters.find("filter_1") != added_filters.end());
+    EXPECT_TRUE(added_filters.contains("filter_1"));
     EXPECT_EQ(added_filters.size(), 1);
   }
 }

--- a/test/common/network/socket_option_test.h
+++ b/test/common/network/socket_option_test.h
@@ -99,7 +99,7 @@ public:
     };
     unset_socketstates.remove_if(
         [&](envoy::config::core::v3::SocketOption::SocketState state) -> bool {
-          return when.find(state) != when.end();
+          return when.contains(state);
         });
     for (auto state : unset_socketstates) {
       EXPECT_CALL(os_sys_calls_, setsockopt_(_, _, _, _, _)).Times(0);

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1414,8 +1414,8 @@ TEST_F(ProtobufUtilityTest, HashedValueStdHash) {
   set.emplace(hv3);
 
   EXPECT_EQ(set.size(), 2); // hv1 == hv2
-  EXPECT_NE(set.find(hv1), set.end());
-  EXPECT_NE(set.find(hv3), set.end());
+  EXPECT_TRUE(set.contains(hv1));
+  EXPECT_TRUE(set.contains(hv3));
 }
 
 TEST_F(ProtobufUtilityTest, AnyBytes) {

--- a/test/common/quic/envoy_quic_h3_fuzz_helper.cc
+++ b/test/common/quic/envoy_quic_h3_fuzz_helper.cc
@@ -83,7 +83,7 @@ std::string H3Serializer::serialize(bool unidirectional, uint32_t type, uint32_t
   char buffer[kMaxPacketSize];
   quiche::QuicheDataWriter dw(kMaxPacketSize, buffer);
   if (unidirectional) {
-    if (open_unidirectional_streams_.find(id) == open_unidirectional_streams_.end()) {
+    if (!open_unidirectional_streams_.contains(id)) {
       dw.WriteVarInt62(static_cast<uint64_t>(type));
       open_unidirectional_streams_.insert(id);
     }

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -6672,7 +6672,7 @@ public:
   // Returns nullptr (conversion failure) if d is empty.
   std::unique_ptr<const Envoy::Config::TypedMetadata::Object>
   parse(const Protobuf::Struct& d) const override {
-    if (d.fields().find("name") != d.fields().end()) {
+    if (d.fields().contains("name")) {
       return std::make_unique<Baz>(d.fields().at("name").string_value());
     }
     throw EnvoyException("Cannot create a Baz when metadata is empty.");
@@ -8836,7 +8836,7 @@ virtual_hosts:
   std::vector<std::string> custom_tags{"ltag", "etag", "rtag", "mtag"};
   const Tracing::CustomTagMap& map = route3->tracingConfig()->getCustomTags();
   for (const std::string& custom_tag : custom_tags) {
-    EXPECT_NE(map.find(custom_tag), map.end());
+    EXPECT_TRUE(map.contains(custom_tag));
   }
 
   NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
@@ -10375,7 +10375,7 @@ virtual_hosts:
       genRedirectHeaders("idle.lyft.com", "/regex", true, false);
   const RouteEntry::UpgradeMap& upgrade_map = config.route(headers, 0)->routeEntry()->upgradeMap();
   EXPECT_TRUE(upgrade_map.find("websocket")->second);
-  EXPECT_TRUE(upgrade_map.find("foo") == upgrade_map.end());
+  EXPECT_FALSE(upgrade_map.contains("foo"));
   EXPECT_FALSE(upgrade_map.find("disabled")->second);
 }
 

--- a/test/common/router/scoped_rds_test.cc
+++ b/test/common/router/scoped_rds_test.cc
@@ -441,7 +441,7 @@ scope_key_builder:
           TestUtility::parseYaml<envoy::config::route::v3::RouteConfiguration>(
               fmt::format(route_config_tmpl, name));
       const auto decoded_resources = TestUtility::decodeResources({route_config});
-      if (rds_subscription_by_name_.find(name) == rds_subscription_by_name_.end()) {
+      if (!rds_subscription_by_name_.contains(name)) {
         continue;
       }
       EXPECT_OK(

--- a/test/common/stats/stat_test_utility.h
+++ b/test/common/stats/stat_test_utility.h
@@ -176,7 +176,7 @@ class TestSinkPredicates : public SinkPredicates {
 public:
   ~TestSinkPredicates() override = default;
 
-  bool has(StatName name) { return sinked_stat_names_.find(name) != sinked_stat_names_.end(); }
+  bool has(StatName name) { return sinked_stat_names_.contains(name); }
 
   // Note: The backing store for the StatName needs to live longer than the
   // TestSinkPredicates object.
@@ -184,16 +184,16 @@ public:
 
   // SinkPredicates
   bool includeCounter(const Counter& counter) override {
-    return sinked_stat_names_.find(counter.statName()) != sinked_stat_names_.end();
+    return sinked_stat_names_.contains(counter.statName());
   }
   bool includeGauge(const Gauge& gauge) override {
-    return sinked_stat_names_.find(gauge.statName()) != sinked_stat_names_.end();
+    return sinked_stat_names_.contains(gauge.statName());
   }
   bool includeTextReadout(const TextReadout& text_readout) override {
-    return sinked_stat_names_.find(text_readout.statName()) != sinked_stat_names_.end();
+    return sinked_stat_names_.contains(text_readout.statName());
   }
   bool includeHistogram(const Histogram& histogram) override {
-    return sinked_stat_names_.find(histogram.statName()) != sinked_stat_names_.end();
+    return sinked_stat_names_.contains(histogram.statName());
   }
 
 private:

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -4816,7 +4816,7 @@ public:
   // Returns nullptr (conversion failure) if d is empty.
   std::unique_ptr<const Envoy::Config::TypedMetadata::Object>
   parse(const Protobuf::Struct& d) const override {
-    if (d.fields().find("name") != d.fields().end()) {
+    if (d.fields().contains("name")) {
       return std::make_unique<Baz>(d.fields().at("name").string_value());
     }
     throw EnvoyException("Cannot create a Baz when metadata is empty.");
@@ -5908,7 +5908,7 @@ TEST_F(ClusterInfoImplTest, ExtensionProtocolOptionsForFilterWithOptions) {
       []() -> ProtobufTypes::MessagePtr { return std::make_unique<Protobuf::Struct>(); },
       [&](const Protobuf::Message& msg) -> Upstream::ProtocolOptionsConfigConstSharedPtr {
         const auto& msg_struct = Envoy::Protobuf::DynamicCastMessage<Protobuf::Struct>(msg);
-        EXPECT_TRUE(msg_struct.fields().find("option") != msg_struct.fields().end());
+        EXPECT_TRUE(msg_struct.fields().contains("option"));
 
         return protocol_options;
       });

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -479,7 +479,7 @@ Api::SysCallIntResult OsSysCallsWithMockedDns::getaddrinfo(const char* node,
     }
     return {0, 0};
   }
-  if (nonexisting_addresses_.find(node) != nonexisting_addresses_.end()) {
+  if (nonexisting_addresses_.contains(node)) {
     return {EAI_NONAME, 0};
   }
   std::cerr << "Mock DNS does not have entry for: " << node << std::endl;

--- a/test/mocks/server/config_tracker.cc
+++ b/test/mocks/server/config_tracker.cc
@@ -14,7 +14,7 @@ using ::testing::Invoke;
 MockConfigTracker::MockConfigTracker() {
   ON_CALL(*this, add_(_, _))
       .WillByDefault(Invoke([this](const std::string& key, Cb callback) -> EntryOwner* {
-        EXPECT_TRUE(config_tracker_callbacks_.find(key) == config_tracker_callbacks_.end());
+        EXPECT_FALSE(config_tracker_callbacks_.contains(key));
         config_tracker_callbacks_[key] = callback;
         return new MockEntryOwner();
       }));

--- a/test/mocks/upstream/cluster_manager.cc
+++ b/test/mocks/upstream/cluster_manager.cc
@@ -87,8 +87,7 @@ void MockClusterManager::initializeClusters(const std::vector<std::string>& acti
       }));
   ON_CALL(*this, hasCluster(_))
       .WillByDefault(Invoke([this](absl::string_view cluster_name) -> bool {
-        return active_clusters_.find(cluster_name) != active_clusters_.end() ||
-               warming_clusters_.find(cluster_name) != warming_clusters_.end();
+        return active_clusters_.contains(cluster_name) || warming_clusters_.contains(cluster_name);
       }));
   ON_CALL(*this, hasActiveClusters()).WillByDefault(Return(!active_cluster_names.empty()));
 }

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -2341,8 +2341,8 @@ TEST_F(RealHistogramNativePrometheusTest, NativeHistogramDenseDataAccuracy) {
         NativeHistogramDecoder::expectedBucketIndex(schema, static_cast<double>(v));
 
     // The bucket should exist
-    EXPECT_TRUE(buckets.count(expected_idx) > 0 || buckets.count(expected_idx - 1) > 0 ||
-                buckets.count(expected_idx + 1) > 0)
+    EXPECT_TRUE(buckets.contains(expected_idx) || buckets.contains(expected_idx - 1) ||
+                buckets.contains(expected_idx + 1))
         << "Value " << v << " should be in bucket near index " << expected_idx;
   }
 

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -395,7 +395,7 @@ std::vector<envoy::config::route::v3::RouteConfiguration> XdsFuzzTest::getRoutes
   auto map = test_server_->server().admin()->getConfigTracker().getCallbacksMap();
 
   // There is no route config dump before envoy has a route.
-  if (map.find("routes") == map.end()) {
+  if (!map.contains("routes")) {
     return {};
   }
 

--- a/test/test_common/simulated_time_system.cc
+++ b/test/test_common/simulated_time_system.cc
@@ -180,9 +180,7 @@ private:
       return true;
     }
 
-    bool contains(Alarm& alarm) const {
-      return alarm_registrations_map_.find(&alarm) != alarm_registrations_map_.end();
-    }
+    bool contains(Alarm& alarm) const { return alarm_registrations_map_.contains(&alarm); }
 
   private:
     std::set<AlarmRegistration> sorted_alarms_;


### PR DESCRIPTION
Enable the `readability-container-contains` clang-tidy check so that `count(k)`/`find(k) != end()` membership tests are flagged going forward, and apply the `.contains()` conversion across the non-extensions code (the extensions tree was cleaned up separately).

Readability cleanup with no behavior change.
