### PR TITLE
ssl: use string view rather then string for ciphersuite

### DIFF
--- a/envoy/ssl/connection.h
+++ b/envoy/ssl/connection.h
@@ -258,10 +258,11 @@ public:
   virtual uint16_t ciphersuiteId() const PURE;
 
   /**
-   * @return std::string the OpenSSL name for the set of ciphers used in the established TLS
-   *         connection. Returns "" if there is no current negotiated ciphersuite.
+   * @return absl::string_view the OpenSSL name for the set of ciphers used in the established TLS
+   *         connection. Returns "" if there is no current negotiated ciphersuite. The returned
+   *         view is valid for the lifetime of this object.
    **/
-  virtual std::string ciphersuiteString() const PURE;
+  virtual absl::string_view ciphersuiteString() const PURE;
 
   /**
    * @return uint16_t the OpenSSL id of the group that was used for the key agreement of the

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1926,7 +1926,8 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                  return std::make_unique<
                                      StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
                                      [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.ciphersuiteString();
+                                       return std::make_optional<std::string>(
+                                           connection_info.ciphersuiteString());
                                      });
                                }}},
                              {"UPSTREAM_TLS_GROUP",
@@ -2398,7 +2399,8 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                                  return std::make_unique<
                                      StreamInfoSslConnectionInfoFormatterProvider>(
                                      [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.ciphersuiteString();
+                                       return std::make_optional<std::string>(
+                                           connection_info.ciphersuiteString());
                                      });
                                }}},
                              {"DOWNSTREAM_TLS_GROUP",

--- a/source/common/quic/quic_ssl_connection_info.h
+++ b/source/common/quic/quic_ssl_connection_info.h
@@ -29,10 +29,10 @@ public:
     return crypto_stream->CiphersuiteId();
   }
 
-  std::string ciphersuiteString() const override {
+  absl::string_view ciphersuiteString() const override {
     auto* crypto_stream = session_.GetCryptoStream();
     ASSERT(crypto_stream != nullptr);
-    return std::string(crypto_stream->CiphersuiteString());
+    return crypto_stream->CiphersuiteString();
   }
 
   uint16_t tlsGroupId() const override {

--- a/source/common/tls/connection_info_impl_base.cc
+++ b/source/common/tls/connection_info_impl_base.cc
@@ -358,7 +358,7 @@ uint16_t ConnectionInfoImplBase::ciphersuiteId() const {
   return static_cast<uint16_t>(SSL_CIPHER_get_id(cipher));
 }
 
-std::string ConnectionInfoImplBase::ciphersuiteString() const {
+absl::string_view ConnectionInfoImplBase::ciphersuiteString() const {
   const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl());
   if (cipher == nullptr) {
     return {};

--- a/source/common/tls/connection_info_impl_base.h
+++ b/source/common/tls/connection_info_impl_base.h
@@ -55,7 +55,7 @@ public:
   std::optional<SystemTime> expirationPeerCertificate() const override;
   const std::string& sessionId() const override;
   uint16_t ciphersuiteId() const override;
-  std::string ciphersuiteString() const override;
+  absl::string_view ciphersuiteString() const override;
   uint16_t tlsGroupId() const override;
   absl::string_view tlsGroupString() const override;
   const std::string& tlsVersion() const override;

--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -304,15 +304,13 @@ uint64_t envoy_dynamic_module_callback_access_logger_get_upstream_connection_id(
 bool envoy_dynamic_module_callback_access_logger_get_upstream_tls_cipher(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result) {
-  // ciphersuiteString() returns std::string by value, so we use thread-local storage.
-  static thread_local std::string tls_cipher_str;
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
   const auto upstream = logger->stream_info_->upstreamInfo();
   if (!upstream.has_value() || !upstream->upstreamSslConnection()) {
     return false;
   }
 
-  tls_cipher_str = upstream->upstreamSslConnection()->ciphersuiteString();
+  const absl::string_view tls_cipher_str = upstream->upstreamSslConnection()->ciphersuiteString();
   if (tls_cipher_str.empty()) {
     return false;
   }
@@ -493,15 +491,13 @@ bool envoy_dynamic_module_callback_access_logger_get_upstream_local_dns_san(
 bool envoy_dynamic_module_callback_access_logger_get_downstream_tls_cipher(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result) {
-  // ciphersuiteString() returns std::string by value, so we use thread-local storage.
-  static thread_local std::string tls_cipher_str;
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
   const auto& provider = logger->stream_info_->downstreamAddressProvider();
   if (!provider.sslConnection()) {
     return false;
   }
 
-  tls_cipher_str = provider.sslConnection()->ciphersuiteString();
+  const absl::string_view tls_cipher_str = provider.sslConnection()->ciphersuiteString();
   if (tls_cipher_str.empty()) {
     return false;
   }

--- a/source/extensions/filters/common/lua/wrappers.cc
+++ b/source/extensions/filters/common/lua/wrappers.cc
@@ -391,7 +391,7 @@ int SslConnectionWrapper::luaCiphersuiteId(lua_State* state) {
 }
 
 int SslConnectionWrapper::luaCiphersuiteString(lua_State* state) {
-  const std::string& cipher_suite = connection_info_.ciphersuiteString();
+  const absl::string_view cipher_suite = connection_info_.ciphersuiteString();
   lua_pushlstring(state, cipher_suite.data(), cipher_suite.size());
   return 1;
 }

--- a/test/mocks/ssl/mocks.h
+++ b/test/mocks/ssl/mocks.h
@@ -77,7 +77,7 @@ public:
   MOCK_METHOD(std::optional<SystemTime>, expirationPeerCertificate, (), (const));
   MOCK_METHOD(const std::string&, sessionId, (), (const));
   MOCK_METHOD(uint16_t, ciphersuiteId, (), (const));
-  MOCK_METHOD(std::string, ciphersuiteString, (), (const));
+  MOCK_METHOD(absl::string_view, ciphersuiteString, (), (const));
   MOCK_METHOD(uint16_t, tlsGroupId, (), (const));
   MOCK_METHOD(absl::string_view, tlsGroupString, (), (const));
   MOCK_METHOD(const std::string&, tlsVersion, (), (const));


### PR DESCRIPTION
Commit Message: ssl: use string view rather then string for ciphersuite
Additional Description:

Updated the ciphersuiteString() to return a string view rather than a string. By this way, like all other `issuerPeerCertificate()` and so on, the caller needn't care the lifetime of the returned value, like the `tlsGroupString()`.



Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.