### PR TITLE
mcp_json_rest_bridge: Make tools/list description optional.

### DIFF
--- a/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
+++ b/api/envoy/extensions/filters/http/mcp_json_rest_bridge/v3/mcp_json_rest_bridge.proto
@@ -225,7 +225,7 @@ message ToolsListSpecificConfig {
   string title = 1;
 
   // Human-readable description of functionality.
-  string description = 2 [(validate.rules).string = {min_len: 1}];
+  string description = 2;
 
   // A JSON Schema describing expected parameters, as a serialized JSON string, in the JSON Schema
   // 2020-12 dialect. This should be raw JSON, including the "properties" and "required" keys, but

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -793,63 +793,61 @@ void McpJsonRestBridgeFilter::serveToolsListLocal(
     ASSERT(false, "serveToolsListLocal requires an RPC ID");
   }
 
-  size_t reserve_size = sizeof("{\"jsonrpc\":\"2.0\",\"id\":") - 1 + request_id_json.size() +
-                        sizeof(",\"result\":{\"tools\":[") - 1 + sizeof("]}}") - 1;
+  std::vector<std::unique_ptr<std::string>> owned_response_fragments;
+  std::vector<absl::string_view> response_fragments;
 
-  for (const auto* tool : tools) {
-    reserve_size += sizeof("{\"name\":") - 1 + nlohmann::json(tool->name()).dump().size();
-
-    if (!tool->tool_list_config().title().empty()) {
-      reserve_size += sizeof(",\"title\":") - 1 +
-                      nlohmann::json(tool->tool_list_config().title()).dump().size();
-    }
-
-    reserve_size += sizeof(",\"description\":") - 1 +
-                    nlohmann::json(tool->tool_list_config().description()).dump().size() +
-                    sizeof(",\"inputSchema\":") - 1;
-
-    if (!tool->tool_list_config().input_schema().empty()) {
-      reserve_size += tool->tool_list_config().input_schema().size();
-    } else {
-      reserve_size += sizeof("{\"type\":\"object\"}") - 1;
-    }
-    reserve_size += sizeof("}") - 1 + sizeof(",") - 1;
-  }
-
-  std::string response_data;
-  response_data.reserve(reserve_size);
-  absl::StrAppend(&response_data, "{\"jsonrpc\":\"2.0\",\"id\":", request_id_json,
-                  ",\"result\":{\"tools\":[");
+  response_fragments.emplace_back("{\"jsonrpc\":\"2.0\",\"id\":");
+  response_fragments.emplace_back(request_id_json),
+      response_fragments.emplace_back(",\"result\":{\"tools\":[");
 
   bool first_tool = true;
   for (const auto* tool : tools) {
     if (!first_tool) {
-      absl::StrAppend(&response_data, ",");
+      response_fragments.emplace_back(",");
     }
     first_tool = false;
 
-    absl::StrAppend(&response_data, "{\"name\":", nlohmann::json(tool->name()).dump());
+    response_fragments.emplace_back("{\"name\":");
+    // owned_response_fragments.push_back(nlohmann::json(tool->name()).dump());
+    // response_fragments.emplace_back(owned_response_fragments.back());
+    response_fragments.emplace_back(*owned_response_fragments.emplace_back(
+        std::make_unique<std::string>(nlohmann::json(tool->name()).dump())));
 
     if (!tool->tool_list_config().title().empty()) {
-      absl::StrAppend(&response_data,
-                      ",\"title\":", nlohmann::json(tool->tool_list_config().title()).dump());
+      response_fragments.emplace_back(",\"title\":");
+      response_fragments.emplace_back(*owned_response_fragments.emplace_back(
+          std::make_unique<std::string>(nlohmann::json(tool->tool_list_config().title()).dump())));
     }
 
-    absl::StrAppend(&response_data, ",\"description\":",
-                    nlohmann::json(tool->tool_list_config().description()).dump(),
-                    ",\"inputSchema\":");
+    if (!tool->tool_list_config().description().empty()) {
+      response_fragments.emplace_back(",\"description\":");
+      response_fragments.emplace_back(
+          *owned_response_fragments.emplace_back(std::make_unique<std::string>(
+              nlohmann::json(tool->tool_list_config().description()).dump())));
+    }
+    response_fragments.emplace_back(",\"inputSchema\":");
 
     // WARNING: assumes input_schema is trusted to be a valid JSON fragment. Does not validate.
     if (!tool->tool_list_config().input_schema().empty()) {
-      absl::StrAppend(&response_data, tool->tool_list_config().input_schema());
+      response_fragments.emplace_back(tool->tool_list_config().input_schema());
     } else {
-      absl::StrAppend(&response_data, "{\"type\":\"object\"}");
+      response_fragments.emplace_back("{\"type\":\"object\"}");
     }
 
-    absl::StrAppend(&response_data, "}");
+    response_fragments.emplace_back("}");
   }
 
-  absl::StrAppend(&response_data, "]}}");
+  response_fragments.emplace_back("]}}");
+
+  std::string response_data;
+  size_t reserve_size = 0;
+  for (const auto& fragment : response_fragments) {
+    reserve_size += fragment.size();
+  }
+  response_data.reserve(reserve_size);
+  for (const auto& fragment : response_fragments) {
+    absl::StrAppend(&response_data, fragment);
+  }
 
   decoder_callbacks_->sendLocalReply(
       Http::Code::OK, response_data,

--- a/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter.cc
@@ -808,8 +808,6 @@ void McpJsonRestBridgeFilter::serveToolsListLocal(
     first_tool = false;
 
     response_fragments.emplace_back("{\"name\":");
-    // owned_response_fragments.push_back(nlohmann::json(tool->name()).dump());
-    // response_fragments.emplace_back(owned_response_fragments.back());
     response_fragments.emplace_back(*owned_response_fragments.emplace_back(
         std::make_unique<std::string>(nlohmann::json(tool->name()).dump())));
 

--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -3060,6 +3060,67 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolsListLocalPerRouteConfig) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data, true));
 }
 
