### PR TITLE
reverse_tunnel: deferred-delete handshake wrappers on host removal

### DIFF
--- a/changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-stale-handshake-wrappers.rst
+++ b/changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-stale-handshake-wrappers.rst
@@ -1,0 +1,6 @@
+Fixed a use-after-free where removing a reverse-tunnel remote host (for example after a
+cluster host-map update) immediately destroyed in-flight handshake ``RCConnectionWrapper``
+objects. Wrappers are now shut down (clearing the handshake read-filter back-pointer and HTTP/1
+codec) and deferred-deleted on the worker dispatcher, matching the normal connection-done path,
+so a late handshake read cannot call into ``Http1::ConnectionImpl::dispatch()`` on a freed
+object.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -339,9 +339,7 @@ void RCConnectionWrapper::shutdown() {
   }
   shutdown_called_ = true;
 
-  // Clear the read-filter back-pointer and drop the HTTP/1 codec before touching the connection so
-  // an in-flight or re-entered onData() cannot call into Http1::ConnectionImpl::dispatch() on a
-  // freed / null parser (SEGV @ 0x0).
+  // Stop handshake reads before tearing down the connection.
   read_filter_->clearParent();
   http1_parse_connection_ = nullptr;
   http1_client_codec_.reset();

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
@@ -339,6 +339,13 @@ void RCConnectionWrapper::shutdown() {
   }
   shutdown_called_ = true;
 
+  // Clear the read-filter back-pointer and drop the HTTP/1 codec before touching the connection so
+  // an in-flight or re-entered onData() cannot call into Http1::ConnectionImpl::dispatch() on a
+  // freed / null parser (SEGV @ 0x0).
+  read_filter_->clearParent();
+  http1_parse_connection_ = nullptr;
+  http1_client_codec_.reset();
+
   if (!connection_) {
     ENVOY_LOG(error, "RCConnectionWrapper: Connection already null, nothing to shutdown");
     return;

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.h
@@ -100,6 +100,12 @@ public:
    */
   explicit SimpleConnReadFilter(void* parent) : parent_(parent) {}
 
+  /**
+   * Clear the back-pointer to the owning wrapper. Called from RCConnectionWrapper::shutdown()
+   * so a late onData() after teardown cannot dispatch into a destroyed / half-destroyed codec.
+   */
+  void clearParent() { parent_ = nullptr; }
+
   // Network::ReadFilter overrides
   Network::FilterStatus onData(Buffer::Instance& buffer, bool end_stream) override;
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -515,12 +515,23 @@ void ReverseConnectionIOHandle::removeStaleHostAndCloseConnections(const std::st
       connection->close(Network::ConnectionCloseType::FlushWrite);
     }
 
+    // Detach the handshake read filter / codec before the wrapper leaves the tracking set so a
+    // late onData() cannot dispatch into a destroyed Http1 codec (the SEGV-at-0x0 path in
+    // Http1::ConnectionImpl::dispatch). Match onConnectionDone(): keep the wrapper alive via
+    // deferredDelete until after this dispatcher pass.
+    wrapper->shutdown();
+
     // Remove from wrapper-to-host map.
     conn_wrapper_to_host_map_.erase(wrapper);
-    // Remove the wrapper from connection_wrappers_ vector.
-    std::erase_if(connection_wrappers_, [wrapper](const std::unique_ptr<RCConnectionWrapper>& w) {
-      return w.get() == wrapper;
-    });
+
+    auto wrapper_vector_it = std::find_if(
+        connection_wrappers_.begin(), connection_wrappers_.end(),
+        [wrapper](const std::unique_ptr<RCConnectionWrapper>& w) { return w.get() == wrapper; });
+    if (wrapper_vector_it != connection_wrappers_.end()) {
+      auto wrapper_to_delete = std::move(*wrapper_vector_it);
+      connection_wrappers_.erase(wrapper_vector_it);
+      getThreadLocalDispatcher().deferredDelete(std::move(wrapper_to_delete));
+    }
   }
   // Clear connection keys from host info.
   auto host_it = host_to_conn_info_map_.find(host);

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -515,23 +515,8 @@ void ReverseConnectionIOHandle::removeStaleHostAndCloseConnections(const std::st
       connection->close(Network::ConnectionCloseType::FlushWrite);
     }
 
-    // Detach the handshake read filter / codec before the wrapper leaves the tracking set so a
-    // late onData() cannot dispatch into a destroyed Http1 codec (the SEGV-at-0x0 path in
-    // Http1::ConnectionImpl::dispatch). Match onConnectionDone(): keep the wrapper alive via
-    // deferredDelete until after this dispatcher pass.
     wrapper->shutdown();
-
-    // Remove from wrapper-to-host map.
-    conn_wrapper_to_host_map_.erase(wrapper);
-
-    auto wrapper_vector_it = std::find_if(
-        connection_wrappers_.begin(), connection_wrappers_.end(),
-        [wrapper](const std::unique_ptr<RCConnectionWrapper>& w) { return w.get() == wrapper; });
-    if (wrapper_vector_it != connection_wrappers_.end()) {
-      auto wrapper_to_delete = std::move(*wrapper_vector_it);
-      connection_wrappers_.erase(wrapper_vector_it);
-      getThreadLocalDispatcher().deferredDelete(std::move(wrapper_to_delete));
-    }
+    removeAndDeferredDeleteWrapper(wrapper);
   }
   // Clear connection keys from host info.
   auto host_it = host_to_conn_info_map_.find(host);
@@ -1293,14 +1278,15 @@ void ReverseConnectionIOHandle::onConnectionDone(
     }
   }
 
