### PR TITLE
allow stripping query params in http ext auth

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -495,7 +495,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 11]
+// [#next-free-field: 12]
 message HttpService {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.HttpService";
@@ -525,6 +525,21 @@ message HttpService {
   // .. note::
   //   When this field is set, the ``ext_authz`` filter will buffer the request body for retry purposes.
   config.core.v3.RetryPolicy retry_policy = 9;
+
+  // When set to ``true``, the query string from the original request's ``:path`` header will be
+  // stripped before sending the authorization request to the HTTP service. This is useful when
+  // query parameters contain sensitive information that should not be forwarded to the
+  // authorization server.
+  //
+  // When set to ``false`` (default), the original full path, including query parameters, is
+  // forwarded to the authorization server. This preserves backward compatibility.
+  //
+  // .. note::
+  //   This field only affects the ``:path`` header sent in the HTTP authorization request.
+  //   It has no effect on the gRPC ext_authz service, which includes query parameters in the
+  //   :ref:`path <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.path>`
+  //   field instead.
+  bool strip_query_params = 11;
 }
 
 message AuthorizationRequest {

--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 33]
+// [#next-free-field: 34]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v3.ExtAuthz";
@@ -397,6 +397,24 @@ message ExtAuthz {
   //
   // Defaults to ``false``.
   bool shadow_mode = 32;
+
+  // When set to ``true``, the query string is stripped from the request path before it is sent
+  // to the external authorization service. For gRPC services, the stripped path populates the
+  // :ref:`path <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.path>` field
+  // (and the ``:path`` header entry, if forwarded) of the
+  // :ref:`CheckRequest <envoy_v3_api_msg_service.auth.v3.CheckRequest>`. For HTTP services, the
+  // stripped path is sent as the ``:path`` header of the authorization request, before any
+  // :ref:`path_prefix <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.HttpService.path_prefix>`
+  // is applied. This is useful when query parameters contain sensitive information that should
+  // not be forwarded to the authorization server.
+  //
+  // When set to ``false`` (default), the original full path, including query parameters, is
+  // sent to the authorization server. This preserves backward compatibility.
+  //
+  // .. note::
+  //   This field only affects the path sent to the authorization service; the query string is
+  //   never modified on the original downstream request or the upstream request.
+  bool strip_query_params = 33;
 }
 
 // Serialized form of the shadow-mode authorization decision written to FilterState
@@ -495,7 +513,7 @@ message BufferSettings {
 // metadata as well as body may be added to the client's response. See :ref:`allowed_client_headers
 // <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.AuthorizationResponse.allowed_client_headers>`
 // for details.
-// [#next-free-field: 12]
+// [#next-free-field: 11]
 message HttpService {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.HttpService";
@@ -525,21 +543,6 @@ message HttpService {
   // .. note::
   //   When this field is set, the ``ext_authz`` filter will buffer the request body for retry purposes.
   config.core.v3.RetryPolicy retry_policy = 9;
-
-  // When set to ``true``, the query string from the original request's ``:path`` header will be
-  // stripped before sending the authorization request to the HTTP service. This is useful when
-  // query parameters contain sensitive information that should not be forwarded to the
-  // authorization server.
-  //
-  // When set to ``false`` (default), the original full path, including query parameters, is
-  // forwarded to the authorization server. This preserves backward compatibility.
-  //
-  // .. note::
-  //   This field only affects the ``:path`` header sent in the HTTP authorization request.
-  //   It has no effect on the gRPC ext_authz service, which includes query parameters in the
-  //   :ref:`path <envoy_v3_api_field_service.auth.v3.AttributeContext.HttpRequest.path>`
-  //   field instead.
-  bool strip_query_params = 11;
 }
 
 message AuthorizationRequest {

--- a/changelogs/current/new_features/ext_authz__strip-query-params.rst
+++ b/changelogs/current/new_features/ext_authz__strip-query-params.rst
@@ -1,0 +1,4 @@
+Added ``strip_query_params`` to the HTTP external authorization filter to strip the
+query string from the request ``:path`` header before sending the authorization request
+to the HTTP authorization server. See :ref:`HttpService
+<envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.HttpService>`.

--- a/changelogs/current/new_features/ext_authz__strip-query-params.rst
+++ b/changelogs/current/new_features/ext_authz__strip-query-params.rst
@@ -1,4 +1,4 @@
-Added ``strip_query_params`` to the HTTP external authorization filter to strip the
-query string from the request ``:path`` header before sending the authorization request
-to the HTTP authorization server. See :ref:`HttpService
-<envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.HttpService>`.
+Added ``strip_query_params`` to the external authorization filter to strip the
+query string from the request path before sending the authorization request to the
+authorization server. The behavior applies to both HTTP and gRPC authorization services.
+See :ref:`ExtAuthz <envoy_v3_api_msg_extensions.filters.http.ext_authz.v3.ExtAuthz>`.

--- a/source/common/http/utility.cc
+++ b/source/common/http/utility.cc
@@ -554,10 +554,13 @@ absl::string_view Utility::findQueryStringStart(const HeaderString& path) {
   return path_str;
 }
 
+absl::string_view Utility::stripQueryString(absl::string_view path) {
+  const size_t query_offset = path.find('?');
+  return path.substr(0, query_offset != path.npos ? query_offset : path.size());
+}
+
 std::string Utility::stripQueryString(const HeaderString& path) {
-  absl::string_view path_str = path.getStringView();
-  size_t query_offset = path_str.find('?');
-  return {path_str.data(), query_offset != path_str.npos ? query_offset : path_str.size()};
+  return std::string(Utility::stripQueryString(path.getStringView()));
 }
 
 std::string Utility::QueryParamsMulti::replaceQueryString(const HeaderString& path) const {

--- a/source/common/http/utility.h
+++ b/source/common/http/utility.h
@@ -227,6 +227,13 @@ absl::string_view findQueryStringStart(const HeaderString& path);
 
 /**
  * Returns the path without the query string.
+ * @param path supplies a string_view possibly containing a query string.
+ * @return absl::string_view the path without query string.
+ */
+absl::string_view stripQueryString(absl::string_view path);
+
+/**
+ * Returns the path without the query string.
  * @param path supplies a HeaderString& possibly containing a query string.
  * @return std::string the path without query string.
  */

--- a/source/extensions/filters/common/ext_authz/check_request_utils.cc
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.cc
@@ -128,11 +128,17 @@ void CheckRequestUtils::setHttpRequest(
     envoy::service::auth::v3::AttributeContext::HttpRequest& httpreq, uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
     const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
-    bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
+    bool encode_raw_headers, bool strip_query_params,
+    const MatcherSharedPtr& allowed_headers_matcher,
     const MatcherSharedPtr& disallowed_headers_matcher) {
   httpreq.set_id(std::to_string(stream_id));
   httpreq.set_method(getHeaderStr(headers.Method()));
-  httpreq.set_path(getHeaderStr(headers.Path()));
+  const std::string path = getHeaderStr(headers.Path());
+  if (strip_query_params) {
+    httpreq.set_path(Http::Utility::stripQueryString(path));
+  } else {
+    httpreq.set_path(path);
+  }
   httpreq.set_host(getHeaderStr(headers.Host()));
   httpreq.set_scheme(getHeaderStr(headers.Scheme()));
   httpreq.set_size(stream_info.bytesReceived());
@@ -146,8 +152,9 @@ void CheckRequestUtils::setHttpRequest(
   // Calling mutable_header_map() creates the field in the request; only do so when necessary.
   auto* mutable_header_map = encode_raw_headers ? httpreq.mutable_header_map() : nullptr;
 
-  headers.iterate([encode_raw_headers, allowed_headers_matcher, disallowed_headers_matcher,
-                   mutable_headers, mutable_header_map](const Envoy::Http::HeaderEntry& e) {
+  headers.iterate([encode_raw_headers, strip_query_params, allowed_headers_matcher,
+                   disallowed_headers_matcher, mutable_headers,
+                   mutable_header_map](const Envoy::Http::HeaderEntry& e) {
     // Skip any client EnvoyAuthPartialBody header, which could interfere with internal use.
     if (e.key().getStringView() == Headers::get().EnvoyAuthPartialBody.get()) {
       return Envoy::Http::HeaderMap::Iterate::Continue;
@@ -162,11 +169,17 @@ void CheckRequestUtils::setHttpRequest(
       return Envoy::Http::HeaderMap::Iterate::Continue;
     }
 
+    // Strip the query string from the path header when configured, so that the path sent to the
+    // authorization service is the same for HTTP and gRPC services.
+    const absl::string_view value =
+        strip_query_params && e.key().getStringView() == Http::Headers::get().Path.get()
+            ? Http::Utility::stripQueryString(e.value().getStringView())
+            : e.value().getStringView();
+
     if (encode_raw_headers) {
-      headerMapAddHeader(*mutable_header_map, key, std::string(e.value().getStringView()));
+      headerMapAddHeader(*mutable_header_map, key, std::string(value));
     } else {
-      const std::string sanitized_value =
-          MessageUtil::sanitizeUtf8String(e.value().getStringView());
+      const std::string sanitized_value = MessageUtil::sanitizeUtf8String(value);
 
       if (mutable_headers->find(key) == mutable_headers->end()) {
         (*mutable_headers)[key] = sanitized_value;
@@ -213,12 +226,13 @@ void CheckRequestUtils::setAttrContextRequest(
     envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
     const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
     const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
-    bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
+    bool encode_raw_headers, bool strip_query_params,
+    const MatcherSharedPtr& allowed_headers_matcher,
     const MatcherSharedPtr& disallowed_headers_matcher) {
   setRequestTime(req, stream_info);
   setHttpRequest(*req.mutable_http(), stream_id, stream_info, decoding_buffer, headers,
-                 max_request_bytes, pack_as_bytes, encode_raw_headers, allowed_headers_matcher,
-                 disallowed_headers_matcher);
+                 max_request_bytes, pack_as_bytes, encode_raw_headers, strip_query_params,
+                 allowed_headers_matcher, disallowed_headers_matcher);
 }
 
 void CheckRequestUtils::setTLSSession(
@@ -242,7 +256,7 @@ void CheckRequestUtils::createHttpCheck(
     envoy::config::core::v3::Metadata&& route_metadata_context,
     envoy::service::auth::v3::CheckRequest& request, uint64_t max_request_bytes, bool pack_as_bytes,
     bool encode_raw_headers, bool include_peer_certificate, bool include_tls_session,
-    const Protobuf::Map<std::string, std::string>& destination_labels,
+    bool strip_query_params, const Protobuf::Map<std::string, std::string>& destination_labels,
     const MatcherSharedPtr& allowed_headers_matcher,
     const MatcherSharedPtr& disallowed_headers_matcher) {
 
@@ -259,7 +273,8 @@ void CheckRequestUtils::createHttpCheck(
                      include_peer_certificate);
   setAttrContextRequest(*attrs->mutable_request(), cb->streamId(), cb->streamInfo(),
                         cb->decodingBuffer(), headers, max_request_bytes, pack_as_bytes,
-                        encode_raw_headers, allowed_headers_matcher, disallowed_headers_matcher);
+                        encode_raw_headers, strip_query_params, allowed_headers_matcher,
+                        disallowed_headers_matcher);
 
   if (include_tls_session) {
     setTLSSession(*attrs->mutable_tls_session(), *cb->connection());

--- a/source/extensions/filters/common/ext_authz/check_request_utils.h
+++ b/source/extensions/filters/common/ext_authz/check_request_utils.h
@@ -89,6 +89,7 @@ public:
    * @param encode_raw_headers  when true, will set the check request headers as bytes.
    * @param include_peer_certificate whether to include the peer certificate in the check request.
    * @param include_tls_session whether to include the TLS session details in the check request.
+   * @param strip_query_params when true, strips the query string from the request path.
    */
   static void createHttpCheck(const Envoy::Http::StreamDecoderFilterCallbacks* callbacks,
                               const Envoy::Http::RequestHeaderMap& headers,
@@ -98,7 +99,7 @@ public:
                               envoy::service::auth::v3::CheckRequest& request,
                               uint64_t max_request_bytes, bool pack_as_bytes,
                               bool encode_raw_headers, bool include_peer_certificate,
-                              bool include_tls_session,
+                              bool include_tls_session, bool strip_query_params,
                               const Protobuf::Map<std::string, std::string>& destination_labels,
                               const MatcherSharedPtr& allowed_headers_matcher,
                               const MatcherSharedPtr& disallowed_headers_matcher);
@@ -137,15 +138,18 @@ private:
                              const Buffer::Instance* decoding_buffer,
                              const Envoy::Http::RequestHeaderMap& headers,
                              uint64_t max_request_bytes, bool pack_as_bytes,
-                             bool encode_raw_headers,
+                             bool encode_raw_headers, bool strip_query_params,
                              const MatcherSharedPtr& allowed_headers_matcher,
                              const MatcherSharedPtr& disallowed_headers_matcher);
-  static void setAttrContextRequest(
-      envoy::service::auth::v3::AttributeContext::Request& req, const uint64_t stream_id,
-      const StreamInfo::StreamInfo& stream_info, const Buffer::Instance* decoding_buffer,
-      const Envoy::Http::RequestHeaderMap& headers, uint64_t max_request_bytes, bool pack_as_bytes,
-      bool encode_raw_headers, const MatcherSharedPtr& allowed_headers_matcher,
-      const MatcherSharedPtr& disallowed_headers_matcher);
+  static void setAttrContextRequest(envoy::service::auth::v3::AttributeContext::Request& req,
+                                    const uint64_t stream_id,
+                                    const StreamInfo::StreamInfo& stream_info,
+                                    const Buffer::Instance* decoding_buffer,
+                                    const Envoy::Http::RequestHeaderMap& headers,
+                                    uint64_t max_request_bytes, bool pack_as_bytes,
+                                    bool encode_raw_headers, bool strip_query_params,
+                                    const MatcherSharedPtr& allowed_headers_matcher,
+                                    const MatcherSharedPtr& disallowed_headers_matcher);
   static void setTLSSession(envoy::service::auth::v3::AttributeContext::TLSSession& session,
                             const Envoy::Network::Connection& connection);
   static std::string getHeaderStr(const Envoy::Http::HeaderEntry* entry);

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -178,7 +178,8 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
                         ? THROW_OR_RETURN_VALUE(
                               createRetryPolicy(config.http_service().retry_policy(), context),
                               Router::RetryPolicyConstSharedPtr)
-                        : nullptr) {
+                        : nullptr),
+      strip_query_params_(config.http_service().strip_query_params()) {
   THROW_IF_NOT_OK(
       validateOnlyOneOfPathPrefixOrOverride(path_prefix, config.http_service().path_override()));
 }
@@ -212,7 +213,8 @@ ClientConfig::ClientConfig(
           http_service.has_retry_policy()
               ? THROW_OR_RETURN_VALUE(createRetryPolicy(http_service.retry_policy(), context),
                                       Router::RetryPolicyConstSharedPtr)
-              : nullptr) {
+              : nullptr),
+      strip_query_params_(http_service.strip_query_params()) {
   THROW_IF_NOT_OK(validateOnlyOneOfPathPrefixOrOverride(http_service.path_prefix(),
                                                         http_service.path_override()));
 }
@@ -317,7 +319,20 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
         if (!config_->pathOverride().empty()) {
           headers->addCopy(key, config_->pathOverride());
         } else if (!config_->pathPrefix().empty()) {
-          headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.raw_value()));
+          if (config_->stripQueryParams()) {
+            const auto path = header.raw_value();
+            const auto query_pos = path.find('?');
+            const auto path_without_query =
+                query_pos == absl::string_view::npos ? path : path.substr(0, query_pos);
+            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), path_without_query));
+          } else {
+            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.raw_value()));
+          }
+        } else if (config_->stripQueryParams()) {
+          const auto path = header.raw_value();
+          const auto query_pos = path.find('?');
+          headers->addCopy(key,
+                           query_pos == absl::string_view::npos ? path : path.substr(0, query_pos));
         } else {
           headers->addCopy(key, header.raw_value());
         }
@@ -338,7 +353,19 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
         if (!config_->pathOverride().empty()) {
           headers->addCopy(key, config_->pathOverride());
         } else if (!config_->pathPrefix().empty()) {
-          headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
+          if (config_->stripQueryParams()) {
+            const auto query_pos = header.second.find('?');
+            const auto path_without_query =
+                query_pos == std::string::npos ? header.second : header.second.substr(0, query_pos);
+            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), path_without_query));
+          } else {
+            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
+          }
+        } else if (config_->stripQueryParams()) {
+          const auto query_pos = header.second.find('?');
+          headers->addCopy(key, query_pos == std::string::npos
+                                    ? header.second
+                                    : header.second.substr(0, query_pos));
         } else {
           headers->addCopy(key, header.second);
         }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -178,8 +178,7 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
                         ? THROW_OR_RETURN_VALUE(
                               createRetryPolicy(config.http_service().retry_policy(), context),
                               Router::RetryPolicyConstSharedPtr)
-                        : nullptr),
-      strip_query_params_(config.http_service().strip_query_params()) {
+                        : nullptr) {
   THROW_IF_NOT_OK(
       validateOnlyOneOfPathPrefixOrOverride(path_prefix, config.http_service().path_override()));
 }
@@ -213,8 +212,7 @@ ClientConfig::ClientConfig(
           http_service.has_retry_policy()
               ? THROW_OR_RETURN_VALUE(createRetryPolicy(http_service.retry_policy(), context),
                                       Router::RetryPolicyConstSharedPtr)
-              : nullptr),
-      strip_query_params_(http_service.strip_query_params()) {
+              : nullptr) {
   THROW_IF_NOT_OK(validateOnlyOneOfPathPrefixOrOverride(http_service.path_prefix(),
                                                         http_service.path_override()));
 }
@@ -319,20 +317,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
         if (!config_->pathOverride().empty()) {
           headers->addCopy(key, config_->pathOverride());
         } else if (!config_->pathPrefix().empty()) {
-          if (config_->stripQueryParams()) {
-            const auto path = header.raw_value();
-            const auto query_pos = path.find('?');
-            const auto path_without_query =
-                query_pos == absl::string_view::npos ? path : path.substr(0, query_pos);
-            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), path_without_query));
-          } else {
-            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.raw_value()));
-          }
-        } else if (config_->stripQueryParams()) {
-          const auto path = header.raw_value();
-          const auto query_pos = path.find('?');
-          headers->addCopy(key,
-                           query_pos == absl::string_view::npos ? path : path.substr(0, query_pos));
+          headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.raw_value()));
         } else {
           headers->addCopy(key, header.raw_value());
         }
