### PR TITLE
postgres_proxy: fix partial initial message leaking to upstream

### DIFF
--- a/changelogs/current/bug_fixes/postgres__fix-partial-initial-message-forwarding.rst
+++ b/changelogs/current/bug_fixes/postgres__fix-partial-initial-message-forwarding.rst
@@ -1,0 +1,2 @@
+Fixed the postgres_proxy filter forwarding incomplete initial message bytes to upstream when the
+message arrives in multiple TCP segments, causing PostgreSQL to reject the connection.

--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -211,8 +211,9 @@ Decoder::Result DecoderImpl::onDataInit(Buffer::Instance& data, bool) {
 
   // In Init state the minimum size of the message sufficient for parsing is 4 bytes.
   if (data.length() < 4) {
-    // not enough data in the buffer.
-    return Decoder::Result::NeedMoreData;
+    // Not enough data in the buffer. Stop to avoid forwarding partial
+    // initial message to the next filter.
+    return Decoder::Result::Stopped;
   }
 
   // Validate the message before processing.
@@ -230,7 +231,9 @@ Decoder::Result DecoderImpl::onDataInit(Buffer::Instance& data, bool) {
   Message::ValidationResult validationResult = msgParser->validate(data, 4, message_len_ - 4);
 
   if (validationResult == Message::ValidationNeedMoreData) {
-    return Decoder::Result::NeedMoreData;
+    // Incomplete message. Stop to avoid forwarding partial initial message
+    // to the next filter.
+    return Decoder::Result::Stopped;
   }
 
   if (validationResult == Message::ValidationFailed) {

--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.h
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.h
@@ -65,9 +65,8 @@ public:
   enum class Result {
     ReadyForNext, // Decoder processed previous message and is ready for the next message.
     NeedMoreData, // Decoder needs more data to reconstruct the message.
-    Stopped // Received and processed message disrupts the current flow. Decoder stopped accepting
-            // data. This happens when decoder wants filter to perform some action, for example to
-            // call starttls transport socket to enable TLS.
+    Stopped       // Don't forward data to the next filter. Used when the filter must perform
+                  // an action (e.g., start TLS) or when accumulating a partial initial message.
   };
   virtual Result onData(Buffer::Instance& data, bool frontend) PURE;
   virtual PostgresSession& getSession() PURE;

--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
@@ -38,7 +38,6 @@ Network::FilterStatus PostgresFilter::onData(Buffer::Instance& data, bool) {
   frontend_buffer_.add(data);
   Network::FilterStatus result = doDecode(frontend_buffer_, true);
   if (result == Network::FilterStatus::StopIteration) {
-    ASSERT(frontend_buffer_.length() == 0);
     data.drain(data.length());
   }
   return result;

--- a/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
@@ -109,9 +109,9 @@ TEST_F(PostgresProxyDecoderTest, StartupMessage) {
   // Some other attribute
   data_.add("attribute"); // 9 bytes
   data_.add(buf_, 1);
-  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::NeedMoreData);
+  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::Stopped);
   data_.add("blah"); // 4 bytes
-  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::NeedMoreData);
+  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::Stopped);
   data_.add(buf_, 1);
   ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::ReadyForNext);
   ASSERT_THAT(data_.length(), 0);

--- a/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_filter_test.cc
@@ -363,6 +363,75 @@ TEST_F(PostgresFilterTest, QueryMessageMetadata) {
   ASSERT_THAT(filter_->getStats().statements_parsed_.value(), 1);
 }
 
