### PR TITLE
cleanup: replace erase-remove idiom with std::erase_if or absl::erase_if

### DIFF
--- a/source/common/event/evwatch_observer_manager_impl.cc
+++ b/source/common/event/evwatch_observer_manager_impl.cc
@@ -119,9 +119,7 @@ void EvwatchObserverManagerImpl::cleanupNulledObservers() {
   if (!has_nulled_observers_ || iteration_depth_ > 0) {
     return;
   }
-  observers_.erase(std::remove_if(observers_.begin(), observers_.end(),
-                                  [](const auto& entry) { return !entry.has_value(); }),
-                   observers_.end());
+  std::erase_if(observers_, [](const auto& entry) { return !entry.has_value(); });
   has_nulled_observers_ = false;
 }
 

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -246,9 +246,7 @@ protected:
           auto& values_vec = map_it->second;
           ASSERT(!values_vec.empty());
           // The following call to absl::erase_if removes the elements that satisfy the
-          // UnaryPredicate and shifts the vector elements, but does not resize the vector.
-          // The call to erase that follows erases the unneeded cells (from remove_pos to the
-          // end) and modifies the vector's size.
+          // UnaryPredicate and resizes the vector.
           absl::erase_if(values_vec, [&](HeaderNode it) {
             if (p(*(it->entry_))) {
               // Remove the element from the list.

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -245,23 +245,21 @@ protected:
         for (auto map_it = lazy_map_.begin(); map_it != lazy_map_.end();) {
           auto& values_vec = map_it->second;
           ASSERT(!values_vec.empty());
-          // The following call to std::remove_if removes the elements that satisfy the
+          // The following call to absl::erase_if removes the elements that satisfy the
           // UnaryPredicate and shifts the vector elements, but does not resize the vector.
           // The call to erase that follows erases the unneeded cells (from remove_pos to the
           // end) and modifies the vector's size.
-          const auto remove_pos =
-              std::remove_if(values_vec.begin(), values_vec.end(), [&](HeaderNode it) {
-                if (p(*(it->entry_))) {
-                  // Remove the element from the list.
-                  if (pseudo_headers_end_ == it->entry_) {
-                    pseudo_headers_end_++;
-                  }
-                  headers_.erase(it);
-                  return true;
-                }
-                return false;
-              });
-          values_vec.erase(remove_pos, values_vec.end());
+          absl::erase_if(values_vec, [&](HeaderNode it) {
+            if (p(*(it->entry_))) {
+              // Remove the element from the list.
+              if (pseudo_headers_end_ == it->entry_) {
+                pseudo_headers_end_++;
+              }
+              headers_.erase(it);
+              return true;
+            }
+            return false;
+          });
 
           // If all elements were removed from the map entry, erase it.
           if (values_vec.empty()) {

--- a/source/common/http/http_server_properties_cache_impl.cc
+++ b/source/common/http/http_server_properties_cache_impl.cc
@@ -274,11 +274,8 @@ HttpServerPropertiesCacheImpl::findAlternatives(const Origin& origin) {
 
   auto original_size = protocols.size();
   const MonotonicTime now = dispatcher_.timeSource().monotonicTime();
-  protocols.erase(std::remove_if(protocols.begin(), protocols.end(),
-                                 [now](const AlternateProtocol& protocol) {
-                                   return (now > protocol.expiration_);
-                                 }),
-                  protocols.end());
+  std::erase_if(protocols,
+                [now](const AlternateProtocol& protocol) { return (now > protocol.expiration_); });
 
   if (protocols.empty()) {
     if (key_value_store_) {

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1515,14 +1515,11 @@ ClusterManagerImpl::ClusterInitializationObject::ClusterInitializationObject(
       // overwriting hosts_added.
       if (!update.hosts_removed_.empty()) {
         // Remove all hosts to be removed from the old host_added.
-        auto& host_added = priority_state.hosts_added_;
-        auto removed_section = std::remove_if(
-            host_added.begin(), host_added.end(),
-            [hosts_removed = std::cref(update.hosts_removed_)](const HostSharedPtr& ptr) {
-              return std::find(hosts_removed.get().begin(), hosts_removed.get().end(), ptr) !=
-                     hosts_removed.get().end();
-            });
-        priority_state.hosts_added_.erase(removed_section, priority_state.hosts_added_.end());
+        std::erase_if(priority_state.hosts_added_,
+                      [hosts_removed = std::cref(update.hosts_removed_)](const HostSharedPtr& ptr) {
+                        return std::find(hosts_removed.get().begin(), hosts_removed.get().end(),
+                                         ptr) != hosts_removed.get().end();
+                      });
       }
 
       // Add updated host_added.

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -2593,20 +2593,17 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
 
   // Remove hosts from current_priority_hosts that were matched to an existing host in the
   // previous loop.
-  auto erase_from =
-      std::remove_if(current_priority_hosts.begin(), current_priority_hosts.end(),
-                     [&existing_hosts_for_current_priority](const HostSharedPtr& p) {
-                       auto existing_itr =
-                           existing_hosts_for_current_priority.find(p->address()->asString());
+  std::erase_if(
+      current_priority_hosts, [&existing_hosts_for_current_priority](const HostSharedPtr& p) {
+        auto existing_itr = existing_hosts_for_current_priority.find(p->address()->asString());
 
-                       if (existing_itr != existing_hosts_for_current_priority.end()) {
-                         existing_hosts_for_current_priority.erase(existing_itr);
-                         return true;
-                       }
+        if (existing_itr != existing_hosts_for_current_priority.end()) {
+          existing_hosts_for_current_priority.erase(existing_itr);
+          return true;
+        }
 
-                       return false;
-                     });
-  current_priority_hosts.erase(erase_from, current_priority_hosts.end());
+        return false;
+      });
 
   // If we saw existing hosts during this iteration from a different priority, then we've moved
   // a host from another priority into this one, so we should mark the priority as having changed.
@@ -2626,50 +2623,47 @@ bool BaseDynamicClusterImpl::updateDynamicHostList(
   const bool dont_remove_healthy_hosts =
       health_checker_ != nullptr && !info()->drainConnectionsOnHostRemoval();
   if (!current_priority_hosts.empty() && dont_remove_healthy_hosts) {
-    erase_from = std::remove_if(
-        current_priority_hosts.begin(), current_priority_hosts.end(),
-        [&all_new_hosts, &new_hosts_for_current_priority,
-         &hosts_with_updated_locality_for_current_priority,
-         &hosts_with_active_health_check_flag_changed, &final_hosts,
-         &max_host_weight](const HostSharedPtr& p) {
-          const auto address_string = addressToString(p->address());
-          // This host has already been added as a new host in the
-          // new_hosts_for_current_priority. Return false here to make sure that host
-          // reference with older locality gets cleaned up from the priority.
-          if (hosts_with_updated_locality_for_current_priority.contains(address_string)) {
-            return false;
-          }
-          if (hosts_with_active_health_check_flag_changed.contains(address_string)) {
-            return false;
-          }
+    std::erase_if(current_priority_hosts, [&all_new_hosts, &new_hosts_for_current_priority,
+                                           &hosts_with_updated_locality_for_current_priority,
+                                           &hosts_with_active_health_check_flag_changed,
+                                           &final_hosts, &max_host_weight](const HostSharedPtr& p) {
+      const auto address_string = addressToString(p->address());
+      // This host has already been added as a new host in the
+      // new_hosts_for_current_priority. Return false here to make sure that host
+      // reference with older locality gets cleaned up from the priority.
+      if (hosts_with_updated_locality_for_current_priority.contains(address_string)) {
+        return false;
+      }
+      if (hosts_with_active_health_check_flag_changed.contains(address_string)) {
+        return false;
+      }
 
-          if (all_new_hosts.contains(address_string) &&
-              !new_hosts_for_current_priority.contains(address_string)) {
-            // If the address is being completely deleted from this priority, but is
-            // referenced from another priority, then we assume that the other
-            // priority will perform an in-place update to re-use the existing Host.
-            // We should therefore not mark it as PENDING_DYNAMIC_REMOVAL, but
-            // instead remove it immediately from this priority.
-            // Example: health check address changed and priority also changed
-            return false;
-          }
+      if (all_new_hosts.contains(address_string) &&
+          !new_hosts_for_current_priority.contains(address_string)) {
+        // If the address is being completely deleted from this priority, but is
+        // referenced from another priority, then we assume that the other
+        // priority will perform an in-place update to re-use the existing Host.
+        // We should therefore not mark it as PENDING_DYNAMIC_REMOVAL, but
+        // instead remove it immediately from this priority.
+        // Example: health check address changed and priority also changed
+        return false;
+      }
 
-          // PENDING_DYNAMIC_REMOVAL doesn't apply for the host with disabled active
-          // health check, the host is removed immediately from this priority.
-          if ((!(p->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC) ||
-                 p->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH))) &&
-              !p->disableActiveHealthCheck()) {
-            if (p->weight() > max_host_weight) {
-              max_host_weight = p->weight();
-            }
+      // PENDING_DYNAMIC_REMOVAL doesn't apply for the host with disabled active
+      // health check, the host is removed immediately from this priority.
+      if ((!(p->healthFlagGet(Host::HealthFlag::FAILED_ACTIVE_HC) ||
+             p->healthFlagGet(Host::HealthFlag::FAILED_EDS_HEALTH))) &&
+          !p->disableActiveHealthCheck()) {
+        if (p->weight() > max_host_weight) {
+          max_host_weight = p->weight();
+        }
 
-            final_hosts.push_back(p);
-            p->healthFlagSet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL);
-            return true;
-          }
-          return false;
-        });
-    current_priority_hosts.erase(erase_from, current_priority_hosts.end());
+        final_hosts.push_back(p);
+        p->healthFlagSet(Host::HealthFlag::PENDING_DYNAMIC_REMOVAL);
+        return true;
+      }
+      return false;
+    });
   }
 
   // At this point we've accounted for all the new hosts as well the hosts that previously

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -518,12 +518,9 @@ void ReverseConnectionIOHandle::removeStaleHostAndCloseConnections(const std::st
     // Remove from wrapper-to-host map.
     conn_wrapper_to_host_map_.erase(wrapper);
     // Remove the wrapper from connection_wrappers_ vector.
-    connection_wrappers_.erase(
-        std::remove_if(connection_wrappers_.begin(), connection_wrappers_.end(),
-                       [wrapper](const std::unique_ptr<RCConnectionWrapper>& w) {
-                         return w.get() == wrapper;
-                       }),
-        connection_wrappers_.end());
+    std::erase_if(connection_wrappers_, [wrapper](const std::unique_ptr<RCConnectionWrapper>& w) {
+      return w.get() == wrapper;
+    });
   }
   // Clear connection keys from host info.
   auto host_it = host_to_conn_info_map_.find(host);

--- a/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
+++ b/source/extensions/clusters/dynamic_forward_proxy/cluster.cc
@@ -588,12 +588,10 @@ void Cluster::LoadBalancer::onConnectionDraining(Envoy::Http::ConnectionPool::In
                                                  std::vector<uint8_t>& hash_key,
                                                  const Network::Connection& connection) {
   const LookupKey key = {hash_key, *connection.connectionInfoProvider().remoteAddress()};
-  connection_info_map_[key].erase(
-      std::remove_if(connection_info_map_[key].begin(), connection_info_map_[key].end(),
-                     [&pool, &connection](const ConnectionInfo& info) {
-                       return (info.pool_ == &pool && info.connection_ == &connection);
-                     }),
-      connection_info_map_[key].end());
+
+  std::erase_if(connection_info_map_[key], [&pool, &connection](const ConnectionInfo& info) {
+    return (info.pool_ == &pool && info.connection_ == &connection);
+  });
 }
 
 absl::StatusOr<std::pair<Upstream::ClusterImplBaseSharedPtr, Upstream::ThreadAwareLoadBalancerPtr>>

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -414,27 +414,23 @@ void CacheSession::abortBodyOutOfRangeSubscribers() {
   // real size receive null body rather than reset.
   EndStream end_stream = endStreamAfterBody();
   auto cache_sessions = cache_sessions_.lock();
-  body_subscribers_.erase(
-      std::remove_if(body_subscribers_.begin(), body_subscribers_.end(),
-                     [this, end_stream, &cache_sessions](BodySubscriber& bs)
-                         ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-                           if (bs.range_.begin() >= body_length_available_) {
-                             if (bs.range_.begin() == body_length_available_) {
-                               auto cb = std::move(bs.callback_);
-                               bs.dispatcher().post([cb = std::move(cb), end_stream]() mutable {
-                                 cb(nullptr, end_stream);
-                               });
-                             } else {
-                               bs.callback_(nullptr, EndStream::Reset);
-                             }
-                             if (cache_sessions) {
-                               cache_sessions->stats().subCacheSessionsSubscribers(1);
-                             }
-                             return true;
-                           }
-                           return false;
-                         }),
-      body_subscribers_.end());
+  std::erase_if(body_subscribers_, [this, end_stream, &cache_sessions](
+                                       BodySubscriber& bs) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+    if (bs.range_.begin() >= body_length_available_) {
+      if (bs.range_.begin() == body_length_available_) {
+        auto cb = std::move(bs.callback_);
+        bs.dispatcher().post(
+            [cb = std::move(cb), end_stream]() mutable { cb(nullptr, end_stream); });
+      } else {
+        bs.callback_(nullptr, EndStream::Reset);
+      }
+      if (cache_sessions) {
+        cache_sessions->stats().subCacheSessionsSubscribers(1);
+      }
+      return true;
+    }
+    return false;
+  });
 }
 
 void CacheSession::maybeTriggerBodyReadForWaitingSubscriber() {

--- a/test/server/config_validation/xds_fuzz.cc
+++ b/test/server/config_validation/xds_fuzz.cc
@@ -116,9 +116,7 @@ void XdsFuzzTest::close() {
  */
 bool XdsFuzzTest::eraseListener(const std::string& listener_name) {
   const auto orig_size = listeners_.size();
-  listeners_.erase(std::remove_if(listeners_.begin(), listeners_.end(),
-                                  [&](auto& listener) { return listener.name() == listener_name; }),
-                   listeners_.end());
+  std::erase_if(listeners_, [&](auto& listener) { return listener.name() == listener_name; });
   return orig_size != listeners_.size();
 }
 

--- a/test/server/config_validation/xds_verifier.cc
+++ b/test/server/config_validation/xds_verifier.cc
@@ -245,9 +245,7 @@ void XdsVerifier::updateSotwListeners() {
       rep.state = ACTIVE;
     }
   }
-  listeners_.erase(std::remove_if(listeners_.begin(), listeners_.end(),
-                                  [&](auto& listener) { return listener.state == REMOVED; }),
-                   listeners_.end());
+  std::erase_if(listeners_, [&](auto& listener) { return listener.state == REMOVED; });
 }
 
 /**
@@ -268,9 +266,7 @@ void XdsVerifier::updateDeltaListeners(const envoy::config::route::v3::RouteConf
     }
   }
   // erase any active listeners that were replaced
-  listeners_.erase(std::remove_if(listeners_.begin(), listeners_.end(),
-                                  [&](auto& listener) { return listener.state == REMOVED; }),
-                   listeners_.end());
+  std::erase_if(listeners_, [&](auto& listener) { return listener.state == REMOVED; });
 }
 
 /**


### PR DESCRIPTION
### Description

Replace the traditional erase-remove idiom with the more concise `std::erase_if` and `absl::erase_if` APIs where applicable.

This improves readability by expressing the intent to remove elements matching a predicate directly, while preserving the existing behavior.

### Changes
Replace `std::remove_if` followed by `erase` with `std::erase_if` for standard containers.
Replace the same pattern with `absl::erase_if` for supported Abseil containers.

No functional behavior changes are intended.