### PR TITLE
internal_upstream: provision mutable filter state placeholders, readable on pool failure

### DIFF
--- a/api/envoy/extensions/transport_sockets/internal_upstream/v3/internal_upstream.proto
+++ b/api/envoy/extensions/transport_sockets/internal_upstream/v3/internal_upstream.proto
@@ -46,4 +46,14 @@ message InternalUpstreamTransport {
 
   // The underlying transport socket being wrapped.
   config.core.v3.TransportSocket transport_socket = 3 [(validate.rules).message = {required: true}];
+
+  // Names of registered ``StreamInfo::FilterState::ObjectFactory`` instances. For each name, an
+  // empty object is created on the upstream connection and shared by reference with the downstream
+  // internal connection, under a key equal to the factory's name. A filter on the internal
+  // connection can populate that object in place, and the value is then readable on the upstream
+  // connection, for example via ``%UPSTREAM_FILTER_STATE%``.
+  //
+  // A name whose key is already shared in from the downstream side is skipped, leaving that object
+  // untouched. Objects must be mutable to be populated.
+  repeated string provisioned_placeholder_factories = 4;
 }

--- a/changelogs/current/new_features/router__upstream-filter-state-on-pool-failure.rst
+++ b/changelogs/current/new_features/router__upstream-filter-state-on-pool-failure.rst
@@ -1,0 +1,4 @@
+The upstream connection filter state is now recorded on the connection pool failure path as well as
+on the pool ready path, so filter state written by an upstream transport socket is readable through
+``%UPSTREAM_FILTER_STATE%`` when the upstream connection fails. Previously it was only readable when
+the connection succeeded.

--- a/changelogs/current/new_features/sockets__internal-upstream-provisioned-placeholder-factories.rst
+++ b/changelogs/current/new_features/sockets__internal-upstream-provisioned-placeholder-factories.rst
@@ -1,0 +1,6 @@
+Added
+:ref:`provisioned_placeholder_factories <envoy_v3_api_field_extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport.provisioned_placeholder_factories>`
+to the ``internal_upstream`` transport socket, naming registered filter state object factories to
+provision as empty objects on the upstream connection and share by reference with the downstream
+internal connection. A filter on the internal connection can populate such an object in place, and
+the value is then readable on the upstream connection.

--- a/changelogs/current/new_features/tcp_proxy__fill-existing-tunnel-response-headers-object.rst
+++ b/changelogs/current/new_features/tcp_proxy__fill-existing-tunnel-response-headers-object.rst
@@ -1,0 +1,4 @@
+When ``propagate_response_headers`` is enabled and a filter state object is already present under
+``envoy.tcp_proxy.propagate_response_headers``, the captured CONNECT response headers are now written
+into that object instead of replacing it, so that anything else holding the object observes the value.
+Behavior is unchanged when no such object is present.

--- a/envoy/http/conn_pool.h
+++ b/envoy/http/conn_pool.h
@@ -36,12 +36,14 @@ public:
                              Upstream::HostDescriptionConstSharedPtr host) PURE;
 
   /**
-   * Overload of onPoolFailure that additionally supplies the filter state of the connection whose
-   * failure caused the error.
+   * As onPoolFailure, additionally supplying the filter state of the connection whose failure
+   * caused the error. Deliberately not an overload of onPoolFailure: an overload would be hidden
+   * in every implementation that declares only the three-argument form.
    */
