### PR TITLE
Add log level setters with Logger::Level

### DIFF
--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -133,13 +133,13 @@ AdminResponseSharedPtr MainCommonBase::adminRequest(absl::string_view path_and_q
 #endif
 
 MainCommon::MainCommon(const std::vector<std::string>& args)
-    : options_(args, &MainCommon::hotRestartVersion, spdlog::level::info),
+    : options_(args, &MainCommon::hotRestartVersion, Logger::Levels::info),
       base_(options_, real_time_system_, default_listener_hooks_, prod_component_factory_,
             std::make_unique<PlatformImpl>(), std::make_unique<Random::RandomGeneratorImpl>(),
             nullptr) {}
 
 MainCommon::MainCommon(int argc, const char* const* argv)
-    : options_(argc, argv, &MainCommon::hotRestartVersion, spdlog::level::info),
+    : options_(argc, argv, &MainCommon::hotRestartVersion, Logger::Levels::info),
       base_(options_, real_time_system_, default_listener_hooks_, prod_component_factory_,
             std::make_unique<PlatformImpl>(), std::make_unique<Random::RandomGeneratorImpl>(),
             nullptr) {}

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -41,6 +41,7 @@ envoy_cc_library(
         "//envoy/ssl:context_manager_interface",
         "//source/common/access_log:access_log_lib",
         "//source/common/common:assert_lib",
+        "//source/common/common:base_logger_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:runtime_utility_lib",

--- a/source/server/options_impl.cc
+++ b/source/server/options_impl.cc
@@ -40,12 +40,23 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv,
                          spdlog::level::level_enum default_log_level)
     : OptionsImpl(toArgsVector(argc, argv), hot_restart_version_cb, default_log_level) {}
 
+OptionsImpl::OptionsImpl(int argc, const char* const* argv,
+                         const HotRestartVersionCb& hot_restart_version_cb,
+                         Logger::Levels default_log_level)
+    : OptionsImpl(toArgsVector(argc, argv), hot_restart_version_cb, default_log_level) {}
+
 OptionsImpl::OptionsImpl(std::vector<std::string> args,
                          const HotRestartVersionCb& hot_restart_version_cb,
-                         spdlog::level::level_enum default_log_level) {
+                         spdlog::level::level_enum default_log_level)
+    : OptionsImpl(args, hot_restart_version_cb, static_cast<Logger::Levels>(default_log_level)) {}
+
+OptionsImpl::OptionsImpl(std::vector<std::string> args,
+                         const HotRestartVersionCb& hot_restart_version_cb,
+                         Logger::Levels default_log_level) {
   std::string log_levels_string = fmt::format("Log levels: {}", allowedLogLevels());
   log_levels_string +=
-      fmt::format("\nDefault is [{}]", spdlog::level::level_string_views[default_log_level]);
+      fmt::format("\nDefault is [{}]",
+                  spdlog::level::level_string_views[static_cast<uint32_t>(default_log_level)]);
 
   const std::string component_log_level_string =
       "Comma-separated list of component log levels. For example upstream:debug,config:trace";
@@ -117,7 +128,8 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
                                                         false, "v4", "string", cmd);
   TCLAP::ValueArg<std::string> log_level(
       "l", "log-level", log_levels_string, false,
-      spdlog::level::level_string_views[default_log_level].data(), "string", cmd);
+      spdlog::level::level_string_views[static_cast<uint32_t>(default_log_level)].data(), "string",
+      cmd);
   TCLAP::ValueArg<std::string> component_log_level(
       "", "component-log-level", component_log_level_string, false, "", "string", cmd);
   TCLAP::ValueArg<std::string> log_format("", "log-format", log_format_string, false,
@@ -220,7 +232,7 @@ OptionsImpl::OptionsImpl(std::vector<std::string> args,
     }
     log_level_ = status_or_error.value();
   } else {
-    log_level_ = default_log_level;
+    log_level_ = static_cast<spdlog::level::level_enum>(default_log_level);
   }
 
   log_format_ = log_format.getValue();
@@ -478,4 +490,11 @@ OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& 
   setServiceZone(service_zone);
 }
 
+OptionsImpl::OptionsImpl(const std::string& service_cluster, const std::string& service_node,
+                         const std::string& service_zone, Logger::Levels log_level) {
+  setLogLevel(log_level);
+  setServiceClusterName(service_cluster);
+  setServiceNodeName(service_node);
+  setServiceZone(service_zone);
+}
 } // namespace Envoy

--- a/source/server/options_impl.h
+++ b/source/server/options_impl.h
@@ -9,6 +9,7 @@
 #include "envoy/registry/registry.h"
 #include "envoy/server/options.h"
 
+#include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
 #include "source/common/config/well_known_names.h"
 #include "source/server/options_impl_base.h"
@@ -34,8 +35,11 @@ public:
    * @throw MalformedArgvException if something is wrong with the arguments (invalid flag or flag
    *        value). The caller should call exit(1) after any necessary cleanup.
    */
