### PR TITLE
Allow connection teardown even when cert selection is not yet complete

### DIFF
--- a/changelogs/current/bug_fixes/tls__allow-connection-teardown-during-async-cert-selection.rst
+++ b/changelogs/current/bug_fixes/tls__allow-connection-teardown-during-async-cert-selection.rst
@@ -1,0 +1,2 @@
+Fixed a bug in TLS where a false positive ``IS_ENVOY_BUG`` assertion was triggered when a
+connection was torn down while asynchronous certificate selection was still in progress.

--- a/source/common/tls/ssl_socket.cc
+++ b/source/common/tls/ssl_socket.cc
@@ -466,11 +466,9 @@ void SslSocket::onAsynchronousCertValidationComplete() {
 
 void SslSocket::onAsynchronousCertificateSelectionComplete() {
   ENVOY_CONN_LOG(debug, "Async cert selection completed", callbacks_->connection());
-  if (info_->state() != Ssl::SocketState::HandshakeBlockedOnAsyncOperation) {
-    IS_ENVOY_BUG(fmt::format("unexpected handshake state: {}", static_cast<int>(info_->state())));
-    return;
+  if (info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation) {
+    resumeHandshake();
   }
-  resumeHandshake();
 }
 
 } // namespace Tls

--- a/source/common/tls/ssl_socket.cc
+++ b/source/common/tls/ssl_socket.cc
@@ -466,6 +466,10 @@ void SslSocket::onAsynchronousCertValidationComplete() {
 
 void SslSocket::onAsynchronousCertificateSelectionComplete() {
   ENVOY_CONN_LOG(debug, "Async cert selection completed", callbacks_->connection());
+  // The state may not be HandshakeBlockedOnAsyncOperation if the socket was closed or
+  // shut down while the asynchronous operation was in progress. For example, closeSocket()
+  // calls shutdownSsl(), which transitions the state to ShutdownSent. In this case,
+  // we should not attempt to resume the handshake.
   if (info_->state() == Ssl::SocketState::HandshakeBlockedOnAsyncOperation) {
     resumeHandshake();
   }

--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -7558,6 +7558,37 @@ TEST_P(SslSocketTest, TestTransportSocketCallback) {
   EXPECT_EQ(ssl_socket->transportSocketCallbacks(), &callbacks);
 }
 
+TEST_P(SslSocketTest, AsyncCertSelectionCallbackWhenNotBlocked) {
+  // Make MockTransportSocketCallbacks.
+  Network::MockIoHandle io_handle;
+  NiceMock<Network::MockTransportSocketCallbacks> callbacks;
+  ON_CALL(callbacks, ioHandle()).WillByDefault(ReturnRef(io_handle));
+  NiceMock<Network::MockConnection> mock_connection;
+  ON_CALL(callbacks, connection()).WillByDefault(ReturnRef(mock_connection));
+
+  // Make SslSocket.
+  NiceMock<LocalInfo::MockLocalInfo> local_info;
+  ON_CALL(factory_context_.server_context_, localInfo()).WillByDefault(ReturnRef(local_info));
+
+  envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+  auto client_cfg = *ClientContextConfigImpl::create(tls_context, factory_context_);
+
+  ContextManagerImpl manager(factory_context_.serverFactoryContext());
+  auto client_ssl_socket_factory = *ClientSslSocketFactory::create(
+      std::move(client_cfg), manager, *factory_context_.store_.rootScope());
+
+  Network::TransportSocketPtr transport_socket =
+      client_ssl_socket_factory->createTransportSocket(nullptr, nullptr);
+
+  SslSocket* ssl_socket = dynamic_cast<SslSocket*>(transport_socket.get());
+  ssl_socket->setTransportSocketCallbacks(callbacks);
+
+  // Call onAsynchronousCertificateSelectionComplete() when the handshake is NOT in
+  // HandshakeBlockedOnAsyncOperation state. This test prevents a regression where
+  // an ENVOY_BUG is thrown.
+  ssl_socket->onAsynchronousCertificateSelectionComplete();
+}
+
 class SslReadBufferLimitTest : public SslSocketTest {
 protected:
   void initialize() {


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/45755 allowed the socket state to transition to `ShutdownSent` before cert selection is complete (as intended). However, this could cause `ENVOY_BUG` to be thrown when `SslSocket::onAsynchronousCertificateSelectionComplete()` is invoked. This patch updates `SslSocket::onAsynchronousCertificateSelectionComplete` to allow this socket state which is consistent with the implementation of `SslSocket::onAsynchronousCertValidationComplete` and avoids the `ENVOY_BUG` in the case of valid states such as `ShutdownSent`.

Change-Id: I155b874accd54affa65bfa0b744ff99154060570

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
