### PR TITLE
Avoid deadlock in `handleHeaderContinue`

### DIFF
--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -248,7 +248,7 @@ absl::Status ProcessorState::handleHeaderContinue() {
   if (no_body_) {
     // Fall through if there was never a body in the first place.
     ENVOY_STREAM_LOG(debug, "The message had no body", *filterCallbacks());
-  } else if (complete_body_available_ && body_mode_ != ProcessingMode::NONE) {
+  } else if (checkCompleteBodyAvailable() && body_mode_ != ProcessingMode::NONE) {
     return handleCompleteBodyAvailable();
   } else if (body_mode_ == ProcessingMode::BUFFERED) {
     // Here, we're not ready to continue processing because then

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -119,6 +119,7 @@ public:
 
   bool completeBodyAvailable() const { return complete_body_available_; }
   void setCompleteBodyAvailable(bool d) { complete_body_available_ = d; }
+  virtual bool checkCompleteBodyAvailable() { return complete_body_available_; }
   bool hasNoBody() const { return no_body_; }
   void setHasNoBody(bool b) { no_body_ = b; }
   bool bodyReplaced() const { return body_replaced_; }
@@ -561,6 +562,17 @@ public:
     decoder_callbacks_ = &callbacks;
   }
 
+  bool checkCompleteBodyAvailable() override {
+    if (complete_body_available_) {
+      return true;
+    }
+    if (decoder_callbacks_ && decoder_callbacks_->requestTrailers().has_value()) {
+      trailers_ = &decoder_callbacks_->requestTrailers().value().get();
+      return true;
+    }
+    return false;
+  }
+
   const Buffer::Instance* bufferedData() const override {
     return decoder_callbacks_->decodingBuffer();
   }
@@ -709,6 +721,17 @@ public:
 
   void setEncoderFilterCallbacks(Http::StreamEncoderFilterCallbacks& callbacks) {
     encoder_callbacks_ = &callbacks;
+  }
+
+  bool checkCompleteBodyAvailable() override {
+    if (complete_body_available_) {
+      return true;
+    }
+    if (encoder_callbacks_ && encoder_callbacks_->responseTrailers().has_value()) {
+      trailers_ = &encoder_callbacks_->responseTrailers().value().get();
+      return true;
+    }
+    return false;
   }
 
   const Buffer::Instance* bufferedData() const override {


### PR DESCRIPTION
... when trailers are already buffered

Change-Id: Ib59de708667d4ff61dbae165e59d30309e975c53

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