+TEST_F(McpJsonRestBridgeFilterTest, ToolsListLocalNoDescription) {
+  proto_config_.Clear();
+  auto* tool_config = proto_config_.mutable_tool_config();
+  tool_config->mutable_tool_list_local();
+
+  auto* tool1 = tool_config->add_tools();
+  tool1->set_name("tool_1");
+  tool1->mutable_tool_list_config()->set_title("Tool with no description");
+  tool1->mutable_tool_list_config()->set_input_schema(R"({"type":"object"})");
+
+  auto* tool2 = tool_config->add_tools();
+  tool2->set_name("tool_2");
+  tool2->mutable_tool_list_config()->set_title("Tool with a description");
+  tool2->mutable_tool_list_config()->set_description("Description.");
+  tool2->mutable_tool_list_config()->set_input_schema(R"({"type":"object"})");
+
+  makeFilter();
+  EXPECT_CALL(decoder_callbacks_, requestHeaders())
+      .WillRepeatedly(testing::Return(Http::RequestHeaderMapOptRef(request_headers_)));
+
+  request_headers_.setMethod("POST");
+  request_headers_.setPath("/mcp");
+  request_headers_.setContentType("application/json");
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers_, false));
+
+  std::string json = R"({"jsonrpc": "2.0", "method": "tools/list", "id": "req-2"})";
+  Buffer::OwnedImpl data(json);
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Eq(Http::Code::OK), _, _, Eq(Grpc::Status::WellKnownGrpcStatus::Ok),
+                             StrEq("mcp_json_rest_bridge_tools_list")))
+      .WillOnce(
+          testing::Invoke([](Http::Code, absl::string_view body,
+                             std::function<void(Http::ResponseHeaderMap&)> modify_headers,
+                             const std::optional<Grpc::Status::GrpcStatus>, absl::string_view) {
+            auto parsed_response = nlohmann::json::parse(body);
+
+            EXPECT_EQ(parsed_response["jsonrpc"], "2.0");
+            EXPECT_EQ(parsed_response["id"], "req-2");
+            auto tools = parsed_response["result"]["tools"];
+            EXPECT_EQ(tools.size(), 2);
+            EXPECT_EQ(tools[0]["name"], "tool_1");
+            EXPECT_EQ(tools[0]["title"], "Tool with no description");
+            EXPECT_FALSE(tools[0].contains("description"));
+            EXPECT_EQ(tools[0]["inputSchema"]["type"], "object");
+
+            EXPECT_EQ(tools[1]["name"], "tool_2");
+            EXPECT_EQ(tools[1]["title"], "Tool with a description");
+            EXPECT_EQ(tools[1]["description"], "Description.");
+            EXPECT_EQ(tools[1]["inputSchema"]["type"], "object");
+
+            Http::TestResponseHeaderMapImpl headers;
+            modify_headers(headers);
+            EXPECT_EQ("application/json", headers.getContentTypeValue());
+          }));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(data, true));
+}
+
 TEST_F(McpJsonRestBridgeFilterTest, DefaultClearRouteCacheIsTrue) {
   makeFilter();
   EXPECT_TRUE(config_->clearRouteCache());


### PR DESCRIPTION
Commit Message: mcp_json_rest_bridge: Make tools/list description optional.
Additional Description:
Remove the validation requirement for ToolsListSpecificConfig to be present.
Also refactor serveToolsListLocal() to use the same data for calculating the length to reserve and for constructing the output.
Risk Level: Low
Testing: Unit and integraition tests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
[API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md): xDS-gated config. Accepts some config that would previously be rejected; no affect on previously-working config.
 