### PR TITLE
quic: support P-384 and P-521 ECDSA certificates in QUIC transport socket

### DIFF
--- a/source/common/quic/envoy_quic_utils.cc
+++ b/source/common/quic/envoy_quic_utils.cc
@@ -343,17 +343,29 @@ int deduceSignatureAlgorithmFromPublicKey(const EVP_PKEY* public_key, std::strin
   const int pkey_id = EVP_PKEY_id(public_key);
   switch (pkey_id) {
   case EVP_PKEY_EC: {
-    // We only support P-256 ECDSA today.
     const EC_KEY* ecdsa_public_key = EVP_PKEY_get0_EC_KEY(public_key);
     // Since we checked the key type above, this should be valid.
     ASSERT(ecdsa_public_key != nullptr);
     const EC_GROUP* ecdsa_group = EC_KEY_get0_group(ecdsa_public_key);
-    if (ecdsa_group == nullptr || EC_GROUP_get_curve_name(ecdsa_group) != NID_X9_62_prime256v1) {
-      *error_details = "Invalid leaf cert, only P-256 ECDSA certificates are supported";
+    if (ecdsa_group == nullptr) {
+      *error_details = "Invalid leaf cert, bad EC key";
       break;
     }
-    // QUICHE uses SHA-256 as hash function in cert signature.
-    sign_alg = SSL_SIGN_ECDSA_SECP256R1_SHA256;
+    const int curve_nid = EC_GROUP_get_curve_name(ecdsa_group);
+    switch (curve_nid) {
+    case NID_X9_62_prime256v1:
+      sign_alg = SSL_SIGN_ECDSA_SECP256R1_SHA256;
+      break;
+    case NID_secp384r1:
+      sign_alg = SSL_SIGN_ECDSA_SECP384R1_SHA384;
+      break;
+    case NID_secp521r1:
+      sign_alg = SSL_SIGN_ECDSA_SECP521R1_SHA512;
+      break;
+    default:
+      *error_details = "Invalid leaf cert, only P-256, P-384, and P-521 ECDSA certificates are supported";
+      break;
+    }
   } break;
   case EVP_PKEY_RSA: {
     // We require RSA certificates with 2048-bit or larger keys.

--- a/source/common/quic/quic_server_transport_socket_factory.cc
+++ b/source/common/quic/quic_server_transport_socket_factory.cc
@@ -177,7 +177,7 @@ QuicServerTransportSocketFactory::getTlsCertificateAndKey(absl::string_view sni,
   auto ctx =
       std::dynamic_pointer_cast<Extensions::TransportSockets::Tls::ServerContextImpl>(ssl_ctx);
   auto [tls_context, ocsp_staple_action] =
-      ctx->findTlsContext(sni, Ssl::CurveNIDVector{NID_X9_62_prime256v1} /* TODO: ecdsa_capable */,
+      ctx->findTlsContext(sni, Ssl::CurveNIDVector{NID_X9_62_prime256v1, NID_secp384r1, NID_secp521r1} /* TODO: ecdsa_capable */,
                           false /* TODO: ocsp_capable */, cert_matched_sni);
 
   // Thread safety note: accessing the tls_context requires holding a shared_ptr to the ``ssl_ctx``.


### PR DESCRIPTION
Fix #46694

## Summary

QUIC listeners currently fail to serve ECDSA-384 (P-384) and ECDSA-521 (P-521) certificates. The QUIC certificate selection path had two hardcoded P-256-only assumptions:

1. **`quic_server_transport_socket_factory.cc`**: `getTlsCertificateAndKey` passed `Ssl::CurveNIDVector{NID_X9_62_prime256v1}` to `findTlsContext`, causing the certificate selector to reject any EC certificate whose curve wasn't P-256.

2. **`envoy_quic_utils.cc`**: `deduceSignatureAlgorithmFromPublicKey` rejected all ECDSA keys that weren't P-256 with "Invalid leaf cert, only P-256 ECDSA certificates are supported".

## Changes

- **`source/common/quic/quic_server_transport_socket_factory.cc`**: Extended the ECDSA curve vector to include `NID_secp384r1` (P-384) and `NID_secp521r1` (P-521), matching the same set used by the regular TLS path in `server_context_impl.cc`.

- **`source/common/quic/envoy_quic_utils.cc`**: Replaced the single P-256 check in `deduceSignatureAlgorithmFromPublicKey` with a `switch` statement that maps each curve to the correct signature algorithm:
  - P-256 → `SSL_SIGN_ECDSA_SECP256R1_SHA256`
  - P-384 → `SSL_SIGN_ECDSA_SECP384R1_SHA384`
  - P-521 → `SSL_SIGN_ECDSA_SECP521R1_SHA512`

## Testing

- Existing tests continue to pass (P-256 certificates remain the primary use case).
- Manual verification: QUIC handshake succeeds with ECDSA-384 certificates where it previously failed with "No certificate is configured in transport socket config" and "select_cert_error: proof_source".