@@ -353,19 +338,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
         if (!config_->pathOverride().empty()) {
           headers->addCopy(key, config_->pathOverride());
         } else if (!config_->pathPrefix().empty()) {
-          if (config_->stripQueryParams()) {
-            const auto query_pos = header.second.find('?');
-            const auto path_without_query =
-                query_pos == std::string::npos ? header.second : header.second.substr(0, query_pos);
-            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), path_without_query));
-          } else {
-            headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
-          }
-        } else if (config_->stripQueryParams()) {
-          const auto query_pos = header.second.find('?');
-          headers->addCopy(key, query_pos == std::string::npos
-                                    ? header.second
-                                    : header.second.substr(0, query_pos));
+          headers->addCopy(key, absl::StrCat(config_->pathPrefix(), header.second));
         } else {
           headers->addCopy(key, header.second);
         }

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -108,6 +108,11 @@ public:
    */
   const Router::RetryPolicyConstSharedPtr& retryPolicy() const { return retry_policy_; }
 
+  /**
+   * Returns whether or not to strip query params from the path when sending to the auth server.
+   */
+  bool stripQueryParams() const { return strip_query_params_; }
+
 private:
   static MatcherSharedPtr toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
                                            Server::Configuration::CommonFactoryContext& context);
@@ -135,6 +140,7 @@ private:
   Router::HeaderParserPtr request_headers_parser_;
   const bool encode_raw_headers_;
   const Router::RetryPolicyConstSharedPtr retry_policy_;
