### PR TITLE
Rescope Logger::Levels enum so it can be moved to envoy/ directory

### DIFF
--- a/mobile/examples/cc/fetch_client/fetch_client_main.cc
+++ b/mobile/examples/cc/fetch_client/fetch_client_main.cc
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
   absl::Notification engine_running;
   Envoy::Platform::EngineSharedPtr engine =
       Envoy::Platform::EngineBuilder()
-          .setLogLevel(Envoy::Logger::Logger::trace)
+          .setLogLevel(Envoy::Logger::Levels::trace)
           .addRuntimeGuard("dns_cache_set_ip_version_to_remove", true)
           .addRuntimeGuard("quic_no_tcp_delay", true)
           .setOnEngineRunning([&engine_running]() { engine_running.Notify(); })

--- a/mobile/library/cc/engine_builder.cc
+++ b/mobile/library/cc/engine_builder.cc
@@ -60,7 +60,7 @@ EngineBuilder& EngineBuilder::setBufferHighWatermark(size_t high_watermark) {
   return *this;
 }
 
-EngineBuilder& EngineBuilder::setLogLevel(Logger::Logger::Levels log_level) {
+EngineBuilder& EngineBuilder::setLogLevel(Logger::Levels log_level) {
   log_level_ = log_level;
   return *this;
 }

--- a/mobile/library/cc/engine_builder.h
+++ b/mobile/library/cc/engine_builder.h
@@ -33,7 +33,7 @@ public:
   virtual ~EngineBuilder() = default;
   static std::string nativeNameToConfig(absl::string_view name);
 
-  EngineBuilder& setLogLevel(Logger::Logger::Levels log_level);
+  EngineBuilder& setLogLevel(Logger::Levels log_level);
   EngineBuilder& setLogger(std::unique_ptr<EnvoyLogger> logger);
   EngineBuilder& enableLogger(bool logger_on);
   EngineBuilder& setEngineCallbacks(std::unique_ptr<EngineCallbacks> callbacks);
@@ -199,7 +199,7 @@ private:
     Protobuf::Any typed_config_{};
   };
 
-  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
+  Logger::Levels log_level_ = Logger::Levels::info;
   std::unique_ptr<EnvoyLogger> logger_{nullptr};
   bool enable_logger_{true};
   std::unique_ptr<EngineCallbacks> callbacks_;

--- a/mobile/library/cc/engine_builder_base.h
+++ b/mobile/library/cc/engine_builder_base.h
@@ -73,7 +73,7 @@ public:
   virtual ~EngineBuilderBase() = default;
   EngineBuilderBase(EngineBuilderBase&&) = default;
 