-  virtual void onPoolFailure(PoolFailureReason reason, absl::string_view transport_failure_reason,
-                             Upstream::HostDescriptionConstSharedPtr host,
-                             StreamInfo::FilterStateSharedPtr) {
+  virtual void onPoolFailureWithFilterState(PoolFailureReason reason,
+                                            absl::string_view transport_failure_reason,
+                                            Upstream::HostDescriptionConstSharedPtr host,
+                                            StreamInfo::FilterStateSharedPtr) {
     onPoolFailure(reason, transport_failure_reason, host);
   }
 

--- a/envoy/http/conn_pool.h
+++ b/envoy/http/conn_pool.h
@@ -7,6 +7,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/codec.h"
+#include "envoy/stream_info/filter_state.h"
 #include "envoy/upstream/upstream.h"
 
 namespace Envoy {
@@ -33,6 +34,16 @@ public:
    */
   virtual void onPoolFailure(PoolFailureReason reason, absl::string_view transport_failure_reason,
                              Upstream::HostDescriptionConstSharedPtr host) PURE;
+
+  /**
+   * Overload of onPoolFailure that additionally supplies the filter state of the connection whose
+   * failure caused the error.
+   */
+  virtual void onPoolFailure(PoolFailureReason reason, absl::string_view transport_failure_reason,
+                             Upstream::HostDescriptionConstSharedPtr host,
+                             StreamInfo::FilterStateSharedPtr) {
+    onPoolFailure(reason, transport_failure_reason, host);
+  }
 
   /**
    * Called when a connection is available to process a request/response.

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1595,6 +1595,18 @@ public:
   virtual void onPoolFailure(ConnectionPool::PoolFailureReason reason,
                              absl::string_view transport_failure_reason,
                              Upstream::HostDescriptionConstSharedPtr host) PURE;
+
+  /**
+   * Overload of onPoolFailure that additionally supplies the filter state of the connection whose
+   * failure caused the error.
+   */
+  virtual void onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                             absl::string_view transport_failure_reason,
+                             Upstream::HostDescriptionConstSharedPtr host,
+                             StreamInfo::FilterStateSharedPtr) {
+    onPoolFailure(reason, transport_failure_reason, host);
+  }
+
   /**
    * Called when GenericConnPool::newStream has established a new stream.
    *

--- a/envoy/router/router.h
+++ b/envoy/router/router.h
@@ -1597,13 +1597,14 @@ public:
                              Upstream::HostDescriptionConstSharedPtr host) PURE;
 
   /**
-   * Overload of onPoolFailure that additionally supplies the filter state of the connection whose
-   * failure caused the error.
+   * As onPoolFailure, additionally supplying the filter state of the connection whose failure
+   * caused the error. Deliberately not an overload of onPoolFailure: an overload would be hidden
+   * in every implementation that declares only the three-argument form.
    */
-  virtual void onPoolFailure(ConnectionPool::PoolFailureReason reason,
-                             absl::string_view transport_failure_reason,
-                             Upstream::HostDescriptionConstSharedPtr host,
-                             StreamInfo::FilterStateSharedPtr) {
+  virtual void onPoolFailureWithFilterState(ConnectionPool::PoolFailureReason reason,
+                                            absl::string_view transport_failure_reason,
+                                            Upstream::HostDescriptionConstSharedPtr host,
+                                            StreamInfo::FilterStateSharedPtr) {
     onPoolFailure(reason, transport_failure_reason, host);
   }
 

--- a/source/common/conn_pool/conn_pool_base.cc
+++ b/source/common/conn_pool/conn_pool_base.cc
@@ -249,7 +249,7 @@ void ConnPoolImplBase::attachStreamToClient(Envoy::ConnectionPool::ActiveClient&
   if (enforceMaxRequests() && !host_->cluster().resourceManager(priority_).requests().canCreate()) {
     ENVOY_LOG(debug, "max streams overflow");
     onPoolFailure(client.real_host_description_, absl::string_view(),
-                  ConnectionPool::PoolFailureReason::Overflow, context);
+                  ConnectionPool::PoolFailureReason::Overflow, context, nullptr);
     traffic_stats.upstream_rq_active_overflow_.inc();
     if (!skip_pending_overflow_on_active_rq_) {
       traffic_stats.upstream_rq_pending_overflow_.inc();
@@ -364,7 +364,7 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStreamImpl(AttachContext& cont
   if (!host_->cluster().resourceManager(priority_).pendingRequests().canCreate()) {
     ENVOY_LOG(debug, "max pending streams overflow");
     onPoolFailure(nullptr, absl::string_view(), ConnectionPool::PoolFailureReason::Overflow,
-                  context);
+                  context, nullptr);
     host_->cluster().trafficStats()->upstream_rq_pending_overflow_.inc();
     return nullptr;
   }
@@ -391,12 +391,12 @@ ConnectionPool::Cancellable* ConnPoolImplBase::newStreamImpl(AttachContext& cont
     // Trigger connection failure.
     pending->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
     onPoolFailure(nullptr, absl::string_view(),
-                  ConnectionPool::PoolFailureReason::LocalConnectionFailure, context);
+                  ConnectionPool::PoolFailureReason::LocalConnectionFailure, context, nullptr);
     return nullptr;
   } else if (result == ConnectionResult::LoadShed) {
     pending->cancel(Envoy::ConnectionPool::CancelPolicy::CloseExcess);
     onPoolFailure(nullptr, absl::string_view(), ConnectionPool::PoolFailureReason::Overflow,
-                  context);
+                  context, nullptr);
     return nullptr;
   }
   return pending;
@@ -625,7 +625,8 @@ void ConnPoolImplBase::onConnectionEvent(ActiveClient& client, absl::string_view
       // what to do with the stream.
       // NOTE: We move the existing pending streams to a temporary list. This is done so that
       //       if retry logic submits a new stream to the pool, we don't fail it inline.
-      purgePendingStreams(client.real_host_description_, failure_reason, reason);
+      purgePendingStreams(client.real_host_description_, failure_reason, reason,
+                          client.connectionFilterState());
       // See if we should preconnect based on active connections.
       if (!is_draining_for_deletion_) {
         tryCreateNewConnections();
@@ -741,7 +742,8 @@ void PendingStream::cancel(Envoy::ConnectionPool::CancelPolicy policy) {
 
 void ConnPoolImplBase::purgePendingStreams(
     const Upstream::HostDescriptionConstSharedPtr& host_description,
-    absl::string_view failure_reason, ConnectionPool::PoolFailureReason reason) {
+    absl::string_view failure_reason, ConnectionPool::PoolFailureReason reason,
+    StreamInfo::FilterStateSharedPtr connection_filter_state) {
   // NOTE: We move the existing pending streams to a temporary list. This is done so that
   //       if retry logic submits a new stream to the pool, we don't fail it inline.
   cluster_connectivity_state_.decrPendingStreams(pending_streams_.size());
@@ -750,7 +752,8 @@ void ConnPoolImplBase::purgePendingStreams(
     PendingStreamPtr stream =
         pending_streams_to_purge_.front()->removeFromList(pending_streams_to_purge_);
     host_->cluster().trafficStats()->upstream_rq_pending_failure_eject_.inc();
-    onPoolFailure(host_description, failure_reason, reason, stream->context());
+    onPoolFailure(host_description, failure_reason, reason, stream->context(),
+                  connection_filter_state);
   }
 }
 

--- a/source/common/conn_pool/conn_pool_base.h
+++ b/source/common/conn_pool/conn_pool_base.h
@@ -5,6 +5,7 @@
 #include "envoy/network/connection.h"
 #include "envoy/server/overload/overload_manager.h"
 #include "envoy/stats/timespan.h"
+#include "envoy/stream_info/filter_state.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "source/common/common/debug_recursion_checker.h"
@@ -33,6 +34,8 @@ class ActiveClient : public LinkedObject<ActiveClient>,
                      public Event::DeferredDeletable,
                      protected Logger::Loggable<Logger::Id::pool> {
 public:
+  virtual StreamInfo::FilterStateSharedPtr connectionFilterState() { return nullptr; }
+
   ActiveClient(ConnPoolImplBase& parent, uint32_t lifetime_stream_limit,
                uint32_t effective_concurrent_streams, uint32_t concurrent_stream_limit);
   ActiveClient(ConnPoolImplBase& parent, uint32_t lifetime_stream_limit,
@@ -245,7 +248,8 @@ public:
   // Fails all pending streams, calling onPoolFailure on the associated callbacks.
   void purgePendingStreams(const Upstream::HostDescriptionConstSharedPtr& host_description,
                            absl::string_view failure_reason,
-                           ConnectionPool::PoolFailureReason pool_failure_reason);
+                           ConnectionPool::PoolFailureReason pool_failure_reason,
+                           StreamInfo::FilterStateSharedPtr connection_filter_state);
 
   // Closes any idle connections as this pool is drained.
   void closeIdleConnectionsForDrainingPool();
@@ -274,7 +278,8 @@ public:
   virtual void onPoolFailure(const Upstream::HostDescriptionConstSharedPtr& host_description,
                              absl::string_view failure_reason,
                              ConnectionPool::PoolFailureReason pool_failure_reason,
-                             AttachContext& context) PURE;
+                             AttachContext& context,
+                             StreamInfo::FilterStateSharedPtr connection_filter_state) PURE;
   virtual void onPoolReady(ActiveClient& client, AttachContext& context) PURE;
   // Called by derived classes any time a stream is completed or destroyed for any reason.
   void onStreamClosed(Envoy::ConnectionPool::ActiveClient& client, bool delay_attaching_stream);

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -88,9 +88,10 @@ public:
                                                 bool can_send_early_data) override;
   void onPoolFailure(const Upstream::HostDescriptionConstSharedPtr& host_description,
                      absl::string_view failure_reason, ConnectionPool::PoolFailureReason reason,
-                     Envoy::ConnectionPool::AttachContext& context) override {
+                     Envoy::ConnectionPool::AttachContext& context,
+                     StreamInfo::FilterStateSharedPtr connection_filter_state) override {
     auto* callbacks = typedContext<HttpAttachContext>(context).callbacks_;
-    callbacks->onPoolFailure(reason, failure_reason, host_description);
+    callbacks->onPoolFailure(reason, failure_reason, host_description, connection_filter_state);
   }
   void onPoolReady(Envoy::ConnectionPool::ActiveClient& client,
                    Envoy::ConnectionPool::AttachContext& context) override;
@@ -164,6 +165,9 @@ public:
   }
   uint32_t numActiveStreams() const override { return codec_client_->numActiveRequests(); }
   uint64_t id() const override { return codec_client_->id(); }
+  StreamInfo::FilterStateSharedPtr connectionFilterState() override {
+    return codec_client_ != nullptr ? codec_client_->streamInfo().filterState() : nullptr;
+  }
   HttpConnPoolImplBase& parent() { return *static_cast<HttpConnPoolImplBase*>(&parent_); }
 
   Http::CodecClientPtr codec_client_;

--- a/source/common/http/conn_pool_base.h
+++ b/source/common/http/conn_pool_base.h
@@ -91,7 +91,8 @@ public:
                      Envoy::ConnectionPool::AttachContext& context,
                      StreamInfo::FilterStateSharedPtr connection_filter_state) override {
     auto* callbacks = typedContext<HttpAttachContext>(context).callbacks_;
-    callbacks->onPoolFailure(reason, failure_reason, host_description, connection_filter_state);
+    callbacks->onPoolFailureWithFilterState(reason, failure_reason, host_description,
+                                            connection_filter_state);
   }
   void onPoolReady(Envoy::ConnectionPool::ActiveClient& client,
                    Envoy::ConnectionPool::AttachContext& context) override;

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -606,6 +606,16 @@ void UpstreamRequest::recordConnectionPoolCallbackLatency() {
       start_time_, parent_.callbacks()->dispatcher().timeSource());
 }
 
+void UpstreamRequest::onPoolFailure(
+    ConnectionPool::PoolFailureReason reason, absl::string_view transport_failure_reason,
+    Upstream::HostDescriptionConstSharedPtr host,
+    StreamInfo::FilterStateSharedPtr connection_filter_state) {
+  if (connection_filter_state != nullptr && stream_info_.upstreamInfo() != nullptr) {
+    stream_info_.upstreamInfo()->setUpstreamFilterState(connection_filter_state);
+  }
+  onPoolFailure(reason, transport_failure_reason, host);
+}
+
 void UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason reason,
                                     absl::string_view transport_failure_reason,
                                     Upstream::HostDescriptionConstSharedPtr host) {

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -606,10 +606,10 @@ void UpstreamRequest::recordConnectionPoolCallbackLatency() {
       start_time_, parent_.callbacks()->dispatcher().timeSource());
 }
 
-void UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason reason,
-                                    absl::string_view transport_failure_reason,
-                                    Upstream::HostDescriptionConstSharedPtr host,
-                                    StreamInfo::FilterStateSharedPtr connection_filter_state) {
+void UpstreamRequest::onPoolFailureWithFilterState(
+    ConnectionPool::PoolFailureReason reason, absl::string_view transport_failure_reason,
+    Upstream::HostDescriptionConstSharedPtr host,
+    StreamInfo::FilterStateSharedPtr connection_filter_state) {
   if (connection_filter_state != nullptr && stream_info_.upstreamInfo() != nullptr) {
     stream_info_.upstreamInfo()->setUpstreamFilterState(connection_filter_state);
   }

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -606,10 +606,10 @@ void UpstreamRequest::recordConnectionPoolCallbackLatency() {
       start_time_, parent_.callbacks()->dispatcher().timeSource());
 }
 
-void UpstreamRequest::onPoolFailure(
-    ConnectionPool::PoolFailureReason reason, absl::string_view transport_failure_reason,
-    Upstream::HostDescriptionConstSharedPtr host,
-    StreamInfo::FilterStateSharedPtr connection_filter_state) {
+void UpstreamRequest::onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                                    absl::string_view transport_failure_reason,
+                                    Upstream::HostDescriptionConstSharedPtr host,
+                                    StreamInfo::FilterStateSharedPtr connection_filter_state) {
   if (connection_filter_state != nullptr && stream_info_.upstreamInfo() != nullptr) {
     stream_info_.upstreamInfo()->setUpstreamFilterState(connection_filter_state);
   }

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -122,6 +122,10 @@ public:
   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
                      absl::string_view transport_failure_reason,
                      Upstream::HostDescriptionConstSharedPtr host) override;
+  void onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                     absl::string_view transport_failure_reason,
+                     Upstream::HostDescriptionConstSharedPtr host,
+                     StreamInfo::FilterStateSharedPtr connection_filter_state) override;
   void onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
                    Upstream::HostDescriptionConstSharedPtr host,
                    const Network::ConnectionInfoProvider& address_provider,

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -122,10 +122,11 @@ public:
   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
                      absl::string_view transport_failure_reason,
                      Upstream::HostDescriptionConstSharedPtr host) override;
