### PR TITLE
Create Snapshot of runtime stats before incrementing counter

### DIFF
--- a/source/common/runtime/runtime_impl.cc
+++ b/source/common/runtime/runtime_impl.cc
@@ -772,6 +772,7 @@ absl::StatusOr<SnapshotImplPtr> LoaderImpl::createNewSnapshot() {
     }
   }
   stats_.num_layers_.set(layers.size());
+  auto snapshot = std::make_unique<SnapshotImpl>(generator_, stats_, std::move(layers));
   if (error_layers == 0) {
     stats_.load_success_.inc();
   } else {
@@ -782,7 +783,7 @@ absl::StatusOr<SnapshotImplPtr> LoaderImpl::createNewSnapshot() {
   } else {
     stats_.override_dir_not_exists_.inc();
   }
-  return std::make_unique<SnapshotImpl>(generator_, stats_, std::move(layers));
+  return snapshot;
 }
 
 } // namespace Runtime


### PR DESCRIPTION
The stats_.load_success_ counter is incremented before the Snapshot of runtime metrics is taken. This leads to a small window where a client can request runtime metrics after load_success_ counter indicates a successful load but before the latest runtime metrics are available.

Change-Id: Iac433fdf7637eec59186cfa44f2e065d367fc73f

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
