### PR TITLE
rlqs: hardcode usage reporting interval to 1s

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/filter_persistence.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter_persistence.cc
@@ -42,7 +42,7 @@ initTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
   // TODO(bsurber): Implement report timing & usage aggregation based on each
   // bucket's reporting_interval field. Currently this is not supported and all
   // usage is reported on a hardcoded interval.
-  std::chrono::milliseconds reporting_interval(5000);
+  std::chrono::milliseconds reporting_interval(1000);
 
   // Create the global client resource to be shared via TLS to all worker
   // threads (accessed through a filter-specific LocalRateLimitClient).

--- a/test/extensions/filters/http/rate_limit_quota/integration_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/integration_test.cc
@@ -312,7 +312,7 @@ protected:
   // TODO(bsurber): Implement report timing & usage aggregation based on each
   // bucket's reporting_interval field. Currently this is not supported and all
   // usage is reported on a hardcoded interval.
-  int report_interval_sec_ = 5;
+  int report_interval_sec_ = 1;
   RateLimitStrategy deny_all_strategy;
   RateLimitStrategy allow_all_strategy;
   // Prefer initialization around this default matcher if manipulations aren't needed.


### PR DESCRIPTION
The filter ignores RateLimitQuotaBucketSettings.reporting_interval and uses a fixed timer; shorten it from 5s to 1s for faster quota updates.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
