### PR TITLE
coroutine: add ASSIGN_OR_CO_RETURN and CO_RETURN_IF_ERROR macros

### DIFF
--- a/source/common/coroutine/BUILD
+++ b/source/common/coroutine/BUILD
@@ -27,10 +27,20 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "status_macros_lib",
+    hdrs = ["status_macros.h"],
+    deps = [
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+    ],
+)
+
+envoy_cc_library(
     name = "task_lib",
     hdrs = ["task.h"],
     deps = [
         ":context_lib",
+        ":status_macros_lib",
         "//source/common/common:assert_lib",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:statusor",
@@ -81,6 +91,7 @@ envoy_cc_library(
         ":executor_lib",
         ":launch_lib",
         ":leaf_awaitable_lib",
+        ":status_macros_lib",
         ":task_lib",
     ],
 )

--- a/source/common/coroutine/status_macros.h
+++ b/source/common/coroutine/status_macros.h
@@ -29,7 +29,7 @@
                           __VA_ARGS__)
 
 /**
- * Evaluates `expr` (producing `absl::StatusOr<T>`), `co_return`s early if `!statusor.ok()`,
+ * Evaluates `expr` (producing `absl::StatusOr<T>`), `co_return`s early if `!status_or.ok()`,
  * or unpacks the value into `lhs`.
  *
  * Examples:

--- a/source/common/coroutine/status_macros.h
+++ b/source/common/coroutine/status_macros.h
@@ -29,7 +29,7 @@
                           __VA_ARGS__)
 
 /**
- * Evaluates `rexpr` (producing `absl::StatusOr<T>`), `co_return`s early if `!statusor.ok()`,
+ * Evaluates `expr` (producing `absl::StatusOr<T>`), `co_return`s early if `!statusor.ok()`,
  * or unpacks the value into `lhs`.
  *
  * Examples:

--- a/source/common/coroutine/status_macros.h
+++ b/source/common/coroutine/status_macros.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// NOLINT(namespace-envoy)
+
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+#define COROUTINE_STATUS_MACROS_IMPL_CONCAT_INNER(x, y) x##y
+#define COROUTINE_STATUS_MACROS_IMPL_CONCAT(x, y) COROUTINE_STATUS_MACROS_IMPL_CONCAT_INNER(x, y)
+
+/**
+ * Evaluates `expr` (producing `absl::Status`) and `co_return`s early if `!status.ok()`.
+ *
+ * Example:
+ *   CO_RETURN_IF_ERROR(co_await buffer.flush());
+ */
+#define CO_RETURN_IF_ERROR_IMPL(status, ...)                                                       \
+  do {                                                                                             \
+    auto status = (__VA_ARGS__);                                                                   \
+    if (!status.ok()) {                                                                            \
+      co_return std::move(status);                                                                 \
+    }                                                                                              \
+  } while (false)
+
+#define CO_RETURN_IF_ERROR(...)                                                                    \
+  CO_RETURN_IF_ERROR_IMPL(COROUTINE_STATUS_MACROS_IMPL_CONCAT(_coro_status_, __COUNTER__),         \
+                          __VA_ARGS__)
+
+/**
+ * Evaluates `rexpr` (producing `absl::StatusOr<T>`), `co_return`s early if `!statusor.ok()`,
+ * or unpacks the value into `lhs`.
+ *
+ * Examples:
+ *   ASSIGN_OR_CO_RETURN(auto res, co_await client.fetch());
+ *   ASSIGN_OR_CO_RETURN(chunk, co_await buffer.recv());
+ */
+#define ASSIGN_OR_CO_RETURN_IMPL(statusor, lhs, ...)                                               \
+  auto statusor = (__VA_ARGS__);                                                                   \
+  if (!statusor.ok()) {                                                                            \
+    co_return std::move(statusor).status();                                                        \
+  }                                                                                                \
+  lhs = std::move(statusor).value()
+
+#define ASSIGN_OR_CO_RETURN(lhs, ...)                                                              \
+  ASSIGN_OR_CO_RETURN_IMPL(COROUTINE_STATUS_MACROS_IMPL_CONCAT(_coro_status_or_, __COUNTER__),     \
+                           lhs, __VA_ARGS__)

--- a/source/common/coroutine/task.h
+++ b/source/common/coroutine/task.h
@@ -8,6 +8,7 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/coroutine/context.h"
+#include "source/common/coroutine/status_macros.h"
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"

