### PR TITLE
cache_v2: support If-None-Match validation

### DIFF
--- a/source/extensions/filters/http/cache_v2/BUILD
+++ b/source/extensions/filters/http/cache_v2/BUILD
@@ -13,6 +13,13 @@ licenses(["notice"])  # Apache 2
 envoy_extension_package()
 
 envoy_cc_library(
+    name = "etag_utils_lib",
+    srcs = ["etag_utils.cc"],
+    hdrs = ["etag_utils.h"],
+    deps = ["@abseil-cpp//absl/strings:string_view"],
+)
+
+envoy_cc_library(
     name = "http_source_interface",
     hdrs = ["http_source.h"],
     deps = [
@@ -50,6 +57,7 @@ envoy_cc_library(
         "cache_sessions.h",
     ],
     deps = [
+        ":etag_utils_lib",
         ":http_cache_lib",
         ":stats",
         ":upstream_request_lib",

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
@@ -243,7 +243,13 @@ void CacheHeadersUtils::injectValidationHeaders(
   if (etag_header) {
     absl::string_view etag = etag_header->value().getStringView();
     request_headers.setInline(CacheCustomHeaders::ifNoneMatch(), etag);
+  } else {
+    // If-None-Match takes precedence over If-Modified-Since. When the cached response has no ETag,
+    // remove the downstream condition so validation can fall back to the cached Last-Modified or
+    // Date value below.
+    request_headers.removeInline(CacheCustomHeaders::ifNoneMatch());
   }
+
   if (DateUtil::timePointValid(CacheHeadersUtils::httpTime(last_modified_header))) {
     // Valid Last-Modified header exists.
     absl::string_view last_modified = last_modified_header->value().getStringView();

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.h
@@ -111,8 +111,8 @@ Seconds calculateAge(const Http::ResponseHeaderMap& response_headers, SystemTime
 // Create a resource key from headers and cluster name.
 Key makeKey(const Http::RequestHeaderMap& request_headers, absl::string_view cluster_name);
 
-// Adds required conditional headers for cache validation to the request headers
-// according to the previous response headers.
+// Replaces downstream conditional headers with the validators required to validate the cached
+// response.
 void injectValidationHeaders(Http::RequestHeaderMap& request_headers,
                              const Http::ResponseHeaderMap& old_response_headers);
 

--- a/source/extensions/filters/http/cache_v2/cache_sessions.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions.cc
@@ -5,6 +5,7 @@
 #include "source/common/http/utility.h"
 #include "source/extensions/filters/http/cache_v2/cache_custom_headers.h"
 #include "source/extensions/filters/http/cache_v2/cache_headers_utils.h"
+#include "source/extensions/filters/http/cache_v2/etag_utils.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -38,6 +39,22 @@ std::optional<std::vector<RawByteRange>> ActiveLookupRequest::parseRange() const
 
 bool ActiveLookupRequest::isRangeRequest() const {
   return RangeUtils::getRangeHeader(*request_headers_).has_value();
+}
+
+bool ActiveLookupRequest::hasIfNoneMatch() const {
+  return request_headers_->getInline(CacheCustomHeaders::ifNoneMatch()) != nullptr;
+}
+
+bool ActiveLookupRequest::ifNoneMatch(const Http::ResponseHeaderMap& response_headers) const {
+  const Http::HeaderEntry* value = request_headers_->getInline(CacheCustomHeaders::ifNoneMatch());
+  if (value == nullptr) {
+    return false;
+  }
+
+  const Http::HeaderEntry* etag = response_headers.getInline(CacheCustomHeaders::etag());
+  const absl::string_view etag_value =
+      etag == nullptr ? absl::string_view{} : etag->value().getStringView();
+  return EtagUtils::ifNoneMatch(value->value().getStringView(), etag_value);
 }
 
 void ActiveLookupRequest::initializeRequestCacheControl(

--- a/source/extensions/filters/http/cache_v2/cache_sessions.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions.h
@@ -47,6 +47,8 @@ public:
   SystemTime timestamp() const { return timestamp_; }
   bool requiresValidation(const Http::ResponseHeaderMap& response_headers,
                           SystemTime::duration age) const;
+  bool hasIfNoneMatch() const;
+  bool ifNoneMatch(const Http::ResponseHeaderMap& response_headers) const;
   std::optional<std::vector<RawByteRange>> parseRange() const;
   bool isRangeRequest() const;
 

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -85,7 +85,24 @@ static Http::ResponseHeaderMapPtr notSatisfiableHeaders() {
   });
 }
 
+static void makeNotModified(Http::ResponseHeaderMap& headers) {
+  headers.setStatus(enumToInt(Http::Code::NotModified));
+  headers.removeContentLength();
+  headers.remove(Envoy::Http::Headers::get().ContentRange);
+  headers.removeTransferEncoding();
+}
+
 void ActiveLookupContext::getHeaders(GetHeadersCallback&& cb) {
+  if (not_modified_) {
+    entry_->wantHeaders(
+        dispatcher(), lookup().timestamp(),
+        [cb = std::move(cb)](Http::ResponseHeaderMapPtr headers, EndStream) mutable {
+          ASSERT(headers != nullptr, "it should be impossible for headers to be null");
+          makeNotModified(*headers);
+          cb(std::move(headers), EndStream::End);
+        });
+    return;
+  }
   std::optional<std::vector<RawByteRange>> ranges = lookup().parseRange();
   if (ranges) {
     // If it's a range request, inject the appropriate modified content-range and
@@ -269,6 +286,10 @@ void CacheSession::sendSuccessfulLookupResultTo(LookupSubscriber& subscriber,
   mu_.AssertHeld();
   ASSERT(state_ == State::Exists || state_ == State::Inserting);
   auto result = std::make_unique<ActiveLookupResult>();
+  if (subscriber.context_->lookup().ifNoneMatch(*entry_.response_headers_)) {
+    subscriber.context_->setNotModified();
+    status = CacheEntryStatus::FoundNotModified;
+  }
   result->status_ = status;
   result->http_source_ = std::move(subscriber.context_);
   subscriber.dispatcher().post(
@@ -651,21 +672,20 @@ void CacheSession::performUpstreamRequest() {
   ASSERT(!upstream_request_, "should only be one upstream request in flight");
   LookupSubscriber& first_sub = lookup_subscribers_.front();
   const ActiveLookupRequest& lookup = first_sub.context_->lookup();
-  Http::RequestHeaderMapPtr request_headers;
-  bool was_ranged_request = lookup.isRangeRequest();
-  if (was_ranged_request) {
-    request_headers = requestHeadersWithRangeRemoved(lookup.requestHeaders());
-  } else {
-    request_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(lookup.requestHeaders());
-  }
+  Http::RequestHeaderMapPtr request_headers =
+      requestHeadersWithRangeRemoved(lookup.requestHeaders());
+  const bool request_headers_were_modified = lookup.isRangeRequest() || lookup.hasIfNoneMatch();
+  // Fetch the complete representation for insertion. Each downstream condition is evaluated
+  // separately after the representation becomes available from the cache.
+  request_headers->removeInline(CacheCustomHeaders::ifNoneMatch());
   upstream_request_ = lookup.createUpstreamRequest();
   first_sub.dispatcher().post([upstream_request = upstream_request_.get(),
                                request_headers = std::move(request_headers), this,
-                               p = shared_from_this(), was_ranged_request]() mutable {
+                               p = shared_from_this(), request_headers_were_modified]() mutable {
     upstream_request->sendHeaders(std::move(request_headers));
-    upstream_request->getHeaders([this, p = std::move(p), was_ranged_request](
+    upstream_request->getHeaders([this, p = std::move(p), request_headers_were_modified](
                                      Http::ResponseHeaderMapPtr headers, EndStream end_stream) {
-      onUpstreamHeaders(std::move(headers), end_stream, was_ranged_request);
+      onUpstreamHeaders(std::move(headers), end_stream, request_headers_were_modified);
     });
   });
 }
@@ -737,19 +757,17 @@ void CacheSession::processSuccessfulValidation(Http::ResponseHeaderMapPtr header
 }
 
 void CacheSession::onUncacheable(Http::ResponseHeaderMapPtr headers, EndStream end_stream,
-                                 bool range_header_was_stripped) {
+                                 bool request_headers_were_modified) {
   // If it turned out to be not cacheable, mark it as such, pass the already
   // open connection to the first request, and give any other requests in flight
   // a pass-through to upstream.
-  // If the upstream request stripped off a range header from the downstream
-  // request in order to populate the cache, we'll have to drop that upstream
-  // request and just issue a new request for every downstream.
+  // If Range or If-None-Match was stripped from the upstream request in order to populate the
+  // cache, drop that modified stream and issue the original request for every downstream.
   mu_.AssertHeld();
   state_ = State::NotCacheable;
-  bool use_existing_stream = !range_header_was_stripped;
+  bool use_existing_stream = !request_headers_were_modified;
   if (!use_existing_stream) {
-    // Reset the upstream request if the request wanted a range and
-    // the upstream request didn't want a range.
+    // The modified upstream request cannot be passed through as the downstream response.
     upstream_request_ = nullptr;
   }
   for (LookupSubscriber& sub : lookup_subscribers_) {
@@ -774,7 +792,7 @@ void CacheSession::onUncacheable(Http::ResponseHeaderMapPtr headers, EndStream e
 }
 
 void CacheSession::onUpstreamHeaders(Http::ResponseHeaderMapPtr headers, EndStream end_stream,
-                                     bool range_header_was_stripped) {
+                                     bool request_headers_were_modified) {
   absl::MutexLock lock(mu_);
   Event::Dispatcher& dispatcher = lookup_subscribers_.front().dispatcher();
   ASSERT(upstream_request_);
@@ -816,12 +834,12 @@ void CacheSession::onUpstreamHeaders(Http::ResponseHeaderMapPtr headers, EndStre
     absl::SimpleAtoi(cl, &content_length_header_) || (content_length_header_ = 0);
   }
   if (!lookup_subscribers_.front().context_->lookup().isCacheableResponse(*headers)) {
-    return onUncacheable(std::move(headers), end_stream, range_header_was_stripped);
+    return onUncacheable(std::move(headers), end_stream, request_headers_were_modified);
   }
   if (VaryHeaderUtils::hasVary(*headers)) {
     // TODO(ravenblack): implement Vary header support.
     ENVOY_LOG(debug, "Vary header found in upstream response, treating as not cacheable");
-    return onUncacheable(std::move(headers), end_stream, range_header_was_stripped);
+    return onUncacheable(std::move(headers), end_stream, request_headers_were_modified);
   }
   auto cache_sessions = cache_sessions_.lock();
   if (!cache_sessions) {

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.h
@@ -33,11 +33,13 @@ public:
   ActiveLookupRequest& lookup() const { return *lookup_; }
 
   void setContentLength(uint64_t l) { content_length_ = l; }
+  void setNotModified() { not_modified_ = true; }
 
 private:
   ActiveLookupRequestPtr lookup_;
   std::shared_ptr<CacheSession> entry_;
   uint64_t content_length_;
+  bool not_modified_ = false;
 };
 
 class CacheSession : public Logger::Loggable<Logger::Id::cache_filter>,
@@ -221,9 +223,9 @@ private:
   void validateCacheEntry(Event::Dispatcher& dispatcher) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
   void performUpstreamRequest() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
   void onUpstreamHeaders(Http::ResponseHeaderMapPtr headers, EndStream end_stream,
-                         bool range_header_was_stripped) ABSL_LOCKS_EXCLUDED(mu_);
+                         bool request_headers_were_modified) ABSL_LOCKS_EXCLUDED(mu_);
   void onUncacheable(Http::ResponseHeaderMapPtr headers, EndStream end_stream,
-                     bool range_header_was_stripped) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+                     bool request_headers_were_modified) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
   // For the unlikely case that cache config was modified while operations were in flight,
   // requests still in the lookup state are transformed to pass-through.
   // Requests for headers/body/trailers should be able to continue as the cache

--- a/source/extensions/filters/http/cache_v2/cacheability_utils.cc
+++ b/source/extensions/filters/http/cache_v2/cacheability_utils.cc
@@ -25,9 +25,9 @@ const absl::flat_hash_set<absl::string_view>& cacheableStatusCodes() {
 
 const std::vector<const Http::LowerCaseString*>& conditionalHeaders() {
   // As defined by: https://httpwg.org/specs/rfc7232.html#preconditions.
-  CONSTRUCT_ON_FIRST_USE(
-      std::vector<const Http::LowerCaseString*>, &Http::CustomHeaders::get().IfNoneMatch,
-      &Http::CustomHeaders::get().IfModifiedSince, &Http::CustomHeaders::get().IfRange);
+  CONSTRUCT_ON_FIRST_USE(std::vector<const Http::LowerCaseString*>,
+                         &Http::CustomHeaders::get().IfModifiedSince,
+                         &Http::CustomHeaders::get().IfRange);
 }
 } // namespace
 
@@ -35,9 +35,7 @@ absl::Status CacheabilityUtils::canServeRequestFromCache(const Http::RequestHead
   const absl::string_view method = headers.getMethodValue();
   const Http::HeaderValues& header_values = Http::Headers::get();
 
-  // Check if the request contains any conditional headers other than if-unmodified-since
-  // or if-match.
-  // For now, requests with conditional headers bypass the CacheFilter.
+  // For now, requests with unsupported conditional headers bypass the CacheFilter.
   // This behavior does not cause any incorrect results, but may reduce the cache effectiveness.
   // If needed to be handled properly refer to:
   // https://httpwg.org/specs/rfc7234.html#validation.received

--- a/source/extensions/filters/http/cache_v2/etag_utils.cc
+++ b/source/extensions/filters/http/cache_v2/etag_utils.cc
@@ -1,0 +1,129 @@
+#include "source/extensions/filters/http/cache_v2/etag_utils.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace CacheV2 {
+namespace EtagUtils {
+namespace {
+
+struct EntityTag {
+  bool weak_;
+  absl::string_view opaque_tag_;
+};
+
+struct ParsedEntityTag {
+  EntityTag tag_;
+  absl::string_view remaining_;
+};
+
+absl::string_view trimLeadingWhitespace(absl::string_view value) {
+  while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) {
+    value.remove_prefix(1);
+  }
+  return value;
+}
+
+// Parses the complete entity-tag grammar from RFC 9110 section 8.8.3:
+// entity-tag = [ weak ] opaque-tag
+// weak       = %s"W/"
+// opaque-tag = DQUOTE *etagc DQUOTE
+// https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3
+std::optional<ParsedEntityTag> parsePrefix(absl::string_view value) {
+  value = trimLeadingWhitespace(value);
+  bool weak = false;
+  // The %s prefix in the ABNF makes the weakness indicator case-sensitive, so "w/" is invalid.
+  if (value.starts_with("W/")) {
+    weak = true;
+    value.remove_prefix(2);
+  }
+
+  if (value.empty() || value.front() != '"') {
+    return std::nullopt;
+  }
+
+  for (size_t i = 1; i < value.size(); ++i) {
+    // Convert to an unsigned byte before checking obs-text so values from 0x80 through 0xff do not
+    // become negative on platforms where char is signed.
+    const uint8_t byte = static_cast<uint8_t>(value[i]);
+    if (byte == '"') {
+      return ParsedEntityTag{{weak, value.substr(1, i - 1)}, value.substr(i + 1)};
+    }
+    // RFC 9110 section 8.8.3 defines etagc as %x21 / %x23-7E / obs-text (%x80-FF):
+    // https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3
+    if (byte != 0x21 && !(byte >= 0x23 && byte <= 0x7e) && byte < 0x80) {
+      return std::nullopt;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<EntityTag> parse(absl::string_view value) {
+  const std::optional<ParsedEntityTag> parsed = parsePrefix(value);
+  if (!parsed.has_value() || !trimLeadingWhitespace(parsed->remaining_).empty()) {
+    return std::nullopt;
+  }
+  return parsed->tag_;
+}
+
+} // namespace
+
+bool strongMatch(absl::string_view lhs, absl::string_view rhs) {
+  const std::optional<EntityTag> lhs_tag = parse(lhs);
+  const std::optional<EntityTag> rhs_tag = parse(rhs);
+  return lhs_tag.has_value() && rhs_tag.has_value() && !lhs_tag->weak_ && !rhs_tag->weak_ &&
+         lhs_tag->opaque_tag_ == rhs_tag->opaque_tag_;
+}
+
+bool weakMatch(absl::string_view lhs, absl::string_view rhs) {
+  const std::optional<EntityTag> lhs_tag = parse(lhs);
+  const std::optional<EntityTag> rhs_tag = parse(rhs);
+  return lhs_tag.has_value() && rhs_tag.has_value() && lhs_tag->opaque_tag_ == rhs_tag->opaque_tag_;
+}
+
+bool ifNoneMatch(absl::string_view field_value, absl::string_view etag) {
+  field_value = trimLeadingWhitespace(field_value);
+  if (!field_value.empty() && field_value.front() == '*') {
+    field_value.remove_prefix(1);
+    return trimLeadingWhitespace(field_value).empty();
+  }
+
+  const std::optional<EntityTag> selected_tag = parse(etag);
+  if (!selected_tag.has_value()) {
+    return false;
+  }
+
+  bool matched = false;
+  bool parsed_any = false;
+  while (true) {
+    field_value = trimLeadingWhitespace(field_value);
+    // RFC list syntax permits empty elements, so skip commas before parsing the next entity tag.
+    while (!field_value.empty() && field_value.front() == ',') {
+      field_value.remove_prefix(1);
+      field_value = trimLeadingWhitespace(field_value);
+    }
+    if (field_value.empty()) {
+      return parsed_any && matched;
+    }
+
+    const std::optional<ParsedEntityTag> parsed = parsePrefix(field_value);
+    if (!parsed.has_value()) {
+      return false;
+    }
+    parsed_any = true;
+    matched |= parsed->tag_.opaque_tag_ == selected_tag->opaque_tag_;
+    field_value = trimLeadingWhitespace(parsed->remaining_);
+    if (!field_value.empty() && field_value.front() != ',') {
+      return false;
+    }
+  }
+}
+
+} // namespace EtagUtils
+} // namespace CacheV2
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/cache_v2/etag_utils.h
+++ b/source/extensions/filters/http/cache_v2/etag_utils.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace CacheV2 {
+namespace EtagUtils {
+
+// Returns true when both values are valid entity tags, neither is weak, and their opaque tags
+// match character-for-character, as defined by RFC 9110 section 8.8.3.2:
+// https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3.2
+bool strongMatch(absl::string_view lhs, absl::string_view rhs);
+
+// Returns true when both values are valid entity tags and their opaque tags match
+// character-for-character, regardless of whether either entity tag is weak. See RFC 9110 section
+// 8.8.3.2: https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3.2
+bool weakMatch(absl::string_view lhs, absl::string_view rhs);
+
+// Returns true when the If-None-Match field value is "*" or contains an entity tag that weakly
+// matches etag. An invalid field value does not match.
+bool ifNoneMatch(absl::string_view field_value, absl::string_view etag);
+
+} // namespace EtagUtils
+} // namespace CacheV2
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/cache_v2/BUILD
+++ b/test/extensions/filters/http/cache_v2/BUILD
@@ -9,6 +9,15 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+envoy_extension_cc_test(
+    name = "etag_utils_test",
+    srcs = ["etag_utils_test.cc"],
+    extension_names = ["envoy.filters.http.cache_v2"],
+    deps = [
+        "//source/extensions/filters/http/cache_v2:etag_utils_lib",
+    ],
+)
+
 envoy_cc_test_library(
     name = "mocks",
     srcs = ["mocks.cc"],

--- a/test/extensions/filters/http/cache_v2/cache_filter_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_filter_test.cc
@@ -144,10 +144,10 @@ TEST_F(CacheFilterTest, PassThroughIfRequestHasBody) {
   EXPECT_THAT(decoder_callbacks_.details(), Eq(""));
 }
 
-TEST_F(CacheFilterTest, PassThroughIfCacheabilityIsNo) {
+TEST_F(CacheFilterTest, PassThroughIfConditionalHeaderIsUnsupported) {
   auto filter = makeFilter(mock_cache_);
   EXPECT_CALL(stats(), incForStatus(CacheEntryStatus::Uncacheable));
-  request_headers_.addCopy(Http::CustomHeaders::get().IfNoneMatch, "1");
+  request_headers_.addCopy(Http::CustomHeaders::get().IfRange, "1");
   EXPECT_THAT(filter->decodeHeaders(request_headers_, true),
               Eq(Http::FilterHeadersStatus::Continue));
   EXPECT_THAT(filter->encodeHeaders(response_headers_, true),

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -924,12 +924,28 @@ TEST(InjectValidationHeaders, InjectsIfModifiedSince) {
   EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", mod_time));
 }
 
-TEST(InjectValidationHeaders, InjectsIfNoneMatchFromEtag) {
+TEST(InjectValidationHeaders, ReplacesDownstreamIfNoneMatchWithOnlyCachedEtag) {
   Http::TestResponseHeaderMapImpl old_response_headers;
   old_response_headers.setInline(CacheCustomHeaders::etag(), "\"strong-etag-value\"");
   Http::TestRequestHeaderMapImpl request_headers;
+  request_headers.setInline(CacheCustomHeaders::ifNoneMatch(), "\"downstream-etag-value\"");
+  request_headers.addCopy(Http::CustomHeaders::get().IfNoneMatch,
+                          "\"another-downstream-etag-value\"");
   CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
   EXPECT_THAT(request_headers, ContainsHeader("if-none-match", "\"strong-etag-value\""));
+}
+
+TEST(InjectValidationHeaders, RemovesDownstreamIfNoneMatchWhenCachedResponseHasNoEtag) {
+  Http::TestResponseHeaderMapImpl old_response_headers;
+  constexpr absl::string_view mod_time = "Fri, 01 Aug 2025 09:25:10 GMT";
+  old_response_headers.setInline(CacheCustomHeaders::lastModified(), mod_time);
+  Http::TestRequestHeaderMapImpl request_headers;
+  request_headers.setInline(CacheCustomHeaders::ifNoneMatch(), "\"downstream-etag-value\"");
+
+  CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
+
+  EXPECT_EQ(request_headers.getInline(CacheCustomHeaders::ifNoneMatch()), nullptr);
+  EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", mod_time));
 }
 
 TEST(InjectValidationHeaders, FallsBackToDateWhenLastModifiedMissing) {

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -3,6 +3,7 @@
 #include "envoy/event/dispatcher.h"
 
 #include "source/common/http/headers.h"
+#include "source/extensions/filters/http/cache_v2/cache_custom_headers.h"
 #include "source/extensions/filters/http/cache_v2/cache_sessions.h"
 
 #include "test/extensions/filters/http/cache_v2/mocks.h"
@@ -150,6 +151,13 @@ protected:
   ActiveLookupRequestPtr testLookupRequestWithNoCache(absl::string_view path) {
     auto headers = requestHeaders(path);
     headers.addCopy("cache-control", "no-cache");
+    return testLookupRequest(headers);
+  }
+
+  ActiveLookupRequestPtr testLookupRequestWithIfNoneMatch(absl::string_view path,
+                                                          absl::string_view etag) {
+    auto headers = requestHeaders(path);
+    headers.setCopy(Http::CustomHeaders::get().IfNoneMatch, etag);
     return testLookupRequest(headers);
   }
 };
@@ -918,6 +926,433 @@ TEST_F(CacheSessionsTest, VaryHeaderInUpstreamResponseTreatedAsUncacheable) {
   pumpDispatcher();
   ASSERT_THAT(result, NotNull());
   EXPECT_THAT(result->status_, Eq(CacheEntryStatus::Uncacheable));
+}
+
+// Downstream If-None-Match handling. These tests cover cache fill request sanitization, fresh
+// cache hits, combined field lines, wildcard matching, explicit and stale-entry revalidation,
+// validator fallback, replacement representations returned by upstream, and request collapsing
+// across lookup, insertion, validation, and pass-through states.
+
+TEST_F(CacheSessionsTest, CacheMissRemovesIfNoneMatchFromCacheFillRequest) {
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("client-value")"),
+                          [](ActiveLookupResultPtr) {});
+  pumpDispatcher();
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasNoHeader("if-none-match"));
+}
+
+TEST_F(CacheSessionsTest, IfNoneMatchIsEvaluatedForEachCollapsedRequest) {
+  auto response_headers = cacheableResponseHeaders(5);
+  response_headers->setInline(CacheCustomHeaders::etag(), R"("selected")");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(3);
+
+  ActiveLookupResultPtr weak_match, mismatch, wildcard;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"(W/"selected")"),
+                          [&weak_match](ActiveLookupResultPtr r) { weak_match = std::move(r); });
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("different")"),
+                          [&mismatch](ActiveLookupResultPtr r) { mismatch = std::move(r); });
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", "*"),
+                          [&wildcard](ActiveLookupResultPtr r) { wildcard = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime();
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 5});
+  pumpDispatcher();
+
+  ASSERT_THAT(weak_match, NotNull());
+  EXPECT_THAT(weak_match->status_, Eq(CacheEntryStatus::FoundNotModified));
+  ASSERT_THAT(mismatch, NotNull());
+  EXPECT_THAT(mismatch->status_, Eq(CacheEntryStatus::Hit));
+  ASSERT_THAT(wildcard, NotNull());
+  EXPECT_THAT(wildcard->status_, Eq(CacheEntryStatus::FoundNotModified));
+
+  MockFunction<void(Http::ResponseHeaderMapPtr, EndStream)> weak_match_headers;
+  EXPECT_CALL(weak_match_headers,
+              Call(Pointee(AllOf(HasHeader(":status", "304"), HasNoHeader("content-length"))),
+                   EndStream::End));
+  weak_match->http_source_->getHeaders(weak_match_headers.AsStdFunction());
+
+  MockFunction<void(Http::ResponseHeaderMapPtr, EndStream)> mismatch_headers;
+  EXPECT_CALL(mismatch_headers,
+              Call(Pointee(AllOf(HasHeader(":status", "200"), HasHeader("content-length", "5"))),
+                   EndStream::More));
+  mismatch->http_source_->getHeaders(mismatch_headers.AsStdFunction());
+}
+
+TEST_F(CacheSessionsTest, IfNoneMatchCombinesMultipleFieldLines) {
+  auto response_headers = cacheableResponseHeaders();
+  response_headers->setInline(CacheCustomHeaders::etag(), R"("selected")");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+
+  auto request_headers = requestHeaders("/a");
+  request_headers.addCopy(Http::CustomHeaders::get().IfNoneMatch, R"("different")");
+  request_headers.addCopy(Http::CustomHeaders::get().IfNoneMatch, R"(W/"selected")");
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequest(request_headers),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime();
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 0});
+  pumpDispatcher();
+
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::FoundNotModified));
+}
+
+TEST_F(CacheSessionsTest, IfNoneMatchWildcardMatchesCachedResponseWithoutEtag) {
+  auto response_headers = cacheableResponseHeaders();
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", "*"),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime();
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 0});
+  pumpDispatcher();
+
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::FoundNotModified));
+}
+
+TEST_F(CacheSessionsTest, StaleCollapsedRequestsUseCachedValidatorThenEvaluateIndividually) {
+  auto response_headers = cacheableResponseHeaders(5);
+  response_headers->setInline(CacheCustomHeaders::etag(), R"("selected")");
+  response_headers->setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=0");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(2);
+
+  ActiveLookupResultPtr mismatch, match;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("client-value")"),
+                          [&mismatch](ActiveLookupResultPtr r) { mismatch = std::move(r); });
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("selected")"),
+                          [&match](ActiveLookupResultPtr r) { match = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime() - std::chrono::seconds(1);
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 5});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  // Cache validation must use the cached representation's ETag rather than the first downstream
+  // request's ETag.
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasHeader("if-none-match", R"("selected")"));
+
+  auto validation_headers = std::make_unique<Http::TestResponseHeaderMapImpl>();
+  validation_headers->setStatus(304);
+  EXPECT_CALL(*mock_http_cache_, updateHeaders(_, KeyHasPath("/a"), _, _));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(std::move(validation_headers),
+                                                           EndStream::End);
+  pumpDispatcher();
+
+  // Each downstream condition is evaluated after the shared validation completes.
+  ASSERT_THAT(mismatch, NotNull());
+  EXPECT_THAT(mismatch->status_, Eq(CacheEntryStatus::Validated));
+  ASSERT_THAT(match, NotNull());
+  EXPECT_THAT(match->status_, Eq(CacheEntryStatus::FoundNotModified));
+}
+
+TEST_F(CacheSessionsTest, IfNoneMatchWithNoCacheRevalidatesFreshEntryBeforeResponding) {
+  auto response_headers = cacheableResponseHeaders();
+  response_headers->setInline(CacheCustomHeaders::etag(), R"("selected")");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+
+  auto request_headers = requestHeaders("/a");
+  request_headers.setCopy(Http::CustomHeaders::get().IfNoneMatch, R"("selected")");
+  request_headers.setCopy(Http::CustomHeaders::get().CacheControl, "no-cache");
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequest(request_headers),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime();
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 0});
+  pumpDispatcher();
+
+  ASSERT_THAT(result, IsNull());
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasHeader("if-none-match", R"("selected")"));
+
+  auto validation_headers = std::make_unique<Http::TestResponseHeaderMapImpl>();
+  validation_headers->setStatus(304);
+  EXPECT_CALL(*mock_http_cache_, updateHeaders(_, KeyHasPath("/a"), _, _));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(std::move(validation_headers),
+                                                           EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::FoundNotModified));
+}
+
+TEST_F(CacheSessionsTest, StaleIfNoneMatchWithoutCachedEtagUsesLastModifiedForValidation) {
+  constexpr absl::string_view last_modified = "Sun, 06 Nov 1994 08:49:37 GMT";
+  auto response_headers = cacheableResponseHeaders(5);
+  response_headers->setInline(CacheCustomHeaders::lastModified(), last_modified);
+  response_headers->setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=0");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("client-value")"),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime() - std::chrono::seconds(1);
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 5});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasNoHeader("if-none-match"));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasHeader("if-modified-since", last_modified));
+
+  auto validation_headers = std::make_unique<Http::TestResponseHeaderMapImpl>();
+  validation_headers->setStatus(304);
+  validation_headers->setInline(CacheCustomHeaders::lastModified(), last_modified);
+  EXPECT_CALL(*mock_http_cache_, updateHeaders(_, KeyHasPath("/a"), _, _));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(std::move(validation_headers),
+                                                           EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::Validated));
+}
+
+TEST_F(CacheSessionsTest, StaleIfNoneMatchWithoutEtagOrLastModifiedUsesDateForValidation) {
+  constexpr absl::string_view date = "Sun, 06 Nov 1994 08:49:37 GMT";
+  auto response_headers = cacheableResponseHeaders(5);
+  response_headers->setDate(date);
+  response_headers->setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=0");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("client-value")"),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime() - std::chrono::seconds(1);
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 5});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasNoHeader("if-none-match"));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasHeader("if-modified-since", date));
+
+  auto validation_headers = std::make_unique<Http::TestResponseHeaderMapImpl>();
+  validation_headers->setStatus(304);
+  EXPECT_CALL(*mock_http_cache_, updateHeaders(_, KeyHasPath("/a"), _, _));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(std::move(validation_headers),
+                                                           EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::Validated));
+}
+
+TEST_F(CacheSessionsTest, StaleIfNoneMatchEvaluatesNewRepresentationAfterValidationReturnsOk) {
+  auto cached_response_headers = cacheableResponseHeaders();
+  cached_response_headers->setInline(CacheCustomHeaders::etag(), R"("old")");
+  cached_response_headers->setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=0");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(2);
+  EXPECT_CALL(*mock_http_cache_, evict(_, KeyHasPath("/a")));
+
+  ActiveLookupResultPtr match, mismatch;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("new")"),
+                          [&match](ActiveLookupResultPtr r) { match = std::move(r); });
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("different")"),
+                          [&mismatch](ActiveLookupResultPtr r) { mismatch = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime() - std::chrono::seconds(1);
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*cached_response_headers),
+                   nullptr, std::move(metadata), 0});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasHeader("if-none-match", R"("old")"));
+
+  auto new_response_headers = cacheableResponseHeaders();
+  new_response_headers->setInline(CacheCustomHeaders::etag(), R"("new")");
+  std::shared_ptr<CacheProgressReceiver> progress;
+  EXPECT_CALL(*mock_http_cache_,
+              insert(_, KeyHasPath("/a"), Pointee(IsSupersetOfHeaders(*new_response_headers)), _,
+                     IsNull(), _))
+      .WillOnce([&progress](Event::Dispatcher&, Key, Http::ResponseHeaderMapPtr, ResponseMetadata,
+                            HttpSourcePtr, std::shared_ptr<CacheProgressReceiver> receiver) {
+        progress = std::move(receiver);
+      });
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(
+      Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*new_response_headers), EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(progress, NotNull());
+  progress->onHeadersInserted(
+      nullptr, Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*new_response_headers), true);
+  pumpDispatcher();
+
+  ASSERT_THAT(match, NotNull());
+  EXPECT_THAT(match->status_, Eq(CacheEntryStatus::FoundNotModified));
+  ASSERT_THAT(mismatch, NotNull());
+  EXPECT_THAT(mismatch->status_, Eq(CacheEntryStatus::Follower));
+}
+
+TEST_F(CacheSessionsTest, IfNoneMatchCollapsedCacheMissEvaluatesInsertedRepresentation) {
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(2);
+
+  ActiveLookupResultPtr match, mismatch;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("selected")"),
+                          [&match](ActiveLookupResultPtr r) { match = std::move(r); });
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("different")"),
+                          [&mismatch](ActiveLookupResultPtr r) { mismatch = std::move(r); });
+  pumpDispatcher();
+
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasNoHeader("if-none-match"));
+
+  auto response_headers = cacheableResponseHeaders();
+  response_headers->setInline(CacheCustomHeaders::etag(), R"("selected")");
+  std::shared_ptr<CacheProgressReceiver> progress;
+  EXPECT_CALL(
+      *mock_http_cache_,
+      insert(_, KeyHasPath("/a"), Pointee(IsSupersetOfHeaders(*response_headers)), _, IsNull(), _))
+      .WillOnce([&progress](Event::Dispatcher&, Key, Http::ResponseHeaderMapPtr, ResponseMetadata,
+                            HttpSourcePtr, std::shared_ptr<CacheProgressReceiver> receiver) {
+        progress = std::move(receiver);
+      });
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(
+      Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(progress, NotNull());
+  progress->onHeadersInserted(
+      nullptr, Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), true);
+  pumpDispatcher();
+
+  ASSERT_THAT(match, NotNull());
+  EXPECT_THAT(match->status_, Eq(CacheEntryStatus::FoundNotModified));
+  ASSERT_THAT(mismatch, NotNull());
+  EXPECT_THAT(mismatch->status_, Eq(CacheEntryStatus::Follower));
+}
+
+TEST_F(CacheSessionsTest, IfNoneMatchSubscriberJoinsValidationAlreadyInFlight) {
+  auto response_headers = cacheableResponseHeaders();
+  response_headers->setInline(CacheCustomHeaders::etag(), R"("selected")");
+  response_headers->setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=0");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(2);
+
+  ActiveLookupResultPtr match, mismatch;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("selected")"),
+                          [&match](ActiveLookupResultPtr r) { match = std::move(r); });
+  pumpDispatcher();
+
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime() - std::chrono::seconds(1);
+  consumeCallback(captured_lookup_callbacks_[0])(
+      LookupResult{std::make_unique<MockCacheReader>(),
+                   Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers), nullptr,
+                   std::move(metadata), 0});
+  pumpDispatcher();
+
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("different")"),
+                          [&mismatch](ActiveLookupResultPtr r) { mismatch = std::move(r); });
+  pumpDispatcher();
+  EXPECT_THAT(fake_upstream_sent_headers_, testing::SizeIs(1));
+
+  auto validation_headers = std::make_unique<Http::TestResponseHeaderMapImpl>();
+  validation_headers->setStatus(304);
+  EXPECT_CALL(*mock_http_cache_, updateHeaders(_, KeyHasPath("/a"), _, _));
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(std::move(validation_headers),
+                                                           EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(match, NotNull());
+  EXPECT_THAT(match->status_, Eq(CacheEntryStatus::FoundNotModified));
+  ASSERT_THAT(mismatch, NotNull());
+  EXPECT_THAT(mismatch->status_, Eq(CacheEntryStatus::ValidatedFree));
+}
+
+TEST_F(CacheSessionsTest,
+       IfNoneMatchUncacheableFillRetriesEveryCollapsedRequestWithOriginalHeader) {
+  Mock::VerifyAndClearExpectations(mock_cacheable_response_checker_.get());
+  EXPECT_CALL(*mock_cacheable_response_checker_, isCacheableResponse)
+      .Times(testing::AnyNumber())
+      .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _)).Times(2);
+
+  ActiveLookupResultPtr first, second;
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("first")"),
+                          [&first](ActiveLookupResultPtr r) { first = std::move(r); });
+  cache_sessions_->lookup(testLookupRequestWithIfNoneMatch("/a", R"("second")"),
+                          [&second](ActiveLookupResultPtr r) { second = std::move(r); });
+  pumpDispatcher();
+
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{});
+  pumpDispatcher();
+  ASSERT_THAT(fake_upstream_sent_headers_, ElementsAre(NotNull()));
+  EXPECT_THAT(*fake_upstream_sent_headers_[0], HasNoHeader("if-none-match"));
+
+  consumeCallback(fake_upstream_get_headers_callbacks_[0])(uncacheableResponseHeaders(),
+                                                           EndStream::End);
+  pumpDispatcher();
+
+  ASSERT_THAT(first, NotNull());
+  ASSERT_THAT(second, NotNull());
+  EXPECT_THAT(first->status_, Eq(CacheEntryStatus::Uncacheable));
+  EXPECT_THAT(second->status_, Eq(CacheEntryStatus::Uncacheable));
+  ASSERT_THAT(fake_upstream_sent_headers_, testing::SizeIs(3));
+  EXPECT_THAT(*fake_upstream_sent_headers_[1], HasHeader("if-none-match", R"("first")"));
+  EXPECT_THAT(*fake_upstream_sent_headers_[2], HasHeader("if-none-match", R"("second")"));
 }
 
 // TODO: UpdateHeadersSkipSpecificHeaders