-  void onPoolFailure(ConnectionPool::PoolFailureReason reason,
-                     absl::string_view transport_failure_reason,
-                     Upstream::HostDescriptionConstSharedPtr host,
-                     StreamInfo::FilterStateSharedPtr connection_filter_state) override;
+  void
+  onPoolFailureWithFilterState(ConnectionPool::PoolFailureReason reason,
+                               absl::string_view transport_failure_reason,
+                               Upstream::HostDescriptionConstSharedPtr host,
+                               StreamInfo::FilterStateSharedPtr connection_filter_state) override;
   void onPoolReady(std::unique_ptr<GenericUpstream>&& upstream,
                    Upstream::HostDescriptionConstSharedPtr host,
                    const Network::ConnectionInfoProvider& address_provider,

--- a/source/common/tcp/conn_pool.cc
+++ b/source/common/tcp/conn_pool.cc
@@ -210,7 +210,8 @@ void ConnPoolImpl::onPoolReady(Envoy::ConnectionPool::ActiveClient& client,
 void ConnPoolImpl::onPoolFailure(const Upstream::HostDescriptionConstSharedPtr& host_description,
                                  absl::string_view failure_reason,
                                  ConnectionPool::PoolFailureReason reason,
-                                 Envoy::ConnectionPool::AttachContext& context) {
+                                 Envoy::ConnectionPool::AttachContext& context,
+                                 StreamInfo::FilterStateSharedPtr) {
   auto* callbacks = typedContext<TcpAttachContext>(context).callbacks_;
   callbacks->onPoolFailure(reason, failure_reason, host_description);
 }

--- a/source/common/tcp/conn_pool.h
+++ b/source/common/tcp/conn_pool.h
@@ -182,7 +182,8 @@ public:
                    Envoy::ConnectionPool::AttachContext& context) override;
   void onPoolFailure(const Upstream::HostDescriptionConstSharedPtr& host_description,
                      absl::string_view failure_reason, ConnectionPool::PoolFailureReason reason,
-                     Envoy::ConnectionPool::AttachContext& context) override;
+                     Envoy::ConnectionPool::AttachContext& context,
+                     StreamInfo::FilterStateSharedPtr connection_filter_state) override;
   bool enforceMaxRequests() const override { return false; }
   // These two functions exist for testing parity between old and new Tcp Connection Pools.
   virtual void onConnReleased(Envoy::ConnectionPool::ActiveClient&) {}

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -81,6 +81,22 @@ public:
 
 REGISTER_FACTORY(PerConnectionIdleTimeoutMsObjectFactory, StreamInfo::FilterState::ObjectFactory);
 
+class TunnelResponseHeadersObjectFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return TunnelResponseHeaders::key(); }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    // Not deserializable from bytes: instances are created empty and populated when the CONNECT
+    // response arrives. Returns nullptr for non-empty input rather than discarding it.
+    if (!data.empty()) {
+      return nullptr;
+    }
+    return std::make_unique<TunnelResponseHeaders>();
+  }
+};
+
+REGISTER_FACTORY(TunnelResponseHeadersObjectFactory, StreamInfo::FilterState::ObjectFactory);
+
 Config::SimpleRouteImpl::SimpleRouteImpl(const Config& parent, absl::string_view cluster_name)
     : parent_(parent), cluster_name_(cluster_name) {}
 
