### PR TITLE
contrib: migrate the http filter to use the ExceptionFreeFactoryBase

### DIFF
--- a/contrib/checksum/filters/http/source/config.cc
+++ b/contrib/checksum/filters/http/source/config.cc
@@ -12,7 +12,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ChecksumFilter {
 
-Http::FilterFactoryCb ChecksumFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> ChecksumFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig& proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {
   ChecksumFilterConfigSharedPtr filter_config(

--- a/contrib/checksum/filters/http/source/config.h
+++ b/contrib/checksum/filters/http/source/config.h
@@ -14,13 +14,13 @@ namespace ChecksumFilter {
  * Config registration for the checksum filter.
  */
 class ChecksumFilterFactory
-    : public Common::FactoryBase<
+    : public Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig> {
 public:
-  ChecksumFilterFactory() : FactoryBase("envoy.filters.http.checksum") {}
+  ChecksumFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.checksum") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/contrib/dynamo/filters/http/source/config.cc
+++ b/contrib/dynamo/filters/http/source/config.cc
@@ -13,7 +13,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Dynamo {
 
-Http::FilterFactoryCb DynamoFilterConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> DynamoFilterConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::dynamo::v3::Dynamo&, const std::string& stats_prefix,
     Server::Configuration::FactoryContext& context) {
   auto stats = std::make_shared<DynamoStats>(context.scope(), stats_prefix);

--- a/contrib/dynamo/filters/http/source/config.h
+++ b/contrib/dynamo/filters/http/source/config.h
@@ -17,13 +17,13 @@ namespace Dynamo {
 /**
  * Config registration for http dynamodb filter.
  */
-class DynamoFilterConfig
-    : public Common::FactoryBase<envoy::extensions::filters::http::dynamo::v3::Dynamo> {
+class DynamoFilterConfig : public Common::ExceptionFreeFactoryBase<
+                               envoy::extensions::filters::http::dynamo::v3::Dynamo> {
 public:
-  DynamoFilterConfig() : FactoryBase("envoy.filters.http.dynamo") {}
+  DynamoFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.dynamo") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamo::v3::Dynamo& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/contrib/golang/filters/http/source/BUILD
+++ b/contrib/golang/filters/http/source/BUILD
@@ -63,7 +63,6 @@ envoy_cc_contrib_extension(
     deps = [
         ":golang_filter_lib",
         "//contrib/golang/common/dso:dso_lib",
-        "//envoy/common:exception_lib",
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
         "//envoy/server:lifecycle_notifier_interface",

--- a/contrib/golang/filters/http/source/BUILD
+++ b/contrib/golang/filters/http/source/BUILD
@@ -63,6 +63,7 @@ envoy_cc_contrib_extension(
     deps = [
         ":golang_filter_lib",
         "//contrib/golang/common/dso:dso_lib",
+        "//envoy/common:exception_lib",
         "//envoy/registry",
         "//envoy/server:filter_config_interface",
         "//envoy/server:lifecycle_notifier_interface",

--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "envoy/common/exception.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/common/fmt.h"
@@ -14,7 +15,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Golang {
 
-Http::FilterFactoryCb GolangFilterConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> GolangFilterConfig::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
 
@@ -27,13 +28,14 @@ Http::FilterFactoryCb GolangFilterConfig::createFilterFactoryFromProtoTyped(
   auto dso_lib = Dso::DsoManager<Dso::HttpFilterDsoImpl>::load(
       proto_config.library_id(), proto_config.library_path(), proto_config.plugin_name());
   if (dso_lib == nullptr) {
-    throw EnvoyException(fmt::format("golang_filter: load library failed: {} {}",
-                                     proto_config.library_id(), proto_config.library_path()));
+    return absl::InvalidArgumentError(fmt::format("golang_filter: load library failed: {} {}",
+                                                  proto_config.library_id(),
+                                                  proto_config.library_path()));
   }
 
   FilterConfigSharedPtr config = std::make_shared<FilterConfig>(
       proto_config, dso_lib, fmt::format("{}golang.", stats_prefix), context);
-  config->newGoPluginConfig();
+  RETURN_IF_NOT_OK(config->newGoPluginConfig());
   return [config, dso_lib](Http::FilterChainFactoryCallbacks& callbacks) {
     const std::string& worker_name = callbacks.dispatcher().name();
     auto pos = worker_name.find_first_of('_');

--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "envoy/common/exception.h"
 #include "envoy/registry/registry.h"
 
 #include "source/common/common/fmt.h"

--- a/contrib/golang/filters/http/source/config.h
+++ b/contrib/golang/filters/http/source/config.h
@@ -18,16 +18,16 @@ constexpr char CanonicalName[] = "envoy.filters.http.golang";
  * Config registration for the golang extensions  filter. @see
  * NamedHttpFilterConfigFactory.
  */
-class GolangFilterConfig : public Common::FactoryBase<
+class GolangFilterConfig : public Common::ExceptionFreeFactoryBase<
                                envoy::extensions::filters::http::golang::v3alpha::Config,
                                envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute> {
 public:
-  GolangFilterConfig() : FactoryBase(CanonicalName) {}
+  GolangFilterConfig() : ExceptionFreeFactoryBase(CanonicalName) {}
 
 private:
   Server::ServerLifecycleNotifier::HandlePtr handler_;
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
       const std::string& stats_prefix,
       Server::Configuration::FactoryContext& factory_context) override;

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1799,7 +1799,7 @@ FilterConfig::FilterConfig(
       metric_store_(std::make_shared<MetricStore>(context.scope().createScope(""))),
       secret_reader_(std::make_shared<SecretReader>(proto_config, context)) {};
 
-void FilterConfig::newGoPluginConfig() {
+absl::Status FilterConfig::newGoPluginConfig() {
   ENVOY_LOG(debug, "initializing golang filter config");
   std::string buf;
   auto res = plugin_config_.SerializeToString(&buf);
@@ -1818,11 +1818,12 @@ void FilterConfig::newGoPluginConfig() {
   config_id_ = dso_lib_->envoyGoFilterNewHttpPluginConfig(config_);
 
   if (config_id_ == 0) {
-    throw EnvoyException(
+    return absl::InvalidArgumentError(
         fmt::format("golang filter failed to parse plugin config: {} {}", so_id_, so_path_));
   }
 
   ENVOY_LOG(debug, "golang filter new plugin config, id: {}", config_id_);
+  return absl::OkStatus();
 }
 
 FilterConfig::~FilterConfig() {

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -88,7 +88,7 @@ public:
   GolangFilterStats& stats() { return stats_; }
   const SecretReader& getSecretReader() const { return *secret_reader_; }
 
-  void newGoPluginConfig();
+  absl::Status newGoPluginConfig();
   CAPIStatus defineMetric(uint32_t metric_type, absl::string_view name, uint32_t* metric_id);
   CAPIStatus incrementMetric(uint32_t metric_id, int64_t offset);
   CAPIStatus getMetric(uint32_t metric_id, uint64_t* value);

--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -46,6 +46,7 @@ envoy_cc_test(
         "//test/mocks/thread_local:thread_local_mocks",
         "//test/mocks/upstream:cluster_manager_mocks",
         "//test/test_common:logging_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -129,7 +129,7 @@ public:
     config_ = std::make_shared<FilterConfig>(
         proto_config, Dso::DsoManager<Dso::HttpFilterDsoImpl>::getDsoByPluginName(plugin_name), "",
         context_);
-    config_->newGoPluginConfig();
+    ASSERT_TRUE(config_->newGoPluginConfig().ok());
     // Setup per route config for Golang filter.
     per_route_config_ =
         std::make_shared<FilterConfigPerRoute>(per_route_proto_config, server_factory_context_);
@@ -228,7 +228,7 @@ TEST_F(GolangHttpFilterTest, BufferedDataAfterDestroyDuringContinue) {
   TestUtility::loadFromYaml(yaml, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> mock_context;
   auto config = std::make_shared<FilterConfig>(proto_config, dso_lib, "", mock_context);
-  config->newGoPluginConfig();
+  ASSERT_TRUE(config->newGoPluginConfig().ok());
 
   Network::Address::InstanceConstSharedPtr addr(
       (*Network::Address::PipeInstance::create("/test/test.sock")).release());
@@ -282,7 +282,7 @@ TEST_F(GolangHttpFilterTest, ContinueStatusFromInsideHeaderCgoCallbackPostsToDis
   TestUtility::loadFromYaml(yaml, proto_config);
   NiceMock<Server::Configuration::MockFactoryContext> mock_context;
   auto config = std::make_shared<FilterConfig>(proto_config, dso_lib, "", mock_context);
-  config->newGoPluginConfig();
+  ASSERT_TRUE(config->newGoPluginConfig().ok());
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> mock_callbacks;
   NiceMock<Http::MockStreamEncoderFilterCallbacks> mock_enc_callbacks;

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -87,8 +87,8 @@ public:
     Dso::DsoManager<Dso::HttpFilterDsoImpl>::cleanUpForTest();
   }
 
-  void setup(const std::string& lib_id, const std::string& lib_path,
-             const std::string& plugin_name) {
+  absl::Status setupWithStatus(const std::string& lib_id, const std::string& lib_path,
+                               const std::string& plugin_name) {
     const auto yaml_fmt = R"EOF(
     library_id: %s
     library_path: %s
@@ -108,8 +108,14 @@ public:
 
     envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute per_route_proto_config;
     setupDso(lib_id, lib_path, plugin_name);
-    setupConfig(proto_config, per_route_proto_config, plugin_name);
+    RETURN_IF_NOT_OK(setupConfig(proto_config, per_route_proto_config, plugin_name));
     setupFilter(plugin_name);
+    return absl::OkStatus();
+  }
+
+  void setup(const std::string& lib_id, const std::string& lib_path,
+             const std::string& plugin_name) {
+    ASSERT_TRUE(setupWithStatus(lib_id, lib_path, plugin_name).ok());
   }
 
   std::string genSoPath() {
@@ -121,7 +127,7 @@ public:
     Dso::DsoManager<Dso::HttpFilterDsoImpl>::load(id, path, plugin_name);
   }
 
-  void setupConfig(
+  absl::Status setupConfig(
       envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
       envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute& per_route_proto_config,
       std::string plugin_name) {
@@ -129,10 +135,11 @@ public:
     config_ = std::make_shared<FilterConfig>(
         proto_config, Dso::DsoManager<Dso::HttpFilterDsoImpl>::getDsoByPluginName(plugin_name), "",
         context_);
-    ASSERT_TRUE(config_->newGoPluginConfig().ok());
+    RETURN_IF_NOT_OK(config_->newGoPluginConfig());
     // Setup per route config for Golang filter.
     per_route_config_ =
         std::make_shared<FilterConfigPerRoute>(per_route_proto_config, server_factory_context_);
+    return absl::OkStatus();
   }
 
   void setupFilter(const std::string& plugin_name) {
@@ -195,8 +202,10 @@ TEST_F(GolangHttpFilterTest, SetHeaderAtWrongStage) {
 // invalid config for routeconfig filter
 TEST_F(GolangHttpFilterTest, InvalidConfigForRouteConfigFilter) {
   InSequence s;
-  EXPECT_THROW_WITH_REGEX(setup(ROUTECONFIG, genSoPath(), ROUTECONFIG), EnvoyException,
-                          "golang filter failed to parse plugin config");
+  auto status = setupWithStatus(ROUTECONFIG, genSoPath(), ROUTECONFIG);
+  EXPECT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()),
+              testing::HasSubstr("golang filter failed to parse plugin config"));
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/44320.

--- a/contrib/golang/filters/http/test/golang_filter_test.cc
+++ b/contrib/golang/filters/http/test/golang_filter_test.cc
@@ -19,6 +19,7 @@
 #include "test/test_common/environment.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_format.h"
@@ -36,6 +37,8 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Golang {
+
+using Envoy::StatusHelpers::HasStatus;
 
 class TestFilter : public Filter {
 public:
@@ -203,9 +206,8 @@ TEST_F(GolangHttpFilterTest, SetHeaderAtWrongStage) {
 TEST_F(GolangHttpFilterTest, InvalidConfigForRouteConfigFilter) {
   InSequence s;
   auto status = setupWithStatus(ROUTECONFIG, genSoPath(), ROUTECONFIG);
-  EXPECT_FALSE(status.ok());
-  EXPECT_THAT(std::string(status.message()),
-              testing::HasSubstr("golang filter failed to parse plugin config"));
+  EXPECT_THAT(status, HasStatus(absl::StatusCode::kInvalidArgument,
+                                testing::HasSubstr("golang filter failed to parse plugin config")));
 }
 
 // Regression test for https://github.com/envoyproxy/envoy/issues/44320.

--- a/contrib/istio/filters/http/alpn/source/config.cc
+++ b/contrib/istio/filters/http/alpn/source/config.cc
@@ -9,18 +9,11 @@ using istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig;
 namespace Envoy {
 namespace Http {
 namespace Alpn {
-absl::StatusOr<Http::FilterFactoryCb>
-AlpnConfigFactory::createFilterFactoryFromProto(const Protobuf::Message& config, const std::string&,
-                                                Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(dynamic_cast<const FilterConfig&>(config),
-                             context.serverFactoryContext().clusterManager());
+absl::StatusOr<Http::FilterFactoryCb> AlpnConfigFactory::createFilterFactoryFromProtoTyped(
+    const FilterConfig& proto_config, const std::string&,
+    Server::Configuration::FactoryContext& context) {
+  return createFilterFactory(proto_config, context.serverFactoryContext().clusterManager());
 }
-
-ProtobufTypes::MessagePtr AlpnConfigFactory::createEmptyConfigProto() {
-  return ProtobufTypes::MessagePtr{new FilterConfig};
-}
-
-std::string AlpnConfigFactory::name() const { return "istio.alpn"; }
 
 Http::FilterFactoryCb
 AlpnConfigFactory::createFilterFactory(const FilterConfig& proto_config,

--- a/contrib/istio/filters/http/alpn/source/config.h
+++ b/contrib/istio/filters/http/alpn/source/config.h
@@ -3,6 +3,7 @@
 #include "source/extensions/filters/http/common/factory_base.h"
 
 #include "contrib/envoy/extensions/filters/http/alpn/v3/alpn.pb.h"
+#include "contrib/envoy/extensions/filters/http/alpn/v3/alpn.pb.validate.h"
 
 namespace Envoy {
 namespace Http {
@@ -11,16 +12,16 @@ namespace Alpn {
 /**
  * Config registration for the alpn filter.
  */
-class AlpnConfigFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
+class AlpnConfigFactory : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+                              istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig> {
 public:
-  // Server::Configuration::NamedHttpFilterConfigFactory
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
-                               Server::Configuration::FactoryContext& context) override;
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
-  std::string name() const override;
+  AlpnConfigFactory() : ExceptionFreeFactoryBase("istio.alpn") {}
 
 private:
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+      const istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig& proto_config,
+      const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+
   Http::FilterFactoryCb createFilterFactory(
       const istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig& config_pb,
       Upstream::ClusterManager& cluster_manager);

--- a/contrib/istio/filters/http/istio_stats/source/BUILD
+++ b/contrib/istio/filters/http/istio_stats/source/BUILD
@@ -27,6 +27,7 @@ envoy_cc_contrib_extension(
         "//source/common/stream_info:utility_lib",
         "//source/extensions/filters/common/expr:context_lib",
         "//source/extensions/filters/common/expr:evaluator_lib",
+        "//source/extensions/filters/http/common:factory_base_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "//source/extensions/filters/http/grpc_stats:config",
         "@cel-cpp//eval/public:builtin_func_registrar",

--- a/contrib/istio/filters/http/istio_stats/source/istio_stats.cc
+++ b/contrib/istio/filters/http/istio_stats/source/istio_stats.cc
@@ -1271,13 +1271,13 @@ private:
 
 } // namespace
 
-absl::StatusOr<Http::FilterFactoryCb> IstioStatsFilterConfigFactory::createFilterFactoryFromProto(
-    const Protobuf::Message& proto_config, const std::string&,
+absl::StatusOr<Http::FilterFactoryCb>
+IstioStatsFilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const stats::PluginConfig& proto_config, const std::string&,
     Server::Configuration::FactoryContext& factory_context) {
   factory_context.serverFactoryContext().api().customStatNamespaces().registerStatNamespace(
       CustomStatNamespace);
-  ConfigSharedPtr config = std::make_shared<Config>(
-      dynamic_cast<const stats::PluginConfig&>(proto_config), factory_context);
+  ConfigSharedPtr config = std::make_shared<Config>(proto_config, factory_context);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) {
     auto filter = std::make_shared<IstioStatsFilter>(config);
     callbacks.addStreamFilter(filter);

--- a/contrib/istio/filters/http/istio_stats/source/istio_stats.h
+++ b/contrib/istio/filters/http/istio_stats/source/istio_stats.h
@@ -3,24 +3,24 @@
 #include "envoy/server/filter_config.h"
 #include "envoy/stream_info/filter_state.h"
 
+#include "source/extensions/filters/http/common/factory_base.h"
+
 #include "contrib/envoy/extensions/filters/http/istio_stats/v3/istio_stats.pb.h"
+#include "contrib/envoy/extensions/filters/http/istio_stats/v3/istio_stats.pb.validate.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace IstioStats {
 
-class IstioStatsFilterConfigFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
+class IstioStatsFilterConfigFactory : public Common::ExceptionFreeFactoryBase<stats::PluginConfig> {
 public:
-  std::string name() const override { return "envoy.filters.http.istio_stats"; }
+  IstioStatsFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.istio_stats") {}
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<stats::PluginConfig>();
-  }
-
+private:
   absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProto(const Protobuf::Message& proto_config, const std::string&,
-                               Server::Configuration::FactoryContext&) override;
+  createFilterFactoryFromProtoTyped(const stats::PluginConfig& proto_config, const std::string&,
+                                    Server::Configuration::FactoryContext&) override;
 };
 
 class IstioStatsNetworkFilterConfigFactory

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -479,11 +479,10 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
   return Http::FilterHeadersStatus::Continue;
 }
 
-absl::StatusOr<Http::FilterFactoryCb> FilterConfigFactory::createFilterFactoryFromProto(
-    const Protobuf::Message& config, const std::string&,
+absl::StatusOr<Http::FilterFactoryCb> FilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const io::istio::http::peer_metadata::Config& config, const std::string&,
     Server::Configuration::FactoryContext& factory_context) {
-  auto filter_config = std::make_shared<FilterConfig>(
-      dynamic_cast<const io::istio::http::peer_metadata::Config&>(config), factory_context);
+  auto filter_config = std::make_shared<FilterConfig>(config, factory_context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) {
     auto filter = std::make_shared<Filter>(filter_config);
     callbacks.addStreamFilter(filter);

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
@@ -164,17 +164,16 @@ private:
   Context ctx_;
 };
 
-class FilterConfigFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
+class FilterConfigFactory
+    : public Common::ExceptionFreeFactoryBase<io::istio::http::peer_metadata::Config> {
 public:
-  std::string name() const override { return "envoy.filters.http.peer_metadata"; }
+  FilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.peer_metadata") {}
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<io::istio::http::peer_metadata::Config>();
-  }
-
+private:
   absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProto(const Protobuf::Message& proto_config, const std::string&,
-                               Server::Configuration::FactoryContext&) override;
+  createFilterFactoryFromProtoTyped(const io::istio::http::peer_metadata::Config& proto_config,
+                                    const std::string&,
+                                    Server::Configuration::FactoryContext&) override;
 };
 
 } // namespace PeerMetadata

--- a/contrib/language/filters/http/source/config.cc
+++ b/contrib/language/filters/http/source/config.cc
@@ -1,6 +1,5 @@
 #include "contrib/language/filters/http/source/config.h"
 
-#include "envoy/common/exception.h"
 #include "envoy/registry/registry.h"
 
 #include "contrib/language/filters/http/source/language_filter.h"
@@ -18,14 +17,15 @@ struct LocaleHash {
   }
 };
 
-Http::FilterFactoryCb LanguageFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> LanguageFilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::language::v3alpha::Language& proto_config,
     const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
   const auto default_locale = icu::Locale(proto_config.default_language().data());
 
   if (default_locale.isBogus()) {
-    throw EnvoyException(fmt::format("Failed to create icu::Locale from default_language: {}",
-                                     proto_config.default_language().data()));
+    return absl::InvalidArgumentError(
+        fmt::format("Failed to create icu::Locale from default_language: {}",
+                    proto_config.default_language().data()));
   }
 
   absl::flat_hash_set<icu::Locale, LocaleHash> supported_languages({default_locale});
@@ -34,8 +34,8 @@ Http::FilterFactoryCb LanguageFilterFactory::createFilterFactoryFromProtoTyped(
     const auto locale = icu::Locale(supported_language.data());
 
     if (locale.isBogus()) {
-      throw EnvoyException(fmt::format("Failed to create icu::Locale from supported_languages: {}",
-                                       supported_language.data()));
+      return absl::InvalidArgumentError(fmt::format(
+          "Failed to create icu::Locale from supported_languages: {}", supported_language.data()));
     }
 
     supported_languages.insert(locale);
@@ -49,9 +49,10 @@ Http::FilterFactoryCb LanguageFilterFactory::createFilterFactoryFromProtoTyped(
           .build(errorCode));
 
   if (U_FAILURE(errorCode)) {
-    throw EnvoyException(fmt::format("Failed to initialize icu::LocaleMatcher::Builder: ICU error "
-                                     "code icu::LocaleMatcher::Builder build: {}",
-                                     static_cast<int>(errorCode)));
+    return absl::InvalidArgumentError(
+        fmt::format("Failed to initialize icu::LocaleMatcher::Builder: ICU error "
+                    "code icu::LocaleMatcher::Builder build: {}",
+                    static_cast<int>(errorCode)));
   }
 
   auto config = std::make_shared<LanguageFilterConfigImpl>(

--- a/contrib/language/filters/http/source/config.h
+++ b/contrib/language/filters/http/source/config.h
@@ -13,12 +13,12 @@ namespace Language {
 /**
  * Config registration for the language detection filter (i18n). @see NamedHttpFilterConfigFactory.
  */
-class LanguageFilterFactory
-    : public Common::FactoryBase<envoy::extensions::filters::http::language::v3alpha::Language> {
+class LanguageFilterFactory : public Common::ExceptionFreeFactoryBase<
+                                  envoy::extensions::filters::http::language::v3alpha::Language> {
 public:
-  LanguageFilterFactory() : FactoryBase("envoy.filters.http.language") {}
+  LanguageFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.language") {}
 
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::language::v3alpha::Language& proto_config,
       const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/contrib/language/filters/http/test/language_config_test.cc
+++ b/contrib/language/filters/http/test/language_config_test.cc
@@ -18,11 +18,12 @@ using ConfigSharedPtr = std::shared_ptr<LanguageFilterConfig>;
 
 class ConfigTest : public testing::Test {
 public:
-  void initializeFilter(const std::string& yaml) {
+  absl::Status initializeFilter(const std::string& yaml) {
     envoy::extensions::filters::http::language::v3alpha::Language proto_config;
     TestUtility::loadFromYaml(yaml, proto_config);
 
-    factory_.createFilterFactoryFromProtoTyped(proto_config, "stats", factory_context_);
+    return factory_.createFilterFactoryFromProtoTyped(proto_config, "stats", factory_context_)
+        .status();
   }
 
 private:
@@ -36,7 +37,7 @@ default_language: en
 supported_languages: [fr, en-uk]
 )EOF";
 
-  EXPECT_NO_THROW(initializeFilter(yaml));
+  EXPECT_TRUE(initializeFilter(yaml).ok());
 }
 
 } // namespace Language

--- a/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.cc
+++ b/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.cc
@@ -9,7 +9,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace PeakEwma {
 
-Http::FilterFactoryCb PeakEwmaFilterConfigFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+PeakEwmaFilterConfigFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig&, const std::string&,
     Server::Configuration::FactoryContext&) {
   return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.h
+++ b/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.h
@@ -11,13 +11,13 @@ namespace HttpFilters {
 namespace PeakEwma {
 
 class PeakEwmaFilterConfigFactory
-    : public Extensions::HttpFilters::Common::FactoryBase<
+    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
           envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig> {
 public:
-  PeakEwmaFilterConfigFactory() : FactoryBase("envoy.filters.http.peak_ewma") {}
+  PeakEwmaFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.peak_ewma") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig& proto_config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/contrib/sxg/filters/http/source/config.cc
+++ b/contrib/sxg/filters/http/source/config.cc
@@ -33,7 +33,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
 }
 } // namespace
 
-Http::FilterFactoryCb FilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> FilterFactory::createFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::sxg::v3alpha::SXG& proto_config,
     const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
   const auto& certificate = proto_config.certificate();
@@ -44,12 +44,12 @@ Http::FilterFactoryCb FilterFactory::createFilterFactoryFromProtoTyped(
   auto secret_provider_certificate =
       secretsProvider(certificate, server_context, context.initManager());
   if (secret_provider_certificate == nullptr) {
-    throw EnvoyException("invalid certificate secret configuration");
+    return absl::InvalidArgumentError("invalid certificate secret configuration");
   }
   auto secret_provider_private_key =
       secretsProvider(private_key, server_context, context.initManager());
   if (secret_provider_private_key == nullptr) {
-    throw EnvoyException("invalid private_key secret configuration");
+    return absl::InvalidArgumentError("invalid private_key secret configuration");
   }
 
   auto secret_reader = std::make_shared<SDSSecretReader>(

--- a/contrib/sxg/filters/http/source/config.h
+++ b/contrib/sxg/filters/http/source/config.h
@@ -12,13 +12,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace SXG {
 
-class FilterFactory : public Extensions::HttpFilters::Common::FactoryBase<
+class FilterFactory : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
                           envoy::extensions::filters::http::sxg::v3alpha::SXG> {
 public:
-  FilterFactory() : FactoryBase("envoy.filters.http.sxg") {}
+  FilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.sxg") {}
 
 private:
-  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::sxg::v3alpha::SXG& config,
       const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 };

--- a/contrib/sxg/filters/http/test/BUILD
+++ b/contrib/sxg/filters/http/test/BUILD
@@ -39,6 +39,7 @@ envoy_cc_test(
         "//test/mocks/secret:secret_mocks",
         "//test/mocks/server:server_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:status_utility_lib",
         "@envoy_api//contrib/envoy/extensions/filters/http/sxg/v3alpha:pkg_cc_proto",
     ],
 )

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -57,7 +57,7 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
 
 // This loads one of the secrets in credentials, and fails the other one.
 void expectInvalidSecretConfig(const std::string& failed_secret_name,
-                               const std::string& exception_message) {
+                               const std::string& error_message) {
   const std::string yaml = R"YAML(
 certificate:
   name: certificate
@@ -80,9 +80,9 @@ validity_url: "/.sxg/validity.msg"
       .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
-  EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProto(*proto_config, "stats", context).status().IgnoreError(),
-      EnvoyException, exception_message);
+  const auto cb_or_error = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
+  EXPECT_FALSE(cb_or_error.ok());
+  EXPECT_EQ(cb_or_error.status().message(), error_message);
 }
 
 } // namespace

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -7,6 +7,7 @@
 
 #include "test/mocks/secret/mocks.h"
 #include "test/mocks/server/factory_context.h"
+#include "test/test_common/status_utility.h"
 
 #include "contrib/envoy/extensions/filters/http/sxg/v3alpha/sxg.pb.h"
 #include "contrib/sxg/filters/http/source/config.h"
@@ -20,6 +21,8 @@ namespace SXG {
 
 using testing::NiceMock;
 using testing::Return;
+
+using Envoy::StatusHelpers::HasStatus;
 
 namespace {
 
@@ -81,8 +84,8 @@ validity_url: "/.sxg/validity.msg"
           envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
 
   const auto cb_or_error = factory.createFilterFactoryFromProto(*proto_config, "stats", context);
-  EXPECT_FALSE(cb_or_error.ok());
-  EXPECT_EQ(cb_or_error.status().message(), error_message);
+  EXPECT_THAT(cb_or_error.status(),
+              HasStatus(absl::StatusCode::kInvalidArgument, testing::HasSubstr(error_message)));
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: contrib: migrate the http filter to use the ExceptionFreeFactoryBase
Additional Description:

This PR not actually make these HTTP filter be exception free. It only migrate to use the status aware base class first. And then we can migrate these contrib extensions gradually.


Risk Level: low, contrib only.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.