### PR TITLE
fix: health check probes blocked indefinitely when EDS initialFetchTimeout is 0s

### DIFF
--- a/source/common/init/manager_impl.h
+++ b/source/common/init/manager_impl.h
@@ -38,6 +38,7 @@ public:
   void initialize(const Watcher& watcher) override;
   void updateWatcher(const Watcher& watcher) override;
   void dumpUnreadyTargets(envoy::admin::v3::UnreadyTargetsDumps& dumps) override;
+  uint32_t uninitializedCount() const { return count_; }
 
 private:
   // Callback function with an additional target_name parameter, decrease unready targets count by

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1995,10 +1995,9 @@ absl::Status ClusterImplBase::parseDropOverloadConfig(
 void ClusterImplBase::setHealthChecker(const HealthCheckerSharedPtr& health_checker) {
   ASSERT(!health_checker_);
   health_checker_ = health_checker;
-  const bool defer =
-      Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.health_check_after_cluster_warming") &&
-      (!hasZeroInitialFetchTimeout() || init_manager_.uninitializedCount() > 0);
+  const bool defer = Runtime::runtimeFeatureEnabled(
+                         "envoy.reloadable_features.health_check_after_cluster_warming") &&
+                     (!hasZeroInitialFetchTimeout() || init_manager_.uninitializedCount() > 0);
   if (!defer) {
     health_checker_->start();
   }

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1995,8 +1995,11 @@ absl::Status ClusterImplBase::parseDropOverloadConfig(
 void ClusterImplBase::setHealthChecker(const HealthCheckerSharedPtr& health_checker) {
   ASSERT(!health_checker_);
   health_checker_ = health_checker;
-  if (!Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.health_check_after_cluster_warming")) {
+  const bool defer =
+      Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.health_check_after_cluster_warming") &&
+      (!hasZeroInitialFetchTimeout() || init_manager_.uninitializedCount() > 0);
+  if (!defer) {
     health_checker_->start();
   }
   health_checker_->addHostCheckCompleteCb(

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1302,6 +1302,8 @@ protected:
 
   virtual void reloadHealthyHostsHelper(const HostSharedPtr& host);
 
+  virtual bool hasZeroInitialFetchTimeout() const { return false; }
+
   absl::Status parseDropOverloadConfig(
       const envoy::config::endpoint::v3::ClusterLoadAssignment& cluster_load_assignment);
 

--- a/source/extensions/clusters/eds/eds.cc
+++ b/source/extensions/clusters/eds/eds.cc
@@ -43,6 +43,8 @@ EdsClusterImpl::EdsClusterImpl(const envoy::config::cluster::v3::Cluster& cluste
   } else {
     initialize_phase_ = InitializePhase::Secondary;
   }
+  zero_initial_fetch_timeout_ =
+      Config::Utility::configSourceInitialFetchTimeout(eds_config).count() == 0;
   const auto resource_name = resource_type_helper_.getResourceName();
   if (Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.xdstp_based_config_singleton_subscriptions")) {

--- a/source/extensions/clusters/eds/eds.h
+++ b/source/extensions/clusters/eds/eds.h
@@ -77,6 +77,7 @@ private:
   // ClusterImplBase
   void reloadHealthyHostsHelper(const HostSharedPtr& host) override;
   void startPreInit() override;
+  bool hasZeroInitialFetchTimeout() const override { return zero_initial_fetch_timeout_; }
   void onAssignmentTimeout();
 
   // Returns true iff all the LEDS based localities were updated.
@@ -128,6 +129,9 @@ private:
 
   // Tracks whether a cached resource is used as the current EDS resource.
   bool using_cached_resource_{false};
+
+  // True when the EDS config source has initialFetchTimeout of 0.
+  bool zero_initial_fetch_timeout_{false};
 };
 
 using EdsClusterImplSharedPtr = std::shared_ptr<EdsClusterImpl>;

--- a/test/extensions/clusters/eds/eds_test.cc
+++ b/test/extensions/clusters/eds/eds_test.cc
@@ -3612,6 +3612,53 @@ TEST_F(XdstpConfigsEdsTest, DeltaOnConfigUpdateSuccess) {
                      .get()
                      .value());
 }
+
+// EDS-only cluster with initialFetchTimeout: 0s.
+// Health checks must start immediately — deferring would block them forever.
+TEST_F(EdsTest, HealthCheckStartsImmediatelyWithZeroInitialFetchTimeout) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.health_check_after_cluster_warming", "true"}});
+
+  resetCluster(R"EOF(
+      name: name
+      connect_timeout: 0.25s
+      type: EDS
+      lb_policy: ROUND_ROBIN
+      eds_cluster_config:
+        service_name: fare
+        eds_config:
+          initial_fetch_timeout: 0s
+          api_config_source:
+            api_type: GRPC
+            grpc_services:
+              envoy_grpc:
+                cluster_name: eds
+  )EOF",
+               Cluster::InitializePhase::Secondary);
+
+  auto health_checker = std::make_shared<MockHealthChecker>();
+  EXPECT_CALL(*health_checker, start());
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(1);
+  cluster_->setHealthChecker(health_checker);
+}
+
+// EDS cluster with non-zero initialFetchTimeout.
+// Health checks must be deferred until warming completes.
+TEST_F(EdsTest, HealthCheckDeferredWithNonZeroInitialFetchTimeout) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.health_check_after_cluster_warming", "true"}});
+
+  // Default cluster config has no explicit initialFetchTimeout, which defaults to 15s.
+  resetCluster();
+
+  auto health_checker = std::make_shared<MockHealthChecker>();
+  EXPECT_CALL(*health_checker, start()).Times(0);
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(1);
+  cluster_->setHealthChecker(health_checker);
+}
+
 } // namespace
 } // namespace Upstream
 } // namespace Envoy

--- a/test/extensions/clusters/eds/eds_test.cc
+++ b/test/extensions/clusters/eds/eds_test.cc
@@ -3639,7 +3639,7 @@ TEST_F(EdsTest, HealthCheckStartsImmediatelyWithZeroInitialFetchTimeout) {
 
   auto health_checker = std::make_shared<MockHealthChecker>();
   EXPECT_CALL(*health_checker, start());
-  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(1);
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
   cluster_->setHealthChecker(health_checker);
 }
 
@@ -3655,7 +3655,7 @@ TEST_F(EdsTest, HealthCheckDeferredWithNonZeroInitialFetchTimeout) {
 
   auto health_checker = std::make_shared<MockHealthChecker>();
   EXPECT_CALL(*health_checker, start()).Times(0);
-  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_)).Times(1);
+  EXPECT_CALL(*health_checker, addHostCheckCompleteCb(_));
   cluster_->setHealthChecker(health_checker);
 }
 


### PR DESCRIPTION
_Commit Message:_
when a cluster is configured with EDS and initialFetchTimeout: 0s, the cluster stays in warming state indefinitely until EDS delivers its first response, no timeout fires to unblock it.

_Additional Description:_
added a bypass in ClusterImplBase::setHealthChecker(). when health_check_after_cluster_warming is enabled, health checks are still started immediately if both conditions hold:
  1. the EDS config source has initialFetchTimeout: 0s (hasZeroInitialFetchTimeout() == true)
  2. there are no pending SDS init targets (init_manager_.uninitializedCount() == 0)

_Risk Level:_
Low

_Testing:_
Test cases been added.

_Release Notes:_
fix health check probes being blocked indefinitely on EDS clusters configured with initialFetchTimeout: 0s. With health_check_after_cluster_warming enabled(default), health checks are no longer deferred when EDS warming has no timeout deadline.

Fixes #46666