@@ -1050,6 +1066,12 @@ void TunnelingConfigHelperImpl::propagateResponseHeaders(
     Http::ResponseHeaderMapPtr&& headers,
     const StreamInfo::FilterStateSharedPtr& filter_state) const {
   if (!propagate_response_headers_) {
+    return;
+  }
+  if (auto* placeholder =
+          filter_state->getDataMutable<TunnelResponseHeaders>(TunnelResponseHeaders::key());
+      placeholder != nullptr) {
+    placeholder->setResponseHeaders(std::move(headers));
     return;
   }
   filter_state->setData(TunnelResponseHeaders::key(),

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -86,8 +86,8 @@ public:
   std::string name() const override { return TunnelResponseHeaders::key(); }
   std::unique_ptr<StreamInfo::FilterState::Object>
   createFromBytes(absl::string_view data) const override {
-    // Not deserializable from bytes: instances are created empty and populated when the CONNECT
-    // response arrives. Returns nullptr for non-empty input rather than discarding it.
+    // Cannot be deserialized from bytes: instances are created empty and populated when the
+    // CONNECT response arrives. Returns nullptr for non-empty input rather than discarding it.
     if (!data.empty()) {
       return nullptr;
     }

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -138,13 +138,19 @@ using TunnelingConfig =
  */
 class TunnelResponseHeaders : public Http::TunnelResponseHeadersOrTrailersImpl {
 public:
+  // Default-constructed instances hold an empty header map, so value() is safe to call before
+  // any response has been captured.
+  TunnelResponseHeaders() : response_headers_(Http::ResponseHeaderMapImpl::create()) {}
   TunnelResponseHeaders(Http::ResponseHeaderMapPtr&& response_headers)
       : response_headers_(std::move(response_headers)) {}
   const Http::HeaderMap& value() const override { return *response_headers_; }
+  void setResponseHeaders(Http::ResponseHeaderMapPtr&& response_headers) {
+    response_headers_ = std::move(response_headers);
+  }
   static const std::string& key();
 
 private:
-  const Http::ResponseHeaderMapPtr response_headers_;
+  Http::ResponseHeaderMapPtr response_headers_;
 };
 
 /**

--- a/source/extensions/transport_sockets/internal_upstream/BUILD
+++ b/source/extensions/transport_sockets/internal_upstream/BUILD
@@ -14,6 +14,9 @@ envoy_cc_library(
     srcs = ["internal_upstream.cc"],
     hdrs = ["internal_upstream.h"],
     deps = [
+        "//envoy/network:connection_interface",
+        "//envoy/stream_info:filter_state_interface",
+        "//envoy/stream_info:stream_info_interface",
         "//source/extensions/io_socket/user_space:io_handle_lib",
         "//source/extensions/transport_sockets/common:passthrough_lib",
         "@envoy_api//envoy/extensions/transport_sockets/internal_upstream/v3:pkg_cc_proto",

--- a/source/extensions/transport_sockets/internal_upstream/config.cc
+++ b/source/extensions/transport_sockets/internal_upstream/config.cc
@@ -68,6 +68,17 @@ Config::Config(
     }
     metadata_sources_.push_back(MetadataSource(kind, metadata.name()));
   }
+  for (const auto& factory_name : config_proto.provisioned_placeholder_factories()) {
+    auto* factory =
+        Registry::FactoryRegistry<StreamInfo::FilterState::ObjectFactory>::getFactory(factory_name);
+    if (factory == nullptr) {
+      throw EnvoyException(
+          absl::StrCat("internal_upstream: no StreamInfo::FilterState::ObjectFactory registered "
+                       "under provisioned_placeholder_factories name: ",
+                       factory_name));
+    }
+    placeholder_factories_.push_back(factory);
+  }
 }
 
 std::unique_ptr<envoy::config::core::v3::Metadata>
@@ -120,7 +131,8 @@ InternalSocketFactory::createTransportSocket(Network::TransportSocketOptionsCons
   }
   return std::make_unique<InternalSocket>(std::move(inner_socket), std::move(extracted_metadata),
                                           options ? options->downstreamSharedFilterStateObjects()
-                                                  : StreamInfo::FilterState::Objects());
+                                                  : StreamInfo::FilterState::Objects(),
+                                          config_.placeholderFactories());
 }
 
 REGISTER_FACTORY(InternalUpstreamConfigFactory,

--- a/source/extensions/transport_sockets/internal_upstream/config.h
+++ b/source/extensions/transport_sockets/internal_upstream/config.h
@@ -3,6 +3,7 @@
 #include "envoy/extensions/transport_sockets/internal_upstream/v3/internal_upstream.pb.h"
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/stats/stats_macros.h"
+#include "envoy/stream_info/filter_state.h"
 
 #include "source/common/common/logger.h"
 #include "source/extensions/io_socket/user_space/io_handle.h"
@@ -30,6 +31,9 @@ public:
       Stats::Scope& scope);
   std::unique_ptr<envoy::config::core::v3::Metadata>
   extractMetadata(const Upstream::HostDescriptionConstSharedPtr& host) const;
+  const std::vector<const StreamInfo::FilterState::ObjectFactory*>& placeholderFactories() const {
+    return placeholder_factories_;
+  }
 
 private:
   enum class MetadataKind { Host, Cluster };
@@ -40,6 +44,7 @@ private:
   };
   InternalUpstreamStats stats_;
   std::vector<MetadataSource> metadata_sources_;
+  std::vector<const StreamInfo::FilterState::ObjectFactory*> placeholder_factories_;
 };
 
 class InternalSocketFactory : public PassthroughFactory {

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
@@ -1,24 +1,67 @@
 #include "source/extensions/transport_sockets/internal_upstream/internal_upstream.h"
 
+#include "envoy/network/connection.h"
+#include "envoy/stream_info/filter_state.h"
+#include "envoy/stream_info/stream_info.h"
+
+
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {
 namespace InternalUpstream {
 
-InternalSocket::InternalSocket(Network::TransportSocketPtr inner_socket,
-                               std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                               const StreamInfo::FilterState::Objects& filter_state_objects)
+InternalSocket::InternalSocket(
+    Network::TransportSocketPtr inner_socket,
+    std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
+    const StreamInfo::FilterState::Objects& filter_state_objects,
+    const std::vector<const StreamInfo::FilterState::ObjectFactory*>& placeholder_factories)
     : PassthroughSocket(std::move(inner_socket)), metadata_(std::move(metadata)),
-      filter_state_objects_(filter_state_objects) {}
+      filter_state_objects_(filter_state_objects), placeholder_factories_(placeholder_factories) {}
 
 void InternalSocket::setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) {
   transport_socket_->setTransportSocketCallbacks(callbacks);
+  callbacks_ = &callbacks;
   auto* io_handle = dynamic_cast<IoSocket::UserSpace::IoHandle*>(&callbacks.ioHandle());
   if (io_handle != nullptr && io_handle->passthroughState()) {
+    // streamInfo() is not yet available on the connection here, so each created object is held
+    // until onConnected() and only forward-shared at this point.
+    for (const auto* factory : placeholder_factories_) {
+      const std::string key = factory->name();
+      bool already_present = false;
+      for (const auto& obj : filter_state_objects_) {
+        if (obj.name_ == key) {
+          already_present = true;
+          break;
+        }
+      }
+      if (already_present) {
+        continue;
+      }
+      std::shared_ptr<StreamInfo::FilterState::Object> placeholder = factory->createFromBytes("");
+      if (placeholder == nullptr) {
+        continue;
+      }
+      provisioned_.emplace_back(key, placeholder);
+      filter_state_objects_.push_back(
+          {placeholder, StreamInfo::StreamSharingMayImpactPooling::None, key});
+    }
     io_handle->passthroughState()->initialize(std::move(metadata_), filter_state_objects_);
   }
   metadata_ = nullptr;
   filter_state_objects_.clear();
+}
+
+void InternalSocket::onConnected() {
+  // streamInfo() is available at this point, unlike in setTransportSocketCallbacks(). The objects
+  // placed here are the same instances already shared with the internal connection.
+  if (callbacks_ != nullptr) {
+    for (auto& [key, placeholder] : provisioned_) {
+      callbacks_->connection().streamInfo().filterState()->setData(
+          key, placeholder, StreamInfo::FilterState::LifeSpan::Connection);
+    }
+    provisioned_.clear();
+  }
+  PassthroughSocket::onConnected();
 }
 
 } // namespace InternalUpstream

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.cc
@@ -4,7 +4,6 @@
 #include "envoy/stream_info/filter_state.h"
 #include "envoy/stream_info/stream_info.h"
 
-
 namespace Envoy {
 namespace Extensions {
 namespace TransportSockets {

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.h
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "envoy/extensions/transport_sockets/internal_upstream/v3/internal_upstream.pb.h"
-
-#include "source/extensions/io_socket/user_space/io_handle.h"
 #include "envoy/stream_info/filter_state.h"
 
+#include "source/extensions/io_socket/user_space/io_handle.h"
 #include "source/extensions/transport_sockets/common/passthrough.h"
 
 namespace Envoy {
@@ -14,11 +13,11 @@ namespace InternalUpstream {
 
 class InternalSocket : public TransportSockets::PassthroughSocket {
 public:
-  InternalSocket(Network::TransportSocketPtr inner_socket,
-                 std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                 const StreamInfo::FilterState::Objects& filter_state_objects,
-                 const std::vector<const StreamInfo::FilterState::ObjectFactory*>&
-                     placeholder_factories);
+  InternalSocket(
+      Network::TransportSocketPtr inner_socket,
+      std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
+      const StreamInfo::FilterState::Objects& filter_state_objects,
+      const std::vector<const StreamInfo::FilterState::ObjectFactory*>& placeholder_factories);
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;

--- a/source/extensions/transport_sockets/internal_upstream/internal_upstream.h
+++ b/source/extensions/transport_sockets/internal_upstream/internal_upstream.h
@@ -3,6 +3,8 @@
 #include "envoy/extensions/transport_sockets/internal_upstream/v3/internal_upstream.pb.h"
 
 #include "source/extensions/io_socket/user_space/io_handle.h"
+#include "envoy/stream_info/filter_state.h"
+
 #include "source/extensions/transport_sockets/common/passthrough.h"
 
 namespace Envoy {
@@ -14,14 +16,21 @@ class InternalSocket : public TransportSockets::PassthroughSocket {
 public:
   InternalSocket(Network::TransportSocketPtr inner_socket,
                  std::unique_ptr<envoy::config::core::v3::Metadata> metadata,
-                 const StreamInfo::FilterState::Objects& filter_state_objects);
+                 const StreamInfo::FilterState::Objects& filter_state_objects,
+                 const std::vector<const StreamInfo::FilterState::ObjectFactory*>&
+                     placeholder_factories);
 
   // Network::TransportSocket
   void setTransportSocketCallbacks(Network::TransportSocketCallbacks& callbacks) override;
+  void onConnected() override;
 
 private:
   std::unique_ptr<envoy::config::core::v3::Metadata> metadata_;
   StreamInfo::FilterState::Objects filter_state_objects_;
+  std::vector<const StreamInfo::FilterState::ObjectFactory*> placeholder_factories_;
+  Network::TransportSocketCallbacks* callbacks_{nullptr};
+  std::vector<std::pair<std::string, std::shared_ptr<StreamInfo::FilterState::Object>>>
+      provisioned_;
 };
 
 } // namespace InternalUpstream

--- a/source/extensions/upstreams/http/http/upstream_request.cc
+++ b/source/extensions/upstreams/http/http/upstream_request.cc
@@ -55,6 +55,14 @@ void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
   callbacks_->onPoolFailure(reason, transport_failure_reason, host);
 }
 
+void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                                 absl::string_view transport_failure_reason,
+                                 Upstream::HostDescriptionConstSharedPtr host,
+                                 StreamInfo::FilterStateSharedPtr connection_filter_state) {
+  conn_pool_stream_handle_ = nullptr;
+  callbacks_->onPoolFailure(reason, transport_failure_reason, host, connection_filter_state);
+}
+
 void HttpConnPool::onPoolReady(Envoy::Http::RequestEncoder& request_encoder,
                                Upstream::HostDescriptionConstSharedPtr host,
                                StreamInfo::StreamInfo& info,

--- a/source/extensions/upstreams/http/http/upstream_request.cc
+++ b/source/extensions/upstreams/http/http/upstream_request.cc
@@ -55,12 +55,13 @@ void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
   callbacks_->onPoolFailure(reason, transport_failure_reason, host);
 }
 
-void HttpConnPool::onPoolFailure(ConnectionPool::PoolFailureReason reason,
-                                 absl::string_view transport_failure_reason,
-                                 Upstream::HostDescriptionConstSharedPtr host,
-                                 StreamInfo::FilterStateSharedPtr connection_filter_state) {
+void HttpConnPool::onPoolFailureWithFilterState(
+    ConnectionPool::PoolFailureReason reason, absl::string_view transport_failure_reason,
+    Upstream::HostDescriptionConstSharedPtr host,
+    StreamInfo::FilterStateSharedPtr connection_filter_state) {
   conn_pool_stream_handle_ = nullptr;
-  callbacks_->onPoolFailure(reason, transport_failure_reason, host, connection_filter_state);
+  callbacks_->onPoolFailureWithFilterState(reason, transport_failure_reason, host,
+                                           connection_filter_state);
 }
 
 void HttpConnPool::onPoolReady(Envoy::Http::RequestEncoder& request_encoder,

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -42,6 +42,10 @@ public:
   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
                      absl::string_view transport_failure_reason,
                      Upstream::HostDescriptionConstSharedPtr host) override;
+  void onPoolFailure(ConnectionPool::PoolFailureReason reason,
+                     absl::string_view transport_failure_reason,
+                     Upstream::HostDescriptionConstSharedPtr host,
+                     StreamInfo::FilterStateSharedPtr connection_filter_state) override;
   void onPoolReady(Envoy::Http::RequestEncoder& callbacks_encoder,
                    Upstream::HostDescriptionConstSharedPtr host, StreamInfo::StreamInfo& info,
                    std::optional<Envoy::Http::Protocol> protocol) override;

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -42,10 +42,11 @@ public:
   void onPoolFailure(ConnectionPool::PoolFailureReason reason,
                      absl::string_view transport_failure_reason,
                      Upstream::HostDescriptionConstSharedPtr host) override;
-  void onPoolFailure(ConnectionPool::PoolFailureReason reason,
-                     absl::string_view transport_failure_reason,
-                     Upstream::HostDescriptionConstSharedPtr host,
-                     StreamInfo::FilterStateSharedPtr connection_filter_state) override;
+  void
+  onPoolFailureWithFilterState(ConnectionPool::PoolFailureReason reason,
+                               absl::string_view transport_failure_reason,
+                               Upstream::HostDescriptionConstSharedPtr host,
+                               StreamInfo::FilterStateSharedPtr connection_filter_state) override;
   void onPoolReady(Envoy::Http::RequestEncoder& callbacks_encoder,
                    Upstream::HostDescriptionConstSharedPtr host, StreamInfo::StreamInfo& info,
                    std::optional<Envoy::Http::Protocol> protocol) override;

--- a/test/common/conn_pool/conn_pool_base_test.cc
+++ b/test/common/conn_pool/conn_pool_base_test.cc
@@ -93,7 +93,8 @@ public:
   MOCK_METHOD(ActiveClientPtr, instantiateActiveClient, ());
   MOCK_METHOD(void, onPoolFailure,
               (const Upstream::HostDescriptionConstSharedPtr& n, absl::string_view,
-               ConnectionPool::PoolFailureReason, AttachContext&));
+               ConnectionPool::PoolFailureReason, AttachContext&,
+               StreamInfo::FilterStateSharedPtr));
   MOCK_METHOD(void, onPoolReady, (ActiveClient&, AttachContext&));
   void setSkipPendingOverflowForTest(bool value) { skip_pending_overflow_on_active_rq_ = value; }
 };
@@ -757,7 +758,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxActiveRequestsOverflow) {
   newActiveClientAndStream(ActiveClient::State::Ready);
 
   // Second stream: finds the Ready client, attachStreamToClient() overflows.
-  EXPECT_CALL(pool_, onPoolFailure(_, _, ConnectionPool::PoolFailureReason::Overflow, _));
+  EXPECT_CALL(pool_, onPoolFailure(_, _, ConnectionPool::PoolFailureReason::Overflow, _, _));
   pool_.newStreamImpl(context_, /*can_send_early_data=*/false);
 
   EXPECT_EQ(1U, cluster_->traffic_stats_->upstream_rq_active_overflow_.value());
@@ -778,7 +779,7 @@ TEST_F(ConnPoolImplDispatcherBaseTest, MaxActiveRequestsOverflowLegacy) {
 
   newActiveClientAndStream(ActiveClient::State::Ready);
 
-  EXPECT_CALL(pool_, onPoolFailure(_, _, ConnectionPool::PoolFailureReason::Overflow, _));
+  EXPECT_CALL(pool_, onPoolFailure(_, _, ConnectionPool::PoolFailureReason::Overflow, _, _));
   pool_.newStreamImpl(context_, /*can_send_early_data=*/false);
 
   EXPECT_EQ(1U, cluster_->traffic_stats_->upstream_rq_active_overflow_.value());

--- a/test/extensions/transport_sockets/internal_upstream/BUILD
+++ b/test/extensions/transport_sockets/internal_upstream/BUILD
@@ -65,3 +65,37 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/extensions/transport_sockets/internal_upstream/v3:pkg_cc_proto",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "fwd_mutable_placeholder_integration_test",
+    size = "large",
+    srcs = [
+        "fwd_mutable_placeholder_integration_test.cc",
+    ],
+    data = [
+        "//test/config/integration/certs",
+    ],
+    extension_names = [
+        "envoy.bootstrap.internal_listener",
+        "envoy.transport_sockets.internal_upstream",
+    ],
+    rbe_pool = "6gig",
+    deps = [
+        "//envoy/server:filter_config_interface",
+        "//source/common/tcp_proxy:tcp_proxy",
+        "//source/extensions/access_loggers/file:config",
+        "//source/extensions/bootstrap/internal_listener:config",
+        "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "//source/extensions/filters/network/http_connection_manager:config",
+        "//source/extensions/filters/network/tcp_proxy:config",
+        "//source/extensions/transport_sockets/internal_upstream:config",
+        "//source/extensions/transport_sockets/raw_buffer:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//test/integration:http_integration_lib",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/bootstrap/internal_listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
+    ],
+)

--- a/test/extensions/transport_sockets/internal_upstream/BUILD
+++ b/test/extensions/transport_sockets/internal_upstream/BUILD
@@ -82,7 +82,7 @@ envoy_extension_cc_test(
     rbe_pool = "6gig",
     deps = [
         "//envoy/server:filter_config_interface",
-        "//source/common/tcp_proxy:tcp_proxy",
+        "//source/common/tcp_proxy",
         "//source/extensions/access_loggers/file:config",
         "//source/extensions/bootstrap/internal_listener:config",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
@@ -96,6 +96,5 @@ envoy_extension_cc_test(
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/bootstrap/internal_listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/transport_sockets/internal_upstream/fwd_mutable_placeholder_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/fwd_mutable_placeholder_integration_test.cc
@@ -22,8 +22,7 @@ class SeedPlaceholderFilter : public Http::PassThroughFilter {
 public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     decoder_callbacks_->streamInfo().filterState()->setData(
-        TcpProxy::TunnelResponseHeaders::key(),
-        std::make_shared<TcpProxy::TunnelResponseHeaders>(),
+        TcpProxy::TunnelResponseHeaders::key(), std::make_shared<TcpProxy::TunnelResponseHeaders>(),
         StreamInfo::FilterState::LifeSpan::Connection,
         StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
     return Http::FilterHeadersStatus::Continue;
@@ -99,10 +98,9 @@ public:
       // Naming the factory makes internal_upstream provision the object; left unset, the seed
       // filter supplies it.
       const std::string provisioning_block =
-          read_upstream_filter_state_
-              ? "\n        provisioned_placeholder_factories:\n        - "
-                "envoy.tcp_proxy.propagate_response_headers"
-              : "";
+          read_upstream_filter_state_ ? "\n        provisioned_placeholder_factories:\n        - "
+                                        "envoy.tcp_proxy.propagate_response_headers"
+                                      : "";
       const std::string wrapped_transport_socket =
           wrapped_socket_uses_tls_
               ? fmt::format(R"EOF(
@@ -128,7 +126,6 @@ public:
       )EOF",
                                             wrapped_transport_socket, provisioning_block),
                                 *cluster->mutable_transport_socket());
-
 
       TestUtility::loadFromYaml(R"EOF(
       name: internal_listener
@@ -251,7 +248,8 @@ TEST_F(FwdMutablePlaceholderIntegrationTest, ProvisionedPlaceholderReadableOnPoo
 
   // The connection must have failed to connect. If it reached readiness instead, this case would
   // not exercise the failure path at all.
-  EXPECT_GT(test_server_->counter("cluster.internal_listener.upstream_cx_connect_fail")->value(), 0);
+  EXPECT_GT(test_server_->counter("cluster.internal_listener.upstream_cx_connect_fail")->value(),
+            0);
 
   EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr(header_value));
 }

--- a/test/extensions/transport_sockets/internal_upstream/fwd_mutable_placeholder_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/fwd_mutable_placeholder_integration_test.cc
@@ -1,0 +1,260 @@
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/extensions/bootstrap/internal_listener/v3/internal_listener.pb.h"
+#include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/stream_info/filter_state.h"
+
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/tcp_proxy/tcp_proxy.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace {
+
+// Creates an empty TunnelResponseHeaders object on the downstream connection, marked
+// SharedWithUpstreamConnection so that it is forward-shared to the internal connection.
+class SeedPlaceholderFilter : public Http::PassThroughFilter {
+public:
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
+    decoder_callbacks_->streamInfo().filterState()->setData(
+        TcpProxy::TunnelResponseHeaders::key(),
+        std::make_shared<TcpProxy::TunnelResponseHeaders>(),
+        StreamInfo::FilterState::LifeSpan::Connection,
+        StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnection);
+    return Http::FilterHeadersStatus::Continue;
+  }
+};
+
+class SeedPlaceholderFilterFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
+public:
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
+                               Server::Configuration::FactoryContext&) override {
+    return [](Http::FilterChainFactoryCallbacks& callbacks) {
+      callbacks.addStreamFilter(std::make_shared<SeedPlaceholderFilter>());
+    };
+  }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::Struct>();
+  }
+  std::string name() const override { return "envoy.test.seed_placeholder"; }
+};
+
+REGISTER_FACTORY(SeedPlaceholderFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+
+// Topology: outer HCM -> internal_listener cluster carrying the internal_upstream transport
+// socket -> internal listener running tcp_proxy with propagate_response_headers -> fake upstream
+// that rejects the CONNECT.
+class FwdMutablePlaceholderIntegrationTest : public testing::Test, public HttpIntegrationTest {
+public:
+  FwdMutablePlaceholderIntegrationTest()
+      : HttpIntegrationTest(Http::CodecType::HTTP1, TestEnvironment::getIpVersionsForTest().front(),
+                            ConfigHelper::httpProxyConfig()) {
+    setUpstreamCount(1);
+  }
+
+  // Object seeded by a downstream filter and read via %FILTER_STATE% when false; provisioned by
+  // internal_upstream and read via %UPSTREAM_FILTER_STATE% when true.
+  bool seed_via_hcm_filter_{true};
+  bool read_upstream_filter_state_{false};
+  // The wrapped socket's handshake travels through the CONNECT tunnel, so the pool cannot report
+  // readiness until the CONNECT succeeds. Without a handshake, readiness is immediate.
+  bool wrapped_socket_uses_tls_{false};
+
+  void initialize() override {
+    access_log_name_ = TestEnvironment::temporaryPath(TestUtility::uniqueFilename("fwd_fs"));
+
+    if (seed_via_hcm_filter_) {
+      config_helper_.prependFilter(R"EOF(
+      name: envoy.test.seed_placeholder
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+    )EOF");
+    }
+
+    config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      envoy::extensions::bootstrap::internal_listener::v3::InternalListener config;
+      auto* bootstrap_extension = bootstrap.add_bootstrap_extensions();
+      std::ignore = bootstrap_extension->mutable_typed_config()->PackFrom(config);
+      bootstrap_extension->set_name("envoy.bootstrap.internal_listener");
+
+      auto* static_resources = bootstrap.mutable_static_resources();
+
+      auto* cluster = static_resources->mutable_clusters()->Add();
+      cluster->set_name("internal_listener");
+      cluster->clear_load_assignment();
+      cluster->mutable_load_assignment()->set_cluster_name("internal_listener");
+      auto* endpoint = cluster->mutable_load_assignment()
+                           ->add_endpoints()
+                           ->add_lb_endpoints()
+                           ->mutable_endpoint();
+      auto* addr = endpoint->mutable_address()->mutable_envoy_internal_address();
+      addr->set_server_listener_name("internal_listener");
+      addr->set_endpoint_id("lorem_ipsum");
+      // Naming the factory makes internal_upstream provision the object; left unset, the seed
+      // filter supplies it.
+      const std::string provisioning_block =
+          read_upstream_filter_state_
+              ? "\n        provisioned_placeholder_factories:\n        - "
+                "envoy.tcp_proxy.propagate_response_headers"
+              : "";
+      const std::string wrapped_transport_socket =
+          wrapped_socket_uses_tls_
+              ? fmt::format(R"EOF(
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+            common_tls_context:
+              validation_context:
+                trusted_ca:
+                  filename: {})EOF",
+                            TestEnvironment::runfilesPath(
+                                "test/config/integration/certs/upstreamcacert.pem"))
+              : std::string(R"EOF(
+          name: envoy.transport_sockets.raw_buffer
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer)EOF");
+
+      TestUtility::loadFromYaml(fmt::format(R"EOF(
+      name: envoy.transport_sockets.internal_upstream
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport
+        transport_socket:{}{}
+      )EOF",
+                                            wrapped_transport_socket, provisioning_block),
+                                *cluster->mutable_transport_socket());
+
+
+      TestUtility::loadFromYaml(R"EOF(
+      name: internal_listener
+      internal_listener: {}
+      filter_chains:
+      - filters:
+        - name: tcp_proxy
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+            cluster: cluster_0
+            stat_prefix: internal_tunnel
+            tunneling_config:
+              hostname: host.com:443
+              propagate_response_headers: true
+      )EOF",
+                                *static_resources->mutable_listeners()->Add());
+    });
+
+    config_helper_.addConfigModifier(
+        [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
+          hcm.mutable_route_config()
+              ->mutable_virtual_hosts(0)
+              ->mutable_routes(0)
+              ->mutable_route()
+              ->set_cluster("internal_listener");
+          const std::string fs_fmt =
+              read_upstream_filter_state_
+                  ? "%UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%"
+                  : "%FILTER_STATE(envoy.tcp_proxy.propagate_response_headers:TYPED)%";
+          TestUtility::loadFromYaml(fmt::format(R"EOF(
+          name: envoy.file_access_log
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            path: {}
+            log_format:
+              text_format_source:
+                inline_string: "{}\n"
+          )EOF",
+                                                access_log_name_, fs_fmt),
+                                    *hcm.add_access_log());
+        });
+
+    HttpIntegrationTest::initialize();
+  }
+};
+
+// A non-2xx CONNECT status is readable on the downstream connection's filter state.
+TEST_F(FwdMutablePlaceholderIntegrationTest, ForwardMutablePlaceholderCarriesNon2xxStatus) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  EXPECT_EQ(upstream_request_->headers().getMethodValue(), "CONNECT");
+
+  const std::string header_value = "secret-value";
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  response_headers.addCopy("test-header-name", header_value);
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  ASSERT_TRUE(response->waitForEndStream());
+  cleanupUpstreamAndDownstream();
+
+  EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr(header_value));
+}
+
+// internal_upstream provisions the object itself, with no seed filter, and it is read via
+// %UPSTREAM_FILTER_STATE%.
+TEST_F(FwdMutablePlaceholderIntegrationTest, BoundaryProvisionedPlaceholderViaUpstreamFilterState) {
+  seed_via_hcm_filter_ = false;
+  read_upstream_filter_state_ = true;
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  EXPECT_EQ(upstream_request_->headers().getMethodValue(), "CONNECT");
+
+  const std::string header_value = "secret-value";
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  response_headers.addCopy("test-header-name", header_value);
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  ASSERT_TRUE(response->waitForEndStream());
+  cleanupUpstreamAndDownstream();
+
+  EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr(header_value));
+}
+
+// The wrapped socket is TLS, so a rejected CONNECT makes the pool report failure rather than
+// readiness. Covers recording upstream filter state on the failure path.
+TEST_F(FwdMutablePlaceholderIntegrationTest, ProvisionedPlaceholderReadableOnPoolFailure) {
+  seed_via_hcm_filter_ = false;
+  read_upstream_filter_state_ = true;
+  wrapped_socket_uses_tls_ = true;
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+  EXPECT_EQ(upstream_request_->headers().getMethodValue(), "CONNECT");
+
+  const std::string header_value = "secret-value";
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "403"}};
+  response_headers.addCopy("test-header-name", header_value);
+  upstream_request_->encodeHeaders(response_headers, false);
+
+  ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  ASSERT_TRUE(response->waitForEndStream());
+  cleanupUpstreamAndDownstream();
+
+  // The connection must have failed to connect. If it reached readiness instead, this case would
+  // not exercise the failure path at all.
+  EXPECT_GT(test_server_->counter("cluster.internal_listener.upstream_cx_connect_fail")->value(), 0);
+
+  EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr(header_value));
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
@@ -59,13 +59,14 @@ public:
     inner_socket_ = inner_socket.get();
     ON_CALL(transport_callbacks_, ioHandle()).WillByDefault(testing::ReturnRef(io_handle));
     socket_ = std::make_unique<InternalSocket>(std::move(inner_socket), std::move(metadata_),
-                                               filter_state_objects_);
+                                               filter_state_objects_, placeholder_factories_);
     EXPECT_CALL(*inner_socket_, setTransportSocketCallbacks(_));
     socket_->setTransportSocketCallbacks(transport_callbacks_);
   }
 
   std::unique_ptr<envoy::config::core::v3::Metadata> metadata_;
   StreamInfo::FilterState::Objects filter_state_objects_;