--- a/test/common/coroutine/coroutine_test.cc
+++ b/test/common/coroutine/coroutine_test.cc
@@ -480,6 +480,108 @@ TEST(LaunchTest, InlineStartRunsUpToFirstSuspension) {
   EXPECT_TRUE(result->ok());
 }
 
+// ---------------------------------------------------------------------------
+// Status macros tests (ASSIGN_OR_CO_RETURN, CO_RETURN_IF_ERROR, etc.)
+// ---------------------------------------------------------------------------
+
+namespace {
+
+Task<absl::StatusOr<std::string>> helperReturnsStringOrError(bool ok) {
+  if (!ok) {
+    co_return absl::InvalidArgumentError("string error");
+  }
+  co_return "hello";
+}
+
+Task<absl::Status> helperReturnsStatusOrError(bool ok) {
+  if (!ok) {
+    co_return absl::InternalError("status error");
+  }
+  co_return absl::OkStatus();
+}
+
+Task<absl::StatusOr<int>> testAssignOrCoReturn(bool ok) {
+  ASSIGN_OR_CO_RETURN(std::string s, co_await helperReturnsStringOrError(ok));
+  co_return static_cast<int>(s.length());
+}
+
+Task<absl::StatusOr<int>> testAssignOrCoReturnExistingVar(bool ok) {
+  std::string s;
+  ASSIGN_OR_CO_RETURN(s, co_await helperReturnsStringOrError(ok));
+  co_return static_cast<int>(s.length());
+}
+
+Task<absl::Status> testCoReturnIfError(bool ok) {
+  CO_RETURN_IF_ERROR(co_await helperReturnsStatusOrError(ok));
+  co_return absl::OkStatus();
+}
+
+} // namespace
+
+TEST(StatusMacrosTest, AssignOrCoReturnSuccess) {
+  auto exec = std::make_shared<ManualExecutor>();
+  std::optional<absl::StatusOr<int>> result;
+  DetachedHandle handle = launch(
+      testAssignOrCoReturn(true), exec,
+      [&result](absl::StatusOr<int> status_or) { result = std::move(status_or); },
+      StartMode::Inline);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_OK(*result);
+  EXPECT_EQ(result->value(), 5);
+}
+
+TEST(StatusMacrosTest, AssignOrCoReturnFailure) {
+  auto exec = std::make_shared<ManualExecutor>();
+  std::optional<absl::StatusOr<int>> result;
+  DetachedHandle handle = launch(
+      testAssignOrCoReturn(false), exec,
+      [&result](absl::StatusOr<int> status_or) { result = std::move(status_or); },
+      StartMode::Inline);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result->ok());
+  EXPECT_EQ(result->status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(result->status().message(), "string error");
+}
+
+TEST(StatusMacrosTest, AssignOrCoReturnExistingVar) {
+  auto exec = std::make_shared<ManualExecutor>();
+  std::optional<absl::StatusOr<int>> result;
+  DetachedHandle handle = launch(
+      testAssignOrCoReturnExistingVar(true), exec,
+      [&result](absl::StatusOr<int> status_or) { result = std::move(status_or); },
+      StartMode::Inline);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_OK(*result);
+  EXPECT_EQ(result->value(), 5);
+}
+
+TEST(StatusMacrosTest, CoReturnIfErrorSuccess) {
+  auto exec = std::make_shared<ManualExecutor>();
+  std::optional<absl::Status> result;
+  DetachedHandle handle = launch(
+      testCoReturnIfError(true), exec,
+      [&result](absl::Status status) { result = std::move(status); }, StartMode::Inline);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_OK(*result);
+}
+
+TEST(StatusMacrosTest, CoReturnIfErrorFailure) {
+  auto exec = std::make_shared<ManualExecutor>();
+  std::optional<absl::Status> result;
+  DetachedHandle handle = launch(
+      testCoReturnIfError(false), exec,
+      [&result](absl::Status status) { result = std::move(status); }, StartMode::Inline);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result->ok());
+  EXPECT_EQ(result->code(), absl::StatusCode::kInternal);
+  EXPECT_EQ(result->message(), "status error");
+}
+
 } // namespace
 } // namespace Coroutine
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:

These are the macros that mirror directly `RETURN_IF_ERROR` and `ASSIGN_OR_RETURN` but for
`Envoy::Coroutine::Task<absl::Status>` and `Envoy::Coroutine::Task<absl::StatusOr<T>>` coroutines.

Additional Description:
Risk Level: low
Testing: unit test
Docs Changes: N/A
Release Notes: no - internal helper utilities
Platform Specific Features: N/A