+// Split Startup message must not leak partial bytes to the next filter.
+TEST_F(PostgresFilterTest, SplitStartupDoesNotLeak) {
+  Buffer::OwnedImpl startup;
+  createInitialPostgresRequest(startup);
+  const uint64_t total_len = startup.length();
+
+  // First segment: only the 4-byte length field.
+  data_.add(startup.linearize(4), 4);
+  ASSERT_THAT(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+
+  // Nothing leaked to the next filter.
+  ASSERT_THAT(data_.length(), 0);
+  ASSERT_THAT(filter_->getStats().messages_frontend_.value(), 0);
+
+  // Second segment: the rest of the Startup message.
+  data_.add(static_cast<char*>(startup.linearize(total_len)) + 4, total_len - 4);
+  ASSERT_THAT(Network::FilterStatus::Continue, filter_->onData(data_, false));
+
+  ASSERT_THAT(static_cast<DecoderImpl*>(filter_->getDecoder())->state(),
+              DecoderImpl::State::InSyncState);
+}
+
+// Split SSLRequest must not leak partial bytes to the next filter.
+TEST_F(PostgresFilterTest, SplitSSLRequestDoesNotLeak) {
+  // First segment: only the 4-byte length field.
+  data_.writeBEInt<uint32_t>(8);
+  ASSERT_THAT(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+
+  // Nothing leaked to the next filter.
+  ASSERT_THAT(data_.length(), 0);
+  ASSERT_THAT(filter_->getStats().messages_frontend_.value(), 0);
+
+  // Second segment: the SSL request code.
+  data_.writeBEInt<uint32_t>(80877103); // SSL code.
+  ASSERT_THAT(Network::FilterStatus::Continue, filter_->onData(data_, false));
+
+  ASSERT_THAT(filter_->getStats().messages_frontend_.value(), 1);
+}
+
+// Split Startup must not trigger upstream SSL negotiation until fully received.
+TEST_F(PostgresFilterTest, SplitStartupDelaysUpstreamSSLNegotiation) {
+  filter_->getConfig()->upstream_ssl_ =
+      envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::REQUIRE;
+  EXPECT_CALL(read_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
+
+  Buffer::OwnedImpl startup;
+  createInitialPostgresRequest(startup);
+  const uint64_t total_len = startup.length();
+
+  // First segment: only the 4-byte length field.
+  data_.add(startup.linearize(4), 4);
+
+  // No SSLRequest must be sent upstream yet.
+  EXPECT_CALL(read_callbacks_, injectReadDataToFilterChain(_, _)).Times(0);
+  ASSERT_THAT(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+  ASSERT_THAT(data_.length(), 0);
+  testing::Mock::VerifyAndClearExpectations(&read_callbacks_);
+
+  // Second segment: the rest of the Startup message.
+  EXPECT_CALL(read_callbacks_, connection()).WillRepeatedly(ReturnRef(connection_));
+  EXPECT_CALL(read_callbacks_, injectReadDataToFilterChain(_, _))
+      .WillOnce(Invoke([](Buffer::Instance& data, bool) {
+        ASSERT_EQ(8, data.length());
+        ASSERT_EQ(80877103, data.peekBEInt<uint32_t>(4)); // SSL code.
+      }));
+  data_.add(static_cast<char*>(startup.linearize(total_len)) + 4, total_len - 4);
+  ASSERT_THAT(Network::FilterStatus::StopIteration, filter_->onData(data_, false));
+}
+
 // Test verifies that filter reacts to RequestSSL message.
 // It should reply with "S" message and OnData should return
 // Decoder::Stopped.


### PR DESCRIPTION
**Commit Message:**  postgres_proxy: fix partial initial message leaking to upstream

**Additional Description:**

Before this PR the postgres_proxy filter forwarded partial bytes of the initial message (SSLRequest or Startup) to upstream when the message arrives split across multiple `onData()` calls. The upstream PostgreSQL server received an incomplete message fragment and logs an error.

This PR changes the decoder logic to return `Stopped` when processing incomplete initial message, which avoids forwarding the incomplete data to the next filter. The filter drains the connection buffer and waits for more data.


**Risk Level:** Low
**Testing:** Unit tests were added.
**Release Notes:** Fixed the postgres_proxy filter forwarding incomplete initial message bytes to upstream when the message arrives in multiple TCP segments, causing PostgreSQL to reject the connection.

Fixes #46774