+  const bool strip_query_params_;
 };
 
 using ClientConfigSharedPtr = std::shared_ptr<ClientConfig>;

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -108,11 +108,6 @@ public:
    */
   const Router::RetryPolicyConstSharedPtr& retryPolicy() const { return retry_policy_; }
 
-  /**
-   * Returns whether or not to strip query params from the path when sending to the auth server.
-   */
-  bool stripQueryParams() const { return strip_query_params_; }
-
 private:
   static MatcherSharedPtr toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
                                            Server::Configuration::CommonFactoryContext& context);
@@ -140,7 +135,6 @@ private:
   Router::HeaderParserPtr request_headers_parser_;
   const bool encode_raw_headers_;
   const Router::RetryPolicyConstSharedPtr retry_policy_;
-  const bool strip_query_params_;
 };
 
 using ClientConfigSharedPtr = std::shared_ptr<ClientConfig>;

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -134,6 +134,7 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::ext_authz::v3
       pack_as_bytes_(config.has_http_service() || config.with_request_body().pack_as_bytes()),
 
       encode_raw_headers_(config.encode_raw_headers()),
+      strip_query_params_(config.strip_query_params()),
 
       status_on_error_(toErrorCode(config.status_on_error().code())),
       validate_mutations_(config.validate_mutations()), scope_(scope),