+  std::vector<const StreamInfo::FilterState::ObjectFactory*> placeholder_factories_;
   NiceMock<Network::MockTransportSocket>* inner_socket_;
   std::unique_ptr<InternalSocket> socket_;
   NiceMock<Network::MockTransportSocketCallbacks> transport_callbacks_;

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_test.cc
@@ -26,6 +26,32 @@ using IoSocket::UserSpace::PassthroughState;
 
 class TestObject : public StreamInfo::FilterState::Object {};
 
+// Produces an empty object, mirroring how a real placeholder factory behaves: created empty here
+// and populated later by whichever filter owns the value.
+class TestPlaceholderFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "test.placeholder"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view data) const override {
+    if (!data.empty()) {
+      return nullptr;
+    }
+    return std::make_unique<TestObject>();
+  }
+};
+
+REGISTER_FACTORY(TestPlaceholderFactory, StreamInfo::FilterState::ObjectFactory);
+
+// Declines to produce an object at all.
+class NullPlaceholderFactory : public StreamInfo::FilterState::ObjectFactory {
+public:
+  std::string name() const override { return "test.null_placeholder"; }
+  std::unique_ptr<StreamInfo::FilterState::Object>
+  createFromBytes(absl::string_view) const override {
+    return nullptr;
+  }
+};
+
 class MockUserSpaceIoHandle : public Network::MockIoHandle, public IoHandle {
 public:
   MOCK_METHOD(void, setEof, ());
@@ -117,6 +143,98 @@ TEST_F(InternalSocketTest, EmptyPassthroughState) {
         ASSERT_EQ(0, filter_state_objects.size());
       }));
   initialize(io_handle);
