### PR TITLE
formatter: remove unnecessary intermediate abstraction of stream info formatter

### DIFF
--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -142,12 +142,13 @@ MetadataFormatter::formatMetadataValue(const envoy::config::core::v3::Metadata& 
 }
 
 std::optional<std::string>
-MetadataFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
+MetadataFormatter::format(const Context&, const StreamInfo::StreamInfo& stream_info) const {
   auto metadata = get_func_(stream_info);
   return (metadata != nullptr) ? formatMetadata(*metadata) : std::nullopt;
 }
 
-Protobuf::Value MetadataFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
+Protobuf::Value MetadataFormatter::formatValue(const Context&,
+                                               const StreamInfo::StreamInfo& stream_info) const {
   auto metadata = get_func_(stream_info);
   return formatMetadataValue((metadata != nullptr) ? *metadata
                                                    : envoy::config::core::v3::Metadata());
@@ -273,7 +274,7 @@ struct StringFieldVisitor {
 };
 
 std::optional<std::string>
-FilterStateFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
+FilterStateFormatter::format(const Context&, const StreamInfo::StreamInfo& stream_info) const {
   const Envoy::StreamInfo::FilterState::Object* state = filterState(stream_info);
   if (!state) {
     return std::nullopt;
@@ -324,7 +325,8 @@ FilterStateFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
   }
 }
 
-Protobuf::Value FilterStateFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
+Protobuf::Value FilterStateFormatter::formatValue(const Context&,
+                                                  const StreamInfo::StreamInfo& stream_info) const {
   const Envoy::StreamInfo::FilterState::Object* state = filterState(stream_info);
   if (!state) {
     return SubstitutionFormatUtils::unspecifiedValue();
@@ -578,14 +580,15 @@ CommonDurationFormatter::getDurationCount(const StreamInfo::StreamInfo& info) co
 }
 
 std::optional<std::string>
-CommonDurationFormatter::format(const StreamInfo::StreamInfo& info) const {
+CommonDurationFormatter::format(const Context&, const StreamInfo::StreamInfo& info) const {
   auto duration = getDurationCount(info);
   if (!duration.has_value()) {
     return std::nullopt;
   }
   return fmt::format_int(duration.value()).str();
 }
-Protobuf::Value CommonDurationFormatter::formatValue(const StreamInfo::StreamInfo& info) const {
+Protobuf::Value CommonDurationFormatter::formatValue(const Context&,
+                                                     const StreamInfo::StreamInfo& info) const {
   auto duration = getDurationCount(info);
   if (!duration.has_value()) {
     return SubstitutionFormatUtils::unspecifiedValue();
@@ -666,7 +669,7 @@ SystemTimeFormatter::SystemTimeFormatter(absl::string_view format, TimeFieldExtr
 }
 
 std::optional<std::string>
-SystemTimeFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
+SystemTimeFormatter::format(const Context&, const StreamInfo::StreamInfo& stream_info) const {
   const auto time_field = (*time_field_extractor_)(stream_info);
   if (!time_field.has_value()) {
     return std::nullopt;
@@ -677,7 +680,7 @@ SystemTimeFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
   return date_formatter_.fromTime(time_field.value());
 }
 
-bool SystemTimeFormatter::formatTo(std::string& sink,
+bool SystemTimeFormatter::formatTo(std::string& sink, const Context&,
                                    const StreamInfo::StreamInfo& stream_info) const {
   const auto time_field = (*time_field_extractor_)(stream_info);
   if (!time_field.has_value()) {
@@ -691,11 +694,12 @@ bool SystemTimeFormatter::formatTo(std::string& sink,
   return true;
 }
 
-Protobuf::Value SystemTimeFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
-  return ValueUtil::optionalStringValue(format(stream_info));
+Protobuf::Value SystemTimeFormatter::formatValue(const Context& context,
+                                                 const StreamInfo::StreamInfo& stream_info) const {
+  return ValueUtil::optionalStringValue(format(context, stream_info));
 }
 
-void SystemTimeFormatter::formatValueTo(ValueSink& sink,
+void SystemTimeFormatter::formatValueTo(ValueSink& sink, const Context&,
                                         const StreamInfo::StreamInfo& stream_info) const {
   const auto time_field = (*time_field_extractor_)(stream_info);
   if (!time_field.has_value()) {
@@ -723,10 +727,12 @@ EnvironmentFormatter::EnvironmentFormatter(absl::string_view key,
   str_.set_string_value(DefaultUnspecifiedValueString);
 }
 
-std::optional<std::string> EnvironmentFormatter::format(const StreamInfo::StreamInfo&) const {
+std::optional<std::string> EnvironmentFormatter::format(const Context&,
+                                                        const StreamInfo::StreamInfo&) const {
   return str_.string_value();
 }
-Protobuf::Value EnvironmentFormatter::formatValue(const StreamInfo::StreamInfo&) const {
+Protobuf::Value EnvironmentFormatter::formatValue(const Context&,
+                                                  const StreamInfo::StreamInfo&) const {
   return str_;
 }
 
@@ -773,7 +779,8 @@ RequestedServerNameFormatter::create(absl::string_view source, absl::string_view
 }
 
 std::optional<std::string>
-RequestedServerNameFormatter::format(const StreamInfo::StreamInfo& stream_info) const {
+RequestedServerNameFormatter::format(const Context&,
+                                     const StreamInfo::StreamInfo& stream_info) const {
   std::optional<std::string> result;
   switch (source_) {
   case SNI:
@@ -837,8 +844,9 @@ RequestedServerNameFormatter::getHostFromHeaders(const StreamInfo::StreamInfo& s
 }
 
 Protobuf::Value
-RequestedServerNameFormatter::formatValue(const StreamInfo::StreamInfo& stream_info) const {
-  return ValueUtil::optionalStringValue(format(stream_info));
+RequestedServerNameFormatter::formatValue(const Context& context,
+                                          const StreamInfo::StreamInfo& stream_info) const {
+  return ValueUtil::optionalStringValue(format(context, stream_info));
 }
 
 // StreamInfo std::string formatter provider.
@@ -849,15 +857,12 @@ public:
   StreamInfoStringFormatterProvider(FieldExtractor f) : field_extractor_(f) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatTo;
-  using StreamInfoFormatterProvider::formatValue;
-  using StreamInfoFormatterProvider::formatValueTo;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     return field_extractor_(stream_info);
   }
-  bool formatTo(std::string& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  bool formatTo(std::string& sink, const Context&,
+                const StreamInfo::StreamInfo& stream_info) const override {
     const auto value = field_extractor_(stream_info);
     if (!value.has_value()) {
       return false;
@@ -865,10 +870,12 @@ public:
     sink.append(*value);
     return true;
   }
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     return ValueUtil::optionalStringValue(field_extractor_(stream_info));
   }
-  void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  void formatValueTo(ValueSink& sink, const Context&,
+                     const StreamInfo::StreamInfo& stream_info) const override {
     const auto value = field_extractor_(stream_info);
     if (!value.has_value()) {
       // Keep the sink unmodified if no value is extracted and the caller can decide how to
@@ -893,19 +900,16 @@ public:
   StreamInfoStringViewFormatterProvider(FieldExtractor f) : field_extractor_(std::move(f)) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatTo;
-  using StreamInfoFormatterProvider::formatValue;
-  using StreamInfoFormatterProvider::formatValueTo;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     const auto value = field_extractor_(stream_info);
     if (!value.has_value()) {
       return std::nullopt;
     }
     return std::string(*value);
   }
-  bool formatTo(std::string& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  bool formatTo(std::string& sink, const Context&,
+                const StreamInfo::StreamInfo& stream_info) const override {
     const auto value = field_extractor_(stream_info);
     if (!value.has_value()) {
       return false;
@@ -913,14 +917,16 @@ public:
     sink.append(*value);
     return true;
   }
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     const auto value = field_extractor_(stream_info);
     if (!value.has_value()) {
       return SubstitutionFormatUtils::unspecifiedValue();
     }
     return ValueUtil::stringValue(std::string(*value));
   }
-  void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  void formatValueTo(ValueSink& sink, const Context&,
+                     const StreamInfo::StreamInfo& stream_info) const override {
     const auto value = field_extractor_(stream_info);
     if (!value.has_value()) {
       // Keep the sink unmodified if no value is extracted and the caller can decide how to
@@ -943,12 +949,8 @@ public:
   StreamInfoDurationFormatterProvider(FieldExtractor f) : field_extractor_(f) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatTo;
-  using StreamInfoFormatterProvider::formatValue;
-  using StreamInfoFormatterProvider::formatValueTo;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     const auto millis = extractMillis(stream_info);
     if (!millis) {
       return std::nullopt;
@@ -956,7 +958,8 @@ public:
 
     return fmt::format_int(millis.value()).str();
   }
-  bool formatTo(std::string& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  bool formatTo(std::string& sink, const Context&,
+                const StreamInfo::StreamInfo& stream_info) const override {
     const auto millis = extractMillis(stream_info);
     if (!millis) {
       return false;
@@ -966,7 +969,8 @@ public:
     sink.append(formatted.data(), formatted.size());
     return true;
   }
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     const auto millis = extractMillis(stream_info);
     if (!millis) {
       return SubstitutionFormatUtils::unspecifiedValue();
@@ -974,7 +978,8 @@ public:
 
     return ValueUtil::numberValue(millis.value());
   }
-  void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  void formatValueTo(ValueSink& sink, const Context&,
+                     const StreamInfo::StreamInfo& stream_info) const override {
     const auto millis = extractMillis(stream_info);
     if (!millis) {
       // Keep the sink unmodified if no value is extracted and the caller can decide how to
@@ -1005,23 +1010,22 @@ public:
   StreamInfoUInt64FormatterProvider(FieldExtractor f) : field_extractor_(f) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatTo;
-  using StreamInfoFormatterProvider::formatValue;
-  using StreamInfoFormatterProvider::formatValueTo;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     return fmt::format_int(field_extractor_(stream_info)).str();
   }
-  bool formatTo(std::string& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  bool formatTo(std::string& sink, const Context&,
+                const StreamInfo::StreamInfo& stream_info) const override {
     const fmt::format_int formatted(field_extractor_(stream_info));
     sink.append(formatted.data(), formatted.size());
     return true;
   }
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     return ValueUtil::numberValue(field_extractor_(stream_info));
   }
-  void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  void formatValueTo(ValueSink& sink, const Context&,
+                     const StreamInfo::StreamInfo& stream_info) const override {
     // The extractor always yields a value, so the sink is always consumed.
     sink.addNumber(field_extractor_(stream_info));
   }
@@ -1063,12 +1067,8 @@ public:
       : field_extractor_(f), extraction_type_(extraction_type), mask_prefix_len_(mask_prefix_len) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatTo;
-  using StreamInfoFormatterProvider::formatValue;
-  using StreamInfoFormatterProvider::formatValueTo;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     Network::Address::InstanceConstSharedPtr address = field_extractor_(stream_info);
     if (!address) {
       return std::nullopt;
@@ -1076,7 +1076,8 @@ public:
 
     return toString(*address);
   }
-  bool formatTo(std::string& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  bool formatTo(std::string& sink, const Context&,
+                const StreamInfo::StreamInfo& stream_info) const override {
     Network::Address::InstanceConstSharedPtr address = field_extractor_(stream_info);
     if (!address) {
       return false;
@@ -1084,7 +1085,8 @@ public:
     toSink(sink, *address);
     return true;
   }
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     Network::Address::InstanceConstSharedPtr address = field_extractor_(stream_info);
     if (!address) {
       return SubstitutionFormatUtils::unspecifiedValue();
@@ -1100,7 +1102,8 @@ public:
 
     return ValueUtil::stringValue(toString(*address));
   }
-  void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo& stream_info) const override {
+  void formatValueTo(ValueSink& sink, const Context&,
+                     const StreamInfo::StreamInfo& stream_info) const override {
     Network::Address::InstanceConstSharedPtr address = field_extractor_(stream_info);
     if (!address) {
       // Keep the sink unmodified if no value is extracted and the caller can decide how to
@@ -1177,10 +1180,8 @@ public:
   StreamInfoSslConnectionInfoFormatterProvider(FieldExtractor f) : field_extractor_(f) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     if (stream_info.downstreamAddressProvider().sslConnection() == nullptr) {
       return std::nullopt;
     }
@@ -1193,7 +1194,8 @@ public:
     return value;
   }
 
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     if (stream_info.downstreamAddressProvider().sslConnection() == nullptr) {
       return SubstitutionFormatUtils::unspecifiedValue();
     }
@@ -1218,10 +1220,8 @@ public:
   StreamInfoUpstreamSslConnectionInfoFormatterProvider(FieldExtractor f) : field_extractor_(f) {}
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override {
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override {
     if (!stream_info.upstreamInfo() ||
         stream_info.upstreamInfo()->upstreamSslConnection() == nullptr) {
       return std::nullopt;
@@ -1235,7 +1235,8 @@ public:
     return value;
   }
 
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override {
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override {
     if (!stream_info.upstreamInfo() ||
         stream_info.upstreamInfo()->upstreamSslConnection() == nullptr) {
       return SubstitutionFormatUtils::unspecifiedValue();

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -24,81 +24,7 @@
 namespace Envoy {
 namespace Formatter {
 
-class StreamInfoFormatterProvider : public FormatterProvider {
-public:
-  // FormatterProvider
-  std::optional<std::string> format(const Context&,
-                                    const StreamInfo::StreamInfo& stream_info) const override {
-    return format(stream_info);
-  }
-  bool formatTo(std::string& sink, const Context&,
-                const StreamInfo::StreamInfo& stream_info) const override {
-    return formatTo(sink, stream_info);
-  }
-  Protobuf::Value formatValue(const Context&,
-                              const StreamInfo::StreamInfo& stream_info) const override {
-    return formatValue(stream_info);
-  }
-  void formatValueTo(ValueSink& sink, const Context&,
-                     const StreamInfo::StreamInfo& stream_info) const override {
-    formatValueTo(sink, stream_info);
-  }
-
-  /**
-   * Format the value with the given stream info.
-   * @param stream_info supplies the stream info.
-   * @return std::optional<std::string> optional string containing a single value extracted from
-   *         the given stream info.
-   */
-  virtual std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const PURE;
-
-  /**
-   * Append the extracted value to the given sink. This is the allocation-free counterpart of
-   * format() and should be overridden by providers that can write their value directly into the
-   * sink. The default implementation appends the result of format().
-   * @param sink supplies the string the value is appended to. It is left unmodified if no value
-   *        is extracted.
-   * @param stream_info supplies the stream info.
-   * @return bool true if a value was extracted and appended to the sink.
-   */
-  virtual bool formatTo(std::string& sink, const StreamInfo::StreamInfo& stream_info) const {
-    const std::optional<std::string> value = format(stream_info);
-    if (!value.has_value()) {
-      return false;
-    }
-    sink.append(*value);
-    return true;
-  }
-
-  /**
-   * Format the value with the given stream info.
-   * @param stream_info supplies the stream info.
-   * @return Protobuf::Value containing a single value extracted from the given stream info.
-   */
-  virtual Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const PURE;
-
-  /**
-   * Format the value with the given stream info and append it to the given sink. This is the
-   * allocation-free counterpart of formatValue() and should be overridden by providers that can
-   * write their value directly into the sink. The default implementation forwards the result of
-   * formatValue().
-   * @param sink supplies the sink to append the formatted value to. It is left unmodified if no
-   *        value is extracted.
-   * @param stream_info supplies the stream info.
-   */
-  virtual void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo& stream_info) const {
-    const Protobuf::Value value = formatValue(stream_info);
-    // See the comment of FormatterProvider::formatValueTo(): a null value means the provider
-    // couldn't extract a value and the sink is left unmodified so that the caller can decide
-    // whether to add a default value or not.
-    if (value.kind_case() == Protobuf::Value::kNullValue ||
-        value.kind_case() == Protobuf::Value::KIND_NOT_SET) {
-      return;
-    }
-    sink.addValue(value);
-  }
-};
-
+using StreamInfoFormatterProvider = FormatterProvider;
 using StreamInfoFormatterProviderPtr = std::unique_ptr<StreamInfoFormatterProvider>;
 using StreamInfoFormatterResult = absl::StatusOr<StreamInfoFormatterProviderPtr>;
 
@@ -120,11 +46,10 @@ public:
                     std::optional<size_t> max_length, GetMetadataFunction get);
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo& stream_info) const override;
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo& stream_info) const override;
+  std::optional<std::string> format(const Context&,
+                                    const StreamInfo::StreamInfo& stream_info) const override;
+  Protobuf::Value formatValue(const Context&,
+                              const StreamInfo::StreamInfo& stream_info) const override;
 
 protected:
   std::optional<std::string>
@@ -183,11 +108,8 @@ public:
                 bool is_upstream = false, absl::string_view field_name = {});
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
+  std::optional<std::string> format(const Context&, const StreamInfo::StreamInfo&) const override;
+  Protobuf::Value formatValue(const Context&, const StreamInfo::StreamInfo&) const override;
 
 private:
   FilterStateFormatter(absl::string_view key, std::optional<size_t> max_length,
@@ -214,11 +136,8 @@ public:
   create(absl::string_view sub_command);
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
+  std::optional<std::string> format(const Context&, const StreamInfo::StreamInfo&) const override;
+  Protobuf::Value formatValue(const Context&, const StreamInfo::StreamInfo&) const override;
 
   static const absl::flat_hash_map<absl::string_view, TimePointGetter> KnownTimePointGetters;
 
@@ -296,15 +215,10 @@ public:
   }
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatTo;
-  using StreamInfoFormatterProvider::formatValue;
-  using StreamInfoFormatterProvider::formatValueTo;
-  std::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
-  bool formatTo(std::string& sink, const StreamInfo::StreamInfo&) const override;
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
-  void formatValueTo(ValueSink& sink, const StreamInfo::StreamInfo&) const override;
+  std::optional<std::string> format(const Context&, const StreamInfo::StreamInfo&) const override;
+  bool formatTo(std::string& sink, const Context&, const StreamInfo::StreamInfo&) const override;
+  Protobuf::Value formatValue(const Context&, const StreamInfo::StreamInfo&) const override;
+  void formatValueTo(ValueSink& sink, const Context&, const StreamInfo::StreamInfo&) const override;
 
 protected:
   SystemTimeFormatter(absl::string_view format, TimeFieldExtractorPtr f, bool local_time = false);
@@ -398,11 +312,8 @@ public:
   EnvironmentFormatter(absl::string_view key, std::optional<size_t> max_length);
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
+  std::optional<std::string> format(const Context&, const StreamInfo::StreamInfo&) const override;
+  Protobuf::Value formatValue(const Context&, const StreamInfo::StreamInfo&) const override;
 
 private:
   Protobuf::Value str_;
@@ -428,11 +339,8 @@ public:
   create(absl::string_view source, absl::string_view option);
 
   // StreamInfoFormatterProvider
-  // Don't hide the other structure of format and formatValue.
-  using StreamInfoFormatterProvider::format;
-  using StreamInfoFormatterProvider::formatValue;
-  std::optional<std::string> format(const StreamInfo::StreamInfo&) const override;
-  Protobuf::Value formatValue(const StreamInfo::StreamInfo&) const override;
+  std::optional<std::string> format(const Context&, const StreamInfo::StreamInfo&) const override;
+  Protobuf::Value formatValue(const Context&, const StreamInfo::StreamInfo&) const override;
 
   std::optional<std::string> getHostFromHeaders(const StreamInfo::StreamInfo& stream_info) const;
   std::optional<std::string> getSNIFromStreamInfo(const StreamInfo::StreamInfo& stream_info) const;

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -4078,6 +4078,7 @@ void populateMetadataTestData(envoy::config::core::v3::Metadata& metadata) {
 }
 
 TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
+  Context formatter_context;
   envoy::config::core::v3::Metadata metadata;
   populateMetadataTestData(metadata);
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -4086,59 +4087,65 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
 
   {
     DynamicMetadataFormatter formatter("com.test", {}, std::optional<size_t>());
-    std::string val = formatter.format(stream_info).value();
+    std::string val = formatter.format(formatter_context, stream_info).value();
     EXPECT_THAT(val, HasSubstr(R"("test_key":"test_value")"));
     EXPECT_THAT(val, HasSubstr(R"("test_obj":{"inner_key":"inner_value"})"));
     EXPECT_THAT(val, HasSubstr(R"("test_list":["item0",4.2])"));
 
     Protobuf::Value expected_val;
     expected_val.mutable_struct_value()->CopyFrom(metadata.filter_metadata().at("com.test"));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(expected_val));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info), ProtoEq(expected_val));
   }
   {
     DynamicMetadataFormatter formatter("com.test", {"test_key"}, std::optional<size_t>());
-    EXPECT_EQ("test_value", formatter.format(stream_info));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_value")));
+    EXPECT_EQ("test_value", formatter.format(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("test_value")));
   }
   {
     DynamicMetadataFormatter formatter("com.test", {"test_obj"}, std::optional<size_t>());
-    EXPECT_EQ("{\"inner_key\":\"inner_value\"}", formatter.format(stream_info));
+    EXPECT_EQ("{\"inner_key\":\"inner_value\"}", formatter.format(formatter_context, stream_info));
 
     Protobuf::Value expected_val;
     (*expected_val.mutable_struct_value()->mutable_fields())["inner_key"] =
         ValueUtil::stringValue("inner_value");
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(expected_val));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info), ProtoEq(expected_val));
   }
   {
     DynamicMetadataFormatter formatter("com.test", {"test_obj", "inner_key"},
                                        std::optional<size_t>());
-    EXPECT_EQ("inner_value", formatter.format(stream_info));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::stringValue("inner_value")));
+    EXPECT_EQ("inner_value", formatter.format(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("inner_value")));
   }
 
   // not found cases
   {
     DynamicMetadataFormatter formatter("com.notfound", {}, std::optional<size_t>());
-    EXPECT_EQ(std::nullopt, formatter.format(stream_info));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter.format(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   {
     DynamicMetadataFormatter formatter("com.test", {"notfound"}, std::optional<size_t>());
-    EXPECT_EQ(std::nullopt, formatter.format(stream_info));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter.format(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   {
     DynamicMetadataFormatter formatter("com.test", {"test_obj", "notfound"},
                                        std::optional<size_t>());
-    EXPECT_EQ(std::nullopt, formatter.format(stream_info));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter.format(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
 
   // size limit
   {
     DynamicMetadataFormatter formatter("com.test", {"test_key"}, std::optional<size_t>(5));
-    EXPECT_EQ("test_", formatter.format(stream_info));
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_")));
+    EXPECT_EQ("test_", formatter.format(formatter_context, stream_info));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("test_")));
   }
 
   // size limit on struct
@@ -4148,7 +4155,7 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
     Protobuf::Value expected_val;
     (*expected_val.mutable_struct_value()->mutable_fields())["inner_key"] =
         ValueUtil::stringValue("inner_value");
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(expected_val));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info), ProtoEq(expected_val));
   }
 
   // size limit on list
@@ -4158,7 +4165,7 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
     Protobuf::Value expected_val;
     expected_val.mutable_list_value()->add_values()->set_string_value("item0");
     expected_val.mutable_list_value()->add_values()->set_number_value(4.2);
-    EXPECT_THAT(formatter.formatValue(stream_info), ProtoEq(expected_val));
+    EXPECT_THAT(formatter.formatValue(formatter_context, stream_info), ProtoEq(expected_val));
   }
 
   {
@@ -4169,7 +4176,7 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
     (*metadata.mutable_filter_metadata())["com.test"] = struct_obj;
 
     DynamicMetadataFormatter formatter("com.test", {"nan_val"}, std::optional<size_t>());
-    std::optional<std::string> value = formatter.format(stream_info);
+    std::optional<std::string> value = formatter.format(formatter_context, stream_info);
     EXPECT_EQ("null", value.value());
   }
 
@@ -4181,12 +4188,13 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
     (*metadata.mutable_filter_metadata())["com.test"] = struct_obj;
 
     DynamicMetadataFormatter formatter("com.test", {"inf_val"}, std::optional<size_t>());
-    std::optional<std::string> value = formatter.format(stream_info);
+    std::optional<std::string> value = formatter.format(formatter_context, stream_info);
     EXPECT_EQ("inf", value.value());
   }
 }
 
 TEST(SubstitutionFormatterTest, FilterStateFormatter) {
+  Context formatter_context;
   StreamInfo::MockStreamInfo stream_info;
 
   stream_info.filter_state_->setData("key",
@@ -4207,20 +4215,21 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
     auto formatter =
         FilterStateFormatter::createForTest("key", std::optional<size_t>(), false).value();
 
-    EXPECT_EQ("\"test_value\"", formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_value")));
+    EXPECT_EQ("\"test_value\"", formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("test_value")));
   }
   {
     auto formatter =
         FilterStateFormatter::createForTest("key-struct", std::optional<size_t>(), false).value();
 
-    EXPECT_EQ("{\"inner_key\":\"inner_value\"}", formatter->format(stream_info));
+    EXPECT_EQ("{\"inner_key\":\"inner_value\"}", formatter->format(formatter_context, stream_info));
 
     Protobuf::Value expected;
     (*expected.mutable_struct_value()->mutable_fields())["inner_key"] =
         ValueUtil::stringValue("inner_value");
 
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(expected));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info), ProtoEq(expected));
   }
 
   // not found case
@@ -4229,8 +4238,9 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
         FilterStateFormatter::createForTest("key-not-found", std::optional<size_t>(), false)
             .value();
 
-    EXPECT_EQ(std::nullopt, formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
 
   // no serialization case
@@ -4239,8 +4249,9 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
         FilterStateFormatter::createForTest("key-no-serialization", std::optional<size_t>(), false)
             .value();
 
-    EXPECT_EQ(std::nullopt, formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
 
   // serialization error case
@@ -4249,8 +4260,9 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
                                                          std::optional<size_t>(), false)
                          .value();
 
-    EXPECT_EQ(std::nullopt, formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
 
   // size limit
@@ -4258,10 +4270,11 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
     auto formatter =
         FilterStateFormatter::createForTest("key", std::optional<size_t>(5), false).value();
 
-    EXPECT_EQ("\"test", formatter->format(stream_info));
+    EXPECT_EQ("\"test", formatter->format(formatter_context, stream_info));
 
     // N.B. Does not truncate.
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_value")));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("test_value")));
   }
 
   // serializeAsString case
@@ -4269,7 +4282,7 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
     auto formatter =
         FilterStateFormatter::createForTest("test_key", std::optional<size_t>(), true).value();
 
-    EXPECT_EQ("test_value By PLAIN", formatter->format(stream_info));
+    EXPECT_EQ("test_value By PLAIN", formatter->format(formatter_context, stream_info));
   }
 
   // size limit for serializeAsString
@@ -4277,7 +4290,7 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
     auto formatter =
         FilterStateFormatter::createForTest("test_key", std::optional<size_t>(10), true).value();
 
-    EXPECT_EQ("test_value", formatter->format(stream_info));
+    EXPECT_EQ("test_value", formatter->format(formatter_context, stream_info));
   }
 
   // no serialization case for serializeAsString
@@ -4286,8 +4299,9 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
         FilterStateFormatter::createForTest("key-no-serialization", std::optional<size_t>(), true)
             .value();
 
-    EXPECT_EQ(std::nullopt, formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // FIELD test cases
   {
@@ -4295,44 +4309,50 @@ TEST(SubstitutionFormatterTest, FilterStateFormatter) {
                                                          false, "test_field")
                          .value();
 
-    EXPECT_EQ("test_value", formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_value")));
+    EXPECT_EQ("test_value", formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("test_value")));
   }
   {
     auto formatter = FilterStateFormatter::createForTest("test_key", std::optional<size_t>(), false,
                                                          false, "test_num")
                          .value();
 
-    EXPECT_EQ("137", formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::stringValue("137")));
+    EXPECT_EQ("137", formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("137")));
   }
   {
     auto formatter = FilterStateFormatter::createForTest("test_wrong_key", std::optional<size_t>(),
                                                          false, false, "test_field")
                          .value();
 
-    EXPECT_EQ(std::nullopt, formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   {
     auto formatter = FilterStateFormatter::createForTest("test_key", std::optional<size_t>(), false,
                                                          false, "test_wrong_field")
                          .value();
 
-    EXPECT_EQ(std::nullopt, formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   {
     auto formatter = FilterStateFormatter::createForTest("test_key", std::optional<size_t>(5),
                                                          false, false, "test_field")
                          .value();
 
-    EXPECT_EQ("test_", formatter->format(stream_info));
-    EXPECT_THAT(formatter->formatValue(stream_info), ProtoEq(ValueUtil::stringValue("test_")));
+    EXPECT_EQ("test_", formatter->format(formatter_context, stream_info));
+    EXPECT_THAT(formatter->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::stringValue("test_")));
   }
 }
 
 TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
+  Context formatter_context;
   // No downstreamSslConnection
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
@@ -4340,8 +4360,9 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     auto cert_start_formart = makeTimeFormatter<DownstreamPeerCertVStartFormatter>(
                                   "DOWNSTREAM_PEER_CERT_V_START(%Y/%m/%d)")
                                   .value();
-    EXPECT_EQ(std::nullopt, cert_start_formart->format(stream_info));
-    EXPECT_THAT(cert_start_formart->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_start_formart->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_start_formart->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // No validFromPeerCertificate
   {
@@ -4352,8 +4373,9 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(std::nullopt));
     stream_info.downstream_connection_info_provider_->setSslConnection(connection_info);
-    EXPECT_EQ(std::nullopt, cert_start_formart->format(stream_info));
-    EXPECT_THAT(cert_start_formart->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_start_formart->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_start_formart->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // Default format string
   {
@@ -4364,7 +4386,8 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.downstream_connection_info_provider_->setSslConnection(connection_info);
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time), cert_start_format->format(stream_info));
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              cert_start_format->format(formatter_context, stream_info));
   }
   // Custom format string
   {
@@ -4376,18 +4399,21 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVStartFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.downstream_connection_info_provider_->setSslConnection(connection_info);
-    EXPECT_EQ("Mar 28 23:35:58 2018 UTC", cert_start_format->format(stream_info));
+    EXPECT_EQ("Mar 28 23:35:58 2018 UTC",
+              cert_start_format->format(formatter_context, stream_info));
   }
 }
 
 TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
+  Context formatter_context;
   // No downstreamSslConnection
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
     stream_info.downstream_connection_info_provider_->setSslConnection(nullptr);
     auto cert_end_format = makeTimeFormatter<DownstreamPeerCertVEndFormatter>("%Y/%m/%d").value();
-    EXPECT_EQ(std::nullopt, cert_end_format->format(stream_info));
-    EXPECT_THAT(cert_end_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_end_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_end_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // No expirationPeerCertificate
   {
@@ -4396,8 +4422,9 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(std::nullopt));
     stream_info.downstream_connection_info_provider_->setSslConnection(connection_info);
-    EXPECT_EQ(std::nullopt, cert_end_format->format(stream_info));
-    EXPECT_THAT(cert_end_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_end_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_end_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // Default format string
   {
@@ -4408,7 +4435,8 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.downstream_connection_info_provider_->setSslConnection(connection_info);
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time), cert_end_format->format(stream_info));
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              cert_end_format->format(formatter_context, stream_info));
   }
   // Custom format string
   {
@@ -4420,18 +4448,20 @@ TEST(SubstitutionFormatterTest, DownstreamPeerCertVEndFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.downstream_connection_info_provider_->setSslConnection(connection_info);
-    EXPECT_EQ("Mar 28 23:35:58 2018 UTC", cert_end_format->format(stream_info));
+    EXPECT_EQ("Mar 28 23:35:58 2018 UTC", cert_end_format->format(formatter_context, stream_info));
   }
 }
 
 TEST(SubstitutionFormatterTest, UpstreamPeerCertVStartFormatter) {
+  Context formatter_context;
   // No upstream connection
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
     EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(Return(nullptr));
     auto cert_start_format = makeTimeFormatter<UpstreamPeerCertVStartFormatter>("%Y/%m/%d").value();
-    EXPECT_EQ(std::nullopt, cert_start_format->format(stream_info));
-    EXPECT_THAT(cert_start_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_start_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_start_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // No upstreamSslConnection
   {
@@ -4440,8 +4470,9 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVStartFormatter) {
     auto cert_start_format =
         makeTimeFormatter<DownstreamPeerCertVStartFormatter>("UPSTREAM_PEER_CERT_V_START(%Y/%m/%d)")
             .value();
-    EXPECT_EQ(std::nullopt, cert_start_format->format(stream_info));
-    EXPECT_THAT(cert_start_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_start_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_start_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // No validFromPeerCertificate
   {
@@ -4452,8 +4483,9 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVStartFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(std::nullopt));
     stream_info.upstreamInfo()->setUpstreamSslConnection(connection_info);
-    EXPECT_EQ(std::nullopt, cert_start_format->format(stream_info));
-    EXPECT_THAT(cert_start_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_start_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_start_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // Default format string
   {
@@ -4464,7 +4496,8 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVStartFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.upstreamInfo()->setUpstreamSslConnection(connection_info);
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time), cert_start_format->format(stream_info));
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              cert_start_format->format(formatter_context, stream_info));
   }
   // Custom format string
   {
@@ -4476,26 +4509,30 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVStartFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, validFromPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.upstreamInfo()->setUpstreamSslConnection(connection_info);
-    EXPECT_EQ("Mar 28 23:35:58 2018 UTC", cert_start_format->format(stream_info));
+    EXPECT_EQ("Mar 28 23:35:58 2018 UTC",
+              cert_start_format->format(formatter_context, stream_info));
   }
 }
 
 TEST(SubstitutionFormatterTest, UpstreamPeerCertVEndFormatter) {
+  Context formatter_context;
   // No upstream connection
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
     EXPECT_CALL(stream_info, upstreamInfo()).WillRepeatedly(Return(nullptr));
     auto cert_end_format = makeTimeFormatter<UpstreamPeerCertVEndFormatter>("%Y/%m/%d").value();
-    EXPECT_EQ(std::nullopt, cert_end_format->format(stream_info));
-    EXPECT_THAT(cert_end_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_end_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_end_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // No upstreamSslConnection
   {
     NiceMock<StreamInfo::MockStreamInfo> stream_info;
     stream_info.upstreamInfo()->setUpstreamSslConnection(nullptr);
     auto cert_end_format = makeTimeFormatter<UpstreamPeerCertVEndFormatter>("%Y/%m/%d").value();
-    EXPECT_EQ(std::nullopt, cert_end_format->format(stream_info));
-    EXPECT_THAT(cert_end_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_end_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_end_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // No expirationPeerCertificate
   {
@@ -4504,8 +4541,9 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVEndFormatter) {
     auto connection_info = std::make_shared<Ssl::MockConnectionInfo>();
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(std::nullopt));
     stream_info.upstreamInfo()->setUpstreamSslConnection(connection_info);
-    EXPECT_EQ(std::nullopt, cert_end_format->format(stream_info));
-    EXPECT_THAT(cert_end_format->formatValue(stream_info), ProtoEq(ValueUtil::nullValue()));
+    EXPECT_EQ(std::nullopt, cert_end_format->format(formatter_context, stream_info));
+    EXPECT_THAT(cert_end_format->formatValue(formatter_context, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
   }
   // Default format string
   {
@@ -4516,7 +4554,8 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVEndFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.upstreamInfo()->setUpstreamSslConnection(connection_info);
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time), cert_end_format->format(stream_info));
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              cert_end_format->format(formatter_context, stream_info));
   }
   // Custom format string
   {
@@ -4528,11 +4567,12 @@ TEST(SubstitutionFormatterTest, UpstreamPeerCertVEndFormatter) {
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(*connection_info, expirationPeerCertificate()).WillRepeatedly(Return(time));
     stream_info.upstreamInfo()->setUpstreamSslConnection(connection_info);
-    EXPECT_EQ("Mar 28 23:35:58 2018 UTC", cert_end_format->format(stream_info));
+    EXPECT_EQ("Mar 28 23:35:58 2018 UTC", cert_end_format->format(formatter_context, stream_info));
   }
 }
 
 TEST(SubstitutionFormatterTest, StartTimeFormatter) {
+  Context formatter_context;
   NiceMock<StreamInfo::MockStreamInfo> stream_info;
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"}, {":path", "/"}};
   Http::TestResponseHeaderMapImpl response_headers;
@@ -4544,8 +4584,8 @@ TEST(SubstitutionFormatterTest, StartTimeFormatter) {
     time_t test_epoch = 1522280158;
     SystemTime time = std::chrono::system_clock::from_time_t(test_epoch);
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
-    EXPECT_EQ("2018/03/28", start_time_format->format(stream_info));
-    EXPECT_THAT(start_time_format->formatValue(stream_info),
+    EXPECT_EQ("2018/03/28", start_time_format->format(formatter_context, stream_info));
+    EXPECT_THAT(start_time_format->formatValue(formatter_context, stream_info),
                 ProtoEq(ValueUtil::stringValue("2018/03/28")));
   }
 
@@ -4553,8 +4593,9 @@ TEST(SubstitutionFormatterTest, StartTimeFormatter) {
     auto start_time_format = makeTimeFormatter<StartTimeFormatter>("").value();
     SystemTime time;
     EXPECT_CALL(stream_info, startTime()).WillRepeatedly(Return(time));
-    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time), start_time_format->format(stream_info));
-    EXPECT_THAT(start_time_format->formatValue(stream_info),
+    EXPECT_EQ(AccessLogDateTimeFormatter::fromTime(time),
+              start_time_format->format(formatter_context, stream_info));
+    EXPECT_THAT(start_time_format->formatValue(formatter_context, stream_info),
                 ProtoEq(ValueUtil::stringValue(AccessLogDateTimeFormatter::fromTime(time))));
   }
 }


### PR DESCRIPTION
Commit Message: formatter: remove unnecessary intermediate abstraction of stream info formatter
Additional Description:

This PR removed the unnecessary intermediate abstraction of the stream info formatter. In the previous code tree, we will call the `format(context, stream_info)` (interface of `FormatterProvider`), and then call to `format(stream_info)` (interface of `StreamInfoFormatterProvider`).

Now the  `format(context, stream_info)` (interface of `FormatterProvider`) will be used directly.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.