### PR TITLE
Fix Windows build errors in event handlers

### DIFF
--- a/source/common/event/BUILD
+++ b/source/common/event/BUILD
@@ -81,6 +81,7 @@ envoy_cc_win32_library(
         "//source/common/api:os_sys_calls_lib",
         "//source/common/common:thread_lib",
         "//source/common/network:default_socket_interface_lib",
+        "@abseil-cpp//absl/status",
     ],
 )
 

--- a/source/common/event/win32/signal_impl.cc
+++ b/source/common/event/win32/signal_impl.cc
@@ -3,6 +3,7 @@
 #include "source/common/api/os_sys_calls_impl.h"
 #include "source/common/event/dispatcher_impl.h"
 
+#include "absl/status/status.h"
 #include "event2/event.h"
 
 namespace Envoy {
@@ -33,9 +34,10 @@ SignalEventImpl::SignalEventImpl(DispatcherImpl& dispatcher, signal_t signal_num
 
   read_handle_->initializeFileEvent(
       dispatcher,
-      [this](uint32_t events) -> void {
+      [this](uint32_t events) -> absl::Status {
         ASSERT(events == Event::FileReadyType::Read);
         cb_();
+        return absl::OkStatus();
       },
       Event::FileTriggerType::Level, Event::FileReadyType::Read);
   eventBridgeHandlersSingleton::get()[signal_num] = write_handle;

--- a/source/common/filesystem/BUILD
+++ b/source/common/filesystem/BUILD
@@ -123,6 +123,7 @@ envoy_cc_library(
         "//source/common/common:thread_lib",
         "//source/common/common:utility_lib",
         "//source/common/network:default_socket_interface_lib",
+        "@abseil-cpp//absl/status",
     ] + select({
         "//bazel:windows_x86_64": [
             "//source/common/api:os_sys_calls_lib",

--- a/source/common/filesystem/win32/watcher_impl.cc
+++ b/source/common/filesystem/win32/watcher_impl.cc
@@ -5,6 +5,8 @@
 #include "source/common/common/fmt.h"
 #include "source/common/common/thread_impl.h"
 
+#include "absl/status/status.h"
+
 namespace Envoy {
 namespace Filesystem {
 
@@ -23,9 +25,10 @@ WatcherImpl::WatcherImpl(Event::Dispatcher& dispatcher, Filesystem::Instance& fi
 
   read_handle_->initializeFileEvent(
       dispatcher,
-      [this](uint32_t events) -> void {
+      [this](uint32_t events) -> absl::Status {
         ASSERT(events == Event::FileReadyType::Read);
         onDirectoryEvent();
+        return absl::OkStatus();
       },
       Event::FileTriggerType::Level, Event::FileReadyType::Read);
 
@@ -204,7 +207,7 @@ void WatcherImpl::directoryChangeCompletion(DWORD err, DWORD num_bytes, LPOVERLA
       if (watch.file_ == file && (watch.events_ & events)) {
         ENVOY_LOG(debug, "matched callback: file: {}", watcher->wstring_converter_.to_bytes(file));
         const auto cb = watch.cb_;
-        const auto cb_closure = [cb, events]() -> void { cb(events); };
+        const auto cb_closure = [cb, events]() -> void { cb(events).IgnoreError(); };
         watcher->active_callbacks_.push(cb_closure);
         // write a byte to the other end of the socket that libevent is watching
         // this tells the libevent callback to pull this callback off the active_callbacks_


### PR DESCRIPTION
Fixing bitrotted Windows code.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: windows only