+}
+
+// A configured factory name is resolved and an empty object is forward-shared under that name.
+TEST_F(InternalSocketTest, ProvisionsPlaceholderAndForwardShares) {
+  TestPlaceholderFactory factory;
+  placeholder_factories_.push_back(&factory);
+  auto state = std::make_shared<NiceMock<MockPassthroughState>>();
+  NiceMock<MockUserSpaceIoHandle> io_handle;
+  EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
+  EXPECT_CALL(*state, initialize(_, _))
+      .WillOnce(Invoke([&](std::unique_ptr<envoy::config::core::v3::Metadata>,
+                           const StreamInfo::FilterState::Objects& filter_state_objects) -> void {
+        ASSERT_EQ(1, filter_state_objects.size());
+        EXPECT_EQ("test.placeholder", filter_state_objects.at(0).name_);
+        EXPECT_NE(nullptr, filter_state_objects.at(0).data_);
+      }));
+  initialize(io_handle);
+}
+
+// A name already being shared in from the downstream side is left alone rather than provisioned
+// over.
+TEST_F(InternalSocketTest, SkipsProvisioningWhenNameAlreadyShared) {
+  TestPlaceholderFactory factory;
+  placeholder_factories_.push_back(&factory);
+  auto existing = std::make_shared<TestObject>();
+  filter_state_objects_.push_back(
+      {existing, StreamInfo::StreamSharingMayImpactPooling::None, "test.placeholder"});
+
+  auto state = std::make_shared<NiceMock<MockPassthroughState>>();
+  NiceMock<MockUserSpaceIoHandle> io_handle;
+  EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
+  EXPECT_CALL(*state, initialize(_, _))
+      .WillOnce(Invoke([&](std::unique_ptr<envoy::config::core::v3::Metadata>,
+                           const StreamInfo::FilterState::Objects& filter_state_objects) -> void {
+        ASSERT_EQ(1, filter_state_objects.size());
+        EXPECT_EQ(existing.get(), filter_state_objects.at(0).data_.get());
+      }));
+  initialize(io_handle);
+}
+
+// A factory that declines to produce an object contributes nothing.
+TEST_F(InternalSocketTest, SkipsProvisioningWhenFactoryDeclines) {
+  NullPlaceholderFactory factory;
+  placeholder_factories_.push_back(&factory);
+  auto state = std::make_shared<NiceMock<MockPassthroughState>>();
+  NiceMock<MockUserSpaceIoHandle> io_handle;
+  EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
+  EXPECT_CALL(*state, initialize(_, _))
+      .WillOnce(Invoke([&](std::unique_ptr<envoy::config::core::v3::Metadata>,
+                           const StreamInfo::FilterState::Objects& filter_state_objects) -> void {
+        EXPECT_EQ(0, filter_state_objects.size());
+      }));
+  initialize(io_handle);
+}
+
+// The provisioned object is also placed on this connection's own filter state, and it is the same
+// instance that was forward-shared.
+TEST_F(InternalSocketTest, OnConnectedPlacesPlaceholderOnConnectionFilterState) {
+  TestPlaceholderFactory factory;
+  placeholder_factories_.push_back(&factory);
+  auto state = std::make_shared<NiceMock<MockPassthroughState>>();
+  NiceMock<MockUserSpaceIoHandle> io_handle;
+  EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
+
+  const StreamInfo::FilterState::Object* shared = nullptr;
+  EXPECT_CALL(*state, initialize(_, _))
+      .WillOnce(Invoke([&](std::unique_ptr<envoy::config::core::v3::Metadata>,
+                           const StreamInfo::FilterState::Objects& filter_state_objects) -> void {
+        ASSERT_EQ(1, filter_state_objects.size());
+        shared = filter_state_objects.at(0).data_.get();
+      }));
+  initialize(io_handle);
+
+  socket_->onConnected();
+  const auto* placed =
+      transport_callbacks_.connection().streamInfo().filterState()->getDataReadOnly<TestObject>(
+          "test.placeholder");
+  ASSERT_NE(nullptr, placed);
+  EXPECT_EQ(shared, placed);
+}
+
+// Calling onConnected without any provisioned objects is a no-op.
+TEST_F(InternalSocketTest, OnConnectedWithNothingProvisioned) {
+  auto state = std::make_shared<NiceMock<MockPassthroughState>>();
+  NiceMock<MockUserSpaceIoHandle> io_handle;
+  EXPECT_CALL(io_handle, passthroughState()).WillRepeatedly(testing::Return(state));
+  initialize(io_handle);
+  socket_->onConnected();
+  EXPECT_EQ(
+      nullptr,
+      transport_callbacks_.connection().streamInfo().filterState()->getDataReadOnly<TestObject>(
+          "test.placeholder"));
 }
 
 class ConfigTest : public testing::Test {
@@ -213,6 +331,22 @@ TEST_F(ConfigTest, Empty) {
   initialize();
   EXPECT_EQ(nullptr, config_->extractMetadata(host_));
   EXPECT_EQ(0, stats_store_.counter("internal_upstream.no_metadata").value());
+}
+
+// A name that resolves to a registered factory is accepted.
+TEST_F(ConfigTest, RegisteredPlaceholderFactoryAccepted) {
+  TestUtility::loadFromYaml(std::string(SampleConfig), config_proto_);
+  config_proto_.add_provisioned_placeholder_factories("test.placeholder");
+  EXPECT_NO_THROW(initialize());
+}
+
+// A name with no registered factory is rejected at config load rather than silently producing
+// nothing at request time.
+TEST_F(ConfigTest, UnregisteredPlaceholderFactoryRejected) {
+  TestUtility::loadFromYaml(std::string(SampleConfig), config_proto_);
+  config_proto_.add_provisioned_placeholder_factories("test.not_registered");
+  EXPECT_THROW_WITH_REGEX(initialize(), EnvoyException,
+                          "no StreamInfo::FilterState::ObjectFactory registered");
 }
 
 } // namespace


