### PR TITLE
Add MCP method groups and task ID extraction

### DIFF
--- a/changelogs/current/new_features/mcp__new_method_groups.rst
+++ b/changelogs/current/new_features/mcp__new_method_groups.rst
@@ -1,0 +1,1 @@
+Added support for ``server/discover``, ``subscriptions/listen``, and ``tasks/*`` method groups, and support for extracting ``params.taskId`` in MCP JSON parser.

--- a/changelogs/current/new_features/mcp__new_method_groups.rst
+++ b/changelogs/current/new_features/mcp__new_method_groups.rst
@@ -1,1 +1,2 @@
-Added support for ``server/discover``, ``subscriptions/listen``, and ``tasks/*`` method groups, and support for extracting ``params.taskId`` in MCP JSON parser.
+Added support for ``server/discover``, ``subscriptions/listen``, and ``tasks/*`` method groups, and support for extracting
+``params.taskId`` in MCP JSON parser.

--- a/source/extensions/filters/common/mcp/constants.h
+++ b/source/extensions/filters/common/mcp/constants.h
@@ -94,6 +94,17 @@ constexpr absl::string_view LOGGING_SET_LEVEL = "logging/setLevel";
 // Lifecycle
 constexpr absl::string_view INITIALIZE = "initialize";
 
+// Discovery
+constexpr absl::string_view SERVER_DISCOVER = "server/discover";
+
+// Subscriptions
+constexpr absl::string_view SUBSCRIPTIONS_LISTEN = "subscriptions/listen";
+
+// Tasks
+constexpr absl::string_view TASKS_GET = "tasks/get";
+constexpr absl::string_view TASKS_UPDATE = "tasks/update";
+constexpr absl::string_view TASKS_CANCEL = "tasks/cancel";
+
 // Sampling
 constexpr absl::string_view SAMPLING_CREATE_MESSAGE = "sampling/createMessage";
 
@@ -130,6 +141,9 @@ constexpr absl::string_view NOTIFICATION = "notification";
 constexpr absl::string_view LOGGING = "logging";
 constexpr absl::string_view SAMPLING = "sampling";
 constexpr absl::string_view COMPLETION = "completion";
+constexpr absl::string_view DISCOVERY = "discovery";
+constexpr absl::string_view SUBSCRIPTION = "subscription";
+constexpr absl::string_view TASK = "task";
 constexpr absl::string_view UNKNOWN = "unknown";
 } // namespace MethodGroups
 
@@ -137,6 +151,7 @@ constexpr absl::string_view UNKNOWN = "unknown";
 namespace Paths {
 constexpr absl::string_view PARAMS_NAME = "params.name";
 constexpr absl::string_view PARAMS_URI = "params.uri";
+constexpr absl::string_view PARAMS_TASK_ID = "params.taskId";
 constexpr absl::string_view PARAMS_LEVEL = "params.level";
 constexpr absl::string_view PARAMS_REF = "params.ref";
 constexpr absl::string_view PARAMS_PROTOCOL_VERSION = "params.protocolVersion";

--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -54,6 +54,20 @@ void McpParserConfig::initializeDefaults() {
                   {AttributeExtractionRule(std::string(Paths::PARAMS_PROTOCOL_VERSION)),
                    AttributeExtractionRule(std::string(Paths::PARAMS_CLIENT_INFO_NAME))});
 
+  // Discovery.
+  addMethodConfig(Methods::SERVER_DISCOVER, {});
+
+  // Subscriptions.
+  addMethodConfig(Methods::SUBSCRIPTIONS_LISTEN, {});
+
+  // Tasks.
+  addMethodConfig(Methods::TASKS_GET,
+                  {AttributeExtractionRule(std::string(Paths::PARAMS_TASK_ID))});
+  addMethodConfig(Methods::TASKS_UPDATE,
+                  {AttributeExtractionRule(std::string(Paths::PARAMS_TASK_ID))});
+  addMethodConfig(Methods::TASKS_CANCEL,
+                  {AttributeExtractionRule(std::string(Paths::PARAMS_TASK_ID))});
+
   // Notifications.
   addMethodConfig(Methods::NOTIFICATION_INITIALIZED, {});
   addMethodConfig(Methods::NOTIFICATION_CANCELLED,
@@ -149,6 +163,21 @@ std::string McpParserConfig::getBuiltInMethodGroup(const std::string& method) co
   // Lifecycle methods
   if (method == INITIALIZE || method == NOTIFICATION_INITIALIZED || method == PING) {
     return std::string(LIFECYCLE);
+  }
+
+  // Discovery methods
+  if (method == SERVER_DISCOVER) {
+    return std::string(DISCOVERY);
+  }
+
+  // Subscription methods
+  if (method == SUBSCRIPTIONS_LISTEN) {
+    return std::string(SUBSCRIPTION);
+  }
+
+  // Task methods
+  if (method == TASKS_GET || method == TASKS_UPDATE || method == TASKS_CANCEL) {
+    return std::string(TASK);
   }
 
   // Tool methods

--- a/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
@@ -168,6 +168,95 @@ TEST_F(McpJsonParserTest, ResourcesUnsubscribeExtraction) {
   EXPECT_EQ(value->string_value(), "file:///config/settings.json");
 }
 
+TEST_F(McpJsonParserTest, ServerDiscoverExtraction) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "method": "server/discover",
+    "id": 123
+  })";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_EQ(parser_->getMethod(), Methods::SERVER_DISCOVER);
+}
+
+TEST_F(McpJsonParserTest, SubscriptionsListenExtraction) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "method": "subscriptions/listen",
+    "id": 123
+  })";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_EQ(parser_->getMethod(), Methods::SUBSCRIPTIONS_LISTEN);
+}
+
+TEST_F(McpJsonParserTest, TasksGetExtraction) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "method": "tasks/get",
+    "params": {
+      "taskId": "task-123"
+    },
+    "id": 123
+  })";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_EQ(parser_->getMethod(), Methods::TASKS_GET);
+
+  // Check extracted metadata contains params.taskId
+  const auto* value = parser_->getNestedValue("params.taskId");
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(value->string_value(), "task-123");
+}
+
+TEST_F(McpJsonParserTest, TasksUpdateExtraction) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "method": "tasks/update",
+    "params": {
+      "taskId": "task-456"
+    },
+    "id": 123
+  })";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_EQ(parser_->getMethod(), Methods::TASKS_UPDATE);
+
+  // Check extracted metadata contains params.taskId
+  const auto* value = parser_->getNestedValue("params.taskId");
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(value->string_value(), "task-456");
+}
+
+TEST_F(McpJsonParserTest, TasksCancelExtraction) {
+  std::string json = R"({
+    "jsonrpc": "2.0",
+    "method": "tasks/cancel",
+    "params": {
+      "taskId": "task-789"
+    },
+    "id": 123
+  })";
+
+  EXPECT_OK(parser_->parse(json));
+
+  EXPECT_TRUE(parser_->isValidMcpRequest());
+  EXPECT_EQ(parser_->getMethod(), Methods::TASKS_CANCEL);
+
+  // Check extracted metadata contains params.taskId
+  const auto* value = parser_->getNestedValue("params.taskId");
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(value->string_value(), "task-789");
+}
+
 TEST_F(McpJsonParserTest, PromptsListExtraction) {
   std::string json = R"({
     "jsonrpc": "2.0",
@@ -1824,6 +1913,21 @@ TEST(McpParserConfigTest, DefaultSecuritySettings) {
   McpParserConfig config = McpParserConfig::createDefault();
 
   EXPECT_FALSE(config.rejectDuplicateKeys());
+}
+
+TEST(McpParserConfigTest, BuiltInMethodGroupsForNewMethods) {
+  const auto config = McpParserConfig::createDefault();
+
+  EXPECT_EQ(config.getMethodGroup(std::string(Methods::SERVER_DISCOVER)),
+            std::string(MethodGroups::DISCOVERY));
+  EXPECT_EQ(config.getMethodGroup(std::string(Methods::SUBSCRIPTIONS_LISTEN)),
+            std::string(MethodGroups::SUBSCRIPTION));
+  EXPECT_EQ(config.getMethodGroup(std::string(Methods::TASKS_GET)),
+            std::string(MethodGroups::TASK));
+  EXPECT_EQ(config.getMethodGroup(std::string(Methods::TASKS_UPDATE)),
+            std::string(MethodGroups::TASK));
+  EXPECT_EQ(config.getMethodGroup(std::string(Methods::TASKS_CANCEL)),
+            std::string(MethodGroups::TASK));
 }
 
 TEST_F(McpJsonParserTest, ValidJsonRpcResponse) {


### PR DESCRIPTION
Commit Message: Add MCP method groups for the 2026-07-28 protocol update
Additional Description: This change adds support for the new MCP methods introduced in the 2026-07-28 protocol update. It adds method group mappings for server/discover, subscriptions/listen, and the new task methods (tasks/get, tasks/update, and tasks/cancel). It also adds params.taskId extraction for task methods to support the MCP name source mapping. The change is additive and preserves the existing method mappings for compatibility with legacy MCP clients. Unit tests are added to cover the new method groups and task ID extraction.
Risk Level: low
Testing: NA
Docs Changes: NA
Release Notes: Added support for ``server/discover``, ``subscriptions/listen``, and ``tasks/*`` method groups, and support for extracting ``params.taskId`` in MCP JSON parser.
Platform Specific Features: NA