@@ -423,7 +424,7 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
       decoder_callbacks_, headers, std::move(context_extensions), std::move(metadata_context),
       std::move(route_metadata_context), check_request_, max_request_bytes_, config_->packAsBytes(),
       config_->headersAsBytes(), config_->includePeerCertificate(), config_->includeTLSSession(),
-      config_->destinationLabels(), config_->allowedHeadersMatcher(),
+      config_->stripQueryParams(), config_->destinationLabels(), config_->allowedHeadersMatcher(),
       config_->disallowedHeadersMatcher());
 
   ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server.", *decoder_callbacks_);

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -212,6 +212,8 @@ public:
 
   bool headersAsBytes() const { return encode_raw_headers_; }
 
+  bool stripQueryParams() const { return strip_query_params_; }
+
   Filters::Common::MutationRules::CheckResult
   checkDecoderHeaderMutation(const Filters::Common::MutationRules::CheckOperation& operation,
                              const Http::LowerCaseString& key, absl::string_view value) const {
@@ -323,6 +325,7 @@ private:
   const uint32_t max_denied_response_body_bytes_;
   const bool pack_as_bytes_;
   const bool encode_raw_headers_;
+  const bool strip_query_params_;
   const Http::Code status_on_error_;
   const bool validate_mutations_;
   Stats::Scope& scope_;

--- a/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
+++ b/test/extensions/filters/common/ext_authz/check_request_utils_test.cc
@@ -76,7 +76,7 @@ public:
         &callbacks_, request_headers, std::move(context_extensions), std::move(metadata_context),
         envoy::config::core::v3::Metadata(), request, /*max_request_bytes=*/0,
         /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, include_peer_certificate,
-        want_tls_session != nullptr, labels, nullptr, nullptr);
+        want_tls_session != nullptr, /*strip_query_params=*/false, labels, nullptr, nullptr);
 
     EXPECT_EQ("source", request.attributes().source().principal());
     EXPECT_EQ("destination", request.attributes().destination().principal());