### PR DESCRIPTION
### Commit Message

internal_upstream: provision mutable filter state placeholders, readable on pool failure

### Additional Description

In the internal-listener tunneling topology — outer L7 listener → cluster with
`transport_socket: envoy.transport_sockets.internal_upstream` → internal listener → `tcp_proxy`
issuing CONNECT — the response captured by `propagate_response_headers` lands on the **inner**
connection's filter state. The outer L7 listener, which received the original request, cannot read
it. A non-2xx CONNECT (an authorization denial returning 403, say) therefore reaches the client as a
canonical 503.

This is the alternative @kyessenov suggested in
[#45237](https://github.com/envoyproxy/envoy/pull/45237#issuecomment-5075206444): rather than adding
a reverse propagation direction, provision an **empty, mutable** filter state object at the boundary,
forward-share it by reference over the existing `PassthroughState` path, and let `tcp_proxy` fill it
in place. One `shared_ptr`, visible on both sides. No new sharing direction and no close-ordering
dependency.

#### Relationship to #45237

The two are **alternatives for the same goal, not dependencies.** Either can land alone.

| | #45237 — reverse primitive | this PR — forward placeholder |
|---|---|---|
| mechanism | new `SharedWithDownstreamConnectionOnClose` direction; objects copied out at close | existing forward share; one object, mutated in place |
| close ordering | effective only when the inner side closes first | not applicable — the object exists before the CONNECT is sent |
| new interfaces | `IoHandle::addOnPreCloseCallback`, `PassthroughState::captureReverse`/`mergeReverse`, new enum variant | one repeated proto field |
| generality | inner side can send back anything, unilaterally | outer side must name the object up front |
| cost | on the tunneled path only, and only when there is something to carry | one empty object per boundary connection |

The reverse primitive is the more general channel and remains the better long-term contribution. This
one is smaller, order-independent, and adds no new sharing semantics. **Part 3 below is required by
both.**

#### Why the object is provisioned at the boundary, and not seeded from a downstream filter

The same object can be seeded by an ordinary downstream HTTP filter on the outer listener, with no core
change at all. That variant works — it is one of the test cases below — and its smaller footprint makes
it the obvious first suggestion. It is not viable for the deployment this is written for because
the outer listener here is a sidecar's **shared outbound listener**. It carries every outbound request
from the local application, whether that request is tunnelled or not. A downstream filter on it runs for
all of them, and the object cannot be narrowed to the cases that need it:

- it has to exist *before* the upstream connection, so it cannot wait until a failure is known; and
- tunnelled destinations are resolved on demand, after routing, so there is no per-route hook to attach
  it to.

The payload only matters in the error case, and only on the tunnelled path. Seeding downstream therefore
means paying an allocation on **every outbound request** to serve a rare error on a subset of them.

Provisioning at the transport socket avoids that without giving up the idea: the `internal_upstream`
transport socket exists only on clusters that tunnel, so the object is created only on that path — and
once per connection, not once per request. That is the whole reason this PR provisions the object one
hop in rather than at the listener.

The topology and the cost model are set out in more detail in
[this comment on #45237](https://github.com/envoyproxy/envoy/pull/45237#issuecomment-5170765784).

#### The change, in three parts

**Part 1 — `internal_upstream` can be told to provision empty filter state objects.** A new
`provisioned_placeholder_factories` field names registered `FilterState::ObjectFactory` instances.
Each name is resolved when the config loads, so a name that does not resolve is a config rejection
rather than a silent no-op at request time. For each one, an empty object is placed on the upstream
connection and forward-shared into the internal connection over the existing `PassthroughState` path.
It is one object, not a copy, so either side can see what the other writes.

*Where the object lives,* since @kyessenov asked about multiplexing on #45237: on the upstream
connection this transport socket creates. There is one of those per cluster, so the object is never
shared between different upstreams, and it is created per connection rather than per request.

**Part 2 — `tcp_proxy` fills such an object instead of replacing it.** When it captures a CONNECT
response and an object for that key already exists, it now writes the headers into that object rather
than storing a new one over the top. Anything else holding the original therefore sees the headers.
With no object already present, the behaviour is unchanged. An object factory is registered for the
existing `envoy.tcp_proxy.propagate_response_headers` key so that it can be named from config.

**Part 3 — the router records upstream filter state when a connection fails, not only when it
succeeds.** Today `onPoolReady` records it and `onPoolFailure` does not, because the failure callback
is given no `StreamInfo`. A rejected CONNECT is a connection *failure*, so `%UPSTREAM_FILTER_STATE%`
reads nothing on exactly the path where the response status matters.

The HTTP connection pool now passes the failing connection's filter state along with the failure, and
the router records it the same way it already does on success. The new callback forms default to the
existing ones, so no current implementation has to change, and the existing failure handling still
runs unaltered.

#### Why Part 3 is in this PR rather than its own

Part 3 is the failure-path counterpart of an existing success-path capture, and **every** approach that reads the outer connection's filter state needs it —
including #45237, which defers it as an intended follow-up. On that symmetry argument alone it would stand as a PR of its own.
It is included in this PR because  because standing alone it is an API widening with no observable behaviour change and no
test that demonstrates value. Parts 1–2 are that use case: together they make the failure-path
capture observable end to end. If reviewers would rather see Part 3 separately, happy to split it —
Parts 1–2 are then blocked until it lands.

#### What is not in this PR

- **Rewriting the client-visible status.** This makes the CONNECT response *readable* on the outer
  side. Acting on it is a filter, and out of scope here.
- **Clearing the object between requests on a reused tunnel.** Not required: `propagateResponseHeaders`
  is invoked on *every* CONNECT response, before the validity check, so the object always describes
  the CONNECT that established the tunnel it is attached to.
- **The same change for the TCP connection pool.** `Tcp::ConnPoolImpl` has the identical asymmetry. Its
  `onPoolFailure` override does take the new parameter, because the base virtual requires it, but
  ignores the value; carrying it further needs a matching overload on `Tcp::ConnectionPool::Callbacks`
  and a hop in the `upstreams/http/tcp` adapter. Left out deliberately — nothing here exercises that
  path — and it is a small self-contained follow-up.
- Any change to `tcp_proxy` wire behaviour (CONNECT semantics, reset behaviour, retries).

### Risk Level

Low.

- Opt-in throughout. With `provisioned_placeholder_factories` empty, `internal_upstream` behaves
  exactly as today and `tcp_proxy` takes its existing `setData` path.
- Both new `onPoolFailure` overloads default to the existing three-argument form, and
  `ActiveClient::connectionFilterState()` defaults to `nullptr`. No existing implementor changes.
- The capture in `UpstreamRequest::onPoolFailure` is additive; the existing three-argument body still
  runs, so failure handling is otherwise untouched.
- The provisioned object is created empty with a valid header map, so a read before the fill yields
  an empty object rather than a null dereference.

### Testing

New integration tests in
`test/extensions/transport_sockets/internal_upstream/fwd_mutable_placeholder_integration_test.cc`.
The topology in each is: outer HCM → internal-listener cluster carrying the `internal_upstream`
transport socket → internal listener running `tcp_proxy` with `propagate_response_headers: true` →
upstream that rejects the CONNECT with a non-2xx.

1. **Placeholder seeded by a downstream HTTP filter**, read via `%FILTER_STATE%`. Covers the
   by-reference in-place mutation independently of Part 1.
2. **Placeholder provisioned by `internal_upstream`** via `provisioned_placeholder_factories`, read
   via `%UPSTREAM_FILTER_STATE%`. Covers Parts 1 and 2.
3. **Same, but the socket `internal_upstream` wraps is TLS rather than raw buffer.** With no handshake
   the pool reports readiness as soon as the user-space connect returns, so the failure path is never
   taken. A TLS handshake has to travel through the CONNECT tunnel, so a rejected CONNECT means the
   pool reports failure instead. **This is the case that covers Part 3**, and it asserts
   `cluster.internal_listener.upstream_cx_connect_fail > 0` so the premise cannot silently rot back
   into a readiness test.

**Verified end to end in custom deployment mirroring the architecture above** 

### Docs Changes

`internal_upstream.proto`: documents `provisioned_placeholder_factories`, including that a name
already present on the connection from the downstream side is left untouched (no double
provisioning), and that the objects must be mutable for a downstream consumer to fill them.

### Release Notes

`changelogs/current/new_features/sockets__internal-upstream-provisioned-placeholder-factories.rst`:

> Added
> :ref:`provisioned_placeholder_factories <envoy_v3_api_field_extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport.provisioned_placeholder_factories>`
> to the ``internal_upstream`` transport socket, naming registered filter state object factories to
> provision as empty objects on the upstream connection and share by reference with the downstream
> internal connection. A filter on the internal connection can populate such an object in place, and
> the value is then readable on the upstream connection.

`changelogs/current/new_features/router__upstream-filter-state-on-pool-failure.rst`:

> The upstream connection filter state is now recorded on the connection pool failure path as well as
> on the pool ready path, so filter state written by an upstream transport socket is readable through
> ``%UPSTREAM_FILTER_STATE%`` when the upstream connection fails. Previously it was only readable when
> the connection succeeded.

`changelogs/current/new_features/tcp_proxy__fill-existing-tunnel-response-headers-object.rst`:

> When ``propagate_response_headers`` is enabled and a filter state object is already present under
> ``envoy.tcp_proxy.propagate_response_headers``, the captured CONNECT response headers are now written
> into that object instead of replacing it, so that anything else holding the object observes the value.
> Behavior is unchanged when no such object is present.

### Platform Specific Features

N/A.

### Related

- **#43977 — the report this addresses.** It describes this exact topology, asks for the non-2xx
  CONNECT status to reach the client, and notes that
  `UPSTREAM_FILTER_STATE(envoy.tcp_proxy.propagate_response_headers)` at the egress HCM shows nothing
  while the inner `tcp_proxy` access log does show the 403. Part 3 is the fix for that specific
  observation. The issue was closed by #44157, which added visibility on the *inner* side — the side
  the reporter already had — so what the issue actually asks for is still outstanding.
- #44157 — records the non-2xx CONNECT status in the transport failure reason, on the inner side.
- #45237 — the reverse-propagation alternative; see the table above.

No `Fixes:` line, because this is not the whole of #43977: it makes the status *readable* at the
outer listener, and the issue asks for it to reach the client's response, which needs the
response-rewriting filter that is out of scope here.