+  [[deprecated("Use constructor with Logger::Levels")]] OptionsImpl(
+      int argc, const char* const* argv, const HotRestartVersionCb& hot_restart_version_cb,
+      spdlog::level::level_enum default_log_level);
   OptionsImpl(int argc, const char* const* argv, const HotRestartVersionCb& hot_restart_version_cb,
-              spdlog::level::level_enum default_log_level);
+              Logger::Levels default_log_level);
 
   /**
    * @throw NoServingException if Envoy has already done everything specified by the args (e.g.
@@ -44,13 +48,19 @@ public:
    * @throw MalformedArgvException if something is wrong with the arguments (invalid flag or flag
    *        value). The caller should call exit(1) after any necessary cleanup.
    */
+  [[deprecated("Use constructor with Logger::Levels")]] OptionsImpl(
+      std::vector<std::string> args, const HotRestartVersionCb& hot_restart_version_cb,
+      spdlog::level::level_enum default_log_level);
   OptionsImpl(std::vector<std::string> args, const HotRestartVersionCb& hot_restart_version_cb,
-              spdlog::level::level_enum default_log_level);
+              Logger::Levels default_log_level);
 
   // Default constructor; creates "reasonable" defaults, but desired values should be set
   // explicitly.
+  [[deprecated("Use constructor with Logger::Levels")]] OptionsImpl(
+      const std::string& service_cluster, const std::string& service_node,
+      const std::string& service_zone, spdlog::level::level_enum log_level);
   OptionsImpl(const std::string& service_cluster, const std::string& service_node,
-              const std::string& service_zone, spdlog::level::level_enum log_level);
+              const std::string& service_zone, Logger::Levels log_level);
 
   Server::CommandLineOptionsPtr toCommandLineOptions() const override;
   void parseComponentLogLevels(const std::string& component_log_levels);

--- a/source/server/options_impl_base.cc
+++ b/source/server/options_impl_base.cc
@@ -48,7 +48,7 @@ absl::Status OptionsImplBase::setLogLevel(absl::string_view log_level) {
   if (!status_or_level.status().ok()) {
     return status_or_level.status();
   }
-  setLogLevel(status_or_level.value());
+  // setLogLevel(status_or_level.value());
   return absl::OkStatus();
 }
 

--- a/source/server/options_impl_base.cc
+++ b/source/server/options_impl_base.cc
@@ -48,7 +48,7 @@ absl::Status OptionsImplBase::setLogLevel(absl::string_view log_level) {
   if (!status_or_level.status().ok()) {
     return status_or_level.status();
   }
-  // setLogLevel(status_or_level.value());
+  setLogLevel(status_or_level.value());
   return absl::OkStatus();
 }
 

--- a/source/server/options_impl_base.h
+++ b/source/server/options_impl_base.h
@@ -9,6 +9,7 @@
 #include "envoy/registry/registry.h"
 #include "envoy/server/options.h"
 
+#include "source/common/common/base_logger.h"
 #include "source/common/common/logger.h"
 #include "source/common/config/well_known_names.h"
 
@@ -55,7 +56,13 @@ public:
     parent_shutdown_time_ = parent_shutdown_time;
   }
   void setDrainStrategy(Server::DrainStrategy drain_strategy) { drain_strategy_ = drain_strategy; }
-  void setLogLevel(spdlog::level::level_enum log_level) { log_level_ = log_level; }
+  [[deprecated("Use setLogLevel(Logger::Levels)")]] void
+  setLogLevel(spdlog::level::level_enum log_level) {
+    log_level_ = log_level;
+  }
+  void setLogLevel(Logger::Levels log_level) {
+    log_level_ = static_cast<spdlog::level::level_enum>(log_level);
+  }
   absl::Status setLogLevel(absl::string_view log_level);
   void setLogFormat(const std::string& log_format) {
     log_format_ = log_format;

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -44,7 +44,7 @@ createTestOptionsImpl(const std::string& config_path, const std::string& config_
   test_options.setServiceClusterName(service_cluster);
   test_options.setServiceNodeName(service_node);
   test_options.setServiceZone(service_zone);
-  test_options.setLogLevel(spdlog::level::info);
+  test_options.setLogLevel(Logger::Levels::info);
 
   test_options.setConfigPath(config_path);
   test_options.setConfigYaml(config_yaml);

--- a/test/server/options_impl_test.cc
+++ b/test/server/options_impl_test.cc
@@ -196,7 +196,7 @@ TEST_F(OptionsImplTest, SetAll) {
   options->setDrainTime(std::chrono::seconds(42));
   options->setDrainStrategy(Server::DrainStrategy::Immediate);
   options->setParentShutdownTime(std::chrono::seconds(43));
-  options->setLogLevel(spdlog::level::trace);
+  options->setLogLevel(Logger::Levels::trace);
   options->setLogFormat("%L %n %v");
   options->setLogPath("/foo/bar");
   options->setRestartEpoch(44);


### PR DESCRIPTION
Add log level setters with the Logger::Levels  enum. Deprecate old methods that use spdlog enum directly.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