-  // Safely remove wrapper from tracking.
+  removeAndDeferredDeleteWrapper(wrapper);
+}
+
+void ReverseConnectionIOHandle::removeAndDeferredDeleteWrapper(RCConnectionWrapper* wrapper) {
   conn_wrapper_to_host_map_.erase(wrapper);
 
-  // Find and remove wrapper from vector safely.
   auto wrapper_vector_it = std::find_if(
       connection_wrappers_.begin(), connection_wrappers_.end(),
       [wrapper](const std::unique_ptr<RCConnectionWrapper>& w) { return w.get() == wrapper; });
-
   if (wrapper_vector_it != connection_wrappers_.end()) {
     auto wrapper_to_delete = std::move(*wrapper_vector_it);
     connection_wrappers_.erase(wrapper_vector_it);

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -473,6 +473,12 @@ private:
   void removeStaleHostAndCloseConnections(const std::string& host);
 
   /**
+   * Drop a wrapper from tracking and deferred-delete it on the worker dispatcher.
+   * @param wrapper the handshake wrapper to remove
+   */
+  void removeAndDeferredDeleteWrapper(RCConnectionWrapper* wrapper);
+
+  /**
    * Per-host connection tracking for better management.
    * Contains all information needed to track and manage connections to a specific host.
    */

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1873,8 +1873,6 @@ TEST_F(SimpleConnReadFilterTest, OnDataAfterClearParent) {
   filter->clearParent();
 
   Buffer::OwnedImpl buffer("HTTP/1.1 200 OK\r\n\r\n");
-  // After clearParent(), onData must no-op even though the wrapper object is still alive. This
-  // models shutdown() clearing the back-pointer before the wrapper is deferred-deleted.
   auto result = filter->onData(buffer, false);
   EXPECT_EQ(result, Network::FilterStatus::StopIteration);
 }

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -1866,6 +1866,19 @@ TEST_F(SimpleConnReadFilterTest, OnDataWithNullParent) {
   EXPECT_EQ(result, Network::FilterStatus::StopIteration);
 }
 
+TEST_F(SimpleConnReadFilterTest, OnDataAfterClearParent) {
+  auto wrapper = createMockWrapper();
+  auto filter = createFilter(wrapper.get());
+
+  filter->clearParent();
+
+  Buffer::OwnedImpl buffer("HTTP/1.1 200 OK\r\n\r\n");
+  // After clearParent(), onData must no-op even though the wrapper object is still alive. This
+  // models shutdown() clearing the back-pointer before the wrapper is deferred-deleted.
+  auto result = filter->onData(buffer, false);
+  EXPECT_EQ(result, Network::FilterStatus::StopIteration);
+}
+
 TEST_F(SimpleConnReadFilterTest, OnDataWithHttp200Response) {
   // Create wrapper and filter.
   auto wrapper = createMockWrapper();

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -1768,7 +1768,10 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
   EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.1"));
   EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.2"));
 
-  // Verify that connection wrappers for the removed host are removed.
+  // Verify that connection wrappers for the removed host are removed from tracking immediately.
+  // The wrapper itself is held on the deferred-delete list until clearDeferredDeleteList(),
+  // matching onConnectionDone(), so an in-flight handshake read cannot hit a freed
+  // RCConnectionWrapper.
   EXPECT_EQ(getConnectionWrappers().size(), 1);   // Only host 192.168.1.2's wrapper remains
   EXPECT_EQ(getConnWrapperToHostMap().size(), 1); // Only host 192.168.1.2's mapping remains
 
@@ -1776,6 +1779,9 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
   const auto& wrapper_to_host_map = getConnWrapperToHostMap();
   EXPECT_EQ(wrapper_to_host_map.size(), 1);
   EXPECT_EQ(wrapper_to_host_map.begin()->second, "192.168.1.2"); // Only 192.168.1.2 should remain
+
+  // Drain deferred deletes so the removed wrapper is destroyed without leaking into TearDown.
+  dispatcher_.clearDeferredDeleteList();
 }
 
 // Test read() method - should delegate to base class.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -1768,10 +1768,7 @@ TEST_F(ReverseConnectionIOHandleTest, RemoveStaleHostAndCloseConnections) {
   EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.1"));
   EXPECT_TRUE(getHostToConnInfoMap().contains("192.168.1.2"));
 
-  // Verify that connection wrappers for the removed host are removed from tracking immediately.
-  // The wrapper itself is held on the deferred-delete list until clearDeferredDeleteList(),
-  // matching onConnectionDone(), so an in-flight handshake read cannot hit a freed
-  // RCConnectionWrapper.
+  // Tracking drops immediately; the wrapper is deferred-deleted.
   EXPECT_EQ(getConnectionWrappers().size(), 1);   // Only host 192.168.1.2's wrapper remains
   EXPECT_EQ(getConnWrapperToHostMap().size(), 1); // Only host 192.168.1.2's mapping remains
 


### PR DESCRIPTION
Commit Message: reverse_tunnel: deferred-delete handshake wrappers on host removal
Additional Description:
When a reverse-tunnel remote host is removed (e.g. cluster host-map update), `removeStaleHostAndCloseConnections` previously closed and immediately destroyed in-flight handshake `RCConnectionWrapper` objects. A late `SimpleConnReadFilter::onData` could then call into `Http1::ConnectionImpl::dispatch` on a freed wrapper/codec (SEGV at faulting address 0x0).

This change matches the normal `onConnectionDone` path: shut down the wrapper first (clear the handshake read-filter back-pointer and drop the HTTP/1 codec) and deferred-delete it on the worker dispatcher.

AI assistance: used Cursor; I reviewed and understand the change.
Risk Level: Low
Testing: Extended `RemoveStaleHostAndCloseConnections` and added `SimpleConnReadFilterTest.OnDataAfterClearParent`; please rely on CI for full format/tests.
Docs Changes: N/A
Release Notes: changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-stale-handshake-wrappers.rst