### PR TITLE
Fix UB in stream info

### DIFF
--- a/source/common/stream_info/stream_info_impl.h
+++ b/source/common/stream_info/stream_info_impl.h
@@ -353,7 +353,13 @@ struct StreamInfoImpl : public StreamInfo {
   }
 
   const FilterStateSharedPtr& filterState() override { return filter_state_; }
-  const FilterState& filterState() const override { return *filter_state_; }
+  const FilterState& filterState() const override {
+    if (filter_state_ == nullptr) {
+      static const FilterStateImpl empty_filter_state(FilterState::LifeSpan::Request);
+      return empty_filter_state;
+    }
+    return *filter_state_;
+  }
 
   void setRequestHeaders(const Http::RequestHeaderMap& headers) override {
     request_headers_ = &headers;


### PR DESCRIPTION
This is an obviously broken code, which safe to fix upstream. It blocks internal toochain rollout which detects UBs at build time.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