@@ -293,7 +293,8 @@ TEST_F(CheckRequestUtilsTest, BasicHttp) {
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*include_tls_session=*/false, /*strip_query_params=*/false,
+      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
   ASSERT_EQ(size, request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
   EXPECT_FALSE(request_.attributes().request().http().has_header_map());
@@ -322,7 +323,8 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithDuplicateHeaders) {
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*include_tls_session=*/false, /*strip_query_params=*/false,
+      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
   ASSERT_EQ(size, request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
   EXPECT_FALSE(request_.attributes().request().http().has_header_map());
@@ -354,8 +356,8 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithRequestHeaderAllowlist) {
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/false, Protobuf::Map<std::string, std::string>(),
-      createRequestHeaderAllowlist(), nullptr);
+      /*include_tls_session=*/false, /*strip_query_params=*/false,
+      Protobuf::Map<std::string, std::string>(), createRequestHeaderAllowlist(), nullptr);
   ASSERT_EQ(size, request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
   EXPECT_FALSE(request_.attributes().request().http().has_header_map());
@@ -392,8 +394,8 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithRequestHeaderDenylist) {
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/false, Protobuf::Map<std::string, std::string>(), nullptr,
-      createRequestHeaderDenylist());
+      /*include_tls_session=*/false, /*strip_query_params=*/false,
+      Protobuf::Map<std::string, std::string>(), nullptr, createRequestHeaderDenylist());
   ASSERT_EQ(size, request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
   EXPECT_FALSE(request_.attributes().request().http().has_header_map());
@@ -432,8 +434,9 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithRequestHeaderAllowlistAndDenylist) {
       &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/false, Protobuf::Map<std::string, std::string>(),
-      createRequestHeaderAllowlist(), createRequestHeaderDenylist());
+      /*include_tls_session=*/false, /*strip_query_params=*/false,
+      Protobuf::Map<std::string, std::string>(), createRequestHeaderAllowlist(),
+      createRequestHeaderDenylist());
   ASSERT_EQ(size, request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
   EXPECT_FALSE(request_.attributes().request().http().has_header_map());
@@ -464,7 +467,8 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithPartialBody) {
       &callbacks_, headers_, Protobuf::Map<std::string, std::string>(),
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_, size,
       /*pack_as_bytes=*/false, /*encode_raw_headers=*/false, /*include_peer_certificate=*/false,
-      /*include_tls_session=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*include_tls_session=*/false, /*strip_query_params=*/false,
+      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
   ASSERT_EQ(size, request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, size), request_.attributes().request().http().body());
   EXPECT_FALSE(request_.attributes().request().http().has_header_map());
