### PR TITLE
Allow ci/run_envoy_docker.sh callers to set SKIP_REMOTE_DETECTION

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -61,6 +61,7 @@ x-envoy-build-base: &envoy-build-base
   - ENVOY_REPO
   - ENVOY_BUILD_ARCH
   - ENVOY_GEN_COMPDB_OPTIONS
+  - SKIP_REMOTE_DETECTION
 
   # Publishing and artifacts
   - ENVOY_DOCKER_SAVE_IMAGE


### PR DESCRIPTION
External build scripts need to be able to disable RBE detection.

Risk Level: none
Testing: build
Docs Changes: no
Release Notes: no
Platform Specific Features: no