-  T& setLogLevel(Logger::Logger::Levels log_level) {
+  T& setLogLevel(Logger::Levels log_level) {
     log_level_ = log_level;
     return static_cast<T&>(*this);
   }
@@ -420,7 +420,7 @@ private:
   std::vector<envoy::config::listener::v3::Listener> custom_listeners_;
 
   // Common fields for InternalEngine
-  Logger::Logger::Levels log_level_ = Logger::Logger::Levels::info;
+  Logger::Levels log_level_ = Logger::Levels::info;
   std::unique_ptr<EnvoyLogger> logger_{nullptr};
   bool enable_logger_{true};
   std::unique_ptr<EngineCallbacks> callbacks_;

--- a/mobile/library/common/engine_types.h
+++ b/mobile/library/common/engine_types.h
@@ -22,8 +22,8 @@ struct EngineCallbacks {
 
 /** The callbacks for Envoy Logger. */
 struct EnvoyLogger {
-  absl::AnyInvocable<void(Logger::Logger::Levels, const std::string&)> on_log_ =
-      [](Logger::Logger::Levels, const std::string&) {};
+  absl::AnyInvocable<void(Logger::Levels, const std::string&)> on_log_ = [](Logger::Levels,
+                                                                            const std::string&) {};
   absl::AnyInvocable<void()> on_exit_ = [] {};
 };
 

--- a/mobile/library/common/logger/logger_delegate.cc
+++ b/mobile/library/common/logger/logger_delegate.cc
@@ -31,8 +31,8 @@ LambdaDelegate::~LambdaDelegate() {
 }
 
 void LambdaDelegate::log(absl::string_view msg, const spdlog::details::log_msg& log_msg) {
-  // Logger::Levels is simply an alias to spdlog::level::level_enum, so we can safely cast it.
-  logger_->on_log_(static_cast<Logger::Levels>(log_msg.level), std::string(msg));
+  // Levels is simply an alias to spdlog::level::level_enum, so we can safely cast it.
+  logger_->on_log_(static_cast<Levels>(log_msg.level), std::string(msg));
 }
 
 DefaultDelegate::DefaultDelegate(absl::Mutex& mutex, DelegatingLogSinkSharedPtr log_sink)

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -67,7 +67,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   std::unique_ptr<Envoy::EnvoyLogger> logger = std::make_unique<Envoy::EnvoyLogger>();
   if (envoy_logger != nullptr) {
     jobject envoy_logger_global_ref = env->NewGlobalRef(envoy_logger);
-    logger->on_log_ = [envoy_logger_global_ref](Envoy::Logger::Logger::Levels level,
+    logger->on_log_ = [envoy_logger_global_ref](Envoy::Logger::Levels level,
                                                 const std::string& message) {
       Envoy::JNI::JniHelper jni_helper(Envoy::JNI::JniHelper::getThreadLocalEnv());
       Envoy::JNI::LocalRefUniquePtr<jstring> java_message =

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -421,7 +421,7 @@ static envoy_data ios_get_string(const void *context) {
       // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
       // block is necessary to act as a breaker for any Objective-C allocation that happens.
       @autoreleasepool {
-        logger((Envoy::Logger::Levels)level, @(message.c_str()));
+        logger((long)level, @(message.c_str()));
       }
     };
   }

--- a/mobile/library/objective-c/EnvoyEngineImpl.mm
+++ b/mobile/library/objective-c/EnvoyEngineImpl.mm
@@ -416,12 +416,12 @@ static envoy_data ios_get_string(const void *context) {
 
   std::unique_ptr<Envoy::EnvoyLogger> native_logger = std::make_unique<Envoy::EnvoyLogger>();
   if (logger) {
-    native_logger->on_log_ = [logger = std::move(logger)](Envoy::Logger::Logger::Levels level,
+    native_logger->on_log_ = [logger = std::move(logger)](Envoy::Logger::Levels level,
                                                           const std::string &message) {
       // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool
       // block is necessary to act as a breaker for any Objective-C allocation that happens.
       @autoreleasepool {
-        logger(level, @(message.c_str()));
+        logger((Envoy::Logger::Levels)level, @(message.c_str()));
       }
     };
   }

--- a/mobile/library/python/module_definition.cc
+++ b/mobile/library/python/module_definition.cc
@@ -28,14 +28,14 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   // -- Enums --
 
-  py::enum_<Envoy::Logger::Logger::Levels>(m, "LogLevel")
-      .value("trace", Envoy::Logger::Logger::Levels::trace)
-      .value("debug", Envoy::Logger::Logger::Levels::debug)
-      .value("info", Envoy::Logger::Logger::Levels::info)
-      .value("warn", Envoy::Logger::Logger::Levels::warn)
-      .value("error", Envoy::Logger::Logger::Levels::error)
-      .value("critical", Envoy::Logger::Logger::Levels::critical)
-      .value("off", Envoy::Logger::Logger::Levels::off);
+  py::enum_<Envoy::Logger::Levels>(m, "LogLevel")
+      .value("trace", Envoy::Logger::Levels::trace)
+      .value("debug", Envoy::Logger::Levels::debug)
+      .value("info", Envoy::Logger::Levels::info)
+      .value("warn", Envoy::Logger::Levels::warn)
+      .value("error", Envoy::Logger::Levels::error)
+      .value("critical", Envoy::Logger::Levels::critical)
+      .value("off", Envoy::Logger::Levels::off);
 
   py::enum_<envoy_status_t>(m, "EnvoyStatus")
       .value("success", ENVOY_SUCCESS)
@@ -178,7 +178,7 @@ PYBIND11_MODULE(envoy_engine, m) {
       .def(py::init<>())
       .def(
           "set_log_level",
-          [](Envoy::Platform::EngineBuilder& self, Envoy::Logger::Logger::Levels level)
+          [](Envoy::Platform::EngineBuilder& self, Envoy::Logger::Levels level)
               -> Envoy::Platform::EngineBuilder& { return self.setLogLevel(level); },
           py::arg("log_level"), py::return_value_policy::reference)
       .def(

--- a/mobile/test/cc/engine_test.cc
+++ b/mobile/test/cc/engine_test.cc
@@ -14,13 +14,13 @@ namespace Envoy {
 TEST(EngineTest, SetLogger) {
   std::atomic<bool> logging_was_called{false};
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log_ = [&](Logger::Logger::Levels, const std::string&) { logging_was_called = true; };
+  logger->on_log_ = [&](Logger::Levels, const std::string&) { logging_was_called = true; };
 
   absl::Notification engine_running;
   auto engine_callbacks = std::make_unique<EngineCallbacks>();
   engine_callbacks->on_engine_running_ = [&] { engine_running.Notify(); };
   Platform::EngineBuilder engine_builder;
-  engine_builder.setLogLevel(Logger::Logger::debug)
+  engine_builder.setLogLevel(Logger::Levels::debug)
       .setLogger(std::move(logger))
       .setEngineCallbacks(std::move(engine_callbacks))
       .enforceTrustChainVerification(false);
@@ -68,7 +68,7 @@ TEST(EngineTest, SetEngineCallbacks) {
   auto engine_callbacks = std::make_unique<EngineCallbacks>();
   engine_callbacks->on_engine_running_ = [&] { engine_running.Notify(); };
   Platform::EngineBuilder engine_builder;
-  engine_builder.setLogLevel(Logger::Logger::debug)
+  engine_builder.setLogLevel(Logger::Levels::debug)
       .setEngineCallbacks(std::move(engine_callbacks))
       .enforceTrustChainVerification(false);
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);
@@ -126,7 +126,7 @@ TEST(EngineTest, SetEventTracker) {
   event_tracker->on_exit_ = [&] { on_track_exit.Notify(); };
 
   Platform::EngineBuilder engine_builder;
-  engine_builder.setLogLevel(Logger::Logger::debug)
+  engine_builder.setLogLevel(Logger::Levels::debug)
       .setEngineCallbacks(std::move(engine_callbacks))
       .setEventTracker(std::move(event_tracker))
       .enforceTrustChainVerification(false);
@@ -141,7 +141,7 @@ TEST(EngineTest, SetEventTracker) {
 
 TEST(EngineTest, DontWaitForOnEngineRunning) {
   Platform::EngineBuilder engine_builder;
-  engine_builder.setLogLevel(Logger::Logger::debug).enforceTrustChainVerification(false);
+  engine_builder.setLogLevel(Logger::Levels::debug).enforceTrustChainVerification(false);
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);
 
   std::string actual_status_code;
@@ -185,7 +185,7 @@ TEST(EngineTest, TerminateWithoutWaitingForOnEngineRunning) {
   engine_callbacks->on_engine_running_ = [&] { engine_running.Notify(); };
 
   Platform::EngineBuilder engine_builder;
-  auto engine = engine_builder.setLogLevel(Logger::Logger::debug).build();
+  auto engine = engine_builder.setLogLevel(Logger::Levels::debug).build();
 
   engine->terminate();
 }

--- a/mobile/test/cc/integration/base/integration_test.cc
+++ b/mobile/test/cc/integration/base/integration_test.cc
@@ -47,7 +47,7 @@ protected:
       engine_builder.addHcmHttpFilter(std::move(assertion_filter));
     }
 
-    engine_builder.enableLogger(false).setLogLevel(Logger::Logger::debug).setOnEngineRunning([&]() {
+    engine_builder.enableLogger(false).setLogLevel(Logger::Levels::debug).setOnEngineRunning([&]() {
       engine_running.Notify();
     });
     client_engine_with_test_server_ = std::make_unique<TestEngineAndServer>(

--- a/mobile/test/cc/integration/lifetimes_test.cc
+++ b/mobile/test/cc/integration/lifetimes_test.cc
@@ -15,7 +15,7 @@ void sendRequest() {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .setOnEngineRunning([&]() { engine_running.Notify(); });
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);
   engine_running.WaitForNotification();

--- a/mobile/test/cc/integration/receive_data_test.cc
+++ b/mobile/test/cc/integration/receive_data_test.cc
@@ -14,7 +14,7 @@ TEST(ReceiveDataTest, Success) {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .setOnEngineRunning([&]() { engine_running.Notify(); });
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS,
                                                /* headers= */ {}, /* body= */ "hello world",

--- a/mobile/test/cc/integration/receive_headers_test.cc
+++ b/mobile/test/cc/integration/receive_headers_test.cc
@@ -14,7 +14,7 @@ TEST(ReceiveHeadersTest, Success) {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .setOnEngineRunning([&]() { engine_running.Notify(); });
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS,
                                                {{"foo", "bar"}});

--- a/mobile/test/cc/integration/receive_trailers_test.cc
+++ b/mobile/test/cc/integration/receive_trailers_test.cc
@@ -14,7 +14,7 @@ TEST(ReceiveTrailersTest, Success) {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .setOnEngineRunning([&]() { engine_running.Notify(); });
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS,
                                                /* headers= */ {},

--- a/mobile/test/cc/integration/send_data_test.cc
+++ b/mobile/test/cc/integration/send_data_test.cc
@@ -26,7 +26,7 @@ TEST(SendDataTest, Success) {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .addNativeFilter("envoy.filters.http.assertion", typed_config)
       .setOnEngineRunning([&]() { engine_running.Notify(); });
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);

--- a/mobile/test/cc/integration/send_headers_test.cc
+++ b/mobile/test/cc/integration/send_headers_test.cc
@@ -34,7 +34,7 @@ TEST(SendHeadersTest, Success) {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .addNativeFilter("envoy.filters.http.assertion", typed_config)
       .setOnEngineRunning([&]() { engine_running.Notify(); });
   EngineWithTestServer engine_with_test_server(engine_builder, TestServerType::HTTP2_WITH_TLS);

--- a/mobile/test/cc/integration/send_trailers_test.cc
+++ b/mobile/test/cc/integration/send_trailers_test.cc
@@ -28,7 +28,7 @@ TEST(SendTrailersTest, Success) {
   Platform::EngineBuilder engine_builder;
   engine_builder.enforceTrustChainVerification(false)
       .enableLogger(false)
-      .setLogLevel(Logger::Logger::debug)
+      .setLogLevel(Logger::Levels::debug)
       .addNativeFilter("envoy.filters.http.assertion", typed_config)
 
       .setOnEngineRunning([&]() { engine_running.Notify(); });

--- a/mobile/test/cc/unit/fetch_client_test.cc
+++ b/mobile/test/cc/unit/fetch_client_test.cc
@@ -23,7 +23,7 @@ envoy_status_t fetchUrls(const std::vector<std::string> urls,
                          std::vector<Http::Protocol>* used_protocols) {
   absl::Notification engine_running;
   Platform::EngineBuilder engine_builder;
-  engine_builder.setLogLevel(Envoy::Logger::Logger::info)
+  engine_builder.setLogLevel(Envoy::Logger::Levels::info)
       .enableLogger(false)
       .addRuntimeGuard("dns_cache_set_ip_version_to_remove", true)
       .addRuntimeGuard("quic_no_tcp_delay", true)

--- a/mobile/test/common/integration/base_client_integration_test.cc
+++ b/mobile/test/common/integration/base_client_integration_test.cc
@@ -68,8 +68,7 @@ BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion
   defer_listener_finalization_ = true;
   memset(&last_stream_final_intel_, 0, sizeof(envoy_final_stream_intel));
 
-  builder_.setLogLevel(
-      static_cast<Logger::Logger::Levels>(TestEnvironment::getOptions().logLevel()));
+  builder_.setLogLevel(static_cast<Logger::Levels>(TestEnvironment::getOptions().logLevel()));
   // The admin interface gets added by default in the ConfigHelper's constructor. Since the admin
   // interface gets compiled out by default in Envoy Mobile, remove it from the ConfigHelper's
   // bootstrap config.

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -217,7 +217,7 @@ public:
   }
 
 protected:
-  Logger::Logger::Levels log_level_ = Logger::Logger::info;
+  Logger::Levels log_level_ = Logger::Levels::info;
   std::unique_ptr<test::SystemHelperPeer::Handle> helper_handle_;
   bool add_quic_hints_ = false;
   bool add_fake_dns_ = false;
@@ -296,13 +296,12 @@ TEST_P(ClientIntegrationTest, Basic) {
 #if not defined(__APPLE__)
 TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   std::atomic<bool> found_cache_miss{false};
-  LogExpectation log_expect(
-      Envoy::GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
-        if (msg.find("ignoring failed address cache hit for miss for host 'doesnotexist") !=
-            std::string::npos) {
-          found_cache_miss = true;
-        }
-      });
+  LogExpectation log_expect(Envoy::GetLogSink(), [&](Logger::Levels, const std::string& msg) {
+    if (msg.find("ignoring failed address cache hit for miss for host 'doesnotexist") !=
+        std::string::npos) {
+      found_cache_miss = true;
+    }
+  });
 
   // Configure MockDnsResolver with "doesnotexist" as a non-existent domain
   envoy::config::core::v3::TypedExtensionConfig dns_resolver_config;
@@ -313,7 +312,7 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
   builder_.setDnsResolver(dns_resolver_config);
 
   builder_.setDisableDnsRefreshOnFailure(true);
-  log_level_ = Logger::Logger::debug;
+  log_level_ = Logger::Levels::debug;
   initialize();
 
   default_request_headers_.setHost("doesnotexist");
@@ -333,14 +332,13 @@ TEST_P(ClientIntegrationTest, DisableDnsRefreshOnFailure) {
 
 TEST_P(ClientIntegrationTest, DisableDnsRefreshOnNetworkChange) {
   std::atomic<bool> found_force_dns_refresh{false};
-  LogExpectation log_expect(
-      Envoy::GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
-        if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
-          found_force_dns_refresh = true;
-        }
-      });
+  LogExpectation log_expect(Envoy::GetLogSink(), [&](Logger::Levels, const std::string& msg) {
+    if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
+      found_force_dns_refresh = true;
+    }
+  });
   builder_.setDisableDnsRefreshOnNetworkChange(true);
-  log_level_ = Logger::Logger::debug;
+  log_level_ = Logger::Levels::debug;
   initialize();
 
   internalEngine()->onDefaultNetworkChanged(1);
@@ -352,16 +350,15 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
   std::atomic<bool> found_force_dns_refresh{false};
   std::vector<absl::Notification> handled_network_changes(5);
   std::atomic<int> current_change_event{0};
-  LogExpectation log_expect(
-      Envoy::GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
-        if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
-          found_force_dns_refresh = true;
-        } else if (msg.find("Finished the network changed callback") != std::string::npos) {
-          handled_network_changes[current_change_event].Notify();
-        }
-      });
+  LogExpectation log_expect(Envoy::GetLogSink(), [&](Logger::Levels, const std::string& msg) {
+    if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
+      found_force_dns_refresh = true;
+    } else if (msg.find("Finished the network changed callback") != std::string::npos) {
+      handled_network_changes[current_change_event].Notify();
+    }
+  });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
-  log_level_ = Logger::Logger::trace;
+  log_level_ = Logger::Levels::trace;
   initialize();
 
   // Set the network type to WIFI. This should trigger a network change.
@@ -411,18 +408,17 @@ TEST_P(ClientIntegrationTest, HandleNetworkChangeEvents) {
 TEST_P(ClientIntegrationTest, HandleNetworkChangeEventsAndroid) {
   absl::Notification found_force_dns_refresh;
   std::atomic<bool> handled_network_change{false};
-  LogExpectation log_expect(
-      Envoy::GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
-        if (msg.find("Default network state has been changed. Current net configuration key") !=
-            std::string::npos) {
-          handled_network_change = true;
-        }
-        if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
-          found_force_dns_refresh.Notify();
-        }
-      });
+  LogExpectation log_expect(Envoy::GetLogSink(), [&](Logger::Levels, const std::string& msg) {
+    if (msg.find("Default network state has been changed. Current net configuration key") !=
+        std::string::npos) {
+      handled_network_change = true;
+    }
+    if (msg.find("beginning DNS cache force refresh") != std::string::npos) {
+      found_force_dns_refresh.Notify();
+    }
+  });
   builder_.setDisableDnsRefreshOnNetworkChange(false);
-  log_level_ = Logger::Logger::trace;
+  log_level_ = Logger::Levels::trace;
   initialize();
 
   // A new WIFI network appears and becomes the default network. Even though

--- a/mobile/test/common/integration/rtds_integration_test.cc
+++ b/mobile/test/common/integration/rtds_integration_test.cc
@@ -38,7 +38,7 @@ public:
     xds_builder.addRuntimeDiscoveryService("some_rtds_resource", /*timeout_in_seconds=*/1)
         .setSslRootCerts(getUpstreamCert());
     builder_.setXds(std::move(xds_builder));
-    builder_.setLogLevel(Logger::Logger::info);
+    builder_.setLogLevel(Logger::Levels::info);
     builder_.enforceTrustChainVerification(false);
     XdsIntegrationTest::createEnvoy();
   }

--- a/mobile/test/common/internal_engine_test.cc
+++ b/mobile/test/common/internal_engine_test.cc
@@ -28,7 +28,7 @@ using testing::_;
 using testing::ByMove;
 using testing::Return;
 
-constexpr Logger::Logger::Levels LOG_LEVEL = Logger::Logger::Levels::debug;
+constexpr Logger::Levels LOG_LEVEL = Logger::Levels::debug;
 constexpr int kDefaultTimeoutSec = 3 * TIMEOUT_FACTOR;
 
 struct EngineTestContext {
@@ -44,7 +44,7 @@ struct EngineTestContext {
 // between the main thread and the engine thread both writing to the
 // Envoy::Logger::current_log_context global.
 struct TestEngine {
-  TestEngine(std::unique_ptr<EngineCallbacks> callbacks, const Logger::Logger::Levels log_level) {
+  TestEngine(std::unique_ptr<EngineCallbacks> callbacks, const Logger::Levels log_level) {
     engine_ = std::make_unique<InternalEngine>(std::move(callbacks), /*logger=*/nullptr,
                                                /*event_tracker=*/nullptr);
     Platform::EngineBuilder builder;
@@ -111,8 +111,7 @@ public:
   }
 
   envoy_status_t runEngine(const std::unique_ptr<InternalEngine>& engine,
-                           const Platform::EngineBuilder& builder,
-                           const Logger::Logger::Levels log_level) {
+                           const Platform::EngineBuilder& builder, const Logger::Levels log_level) {
     auto bootstrap = builder.generateBootstrap();
     auto options = std::make_shared<Envoy::OptionsImplBase>();
     options->setConfigProto(std::move(bootstrap));
@@ -188,7 +187,7 @@ TEST_F(InternalEngineTest, RecordCounter) {
 TEST_F(InternalEngineTest, Logger) {
   EngineTestContext test_context{};
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log_ = [&](Logger::Logger::Levels, const std::string&) {
+  logger->on_log_ = [&](Logger::Levels, const std::string&) {
     if (!test_context.on_log.HasBeenNotified()) {
       test_context.on_log.Notify();
     }

--- a/mobile/test/common/logger/logger_delegate_test.cc
+++ b/mobile/test/common/logger/logger_delegate_test.cc
@@ -30,7 +30,7 @@ TEST_F(LambdaDelegateTest, LogCb) {
   std::string actual_msg;
 
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log_ = [&](Logger::Levels, const std::string& message) { actual_msg = message; };
+  logger->on_log_ = [&](Levels, const std::string& message) { actual_msg = message; };
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
   ENVOY_LOG_MISC(error, expected_msg);
@@ -43,7 +43,7 @@ TEST_F(LambdaDelegateTest, LogCbWithLevels) {
   std::string actual_msg;
 
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log_ = [&](Logger::Levels, const std::string& message) { actual_msg = message; };
+  logger->on_log_ = [&](Levels, const std::string& message) { actual_msg = message; };
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
   // Set the log to critical. The message should not be logged.
@@ -75,50 +75,50 @@ TEST_F(LambdaDelegateTest, ReleaseCb) {
 }
 
 class LambdaDelegateWithLevelTest
-    : public testing::TestWithParam<std::tuple<Logger::Levels, spdlog::level::level_enum>> {};
+    : public testing::TestWithParam<std::tuple<Levels, spdlog::level::level_enum>> {};
 
-INSTANTIATE_TEST_SUITE_P(
-    LogLevel, LambdaDelegateWithLevelTest,
-    testing::Values(std::make_tuple<>(Logger::Levels::trace, spdlog::level::trace),
-                    std::make_tuple<>(Logger::Levels::debug, spdlog::level::debug),
-                    std::make_tuple<>(Logger::Levels::info, spdlog::level::info),
-                    std::make_tuple<>(Logger::Levels::warn, spdlog::level::warn),
-                    std::make_tuple<>(Logger::Levels::error, spdlog::level::err),
-                    std::make_tuple<>(Logger::Levels::critical, spdlog::level::critical)));
+INSTANTIATE_TEST_SUITE_P(LogLevel, LambdaDelegateWithLevelTest,
+                         testing::Values(std::make_tuple<>(Levels::trace, spdlog::level::trace),
+                                         std::make_tuple<>(Levels::debug, spdlog::level::debug),
+                                         std::make_tuple<>(Levels::info, spdlog::level::info),
+                                         std::make_tuple<>(Levels::warn, spdlog::level::warn),
+                                         std::make_tuple<>(Levels::error, spdlog::level::err),
+                                         std::make_tuple<>(Levels::critical,
+                                                           spdlog::level::critical)));
 
 TEST_P(LambdaDelegateWithLevelTest, Log) {
   std::string expected_msg = "Hello LambdaDelegate";
-  Logger::Levels actual_level;
+  Levels actual_level;
   std::string actual_msg;
   auto logger = std::make_unique<EnvoyLogger>();
-  logger->on_log_ = [&](Logger::Levels level, const std::string& message) {
+  logger->on_log_ = [&](Levels level, const std::string& message) {
     actual_level = level;
     actual_msg = message;
   };
 
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
-  Logger::Levels envoy_log_level = std::get<0>(GetParam());
+  Levels envoy_log_level = std::get<0>(GetParam());
   spdlog::level::level_enum spd_log_level = std::get<1>(GetParam());
 
   Context::changeAllLogLevels(spd_log_level);
   switch (envoy_log_level) {
-  case Logger::Levels::trace:
+  case Levels::trace:
     ENVOY_LOG_MISC(trace, expected_msg);
     break;
-  case Logger::Levels::debug:
+  case Levels::debug:
     ENVOY_LOG_MISC(debug, expected_msg);
     break;
-  case Logger::Levels::info:
+  case Levels::info:
     ENVOY_LOG_MISC(info, expected_msg);
     break;
-  case Logger::Levels::warn:
+  case Levels::warn:
     ENVOY_LOG_MISC(warn, expected_msg);
     break;
-  case Logger::Levels::error:
+  case Levels::error:
     ENVOY_LOG_MISC(error, expected_msg);
     break;
-  case Logger::Levels::critical:
+  case Levels::critical:
     ENVOY_LOG_MISC(critical, expected_msg);
     break;
   default:

--- a/source/common/common/base_logger.h
+++ b/source/common/common/base_logger.h
@@ -9,26 +9,26 @@
 namespace Envoy {
 namespace Logger {
 
+/* This is simple mapping between Logger severity levels and spdlog severity levels.
+ * The only reason for this mapping is to go around the fact that spdlog defines level as err
+ * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
+ * fine spdlog::info corresponds to LOGGER.info method.
+ */
+enum class Levels {
+  trace = spdlog::level::trace,       // NOLINT(readability-identifier-naming)
+  debug = spdlog::level::debug,       // NOLINT(readability-identifier-naming)
+  info = spdlog::level::info,         // NOLINT(readability-identifier-naming)
+  warn = spdlog::level::warn,         // NOLINT(readability-identifier-naming)
+  error = spdlog::level::err,         // NOLINT(readability-identifier-naming)
+  critical = spdlog::level::critical, // NOLINT(readability-identifier-naming)
+  off = spdlog::level::off            // NOLINT(readability-identifier-naming)
+};
+
 /**
  * Logger wrapper for a spdlog logger.
  */
 class Logger {
 public:
-  /* This is simple mapping between Logger severity levels and spdlog severity levels.
-   * The only reason for this mapping is to go around the fact that spdlog defines level as err
-   * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
-   * fine spdlog::info corresponds to LOGGER.info method.
-   */
-  using Levels = enum {
-    trace = spdlog::level::trace,       // NOLINT(readability-identifier-naming)
-    debug = spdlog::level::debug,       // NOLINT(readability-identifier-naming)
-    info = spdlog::level::info,         // NOLINT(readability-identifier-naming)
-    warn = spdlog::level::warn,         // NOLINT(readability-identifier-naming)
-    error = spdlog::level::err,         // NOLINT(readability-identifier-naming)
-    critical = spdlog::level::critical, // NOLINT(readability-identifier-naming)
-    off = spdlog::level::off            // NOLINT(readability-identifier-naming)
-  };
-
   spdlog::string_view_t levelString() const {
     return spdlog::level::level_string_views[logger_->level()];
   }

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -508,7 +508,7 @@ public:
  */
 
 #define ENVOY_SPDLOG_LEVEL(LEVEL)                                                                  \
-  (static_cast<spdlog::level::level_enum>(Envoy::Logger::Logger::LEVEL))
+  (static_cast<spdlog::level::level_enum>(Envoy::Logger::Levels::LEVEL))
 
 #define ENVOY_LOG_COMP_LEVEL(LOGGER, LEVEL) (ENVOY_SPDLOG_LEVEL(LEVEL) >= (LOGGER).level())
 

--- a/test/extensions/watchdog/backtrace_action/backtrace_action_test.cc
+++ b/test/extensions/watchdog/backtrace_action/backtrace_action_test.cc
@@ -123,7 +123,7 @@ TEST_F(BacktraceActionTest, SingleBacktraceLogged) {
 
   absl::Notification logged;
   LogLevelSetter save_levels(spdlog::level::trace);
-  LogExpectation expectation(GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
+  LogExpectation expectation(GetLogSink(), [&](Logger::Levels, const std::string& msg) {
     if (msg.find("Envoy version:") != std::string::npos) {
       logged.Notify();
     }
@@ -180,7 +180,7 @@ TEST_F(BacktraceActionTest, MultipleBacktracesLogged) {
   std::atomic<int> count{0};
   absl::Notification all_logged;
   LogLevelSetter save_levels(spdlog::level::trace);
-  LogExpectation expectation(GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
+  LogExpectation expectation(GetLogSink(), [&](Logger::Levels, const std::string& msg) {
     if (msg.find("Envoy version:") != std::string::npos) {
       if (++count == 2) {
         all_logged.Notify();
@@ -229,7 +229,7 @@ TEST_F(BacktraceActionTest, CooldownPreventsDuplicateBacktrace) {
   std::atomic<int> count{0};
   absl::Notification first_logged;
   LogLevelSetter save_levels(spdlog::level::trace);
-  LogExpectation expectation(GetLogSink(), [&](Logger::Logger::Levels, const std::string& msg) {
+  LogExpectation expectation(GetLogSink(), [&](Logger::Levels, const std::string& msg) {
     if (msg.find("Envoy version:") != std::string::npos) {
       if (count.fetch_add(1, std::memory_order_relaxed) == 0) {
         first_logged.Notify();

--- a/test/test_common/logging.cc
+++ b/test/test_common/logging.cc
@@ -34,9 +34,8 @@ LogLevelSetter::~LogLevelSetter() {
   }
 }
 
-LogExpectation::LogExpectation(
-    LogRecordingSink& sink,
-    absl::AnyInvocable<void(Logger::Logger::Levels, const std::string&)> on_log)
+LogExpectation::LogExpectation(LogRecordingSink& sink,
+                               absl::AnyInvocable<void(Logger::Levels, const std::string&)> on_log)
     : sink_(sink), on_log_(std::move(on_log)) {
   sink_.addExpectation(this);
 }
@@ -59,7 +58,7 @@ void LogRecordingSink::log(absl::string_view msg, const spdlog::details::log_msg
 
   absl::MutexLock ml(exp_mtx_);
   for (auto* expect : expectations_) {
-    expect->on_log_(static_cast<Logger::Logger::Levels>(log_msg.level), std::string(msg));
+    expect->on_log_(static_cast<Logger::Levels>(log_msg.level), std::string(msg));
   }
 }
 

--- a/test/test_common/logging.h
+++ b/test/test_common/logging.h
@@ -80,10 +80,10 @@ private:
 class LogExpectation {
 public:
   LogExpectation(LogRecordingSink& sink,
-                 absl::AnyInvocable<void(Logger::Logger::Levels, const std::string&)> on_log);
+                 absl::AnyInvocable<void(Logger::Levels, const std::string&)> on_log);
   ~LogExpectation();
   LogRecordingSink& sink_;
-  absl::AnyInvocable<void(Logger::Logger::Levels, const std::string&)> on_log_;
+  absl::AnyInvocable<void(Logger::Levels, const std::string&)> on_log_;
 };
 
 // Initializes the global log environment and must be called prior to execution of Envoy code.


### PR DESCRIPTION
The main change is in the source/common/common/base_logger.h, moving the Levels enum out of the Logger class into the outer Logger namespace.

This is intermediate step to using this enum in Envoy's interfaces in the envoy/ directory. This will prevent leaking of the spdlog dependency to proprietary components that need to manipulate Envoy's log level programmatically. 

Risk Level: low
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
