### PR TITLE
Fix linkopts for zstd on Windows

### DIFF
--- a/bazel/external/zstd.BUILD
+++ b/bazel/external/zstd.BUILD
@@ -63,7 +63,10 @@ cc_library(
         "//conditions:default": [],
     }),
     includes = ["lib"],
-    linkopts = ["-pthread"],
+    linkopts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-pthread"],
+    }),
     linkstatic = True,
 )
 


### PR DESCRIPTION
Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