--- a/test/extensions/filters/http/cache_v2/cacheability_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cacheability_utils_test.cc
@@ -106,8 +106,7 @@ TEST_F(CanServeRequestFromCacheTest, AuthorizationHeader) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ConditionalHeaders, RequestConditionalHeadersTest,
-                         testing::Values("if-none-match", "if-modified-since", "if-range"),
-                         [](const auto& info) {
+                         testing::Values("if-modified-since", "if-range"), [](const auto& info) {
                            std::string test_name = info.param;
                            absl::c_replace_if(
                                test_name, [](char c) { return !std::isalnum(c); }, '_');
@@ -119,6 +118,11 @@ TEST_P(RequestConditionalHeadersTest, ConditionalHeaders) {
   request_headers_.setCopy(Http::LowerCaseString{conditionalHeader()}, "test-value");
   EXPECT_THAT(CacheabilityUtils::canServeRequestFromCache(request_headers_),
               HasStatus(absl::StatusCode::kInvalidArgument, HasSubstr(conditionalHeader())));
+}
+
+TEST_F(CanServeRequestFromCacheTest, IfNoneMatchIsCacheable) {
+  request_headers_.setCopy(Http::CustomHeaders::get().IfNoneMatch, R"("etag")");
+  EXPECT_OK(CacheabilityUtils::canServeRequestFromCache(request_headers_));
 }
 
 TEST_F(IsCacheableResponseTest, CacheableResponse) {

--- a/test/extensions/filters/http/cache_v2/etag_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/etag_utils_test.cc
@@ -1,0 +1,101 @@
+#include <string>
+
+#include "source/extensions/filters/http/cache_v2/etag_utils.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace CacheV2 {
+namespace EtagUtils {
+namespace {
+
+struct ComparisonTestCase {
+  absl::string_view lhs_;
+  absl::string_view rhs_;
+  bool strong_match_;
+  bool weak_match_;
+};
+
+class EtagComparisonTest : public testing::TestWithParam<ComparisonTestCase> {};
+
+TEST_P(EtagComparisonTest, MatchesAsExpected) {
+  const ComparisonTestCase& test_case = GetParam();
+  EXPECT_EQ(test_case.strong_match_, strongMatch(test_case.lhs_, test_case.rhs_));
+  EXPECT_EQ(test_case.weak_match_, weakMatch(test_case.lhs_, test_case.rhs_));
+}
+
+INSTANTIATE_TEST_SUITE_P(Rfc9110Examples, EtagComparisonTest,
+                         testing::Values(ComparisonTestCase{R"(W/"1")", R"(W/"1")", false, true},
+                                         ComparisonTestCase{R"(W/"1")", R"(W/"2")", false, false},
+                                         ComparisonTestCase{R"(W/"1")", R"("1")", false, true},
+                                         ComparisonTestCase{R"("1")", R"("1")", true, true}));
+
+TEST(EtagUtilsTest, EmptyOpaqueTagsMatch) {
+  EXPECT_TRUE(strongMatch(R"("")", R"("")"));
+  EXPECT_TRUE(weakMatch(R"(W/"")", R"("")"));
+}
+
+TEST(EtagUtilsTest, OpaqueTagsAreCaseSensitive) {
+  EXPECT_FALSE(strongMatch(R"("etag")", R"("ETag")"));
+  EXPECT_FALSE(weakMatch(R"(W/"etag")", R"("ETag")"));
+}
+
+TEST(EtagUtilsTest, AllowsEveryAsciiEtagCharacter) {
+  constexpr absl::string_view etag =
+      R"("!#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~")";
+  EXPECT_TRUE(strongMatch(etag, etag));
+}
+
+TEST(EtagUtilsTest, AllowsObsText) {
+  const std::string etag =
+      std::string{"\""} + static_cast<char>(0x80) + static_cast<char>(0xff) + "\"";
+  EXPECT_TRUE(strongMatch(etag, etag));
+}
+
+class InvalidEtagTest : public testing::TestWithParam<absl::string_view> {};
+
+TEST_P(InvalidEtagTest, DoesNotMatch) {
+  EXPECT_FALSE(strongMatch(GetParam(), GetParam()));
+  EXPECT_FALSE(weakMatch(GetParam(), GetParam()));
+  EXPECT_FALSE(weakMatch(GetParam(), R"("valid")"));
+  EXPECT_FALSE(weakMatch(R"("valid")", GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(InvalidEntityTags, InvalidEtagTest,
+                         testing::Values("", "etag", R"("unterminated)", R"(unterminated")",
+                                         R"(w/"etag")", R"(W\"etag\")", R"("embedded"quote")",
+                                         "\"space \"", "\"tab\t\"", "\"delete\x7f\"",
+                                         R"("etag"suffix)", R"(W/W/"etag")"));
+
+TEST(IfNoneMatchTest, MatchesWildcard) { EXPECT_TRUE(ifNoneMatch("*", "")); }
+
+TEST(IfNoneMatchTest, WeaklyMatchesAnyEntityTagInList) {
+  EXPECT_TRUE(ifNoneMatch(R"("one,with-comma", W/"selected", "three")", R"("selected")"));
+}
+
+TEST(IfNoneMatchTest, AllowsOptionalWhitespaceAndEmptyListElements) {
+  EXPECT_TRUE(ifNoneMatch(" , \t, W/\"selected\" , ", R"("selected")"));
+}
+
+TEST(IfNoneMatchTest, DoesNotMatchDifferentEntityTags) {
+  EXPECT_FALSE(ifNoneMatch(R"("one", W/"two")", R"("three")"));
+}
+
+TEST(IfNoneMatchTest, InvalidFieldValueDoesNotMatch) {
+  EXPECT_FALSE(ifNoneMatch(R"("selected" trailing)", R"("selected")"));
+  EXPECT_FALSE(ifNoneMatch(R"(*, "selected")", R"("selected")"));
+  EXPECT_FALSE(ifNoneMatch(",,,", R"("selected")"));
+}
+
+TEST(IfNoneMatchTest, InvalidSelectedEtagDoesNotMatchList) {
+  EXPECT_FALSE(ifNoneMatch(R"("selected")", "selected"));
+}
+
+} // namespace
+} // namespace EtagUtils
+} // namespace CacheV2
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: cache_v2: support If-None-Match validation

Additional Description: Adds downstream If-None-Match support to the cache v2 filter. The change is limited to cache v2 requests containing If-None-Match. Existing If-Modified-Since and If-Range requests continue to bypass cache v2.

The change:
- Parses entity tags according to RFC 9110, including weak tags, wildcard values, and lists.
- Evaluates each downstream If-None-Match condition against the final usable cached representation.
- Returns a bodyless 304 Not Modified when the condition matches.
- Keeps downstream preconditions separate from cache-to-upstream revalidation.
- Preserves request collapsing while evaluating each subscriber independently.
- Replaces downstream validators with validators from the cached response during upstream revalidation.
- Requests a complete representation on cache miss before evaluating downstream conditions.

AI assistance was used while developing this change. The submitter has reviewed and understands the resulting code.

Risk Level: Low. 
Fixes: #9855 

Testing:
- Added unit tests for strong and weak ETag comparison, wildcard matching, ETag lists, optional whitespace, obs-text, empty tags, and malformed values.
- Added cache session tests covering fresh hits, cache misses, stale validation, wildcard matching, and independently evaluated collapsed requests.
- Added cacheability and filter tests verifying that If-None-Match requests enter cache v2.

Docs Changes: N/A

Release Notes:
Added downstream If-None-Match support to the cache v2 HTTP filter, including local 304 responses and shared cache revalidation.