@@ -486,7 +490,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithFullBody) {
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_,
       buffer_->length(), /*pack_as_bytes=*/false, /*encode_raw_headers=*/false,
       /*include_peer_certificate=*/false, /*include_tls_session=*/false,
-      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*strip_query_params=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
   ASSERT_EQ(buffer_->length(), request_.attributes().request().http().body().size());
   EXPECT_EQ(buffer_->toString().substr(0, buffer_->length()),
             request_.attributes().request().http().body());
@@ -521,7 +525,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithFullBodyPackAsBytes) {
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request_,
       buffer_->length(), /*pack_as_bytes=*/true, /*encode_raw_headers=*/false,
       /*include_peer_certificate=*/false, /*include_tls_session=*/false,
-      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*strip_query_params=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
 
   // TODO(dio): Find a way to test this without using function from testing::internal namespace.
   testing::internal::CaptureStderr();
@@ -563,7 +567,7 @@ TEST_F(CheckRequestUtilsTest, BasicHttpWithHeadersAsBytes) {
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request,
       buffer_->length(), /*pack_as_bytes=*/false, /*encode_raw_headers=*/true,
       /*include_peer_certificate=*/false, /*include_tls_session=*/false,
-      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*strip_query_params=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
 
   // Headers field should be empty since ext_authz should populate header_map INSTEAD.
   EXPECT_EQ(0, request.attributes().request().http().headers().size());
@@ -597,7 +601,7 @@ TEST_F(CheckRequestUtilsTest, HeadersAsBytesNoConcatentation) {
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request,
       buffer_->length(), /*pack_as_bytes=*/false, /*encode_raw_headers=*/true,
       /*include_peer_certificate=*/false, /*include_tls_session=*/false,
-      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*strip_query_params=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
 
   EXPECT_EQ(0, request.attributes().request().http().headers().size());
   ASSERT_TRUE(request.attributes().request().http().has_header_map());
@@ -628,7 +632,7 @@ TEST_F(CheckRequestUtilsTest, HeadersAsBytesExistingPartialBodyHeader) {
       envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request,
       buffer_->length(), /*pack_as_bytes=*/false, /*encode_raw_headers=*/true,
       /*include_peer_certificate=*/false, /*include_tls_session=*/false,
-      Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+      /*strip_query_params=*/false, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
 
   EXPECT_EQ(0, request.attributes().request().http().headers().size());
   ASSERT_TRUE(request.attributes().request().http().has_header_map());
@@ -769,6 +773,67 @@ TEST_F(CheckRequestUtilsTest, CheckAttrContextPeerTLSSessionWithoutSNI) {
   EXPECT_CALL(*ssl_, sni()).WillOnce(ReturnRef(want_tls_session.sni()));
 
   callHttpCheckAndValidateRequestAttributes(false, &want_tls_session);
+}
+
+// Verify that createHttpCheck strips the query string from both the path field and the
+// forwarded :path header entry when strip_query_params is set, in both sanitized-headers
+// and raw-headers modes.
+TEST_F(CheckRequestUtilsTest, StripQueryParams) {
+  for (const bool encode_raw_headers : {false, true}) {
+    for (const bool strip_query_params : {false, true}) {
+      Http::TestRequestHeaderMapImpl request_headers{{":path", "/api?secret=1&foo=bar"},
+                                                     {"x-key", "value"}};
+
+      EXPECT_CALL(*ssl_, uriSanPeerCertificate())
+          .WillOnce(Return(std::vector<std::string>{"source"}));
+      EXPECT_CALL(*ssl_, uriSanLocalCertificate())
+          .WillOnce(Return(std::vector<std::string>{"destination"}));
+      expectBasicHttp();
+
+      envoy::service::auth::v3::CheckRequest request;
+      CheckRequestUtils::createHttpCheck(
+          &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
+          envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request,
+          /*max_request_bytes=*/0, /*pack_as_bytes=*/false, encode_raw_headers,
+          /*include_peer_certificate=*/false, /*include_tls_session=*/false, strip_query_params,
+          Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+
+      const std::string expected_path = strip_query_params ? "/api" : "/api?secret=1&foo=bar";
+
+      // The path field and the forwarded :path header entry carry the same path.
+      EXPECT_EQ(expected_path, request.attributes().request().http().path());
+      if (encode_raw_headers) {
+        EXPECT_EQ(0, request.attributes().request().http().headers().size());
+        expectHeadersInHeaderMap(request.attributes().request().http().header_map(),
+                                 {{":path", expected_path}, {"x-key", "value"}});
+      } else {
+        EXPECT_EQ(expected_path, request.attributes().request().http().headers().at(":path"));
+        EXPECT_EQ("value", request.attributes().request().http().headers().at("x-key"));
+        EXPECT_FALSE(request.attributes().request().http().has_header_map());
+      }
+    }
+  }
+}
+
+// A path without a query string is unchanged when strip_query_params is set.
+TEST_F(CheckRequestUtilsTest, StripQueryParamsNoQueryString) {
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/api"}};
+
+  EXPECT_CALL(*ssl_, uriSanPeerCertificate()).WillOnce(Return(std::vector<std::string>{"source"}));
+  EXPECT_CALL(*ssl_, uriSanLocalCertificate())
+      .WillOnce(Return(std::vector<std::string>{"destination"}));
+  expectBasicHttp();
+
+  envoy::service::auth::v3::CheckRequest request;
+  CheckRequestUtils::createHttpCheck(
+      &callbacks_, request_headers, Protobuf::Map<std::string, std::string>(),
+      envoy::config::core::v3::Metadata(), envoy::config::core::v3::Metadata(), request,
+      /*max_request_bytes=*/0, /*pack_as_bytes=*/false, /*encode_raw_headers=*/false,
+      /*include_peer_certificate=*/false, /*include_tls_session=*/false,
+      /*strip_query_params=*/true, Protobuf::Map<std::string, std::string>(), nullptr, nullptr);
+
+  EXPECT_EQ("/api", request.attributes().request().http().path());
+  EXPECT_EQ("/api", request.attributes().request().http().headers().at(":path"));
 }
 
 } // namespace

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -1197,102 +1197,26 @@ TEST_F(ExtAuthzHttpClientTest, TestHttpClientResetOnComplete) {
   client_->onSuccess(async_request_, std::move(check_response));
 }
 
-// Test that strip_query_params: true strips the query string from the :path header.
-TEST_F(ExtAuthzHttpClientTest, StripQueryParamsDefault) {
+// The HTTP client forwards the path from the check request verbatim; query string stripping
+// (controlled by ExtAuthz.strip_query_params) happens when the check request is built, so the
+// client applies the same behavior for HTTP and gRPC services.
+TEST_F(ExtAuthzHttpClientTest, ForwardsPathVerbatim) {
+  // Initialize without a path_prefix so the forwarded path is the check request's path verbatim.
   const std::string yaml = R"EOF(
   http_service:
     server_uri:
       uri: "ext_authz:9000"
       cluster: "ext_authz"
       timeout: 0.25s
-  )EOF";
-  initialize(yaml);
-  // By default, strip_query_params is false, so query params are retained.
-  Http::RequestMessagePtr message_ptr =
-      sendRequest({{":path", "/hello?name=value&foo=bar"}, {"foo", "bar"}});
-  EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello?name=value&foo=bar");
-}
-
-TEST_F(ExtAuthzHttpClientTest, StripQueryParamsTrue) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-    strip_query_params: true
   )EOF";
   initialize(yaml);
   Http::RequestMessagePtr message_ptr =
       sendRequest({{":path", "/hello?name=value&foo=bar"}, {"foo", "bar"}});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello?name=value&foo=bar");
+
+  // A pre-stripped path in the check request (built with strip_query_params) is forwarded as-is.
+  message_ptr = sendRequest({{":path", "/hello"}, {"foo", "bar"}});
   EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello");
-}
-
-// When strip_query_params: true and there are no query params in the path,
-// the path is unchanged.
-TEST_F(ExtAuthzHttpClientTest, StripQueryParamsTrueNoQueryString) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-    strip_query_params: true
-  )EOF";
-  initialize(yaml);
-  Http::RequestMessagePtr message_ptr = sendRequest({{":path", "/hello"}, {"foo", "bar"}});
-  EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello");
-}
-
-// strip_query_params: true with encode_raw_headers.
-TEST_F(ExtAuthzHttpClientTest, StripQueryParamsTrueWithRawHeaders) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-    strip_query_params: true
-  encode_raw_headers: true
-  )EOF";
-  initialize(yaml);
-  Http::RequestMessagePtr message_ptr =
-      sendRequest({{":path", "/foo?a=1&b=2"}}, SendRequestOpts{.encode_raw_headers = true});
-  EXPECT_EQ(message_ptr->headers().getPathValue(), "/foo");
-}
-
-// strip_query_params: true with path_prefix strips query params before prepending the prefix.
-TEST_F(ExtAuthzHttpClientTest, StripQueryParamsWithPathPrefix) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-    path_prefix: "/auth"
-    strip_query_params: true
-  )EOF";
-  initialize(yaml);
-  Http::RequestMessagePtr message_ptr =
-      sendRequest({{":path", "/hello?name=value"}, {"foo", "bar"}});
-  EXPECT_EQ(message_ptr->headers().getPathValue(), "/auth/hello");
-}
-
-// strip_query_params: true does not affect path_override.
-TEST_F(ExtAuthzHttpClientTest, StripQueryParamsWithPathOverride) {
-  const std::string yaml = R"EOF(
-  http_service:
-    server_uri:
-      uri: "ext_authz:9000"
-      cluster: "ext_authz"
-      timeout: 0.25s
-    path_override: "/auth"
-    strip_query_params: true
-  )EOF";
-  initialize(yaml);
-  Http::RequestMessagePtr message_ptr =
-      sendRequest({{":path", "/hello?name=value"}, {"foo", "bar"}});
-  EXPECT_EQ(message_ptr->headers().getPathValue(), "/auth");
 }
 
 } // namespace

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -1197,6 +1197,104 @@ TEST_F(ExtAuthzHttpClientTest, TestHttpClientResetOnComplete) {
   client_->onSuccess(async_request_, std::move(check_response));
 }
 
