### PR TITLE
fix: use macOS host platform for clang config on Apple Silicon

### DIFF
--- a/bazel/toolchains.bzl
+++ b/bazel/toolchains.bzl
@@ -1,7 +1,6 @@
 load("@com_google_protobuf//bazel/private/oss/toolchains/prebuilt:protoc_toolchain.bzl", "prebuilt_protoc_repo")
 load("@com_google_protobuf//toolchain:platforms.bzl", "PROTOBUF_PLATFORMS")
 load("@envoy_repo//:compiler.bzl", "LLVM_LIB_DIR", "LLVM_PATH", "LLVM_VERSION_LOCAL", "USE_LIBSTDCPP", "USE_LOCAL_SYSROOT")
-load("@envoy_toolshed//repository:utils.bzl", "arch_alias")
 load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 
 _LLVM_VERSION_HERMETIC = "22.1.8"
@@ -46,12 +45,15 @@ filegroup(
 
 def envoy_toolchains():
     native.register_toolchains("@envoy//bazel/rbe/toolchains/configs/linux/gcc/config:cc-toolchain")
-    arch_alias(
+    native.alias(
         name = "clang_platform",
-        aliases = {
-            "amd64": "@envoy//bazel/platforms/rbe:linux_x64",
-            "aarch64": "@envoy//bazel/platforms/rbe:linux_arm64",
-        },
+        actual = select({
+            "@envoy//bazel:darwin_arm64": "@envoy//bazel/platforms:macos_arm64",
+            "@envoy//bazel:darwin_x86_64": "@envoy//bazel/platforms:macos_x86_64",
+            "@envoy//bazel:linux_aarch64": "@envoy//bazel/platforms/rbe:linux_arm64",
+            "@envoy//bazel:linux_x86_64": "@envoy//bazel/platforms/rbe:linux_x64",
+            "//conditions:default": "@envoy//bazel/platforms/rbe:linux_x64",
+        }),
     )
 
     if LLVM_PATH and "llvm_toolchain_llvm" not in native.existing_rules():


### PR DESCRIPTION
## Description

On macOS, `./ci/do_ci.sh check_proto_format` fails because the `clang_platform` alias unconditionally maps all aarch64 and amd64 hosts to the RBE Linux platform (`rbe:linux_arm64` / `rbe:linux_x64`), even when the host is macOS. This causes the `jq` toolchain (from `@aspect_bazel_lib`) to resolve to a Linux ARM64 jq binary, which cannot execute on macOS.

## Root cause

`.bazelrc` sets `common:clang --host_platform=@clang_platform`, where `clang_platform` is defined by `arch_alias` in `bazel/toolchains.bzl` as:

```python
arch_alias(
    name = "clang_platform",
    aliases = {
        "amd64": "@envoy//bazel/platforms/rbe:linux_x64",
        "aarch64": "@envoy//bazel/platforms/rbe:linux_arm64",
    },
)
```

This alias only distinguishes CPU architecture, not the operating system. macOS Apple Silicon (aarch64) is incorrectly mapped to the RBE Linux ARM64 platform, so Bazel's `jq` toolchain picks the Linux jq binary.

## Fix

Replace the `arch_alias` with `native.alias` + `select()`, using envoy's existing `config_setting` entries (`darwin_arm64`, `darwin_x86_64`, `linux_aarch64`, `linux_x86_64`) to choose the correct platform based on both OS and CPU:

- macOS arm64 → `//bazel/platforms:macos_arm64`
- macOS x86_64 → `//bazel/platforms:macos_x86_64`
- Linux aarch64 → `//bazel/platforms/rbe:linux_arm64`
- Linux x86_64 → `//bazel/platforms/rbe:linux_x64`

Fixes #46716

Signed-off-by: waterWang <waterWang@users.noreply.github.com>
