### PR TITLE
datadog: set span.kind based on traffic direction (Ingress/Egress)

### DIFF
--- a/source/extensions/tracers/datadog/span.cc
+++ b/source/extensions/tracers/datadog/span.cc
@@ -95,7 +95,7 @@ void Span::injectContext(Tracing::TraceContext& trace_context, const Tracing::Up
   span_->inject(writer);
 }
 
-Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& name,
+Tracing::SpanPtr Span::spawnChild(const Tracing::Config& config, const std::string& name,
                                   SystemTime start_time) {
   if (!span_) {
     // I don't expect this to happen. This means that `spawnChild` was called
@@ -103,18 +103,22 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& nam
     return std::make_unique<Tracing::NullSpan>();
   }
 
-  // The OpenTracing implementation ignored the `Tracing::Config` argument,
-  // so we will as well.
-  // The `name` parameter to this function more closely matches Datadog's
-  // concept of "resource name." Datadog's "span name," or "operation name,"
-  // instead describes the category of operation being performed, which here
-  // we hard-code.
-  datadog::tracing::SpanConfig config;
-  config.name = "envoy.proxy";
-  config.resource = name;
-  config.start = estimateTime(start_time);
+  datadog::tracing::SpanConfig span_config;
+  span_config.name = "envoy.proxy";
+  span_config.resource = name;
+  span_config.start = estimateTime(start_time);
 
-  return std::make_unique<Span>(span_->create_child(config));
+  // Set span.kind for child spans based on the traffic direction.
+  switch (config.operationName()) {
+  case Tracing::OperationName::Ingress:
+    span_config.tags["span.kind"] = "server";
+    break;
+  case Tracing::OperationName::Egress:
+    span_config.tags["span.kind"] = "client";
+    break;
+  }
+
+  return std::make_unique<Span>(span_->create_child(span_config));
 }
 
 void Span::setSampled(bool sampled) {

--- a/source/extensions/tracers/datadog/tracer.cc
+++ b/source/extensions/tracers/datadog/tracer.cc
@@ -82,7 +82,7 @@ Tracer::Tracer(const std::string& collector_cluster, const std::string& collecto
 
 // Tracer::TracingDriver
 
-Tracing::SpanPtr Tracer::startSpan(const Tracing::Config&, Tracing::TraceContext& trace_context,
+Tracing::SpanPtr Tracer::startSpan(const Tracing::Config& config, Tracing::TraceContext& trace_context,
                                    const StreamInfo::StreamInfo& stream_info,
                                    const std::string& operation_name,
                                    Tracing::Decision tracing_decision) {
@@ -91,16 +91,21 @@ Tracing::SpanPtr Tracer::startSpan(const Tracing::Config&, Tracing::TraceContext
     return std::make_unique<Tracing::NullSpan>();
   }
 
-  // The OpenTracing implementation ignored the `Tracing::Config` argument,
-  // so we will as well.
   datadog::tracing::SpanConfig span_config;
-  // The `operation_name` parameter to this function more closely matches
-  // Datadog's concept of "resource name." Datadog's "span name," or "operation
-  // name," instead describes the category of operation being performed, which
-  // here we hard-code.
   span_config.name = "envoy.proxy";
   span_config.resource = operation_name;
   span_config.start = estimateTime(stream_info.startTime());
+
+  // Set span.kind based on the traffic direction. Ingress traffic is mapped
+  // to span.kind=server, egress to span.kind=client.
+  switch (config.operationName()) {
+  case Tracing::OperationName::Ingress:
+    span_config.tags["span.kind"] = "server";
+    break;
+  case Tracing::OperationName::Egress:
+    span_config.tags["span.kind"] = "client";
+    break;
+  }
 
   TraceContextReader reader{trace_context};
   datadog::tracing::Span span =

--- a/test/extensions/tracers/datadog/tracer_test.cc
+++ b/test/extensions/tracers/datadog/tracer_test.cc
@@ -7,6 +7,7 @@
 #include "source/extensions/tracers/datadog/tracer.h"
 
 #include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/tracing/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/test_common/environment.h"
@@ -163,6 +164,89 @@ TEST_F(DatadogTracerTest, SpanProperties) {
   EXPECT_EQ(int(datadog::tracing::SamplingPriority::USER_DROP),
             dd_span.trace_segment().sampling_decision()->priority);
   EXPECT_EQ(start, dd_span.start_time().wall);
+}
+
+
+TEST_F(DatadogTracerTest, SpanKindIngress) {
+  // Verify that span.kind=server is set for ingress traffic.
+  datadog::tracing::TracerConfig config;
+  config.service = "envoy";
+  config.report_traces = false;
+  config.telemetry.enabled = false;
+  config.trace_sampler.sample_rate = 1.0;
+
+  Tracer tracer("fake_cluster", "test_host", config, cluster_manager_, *store_.rootScope(),
+                thread_local_slot_allocator_, time_);
+
+  Tracing::TestTraceContextImpl context{};
+  Tracing::Decision decision;
+  decision.reason = Tracing::Reason::Sampling;
+  decision.traced = true;
+
+  const std::string operation_name = "do.thing";
+  const SystemTime start = time_.timeSystem().systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(testing::Return(start));
+
+  NiceMock<Tracing::MockConfig> config_mock;
+  ON_CALL(config_mock, operationName())
+      .WillByDefault(testing::Return(Tracing::OperationName::Ingress));
+
+  const Tracing::SpanPtr span =
+      tracer.startSpan(config_mock, context, stream_info_, operation_name, decision);
+  ASSERT_TRUE(span);
+  const auto as_dd_span_wrapper = dynamic_cast<Span*>(span.get());
+  EXPECT_NE(nullptr, as_dd_span_wrapper);
+
+  const datadog::tracing::Optional<datadog::tracing::Span>& maybe_dd_span =
+      as_dd_span_wrapper->impl();
+  ASSERT_TRUE(maybe_dd_span);
+  const datadog::tracing::Span& dd_span = *maybe_dd_span;
+
+  // Ingress traffic must produce span.kind=server.
+  auto tag = dd_span.lookup_tag("span.kind");
+  ASSERT_TRUE(tag);
+  EXPECT_EQ("server", *tag);
+}
+
+TEST_F(DatadogTracerTest, SpanKindEgress) {
+  // Verify that span.kind=client is set for egress traffic.
+  datadog::tracing::TracerConfig config;
+  config.service = "envoy";
+  config.report_traces = false;
+  config.telemetry.enabled = false;
+  config.trace_sampler.sample_rate = 1.0;
+
+  Tracer tracer("fake_cluster", "test_host", config, cluster_manager_, *store_.rootScope(),
+                thread_local_slot_allocator_, time_);
+
+  Tracing::TestTraceContextImpl context{};
+  Tracing::Decision decision;
+  decision.reason = Tracing::Reason::Sampling;
+  decision.traced = true;
+
+  const std::string operation_name = "do.thing";
+  const SystemTime start = time_.timeSystem().systemTime();
+  ON_CALL(stream_info_, startTime()).WillByDefault(testing::Return(start));
+
+  NiceMock<Tracing::MockConfig> config_mock;
+  ON_CALL(config_mock, operationName())
+      .WillByDefault(testing::Return(Tracing::OperationName::Egress));
+
+  const Tracing::SpanPtr span =
+      tracer.startSpan(config_mock, context, stream_info_, operation_name, decision);
+  ASSERT_TRUE(span);
+  const auto as_dd_span_wrapper = dynamic_cast<Span*>(span.get());
+  EXPECT_NE(nullptr, as_dd_span_wrapper);
+
+  const datadog::tracing::Optional<datadog::tracing::Span>& maybe_dd_span =
+      as_dd_span_wrapper->impl();
+  ASSERT_TRUE(maybe_dd_span);
+  const datadog::tracing::Span& dd_span = *maybe_dd_span;
+
+  // Egress traffic must produce span.kind=client.
+  auto tag = dd_span.lookup_tag("span.kind");
+  ASSERT_TRUE(tag);
+  EXPECT_EQ("client", *tag);
 }
 
 TEST_F(DatadogTracerTest, ExtractionSuccess) {


### PR DESCRIPTION
### Description

The Datadog tracer currently ignores the `Tracing::Config` argument in both `Tracer::startSpan` and `Span::spawnChild`. This means `span.kind` is never set on Datadog spans, causing all spans to have `span.kind=internal` in Datadog APM. As a result, client/server metrics (which Datadog segments by `span.kind`) are lost.

### Fix

Use `config.operationName()` to determine the traffic direction:
- **Ingress** → `span.kind=server`
- **Egress** → `span.kind=client`

### Changes

1. **`source/extensions/tracers/datadog/tracer.cc`**: Name the `Config` parameter and set `span_config.tags["span.kind"]` based on `config.operationName()`.
2. **`source/extensions/tracers/datadog/span.cc`**: Same fix for `spawnChild`. Also rename the local `SpanConfig` variable from `config` to `span_config` to avoid shadowing the function parameter.
3. **`test/extensions/tracers/datadog/tracer_test.cc`**: Add two new tests (`SpanKindIngress`, `SpanKindEgress`) that verify `span.kind=server` and `span.kind=client` respectively.

### Related issue

Fixes #46712