+// Test that strip_query_params: true strips the query string from the :path header.
+TEST_F(ExtAuthzHttpClientTest, StripQueryParamsDefault) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 0.25s
+  )EOF";
+  initialize(yaml);
+  // By default, strip_query_params is false, so query params are retained.
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/hello?name=value&foo=bar"}, {"foo", "bar"}});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello?name=value&foo=bar");
+}
+
+TEST_F(ExtAuthzHttpClientTest, StripQueryParamsTrue) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 0.25s
+    strip_query_params: true
+  )EOF";
+  initialize(yaml);
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/hello?name=value&foo=bar"}, {"foo", "bar"}});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello");
+}
+
+// When strip_query_params: true and there are no query params in the path,
+// the path is unchanged.
+TEST_F(ExtAuthzHttpClientTest, StripQueryParamsTrueNoQueryString) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 0.25s
+    strip_query_params: true
+  )EOF";
+  initialize(yaml);
+  Http::RequestMessagePtr message_ptr = sendRequest({{":path", "/hello"}, {"foo", "bar"}});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/hello");
+}
+
+// strip_query_params: true with encode_raw_headers.
+TEST_F(ExtAuthzHttpClientTest, StripQueryParamsTrueWithRawHeaders) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 0.25s
+    strip_query_params: true
+  encode_raw_headers: true
+  )EOF";
+  initialize(yaml);
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/foo?a=1&b=2"}}, SendRequestOpts{.encode_raw_headers = true});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/foo");
+}
+
+// strip_query_params: true with path_prefix strips query params before prepending the prefix.
+TEST_F(ExtAuthzHttpClientTest, StripQueryParamsWithPathPrefix) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 0.25s
+    path_prefix: "/auth"
+    strip_query_params: true
+  )EOF";
+  initialize(yaml);
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/hello?name=value"}, {"foo", "bar"}});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/auth/hello");
+}
+
+// strip_query_params: true does not affect path_override.
+TEST_F(ExtAuthzHttpClientTest, StripQueryParamsWithPathOverride) {
+  const std::string yaml = R"EOF(
+  http_service:
+    server_uri:
+      uri: "ext_authz:9000"
+      cluster: "ext_authz"
+      timeout: 0.25s
+    path_override: "/auth"
+    strip_query_params: true
+  )EOF";
+  initialize(yaml);
+  Http::RequestMessagePtr message_ptr =
+      sendRequest({{":path", "/hello?name=value"}, {"foo", "bar"}});
+  EXPECT_EQ(message_ptr->headers().getPathValue(), "/auth");
+}
+
 } // namespace
 } // namespace ExtAuthz
 } // namespace Common

