### PR TITLE
Restrict local reply streaming integration tests

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc
@@ -30,6 +30,13 @@ using Http::LowerCaseString;
 
 class ExtProcLocalReplyStreamingIntegrationTest : public ExtProcIntegrationTest {
 public:
+  void SetUp() override {
+    if (!IsEnvoyGrpc()) {
+      GTEST_SKIP()
+          << "Google gRPC client is not supported for local reply streaming integration tests";
+    }
+  }
+
   void sendLocalResponseBody(bool end_of_stream) {
     ProcessingResponse body_response;
     auto streamed_response =


### PR DESCRIPTION
... so that it runs only on Envoy gRPC

Change-Id: If3ff45c3ee9db39b14ed506a7ef85ae00ec7db24

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
