### PR TITLE
SubstitutionFormatUtils can log multiple occurrences of same header

### DIFF
--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -153,28 +153,32 @@ Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> heade
   }
 }
 
-/*Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> headers) const {
-  const Http::HeaderEntry* header = findHeader(headers);
-  if (!header) {
-    return SubstitutionFormatUtils::unspecifiedValue();
-  }
-
-  absl::string_view val = header->value().getStringView();
-  val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
-  return ValueUtil::stringValue(std::string(val));
-}*/
-
 void HeaderFormatter::formatValueTo(ValueSink& sink, OptRef<const Http::HeaderMap> headers) const {
-  const Http::HeaderEntry* header = findHeader(headers);
-  if (!header) {
-    // Keep the sink unmodified if no value is extracted and the caller can decide how to
-    // handle the missing value.
+  const Http::LowerCaseString* headerName = findHeader(headers);
+  if (!headerName) {
     return;
   }
 
-  absl::string_view val = header->value().getStringView();
-  val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
-  sink.addString(val);
+  if (multi_value_.has_value() && multi_value_.value()) {
+    // we want to parse all occurrences of header key
+    const auto multiVal =
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+    if (!multiVal.result().has_value()) {
+      return;
+    }
+    absl::string_view val =
+        SubstitutionFormatUtils::truncateStringView(multiVal.result().value(), max_length_);
+    sink.addString(val);
+    return;
+  } else {
+
+    const auto header = headers->get(*headerName);
+    // only pick the first header for the backwards compatible scenario
+    absl::string_view val = header[0]->value().getStringView();
+    val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
+    sink.addString(val);
+    return;
+  }
 }
 
 ResponseHeaderFormatter::ResponseHeaderFormatter(absl::string_view main_header,

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -16,6 +16,7 @@
 #include "source/common/grpc/common.h"
 #include "source/common/grpc/status.h"
 #include "source/common/http/header_map_impl.h"
+#include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
 #include "source/common/protobuf/utility.h"
@@ -51,10 +52,12 @@ Protobuf::Value AccessLogTypeFormatter::formatValue(const Context& context,
 
 HeaderFormatter::HeaderFormatter(absl::string_view main_header,
                                  absl::string_view alternative_header,
-                                 std::optional<size_t> max_length)
-    : main_header_(main_header), alternative_header_(alternative_header), max_length_(max_length) {}
+                                 std::optional<size_t> max_length, std::optional<bool> multi_value)
+    : main_header_(main_header), alternative_header_(alternative_header), max_length_(max_length),
+      multi_value_(multi_value) {}
 
-const Http::HeaderEntry* HeaderFormatter::findHeader(OptRef<const Http::HeaderMap> headers) const {
+const Http::LowerCaseString*
+HeaderFormatter::findHeader(OptRef<const Http::HeaderMap> headers) const {
   if (!headers.has_value()) {
     return nullptr;
   }
@@ -64,35 +67,93 @@ const Http::HeaderEntry* HeaderFormatter::findHeader(OptRef<const Http::HeaderMa
   if (header.empty() && !alternative_header_.get().empty()) {
     const auto alternate_header = headers->get(alternative_header_);
     // TODO(https://github.com/envoyproxy/envoy/issues/13454): Potentially log all header values.
-    return alternate_header.empty() ? nullptr : alternate_header[0];
+    return alternate_header.empty() ? nullptr : &alternative_header_;
   }
 
-  return header.empty() ? nullptr : header[0];
+  return header.empty() ? nullptr : &main_header_;
 }
 
 std::optional<std::string> HeaderFormatter::format(OptRef<const Http::HeaderMap> headers) const {
-  const Http::HeaderEntry* header = findHeader(headers);
-  if (!header) {
+  const Http::LowerCaseString* headerName = findHeader(headers);
+  if (!headerName) {
     return std::nullopt;
   }
 
-  absl::string_view val = header->value().getStringView();
-  val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
-  return std::string(val);
+  if (multi_value_.has_value() && multi_value_.value()) {
+    // we want to parse all occurrences of header key
+    const auto multiVal =
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+    if (!multiVal.result().has_value()) {
+      return std::nullopt;
+    }
+    absl::string_view val =
+        SubstitutionFormatUtils::truncateStringView(multiVal.result().value(), max_length_);
+    return std::string(val);
+  } else {
+
+    const auto header = headers->get(*headerName);
+    // only pick the first header for the backwards compatible scenario
+    absl::string_view val = header[0]->value().getStringView();
+    val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
+    return std::string(val);
+  }
 }
 
 bool HeaderFormatter::formatTo(std::string& sink, OptRef<const Http::HeaderMap> headers) const {
-  const Http::HeaderEntry* header = findHeader(headers);
-  if (!header) {
+  const Http::LowerCaseString* headerName = findHeader(headers);
+  if (!headerName) {
     return false;
   }
 
-  absl::string_view val = header->value().getStringView();
-  sink.append(SubstitutionFormatUtils::truncateStringView(val, max_length_));
-  return true;
+  if (multi_value_.has_value() && multi_value_.value()) {
+    // we want to parse all occurrences of header key
+    const auto multiVal =
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+    if (!multiVal.result().has_value()) {
+      return false;
+    }
+    absl::string_view val =
+        SubstitutionFormatUtils::truncateStringView(multiVal.result().value(), max_length_);
+    sink.append(val);
+    return true;
+  } else {
+
+    const auto header = headers->get(*headerName);
+    // only pick the first header for the backwards compatible scenario
+    absl::string_view val = header[0]->value().getStringView();
+    val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
+    sink.append(val);
+    return true;
+  }
 }
 
 Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> headers) const {
+  const Http::LowerCaseString* headerName = findHeader(headers);
+  if (!headerName) {
+    return SubstitutionFormatUtils::unspecifiedValue();
+  }
+
+  if (multi_value_.has_value() && multi_value_.value()) {
+    // we want to parse all occurrences of header key
+    const auto multiVal =
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+    if (!multiVal.result().has_value()) {
+      return SubstitutionFormatUtils::unspecifiedValue();
+    }
+    absl::string_view val =
+        SubstitutionFormatUtils::truncateStringView(multiVal.result().value(), max_length_);
+    return ValueUtil::stringValue(val);
+  } else {
+
+    const auto header = headers->get(*headerName);
+    // only pick the first header for the backwards compatible scenario
+    absl::string_view val = header[0]->value().getStringView();
+    val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
+    return ValueUtil::stringValue(val);
+  }
+}
+
+/*Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> headers) const {
   const Http::HeaderEntry* header = findHeader(headers);
   if (!header) {
     return SubstitutionFormatUtils::unspecifiedValue();
@@ -101,7 +162,7 @@ Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> heade
   absl::string_view val = header->value().getStringView();
   val = SubstitutionFormatUtils::truncateStringView(val, max_length_);
   return ValueUtil::stringValue(std::string(val));
-}
+}*/
 
 void HeaderFormatter::formatValueTo(ValueSink& sink, OptRef<const Http::HeaderMap> headers) const {
   const Http::HeaderEntry* header = findHeader(headers);
@@ -118,8 +179,9 @@ void HeaderFormatter::formatValueTo(ValueSink& sink, OptRef<const Http::HeaderMa
 
 ResponseHeaderFormatter::ResponseHeaderFormatter(absl::string_view main_header,
                                                  absl::string_view alternative_header,
-                                                 std::optional<size_t> max_length)
-    : HeaderFormatter(main_header, alternative_header, max_length) {}
+                                                 std::optional<size_t> max_length,
+                                                 std::optional<bool> multi_value)
+    : HeaderFormatter(main_header, alternative_header, max_length, multi_value) {}
 
 std::optional<std::string> ResponseHeaderFormatter::format(const Context& context,
                                                            const StreamInfo::StreamInfo&) const {
@@ -143,8 +205,9 @@ void ResponseHeaderFormatter::formatValueTo(ValueSink& sink, const Context& cont
 
 RequestHeaderFormatter::RequestHeaderFormatter(absl::string_view main_header,
                                                absl::string_view alternative_header,
-                                               std::optional<size_t> max_length)
-    : HeaderFormatter(main_header, alternative_header, max_length) {}
+                                               std::optional<size_t> max_length,
+                                               std::optional<bool> multi_value)
+    : HeaderFormatter(main_header, alternative_header, max_length, multi_value) {}
 
 std::optional<std::string> RequestHeaderFormatter::format(const Context& context,
                                                           const StreamInfo::StreamInfo&) const {
@@ -169,7 +232,7 @@ void RequestHeaderFormatter::formatValueTo(ValueSink& sink, const Context& conte
 ResponseTrailerFormatter::ResponseTrailerFormatter(absl::string_view main_header,
                                                    absl::string_view alternative_header,
                                                    std::optional<size_t> max_length)
-    : HeaderFormatter(main_header, alternative_header, max_length) {}
+    : HeaderFormatter(main_header, alternative_header, max_length, false) {}
 
 std::optional<std::string> ResponseTrailerFormatter::format(const Context& context,
                                                             const StreamInfo::StreamInfo&) const {
@@ -307,7 +370,7 @@ GrpcStatusFormatter::parseFormat(absl::string_view format) {
 GrpcStatusFormatter::GrpcStatusFormatter(const std::string& main_header,
                                          const std::string& alternative_header,
                                          std::optional<size_t> max_length, Format format)
-    : HeaderFormatter(main_header, alternative_header, max_length), format_(format) {}
+    : HeaderFormatter(main_header, alternative_header, max_length, false), format_(format) {}
 
 std::optional<std::string> GrpcStatusFormatter::format(const Context& context,
                                                        const StreamInfo::StreamInfo& info) const {
@@ -543,8 +606,17 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
+           return std::make_unique<RequestHeaderFormatter>(
+               result.value().first, result.value().second, max_length, false);
+         }}},
+       {"REQ_MULTI", // Same as REQUEST_HEADER and used for backward compatibility.
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format,
+            std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
+           auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
+           RETURN_IF_NOT_OK(result.status());
            return std::make_unique<RequestHeaderFormatter>(result.value().first,
-                                                           result.value().second, max_length);
+                                                           result.value().second, max_length, true);
          }}},
        {"REQUEST_HEADER",
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
@@ -552,8 +624,17 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
+           return std::make_unique<RequestHeaderFormatter>(
+               result.value().first, result.value().second, max_length, false);
+         }}},
+       {"REQUEST_HEADER_MULTI",
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format,
+            std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
+           auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
+           RETURN_IF_NOT_OK(result.status());
            return std::make_unique<RequestHeaderFormatter>(result.value().first,
-                                                           result.value().second, max_length);
+                                                           result.value().second, max_length, true);
          }}},
        {"RESP", // Same as RESPONSE_HEADER and used for backward compatibility.
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
@@ -561,8 +642,8 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
-           return std::make_unique<ResponseHeaderFormatter>(result.value().first,
-                                                            result.value().second, max_length);
+           return std::make_unique<ResponseHeaderFormatter>(
+               result.value().first, result.value().second, max_length, false);
          }}},
        {"RESPONSE_HEADER",
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
@@ -570,8 +651,26 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
-           return std::make_unique<ResponseHeaderFormatter>(result.value().first,
-                                                            result.value().second, max_length);
+           return std::make_unique<ResponseHeaderFormatter>(
+               result.value().first, result.value().second, max_length, false);
+         }}},
+       {"RESP_MULTI", // Same as RESPONSE_HEADER and used for backward compatibility.
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format,
+            std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
+           auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
+           RETURN_IF_NOT_OK(result.status());
+           return std::make_unique<ResponseHeaderFormatter>(
+               result.value().first, result.value().second, max_length, true);
+         }}},
+       {"RESPONSE_HEADER_MULTI",
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format,
+            std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
+           auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
+           RETURN_IF_NOT_OK(result.status());
+           return std::make_unique<ResponseHeaderFormatter>(
+               result.value().first, result.value().second, max_length, true);
          }}},
        {"TRAILER", // Same as RESPONSE_TRAILER and used for backward compatibility.
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
@@ -640,8 +739,8 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
-           return std::make_unique<RequestHeaderFormatter>(result.value().first,
-                                                           result.value().second, max_length);
+           return std::make_unique<RequestHeaderFormatter>(
+               result.value().first, result.value().second, max_length, false);
          }}},
        {"TRACE_ID",
         {CommandSyntaxChecker::COMMAND_ONLY,

--- a/source/common/formatter/http_specific_formatter.cc
+++ b/source/common/formatter/http_specific_formatter.cc
@@ -52,7 +52,7 @@ Protobuf::Value AccessLogTypeFormatter::formatValue(const Context& context,
 
 HeaderFormatter::HeaderFormatter(absl::string_view main_header,
                                  absl::string_view alternative_header,
-                                 std::optional<size_t> max_length, std::optional<bool> multi_value)
+                                 std::optional<size_t> max_length, bool multi_value)
     : main_header_(main_header), alternative_header_(alternative_header), max_length_(max_length),
       multi_value_(multi_value) {}
 
@@ -79,10 +79,10 @@ std::optional<std::string> HeaderFormatter::format(OptRef<const Http::HeaderMap>
     return std::nullopt;
   }
 
-  if (multi_value_.has_value() && multi_value_.value()) {
+  if (multi_value_) {
     // we want to parse all occurrences of header key
     const auto multiVal =
-        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, *headerName);
     if (!multiVal.result().has_value()) {
       return std::nullopt;
     }
@@ -105,10 +105,10 @@ bool HeaderFormatter::formatTo(std::string& sink, OptRef<const Http::HeaderMap> 
     return false;
   }
 
-  if (multi_value_.has_value() && multi_value_.value()) {
+  if (multi_value_) {
     // we want to parse all occurrences of header key
     const auto multiVal =
-        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, *headerName);
     if (!multiVal.result().has_value()) {
       return false;
     }
@@ -133,10 +133,10 @@ Protobuf::Value HeaderFormatter::formatValue(OptRef<const Http::HeaderMap> heade
     return SubstitutionFormatUtils::unspecifiedValue();
   }
 
-  if (multi_value_.has_value() && multi_value_.value()) {
+  if (multi_value_) {
     // we want to parse all occurrences of header key
     const auto multiVal =
-        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, *headerName);
     if (!multiVal.result().has_value()) {
       return SubstitutionFormatUtils::unspecifiedValue();
     }
@@ -159,10 +159,10 @@ void HeaderFormatter::formatValueTo(ValueSink& sink, OptRef<const Http::HeaderMa
     return;
   }
 
-  if (multi_value_.has_value() && multi_value_.value()) {
+  if (multi_value_) {
     // we want to parse all occurrences of header key
     const auto multiVal =
-        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, ":");
+        Http::HeaderUtility::getAllOfHeaderAsString(headers.ref(), *headerName, *headerName);
     if (!multiVal.result().has_value()) {
       return;
     }
@@ -183,8 +183,7 @@ void HeaderFormatter::formatValueTo(ValueSink& sink, OptRef<const Http::HeaderMa
 
 ResponseHeaderFormatter::ResponseHeaderFormatter(absl::string_view main_header,
                                                  absl::string_view alternative_header,
-                                                 std::optional<size_t> max_length,
-                                                 std::optional<bool> multi_value)
+                                                 std::optional<size_t> max_length, bool multi_value)
     : HeaderFormatter(main_header, alternative_header, max_length, multi_value) {}
 
 std::optional<std::string> ResponseHeaderFormatter::format(const Context& context,
@@ -209,8 +208,7 @@ void ResponseHeaderFormatter::formatValueTo(ValueSink& sink, const Context& cont
 
 RequestHeaderFormatter::RequestHeaderFormatter(absl::string_view main_header,
                                                absl::string_view alternative_header,
-                                               std::optional<size_t> max_length,
-                                               std::optional<bool> multi_value)
+                                               std::optional<size_t> max_length, bool multi_value)
     : HeaderFormatter(main_header, alternative_header, max_length, multi_value) {}
 
 std::optional<std::string> RequestHeaderFormatter::format(const Context& context,
@@ -235,8 +233,9 @@ void RequestHeaderFormatter::formatValueTo(ValueSink& sink, const Context& conte
 
 ResponseTrailerFormatter::ResponseTrailerFormatter(absl::string_view main_header,
                                                    absl::string_view alternative_header,
-                                                   std::optional<size_t> max_length)
-    : HeaderFormatter(main_header, alternative_header, max_length, false) {}
+                                                   std::optional<size_t> max_length,
+                                                   bool multi_value)
+    : HeaderFormatter(main_header, alternative_header, max_length, multi_value) {}
 
 std::optional<std::string> ResponseTrailerFormatter::format(const Context& context,
                                                             const StreamInfo::StreamInfo&) const {
@@ -682,8 +681,8 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
-           return std::make_unique<ResponseTrailerFormatter>(result.value().first,
-                                                             result.value().second, max_length);
+           return std::make_unique<ResponseTrailerFormatter>(
+               result.value().first, result.value().second, max_length, false);
          }}},
        {"RESPONSE_TRAILER",
         {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
@@ -691,8 +690,26 @@ BuiltInHttpCommandParser::getKnownFormatters() {
             std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
            auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
            RETURN_IF_NOT_OK(result.status());
-           return std::make_unique<ResponseTrailerFormatter>(result.value().first,
-                                                             result.value().second, max_length);
+           return std::make_unique<ResponseTrailerFormatter>(
+               result.value().first, result.value().second, max_length, false);
+         }}},
+       {"TRAILER_MULTI", // Same as RESPONSE_TRAILER and used for backward compatibility.
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format,
+            std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
+           auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
+           RETURN_IF_NOT_OK(result.status());
+           return std::make_unique<ResponseTrailerFormatter>(
+               result.value().first, result.value().second, max_length, true);
+         }}},
+       {"RESPONSE_TRAILER_MULTI",
+        {CommandSyntaxChecker::PARAMS_REQUIRED | CommandSyntaxChecker::LENGTH_ALLOWED,
+         [](absl::string_view format,
+            std::optional<size_t> max_length) -> absl::StatusOr<FormatterProviderPtr> {
+           auto result = SubstitutionFormatUtils::parseSubcommandHeaders(format);
+           RETURN_IF_NOT_OK(result.status());
+           return std::make_unique<ResponseTrailerFormatter>(
+               result.value().first, result.value().second, max_length, true);
          }}},
        {"LOCAL_REPLY_BODY",
         {CommandSyntaxChecker::COMMAND_ONLY,

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -50,7 +50,7 @@ public:
 class HeaderFormatter {
 public:
   HeaderFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                  std::optional<size_t> max_length);
+                  std::optional<size_t> max_length, std::optional<bool> multi_value);
 
 protected:
   std::optional<std::string> format(OptRef<const Http::HeaderMap> headers) const;
@@ -59,11 +59,12 @@ protected:
   void formatValueTo(ValueSink& sink, OptRef<const Http::HeaderMap> headers) const;
 
 private:
-  const Http::HeaderEntry* findHeader(OptRef<const Http::HeaderMap> headers) const;
+  const Http::LowerCaseString* findHeader(OptRef<const Http::HeaderMap> headers) const;
 
   Http::LowerCaseString main_header_;
   Http::LowerCaseString alternative_header_;
   std::optional<size_t> max_length_;
+  std::optional<bool> multi_value_;
 };
 
 /**
@@ -94,7 +95,7 @@ private:
 class RequestHeaderFormatter : public FormatterProvider, HeaderFormatter {
 public:
   RequestHeaderFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                         std::optional<size_t> max_length);
+                         std::optional<size_t> max_length, std::optional<bool> multi_value);
 
   // FormatterProvider
   std::optional<std::string> format(const Context& context,
@@ -113,7 +114,7 @@ public:
 class ResponseHeaderFormatter : public FormatterProvider, HeaderFormatter {
 public:
   ResponseHeaderFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                          std::optional<size_t> max_length);
+                          std::optional<size_t> max_length, std::optional<bool> multi_value);
 
   // FormatterProvider
   std::optional<std::string> format(const Context& context,

--- a/source/common/formatter/http_specific_formatter.h
+++ b/source/common/formatter/http_specific_formatter.h
@@ -50,7 +50,7 @@ public:
 class HeaderFormatter {
 public:
   HeaderFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                  std::optional<size_t> max_length, std::optional<bool> multi_value);
+                  std::optional<size_t> max_length, bool multi_value);
 
 protected:
   std::optional<std::string> format(OptRef<const Http::HeaderMap> headers) const;
@@ -64,7 +64,7 @@ private:
   Http::LowerCaseString main_header_;
   Http::LowerCaseString alternative_header_;
   std::optional<size_t> max_length_;
-  std::optional<bool> multi_value_;
+  bool multi_value_;
 };
 
 /**
@@ -95,7 +95,7 @@ private:
 class RequestHeaderFormatter : public FormatterProvider, HeaderFormatter {
 public:
   RequestHeaderFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                         std::optional<size_t> max_length, std::optional<bool> multi_value);
+                         std::optional<size_t> max_length, bool multi_value);
 
   // FormatterProvider
   std::optional<std::string> format(const Context& context,
@@ -114,7 +114,7 @@ public:
 class ResponseHeaderFormatter : public FormatterProvider, HeaderFormatter {
 public:
   ResponseHeaderFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                          std::optional<size_t> max_length, std::optional<bool> multi_value);
+                          std::optional<size_t> max_length, bool multi_value);
 
   // FormatterProvider
   std::optional<std::string> format(const Context& context,
@@ -133,7 +133,7 @@ public:
 class ResponseTrailerFormatter : public FormatterProvider, HeaderFormatter {
 public:
   ResponseTrailerFormatter(absl::string_view main_header, absl::string_view alternative_header,
-                           std::optional<size_t> max_length);
+                           std::optional<size_t> max_length, bool multi_value);
 
   // FormatterProvider
   std::optional<std::string> format(const Context& context,

--- a/test/common/access_log/access_log_impl_test.cc
+++ b/test/common/access_log/access_log_impl_test.cc
@@ -103,6 +103,45 @@ typed_config:
             output_);
 }
 
+TEST_F(AccessLogImplTest, MultiValueHeader) {
+  const std::string yaml = R"EOF(
+name: accesslog
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+  path: /dev/null
+  log_format:
+    text_format_source:
+      inline_string: "[%START_TIME%] \"%REQ_MULTI(:METHOD)% %REQ_MULTI(UNKNOWN?SET-COOKIE)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_HEADER_MULTI(UNKNOWN?COOKIE)% %RESP_MULTI(CONTENT-TYPE)% %TRAILER_MULTI(TRAILER-X)%\n"
+  )EOF";
+
+  InstanceSharedPtr log = AccessLogFactory::fromProto(parseAccessLogFromV3Yaml(yaml), context_);
+
+  EXPECT_CALL(*file_, write(_));
+  stream_info_.setResponseFlag(StreamInfo::CoreResponseFlag::UpstreamConnectionFailure);
+  request_headers_.addCopy(Http::Headers::get().UserAgent, "user-agent-set");
+  request_headers_.addCopy(Http::Headers::get().RequestId, "id");
+  request_headers_.addCopy(Http::Headers::get().Host, "host");
+  request_headers_.addCopy(Http::Headers::get().ForwardedFor, "x.x.x.x");
+  response_headers_.addCopy(Http::Headers::get().ContentType, "application/json");
+
+  // add multi value request header
+  request_headers_.addCopy(Http::Headers::get().SetCookie, "cookie1");
+  request_headers_.addCopy(Http::Headers::get().SetCookie, "cookie2");
+
+  // add multi value response header
+  response_headers_.addCopy(Http::Headers::get().Cookie, "respCookie1");
+  response_headers_.addCopy(Http::Headers::get().Cookie, "respCookie2");
+
+  // add multi value trailers
+  response_trailers_.addCopy("trailer-x", "trailer1");
+  response_trailers_.addCopy("trailer-x", "trailer2");
+
+  log->log(formatter_context_, stream_info_);
+  EXPECT_EQ("[1999-01-01T00:00:00.000Z] \"GET cookie1set-cookiecookie2 HTTP/1.1\" 0 "
+            "respCookie1cookierespCookie2 application/json trailer1trailer-xtrailer2\n",
+            output_);
+}
+
 TEST_F(AccessLogImplTest, DownstreamDisconnect) {
   const std::string yaml = R"EOF(
 name: accesslog


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: SubstitutionFormatUtils can log multiple occurrences of same header

Additional Description:
Existing format specifiers will only emit the first occurrence of a header. Introduce new format specifiers (`REQ_MULTI`, `REQUEST_HEADER_MULTI`, `RESP_MULTI`, `RESPONSE_HEADER_MULTI`)   that allow to print all occurrences of a given header both in the request and response.

Risk Level: Low
Testing:
Manual testing done locally. Added tests that cover the new substitution commands. 

Docs Changes: Updated substitution formatter docs to add the new commands that this PR adds.
Release Notes: Added a file to the `changelogs` directory with a summary.
Platform Specific Features:

Attempt at #13454 