### PR TITLE
Fix Windows thread impl build

### DIFF
--- a/source/common/common/win32/thread_impl.cc
+++ b/source/common/common/win32/thread_impl.cc
@@ -23,9 +23,8 @@ ThreadImplWin32::ThreadImplWin32(std::function<void()> thread_routine, OptionsOp
         return 0;
       },
       this, 0, nullptr));
-  if (options && options.thread_priority_ &&
-      !SetThreadPriority(thread_handle_, *options.thread_priority_)) {
-    ENVOY_LOG_MISC(warn, "Could not set the thread priority to {}", *options.thread_priority_);
+  if (options && options.priority_ && !SetThreadPriority(thread_handle_, *options.priority_)) {
+    ENVOY_LOG_MISC(warn, "Could not set the thread priority to {}", *options.priority_);
   }
   RELEASE_ASSERT(thread_handle_ != 0, "");
 }
@@ -42,7 +41,7 @@ ThreadPtr ThreadFactoryImplWin32::createThread(std::function<void()> thread_rout
   return std::make_unique<ThreadImplWin32>(thread_routine, options);
 }
 
-ThreadId ThreadFactoryImplWin32::currentThreadId() {
+ThreadId ThreadFactoryImplWin32::currentThreadId() const {
   // TODO(mhoran): test this in windows please.
   return ThreadId(static_cast<int64_t>(::GetCurrentThreadId()));
 }

--- a/source/common/common/win32/thread_impl.h
+++ b/source/common/common/win32/thread_impl.h
@@ -37,7 +37,7 @@ class ThreadFactoryImplWin32 : public ThreadFactory {
 public:
   // Thread::ThreadFactory
   ThreadPtr createThread(std::function<void()> thread_routine, OptionsOptConstRef options) override;
-  ThreadId currentThreadId() override;
+  ThreadId currentThreadId() const override;
 };
 
 } // namespace Thread


### PR DESCRIPTION
Class member in common code was renamed.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: Win32 only