--- a/test/extensions/filters/http/ext_authz/ext_authz_test.cc
+++ b/test/extensions/filters/http/ext_authz/ext_authz_test.cc
@@ -1217,6 +1217,65 @@ TEST_P(HttpFilterTestParam, OkResponse) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers_));
 }
 
+// With strip_query_params enabled, the path in the CheckRequest sent to the authorization
+// service excludes the query string, for both gRPC and HTTP services.
+TEST_P(HttpFilterTestParam, StripQueryParams) {
+  const bool http_client = std::get<1>(GetParam());
+  auto proto_config = getFilterConfig(/*failure_mode_allow=*/false, http_client);
+  proto_config.set_strip_query_params(true);
+  initialize(proto_config);
+
+  request_headers_ = Http::TestRequestHeaderMapImpl{{":path", "/path?secret=1&foo=bar"}};
+
+  prepareCheck();
+
+  envoy::service::auth::v3::CheckRequest check_request;
+  EXPECT_CALL(*client_, check(_, _, _, _))
+      .WillOnce(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+                           const envoy::service::auth::v3::CheckRequest& check_param,
+                           Tracing::Span&, const StreamInfo::StreamInfo&) -> void {
+        check_request = check_param;
+        request_callbacks_ = &callbacks;
+      }));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers_, true));
+
+  // Both the path field and the forwarded headers entry carry the stripped path.
+  EXPECT_EQ("/path", check_request.attributes().request().http().path());
+  EXPECT_EQ("/path", check_request.attributes().request().http().headers().at(":path"));
+
+  Filters::Common::ExtAuthz::Response response{};
+  response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
+}
+
+// Without strip_query_params, the full path including query string is sent.
+TEST_P(HttpFilterTestParam, RetainQueryParamsByDefault) {
+  const bool http_client = std::get<1>(GetParam());
+  initialize(getFilterConfig(/*failure_mode_allow=*/false, http_client));
+
+  request_headers_ = Http::TestRequestHeaderMapImpl{{":path", "/path?secret=1&foo=bar"}};
+
+  prepareCheck();
+
+  envoy::service::auth::v3::CheckRequest check_request;
+  EXPECT_CALL(*client_, check(_, _, _, _))
+      .WillOnce(Invoke([&](Filters::Common::ExtAuthz::RequestCallbacks& callbacks,
+                           const envoy::service::auth::v3::CheckRequest& check_param,
+                           Tracing::Span&, const StreamInfo::StreamInfo&) -> void {
+        check_request = check_param;
+        request_callbacks_ = &callbacks;
+      }));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopAllIterationAndWatermark,
+            filter_->decodeHeaders(request_headers_, true));
+
+  EXPECT_EQ("/path?secret=1&foo=bar", check_request.attributes().request().http().path());
+
+  Filters::Common::ExtAuthz::Response response{};
+  response.status = Filters::Common::ExtAuthz::CheckStatus::OK;
+  request_callbacks_->onComplete(std::make_unique<Filters::Common::ExtAuthz::Response>(response));
+}
+
 TEST_P(HttpFilterTestParam, RequestHeaderMatchersForGrpcService) {
   initialize(R"EOF(
     grpc_service:


### PR DESCRIPTION
Commit Message: allow stripping query params in http ext auth

Additional Description:
Adds an optional `strip_query_params` boolean to
`envoy.extensions.filters.http.ext_authz.v3.HttpService`. When `true`, the
query string is stripped from the request `:path` before sending the HTTP
authorization request to the auth server — useful when query params carry
sensitive data that should not be forwarded. Defaults to `false` (backward
compatible). Stripping occurs before `path_prefix` is prepended and does not
affect `path_override`. The field only applies to HTTP ext_authz; the gRPC
ext_authz service is unaffected (it carries query params in
`AttributeContext.HttpRequest.path`).

Risk Level: Low
New optional proto field, defaults to `false`; existing behavior unchanged.

Testing:
Added unit tests in `ext_authz_http_impl_test.cc` covering: default (query
retained), `true` (query stripped), no-query-string path, `encode_raw_headers`,
`path_prefix` (stripped before prefix), and `path_override` (unaffected).

Docs Changes:
New-feature changelog entry added at
`changelogs/current/new_features/ext_authz__strip-query-params.rst`. The field
is documented via its inline proto comment (auto-generates API reference).

Release Notes:
Added a `strip_query_params` option to the HTTP external authorization filter
that strips query parameters from the `:path` header before sending the request
to the authorization server. Defaults to `false`.