### PR TITLE
test/quiche: Move tests into Envoys bazel repo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -209,7 +209,7 @@ build:coverage --coverage_report_generator=@envoy//tools/coverage:report_generat
 
 build:test-coverage --test_arg="-l trace"
 build:test-coverage --test_arg="--log-path /dev/null"
-build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target
+build:test-coverage --test_tag_filters=-nocoverage,-fuzz_target,-quiche
 
 ## Compile-time-options testing
 # Right now, none of the available compile-time options conflict with each other. If this
@@ -359,7 +359,7 @@ build:asan-fuzzer --linkopt=-lc++
 
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
-build:fuzz-coverage --test_tag_filters=-nocoverage
+build:fuzz-coverage --test_tag_filters=-nocoverage,-quiche
 # Existing fuzz tests don't need a full WASM runtime and in generally we don't really want to
 # fuzz dependencies anyways. On the other hand, disabling WASM reduces the build time and
 # resources required to build and run the tests.

--- a/.bazelrc
+++ b/.bazelrc
@@ -250,7 +250,7 @@ common:openssl --@envoy//bazel:crypto=@envoy//compat/openssl:crypto
 common:openssl --copt=-DENVOY_SSL_OPENSSL
 common:openssl --host_copt=-DENVOY_SSL_OPENSSL
 common:openssl --@envoy//bazel:http3=False
-common:openssl --test_tag_filters=-nofips
+common:openssl --test_tag_filters=-nofips,-quiche
 common:openssl --build_tag_filters=-nofips
 
 

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -3,13 +3,11 @@ load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_cc_test",
     "envoy_cc_test_library",
 )
 load(
     "@envoy//bazel/external:quiche.bzl",
     "envoy_quic_cc_library",
-    "envoy_quic_cc_test",
     "envoy_quic_cc_test_library",
     "envoy_quiche_platform_impl_cc_library",
     "envoy_quiche_platform_impl_cc_test_library",
@@ -17,6 +15,8 @@ load(
 )
 
 licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
 
 # QUICHE is Google's implementation of QUIC and related protocols. It is the
 # same code used in Chromium and Google's servers, but packaged in a form that
@@ -43,28 +43,120 @@ src_files = glob([
     "**/*.proto",
 ])
 
-test_suite(
-    name = "ci_tests",
-    tests = [
-        "http2_adapter_event_forwarder_test",
-        "http2_adapter_header_validator_test",
-        "http2_adapter_impl_comparison_test",
-        "http2_adapter_nghttp2_adapter_test",
-        "http2_adapter_nghttp2_data_provider_test",
-        "http2_adapter_nghttp2_session_test",
-        "http2_adapter_oghttp2_adapter_test",
-        "http2_adapter_oghttp2_session_test",
-        "http2_adapter_oghttp2_util_test",
-        "http2_adapter_recording_http2_visitor_test",
-        "http2_adapter_window_manager_test",
-        "http2_platform_api_test",
-        "quiche_balsa_balsa_frame_test",
-        "quiche_balsa_balsa_headers_test",
-        "quiche_balsa_header_properties_test",
-        "quiche_balsa_simple_buffer_test",
-        "quiche_common_test",
-        "quiche_http_header_block_test",
+# Filegroups exposing test sources for consumption by Envoy's test targets
+# in //test/common/quic/quiche/BUILD, which use the real envoy_cc_test macro.
+filegroup(
+    name = "http2_adapter_event_forwarder_test_srcs",
+    srcs = ["quiche/http2/adapter/event_forwarder_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_header_validator_test_srcs",
+    srcs = [
+        "quiche/http2/adapter/header_validator_test.cc",
+        "quiche/http2/adapter/noop_header_validator_test.cc",
     ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_impl_comparison_test_srcs",
+    srcs = ["quiche/http2/adapter/adapter_impl_comparison_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_nghttp2_adapter_test_srcs",
+    srcs = ["quiche/http2/adapter/nghttp2_adapter_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_nghttp2_data_provider_test_srcs",
+    srcs = ["quiche/http2/adapter/nghttp2_data_provider_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_nghttp2_session_test_srcs",
+    srcs = ["quiche/http2/adapter/nghttp2_session_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_oghttp2_adapter_test_srcs",
+    srcs = ["quiche/http2/adapter/oghttp2_adapter_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_oghttp2_session_test_srcs",
+    srcs = ["quiche/http2/adapter/oghttp2_session_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_oghttp2_util_test_srcs",
+    srcs = ["quiche/http2/adapter/oghttp2_util_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_recording_http2_visitor_test_srcs",
+    srcs = ["quiche/http2/adapter/recording_http2_visitor_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_adapter_window_manager_test_srcs",
+    srcs = ["quiche/http2/adapter/window_manager_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "http2_platform_api_test_srcs",
+    srcs = ["quiche/http2/test_tools/http2_random_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "quiche_balsa_balsa_frame_test_srcs",
+    srcs = ["quiche/balsa/balsa_frame_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "quiche_balsa_balsa_headers_test_srcs",
+    srcs = ["quiche/balsa/balsa_headers_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "quiche_balsa_header_properties_test_srcs",
+    srcs = ["quiche/balsa/header_properties_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "quiche_balsa_simple_buffer_test_srcs",
+    srcs = ["quiche/balsa/simple_buffer_test.cc"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "quiche_common_test_srcs",
+    srcs = [
+        "quiche/common/quiche_linked_hash_map_test.cc",
+        "quiche/common/quiche_mem_slice_storage_test.cc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "quiche_http_header_block_test_srcs",
+    srcs = ["quiche/common/http/http_header_block_test.cc"],
+    visibility = ["//visibility:public"],
 )
 
 envoy_cc_test_library(
@@ -85,17 +177,6 @@ envoy_cc_library(
     deps = [
         ":quiche_common_circular_deque_lib",
         ":quiche_common_platform_export",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_chunked_buffer_test",
-    srcs = ["quiche/http2/adapter/chunked_buffer_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_common_platform_test",
-        "@abseil-cpp//absl/strings",
     ],
 )
 
@@ -122,19 +203,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "http2_adapter_event_forwarder_test",
-    srcs = ["quiche/http2/adapter/event_forwarder_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_event_forwarder",
-        ":http2_core_protocol_lib",
-        ":http2_test_tools_mock_spdy_framer_visitor_lib",
-        ":quiche_common_platform_test",
-    ],
-)
-
 envoy_cc_library(
     name = "http2_adapter_header_validator",
     srcs = [
@@ -151,20 +219,6 @@ envoy_cc_library(
     deps = [
         ":http2_constants_lib",
         ":quiche_common_platform_export",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_header_validator_test",
-    srcs = [
-        "quiche/http2/adapter/header_validator_test.cc",
-        "quiche/http2/adapter/noop_header_validator_test.cc",
-    ],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_header_validator",
-        ":quiche_common_platform_test",
     ],
 )
 
@@ -204,22 +258,6 @@ envoy_cc_library(
     deps = [
         ":http2_adapter_http2_protocol",
         ":quiche_common_platform_export",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_impl_comparison_test",
-    srcs = ["quiche/http2/adapter/adapter_impl_comparison_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter",
-        ":http2_adapter_http2_protocol",
-        ":http2_adapter_mock_http2_visitor",
-        ":http2_adapter_recording_http2_visitor",
-        ":http2_adapter_test_frame_sequence",
-        ":http2_adapter_test_utils",
-        ":quiche_common_platform_test",
     ],
 )
 
@@ -293,25 +331,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "http2_adapter_nghttp2_adapter_test",
-    srcs = ["quiche/http2/adapter/nghttp2_adapter_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_http2_protocol",
-        ":http2_adapter_http2_visitor_interface",
-        ":http2_adapter_mock_http2_visitor",
-        ":http2_adapter_nghttp2_adapter",
-        ":http2_adapter_nghttp2_include",
-        ":http2_adapter_nghttp2_test_utils",
-        ":http2_adapter_oghttp2_util",
-        ":http2_adapter_test_frame_sequence",
-        ":http2_adapter_test_utils",
-        ":quiche_common_platform_test",
-    ],
-)
-
 envoy_cc_library(
     name = "http2_adapter_nghttp2_callbacks",
     srcs = ["quiche/http2/adapter/nghttp2_callbacks.cc"],
@@ -344,41 +363,12 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "http2_adapter_nghttp2_data_provider_test",
-    srcs = ["quiche/http2/adapter/nghttp2_data_provider_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_nghttp2_data_provider",
-        ":http2_adapter_test_utils",
-        ":quiche_common_platform_test",
-    ],
-)
-
 envoy_cc_library(
     name = "http2_adapter_nghttp2_include",
     hdrs = ["quiche/http2/adapter/nghttp2.h"],
     copts = quiche_copts,
     external_deps = ["nghttp2"],
     repository = "@envoy",
-)
-
-envoy_cc_test(
-    name = "http2_adapter_nghttp2_session_test",
-    srcs = ["quiche/http2/adapter/nghttp2_session_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter",
-        ":http2_adapter_mock_http2_visitor",
-        ":http2_adapter_nghttp2_callbacks",
-        ":http2_adapter_nghttp2_util",
-        ":http2_adapter_test_frame_sequence",
-        ":http2_adapter_test_utils",
-        ":quiche_common_platform_expect_bug",
-        ":quiche_common_platform_test",
-    ],
 )
 
 envoy_cc_test_library(
@@ -449,38 +439,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "http2_adapter_oghttp2_adapter_test",
-    srcs = ["quiche/http2/adapter/oghttp2_adapter_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_http2_protocol",
-        ":http2_adapter_http2_visitor_interface",
-        ":http2_adapter_mock_http2_visitor",
-        ":http2_adapter_oghttp2_adapter",
-        ":http2_adapter_oghttp2_util",
-        ":http2_adapter_test_frame_sequence",
-        ":http2_adapter_test_utils",
-        ":quiche_common_platform_expect_bug",
-        ":quiche_common_platform_test",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_oghttp2_session_test",
-    srcs = ["quiche/http2/adapter/oghttp2_session_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_mock_http2_visitor",
-        ":http2_adapter_oghttp2_adapter",
-        ":http2_adapter_test_frame_sequence",
-        ":http2_adapter_test_utils",
-        ":quiche_common_platform_test",
-    ],
-)
-
 envoy_cc_library(
     name = "http2_adapter_oghttp2_util",
     srcs = ["quiche/http2/adapter/oghttp2_util.cc"],
@@ -491,19 +449,6 @@ envoy_cc_library(
         ":common_http_http_header_block_lib",
         ":http2_adapter_http2_protocol",
         ":quiche_common_platform_export",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_oghttp2_util_test",
-    srcs = ["quiche/http2/adapter/oghttp2_util_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_http2_protocol",
-        ":http2_adapter_oghttp2_util",
-        ":http2_adapter_test_frame_sequence",
-        ":quiche_common_platform_test",
     ],
 )
 
@@ -518,20 +463,6 @@ envoy_cc_test_library(
         ":http2_adapter_http2_util",
         ":http2_adapter_http2_visitor_interface",
         ":quiche_common_platform_export",
-        ":quiche_common_platform_test",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_recording_http2_visitor_test",
-    srcs = ["quiche/http2/adapter/recording_http2_visitor_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_http2_protocol",
-        ":http2_adapter_http2_visitor_interface",
-        ":http2_adapter_recording_http2_visitor",
-        ":http2_test_tools_random",
         ":quiche_common_platform_test",
     ],
 )
@@ -594,21 +525,6 @@ envoy_cc_library(
         ":quiche_common_callbacks",
         ":quiche_common_platform",
         ":quiche_common_platform_export",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_adapter_window_manager_test",
-    srcs = ["quiche/http2/adapter/window_manager_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":http2_adapter_window_manager",
-        ":http2_test_tools_random",
-        ":quiche_common_platform_expect_bug",
-        ":quiche_common_platform_export",
-        ":quiche_common_platform_test",
-        "@abseil-cpp//absl/functional:bind_front",
     ],
 )
 
@@ -1947,18 +1863,6 @@ envoy_quic_cc_library(
         ":quic_platform_base",
         ":quic_platform_bug_tracker",
         ":quiche_common_lib",
-    ],
-)
-
-envoy_cc_test(
-    name = "quic_core_blocked_writer_list_test",
-    srcs = ["quiche/quic/core/quic_blocked_writer_list_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quic_core_blocked_writer_interface_lib",
-        ":quic_core_blocked_writer_list_lib",
-        ":quic_platform_test",
     ],
 )
 
@@ -5017,30 +4921,6 @@ envoy_cc_test_library(
     deps = ["@envoy//test/common/quic/platform:quiche_test_impl_lib"],
 )
 
-envoy_cc_test(
-    name = "quiche_common_mem_slice_test",
-    srcs = ["quiche/common/quiche_mem_slice_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_common_buffer_allocator_lib",
-        ":quiche_common_mem_slice",
-        ":quiche_common_platform",
-        ":quiche_common_platform_test",
-    ],
-)
-
-envoy_cc_test(
-    name = "quiche_common_time_utils_test",
-    srcs = ["quiche/common/platform/api/quiche_time_utils_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_common_platform",
-        ":quiche_common_platform_test",
-    ],
-)
-
 envoy_cc_library(
     name = "quiche_common_print_elements_lib",
     hdrs = ["quiche/common/print_elements.h"],
@@ -5141,18 +5021,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "quiche_http_header_block_test",
-    srcs = ["quiche/common/http/http_header_block_test.cc"],
-    repository = "@envoy",
-    deps = [
-        ":http2_test_tools_test_utils_lib",
-        ":quiche_common_platform_test",
-        ":quiche_http_header_block_lib",
-        "@abseil-cpp//absl/functional:bind_front",
-    ],
-)
-
 envoy_cc_library(
     name = "quiche_common_structured_headers_lib",
     srcs = ["quiche/common/structured_headers.cc"],
@@ -5174,32 +5042,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_quic_cc_test(
-    name = "quiche_common_test",
-    srcs = [
-        "quiche/common/quiche_linked_hash_map_test.cc",
-        "quiche/common/quiche_mem_slice_storage_test.cc",
-    ],
-    deps = [
-        ":quiche_common_lib",
-        ":quiche_common_mem_slice_storage",
-        ":quiche_common_platform_test",
-    ],
-)
-
-envoy_cc_test(
-    name = "http2_platform_api_test",
-    srcs = [
-        "quiche/http2/test_tools/http2_random_test.cc",
-    ],
-    repository = "@envoy",
-    deps = [
-        ":http2_test_tools_random",
-        ":quiche_common_platform",
-        ":quiche_common_test_tools_test_utils_lib",
-    ],
-)
-
 envoy_quic_cc_library(
     name = "quiche_common_mem_slice_storage",
     srcs = ["quiche/common/quiche_mem_slice_storage.cc"],
@@ -5209,22 +5051,6 @@ envoy_quic_cc_library(
         ":quic_core_utils_lib",
         ":quic_platform_base",
         ":quiche_common_platform",
-    ],
-)
-
-envoy_cc_test(
-    name = "quic_core_batch_writer_batch_writer_test",
-    srcs = select({
-        "@envoy//bazel:linux": ["quiche/quic/core/batch_writer/quic_batch_writer_test.cc"],
-        "//conditions:default": [],
-    }),
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quic_core_batch_writer_batch_writer_test_lib",
-        ":quic_core_batch_writer_gso_batch_writer_lib",
-        ":quic_core_batch_writer_sendmmsg_batch_writer_lib",
-        ":quic_platform",
     ],
 )
 
@@ -5385,19 +5211,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "quiche_balsa_simple_buffer_test",
-    srcs = ["quiche/balsa/simple_buffer_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_balsa_simple_buffer_lib",
-        ":quiche_common_platform_expect_bug",
-        ":quiche_common_platform_test",
-        "@abseil-cpp//absl/strings",
-    ],
-)
-
 envoy_cc_library(
     name = "quiche_balsa_header_properties_lib",
     srcs = ["quiche/balsa/header_properties.cc"],
@@ -5410,17 +5223,6 @@ envoy_cc_library(
         ":quiche_common_text_utils_lib",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/strings",
-    ],
-)
-
-envoy_cc_test(
-    name = "quiche_balsa_header_properties_test",
-    srcs = ["quiche/balsa/header_properties_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_balsa_header_properties_lib",
-        ":quiche_common_platform_test",
     ],
 )
 
@@ -5448,27 +5250,6 @@ envoy_cc_library(
     ],
 )
 
-envoy_cc_test(
-    name = "quiche_balsa_balsa_headers_test",
-    srcs = ["quiche/balsa/balsa_headers_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_balsa_balsa_enums_lib",
-        ":quiche_balsa_balsa_frame_lib",
-        ":quiche_balsa_balsa_headers_lib",
-        ":quiche_balsa_simple_buffer_lib",
-        ":quiche_common_platform_expect_bug",
-        ":quiche_common_platform_logging",
-        ":quiche_common_platform_test",
-        ":quiche_common_test_tools_test_utils_lib",
-        "@abseil-cpp//absl/base:core_headers",
-        "@abseil-cpp//absl/memory",
-        "@abseil-cpp//absl/strings",
-        "@abseil-cpp//absl/strings:str_format",
-    ],
-)
-
 envoy_cc_library(
     name = "quiche_balsa_balsa_frame_lib",
     srcs = ["quiche/balsa/balsa_frame.cc"],
@@ -5489,28 +5270,6 @@ envoy_cc_library(
         ":quiche_common_platform_export",
         ":quiche_common_platform_logging",
         "@abseil-cpp//absl/strings",
-    ],
-)
-
-envoy_cc_test(
-    name = "quiche_balsa_balsa_frame_test",
-    srcs = ["quiche/balsa/balsa_frame_test.cc"],
-    copts = quiche_copts,
-    repository = "@envoy",
-    deps = [
-        ":quiche_balsa_balsa_enums_lib",
-        ":quiche_balsa_balsa_frame_lib",
-        ":quiche_balsa_balsa_headers_lib",
-        ":quiche_balsa_balsa_visitor_interface_lib",
-        ":quiche_balsa_http_validation_policy_lib",
-        ":quiche_balsa_noop_balsa_visitor_lib",
-        ":quiche_balsa_simple_buffer_lib",
-        ":quiche_common_platform_expect_bug",
-        ":quiche_common_platform_logging",
-        ":quiche_common_platform_test",
-        "@abseil-cpp//absl/flags:flag",
-        "@abseil-cpp//absl/strings",
-        "@abseil-cpp//absl/strings:str_format",
     ],
 )
 

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -48,7 +48,6 @@ src_files = glob([
 filegroup(
     name = "http2_adapter_event_forwarder_test_srcs",
     srcs = ["quiche/http2/adapter/event_forwarder_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -57,91 +56,76 @@ filegroup(
         "quiche/http2/adapter/header_validator_test.cc",
         "quiche/http2/adapter/noop_header_validator_test.cc",
     ],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_impl_comparison_test_srcs",
     srcs = ["quiche/http2/adapter/adapter_impl_comparison_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_nghttp2_adapter_test_srcs",
     srcs = ["quiche/http2/adapter/nghttp2_adapter_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_nghttp2_data_provider_test_srcs",
     srcs = ["quiche/http2/adapter/nghttp2_data_provider_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_nghttp2_session_test_srcs",
     srcs = ["quiche/http2/adapter/nghttp2_session_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_oghttp2_adapter_test_srcs",
     srcs = ["quiche/http2/adapter/oghttp2_adapter_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_oghttp2_session_test_srcs",
     srcs = ["quiche/http2/adapter/oghttp2_session_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_oghttp2_util_test_srcs",
     srcs = ["quiche/http2/adapter/oghttp2_util_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_recording_http2_visitor_test_srcs",
     srcs = ["quiche/http2/adapter/recording_http2_visitor_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_adapter_window_manager_test_srcs",
     srcs = ["quiche/http2/adapter/window_manager_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "http2_platform_api_test_srcs",
     srcs = ["quiche/http2/test_tools/http2_random_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "quiche_balsa_balsa_frame_test_srcs",
     srcs = ["quiche/balsa/balsa_frame_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "quiche_balsa_balsa_headers_test_srcs",
     srcs = ["quiche/balsa/balsa_headers_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "quiche_balsa_header_properties_test_srcs",
     srcs = ["quiche/balsa/header_properties_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "quiche_balsa_simple_buffer_test_srcs",
     srcs = ["quiche/balsa/simple_buffer_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
@@ -150,13 +134,11 @@ filegroup(
         "quiche/common/quiche_linked_hash_map_test.cc",
         "quiche/common/quiche_mem_slice_storage_test.cc",
     ],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(
     name = "quiche_http_header_block_test_srcs",
     srcs = ["quiche/common/http/http_header_block_test.cc"],
-    visibility = ["//visibility:public"],
 )
 
 envoy_cc_test_library(
@@ -228,7 +210,6 @@ envoy_cc_library(
     hdrs = ["quiche/http2/adapter/http2_protocol.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
         "@abseil-cpp//absl/strings",
@@ -532,7 +513,6 @@ envoy_cc_library(
     name = "http2_adapter",
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":http2_adapter_nghttp2_adapter",
         ":http2_adapter_oghttp2_adapter",
@@ -950,7 +930,6 @@ envoy_cc_library(
     hdrs = ["quiche/http2/hpack/decoder/hpack_decoder.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":http2_decoder_decode_buffer_lib",
         ":http2_decoder_decode_status_lib",
@@ -1198,7 +1177,6 @@ envoy_cc_library(
     name = "http2_no_op_headers_handler_lib",
     hdrs = ["quiche/http2/core/no_op_headers_handler.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":http2_header_byte_listener_interface_lib",
         ":quiche_common_platform",
@@ -1209,7 +1187,6 @@ envoy_cc_library(
     name = "http2_header_byte_listener_interface_lib",
     hdrs = ["quiche/http2/core/header_byte_listener_interface.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform",
     ],
@@ -1223,7 +1200,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quiche_common_platform"],
 )
 
@@ -1255,7 +1231,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/http/http_header_block.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_platform",
@@ -1271,7 +1246,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quiche_common_platform"],
 )
 
@@ -1324,7 +1298,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":http2_core_protocol_lib",
         ":http2_hpack_huffman_hpack_huffman_encoder_lib",
@@ -1378,7 +1351,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":common_http_http_header_block_lib",
         ":http2_core_alt_svc_wire_format_lib",
@@ -1422,7 +1394,6 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quic_platform",
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
         ":quic_platform_base",
@@ -1436,7 +1407,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_hostname_utils.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_hostname_utils",
     ],
@@ -1448,7 +1418,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_stack_trace.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_stack_trace",
     ],
@@ -1460,7 +1429,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_server_stats.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_server_stats",
     ],
@@ -1480,7 +1448,6 @@ envoy_cc_library(
         # "quiche/quic/platform/api/quic_test_loopback.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
         ":quic_platform_server_stats",
@@ -1501,7 +1468,6 @@ envoy_cc_library(
         "quiche/quic/platform/api/quic_bug_tracker.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
     ],
@@ -1511,7 +1477,6 @@ envoy_cc_library(
     name = "quic_platform_export",
     hdrs = ["quiche/quic/platform/api/quic_export.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
     ],
@@ -1528,7 +1493,6 @@ envoy_cc_library(
     name = "quic_platform_ip_address_family",
     hdrs = ["quiche/quic/platform/api/quic_ip_address_family.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
         ":quiche_common_ip_address_family",
@@ -1540,7 +1504,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_ip_address_family.cc"],
     hdrs = ["quiche/common/quiche_ip_address_family.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_bug_tracker",
     ],
@@ -1551,7 +1514,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/platform/api/quic_ip_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
         ":quic_platform_export",
@@ -1565,7 +1527,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_ip_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
         ":quic_platform_export",
@@ -1589,7 +1550,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_socket_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_export",
         ":quic_platform_ip_address",
@@ -1601,7 +1561,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/platform/api/quic_socket_address.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_export",
         ":quic_platform_ip_address",
@@ -1693,7 +1652,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_ack_listener_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_time_lib",
         ":quic_core_types_lib",
@@ -1749,7 +1707,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_linux_socket_utils_lib",
         ":quic_core_packet_writer_lib",
@@ -1774,7 +1731,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_buffer_lib",
         ":quic_core_packet_writer_lib",
@@ -1816,7 +1772,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":flow_label_lib",
         ":quic_core_batch_writer_batch_writer_base_lib",
@@ -1841,7 +1796,6 @@ envoy_cc_library(
     }),
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_batch_writer_batch_writer_base_lib",
         ":quic_core_linux_socket_utils_lib",
@@ -2319,7 +2273,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_logging",
         "@abseil-cpp//absl/status",
@@ -2584,7 +2537,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quiche_common_random_lib"],
 )
 
@@ -2646,7 +2598,6 @@ envoy_cc_library(
         "quiche/common/simple_buffer_allocator.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_iovec",
@@ -2672,7 +2623,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_logging"],
 )
 
@@ -2707,7 +2657,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_callbacks.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
         "@abseil-cpp//absl/functional:any_invocable",
@@ -2741,7 +2690,6 @@ envoy_cc_library(
     copts = quiche_copts,
     external_deps = ["ssl"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
         ":quic_platform_export",
@@ -2753,7 +2701,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_feature_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
 )
 
 envoy_cc_library(
@@ -2761,7 +2708,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/quiche_protocol_flags_list.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
 )
 
 envoy_quic_cc_library(
@@ -2899,7 +2845,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/capsule.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_data_lib",
         ":quic_core_http_http_frames_lib",
@@ -2919,7 +2864,6 @@ envoy_cc_library(
     hdrs = ["quiche/common/masque/connect_udp_datagram_payload.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_lib",
         ":quiche_common_platform_bug_tracker",
@@ -3189,7 +3133,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_export",
     ],
@@ -3211,7 +3154,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_interval_set.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_interval_lib",
         ":quic_platform_base",
@@ -3253,7 +3195,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_ip_address_family",
@@ -3313,7 +3254,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_lru_cache.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quic_platform_base"],
 )
 
@@ -3438,7 +3378,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_packets_lib",
         ":quic_core_types_lib",
@@ -4067,7 +4006,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/core/quic_tag.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_platform_base",
         ":quiche_common_text_utils_lib",
@@ -4079,7 +4017,6 @@ envoy_cc_library(
     srcs = ["quiche/quic/core/quic_time.cc"],
     hdrs = ["quiche/quic/core/quic_time.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quic_platform_base"],
 )
 
@@ -4540,7 +4477,6 @@ envoy_cc_library(
     name = "quiche_common_endian_lib",
     hdrs = ["quiche/common/quiche_endian.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps =
         [
             ":quiche_common_platform_export",
@@ -4553,7 +4489,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_client_stats.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_default_quiche_platform_impl_client_stats_impl_lib"],
 )
 
@@ -4592,7 +4527,6 @@ envoy_cc_library(
     srcs = ["quiche/common/quiche_mem_slice.cc"],
     hdrs = ["quiche/common/quiche_mem_slice.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_buffer_allocator_lib",
         ":quiche_common_callbacks",
@@ -4617,7 +4551,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_iovec.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
         ":quiche_common_platform_export",
@@ -4631,7 +4564,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_bug_tracker.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
     ] + select({
@@ -4651,7 +4583,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_logging.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
     ] + select({
@@ -4690,7 +4621,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_hostname_utils.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
         ":quiche_common_platform_googleurl",
@@ -4741,7 +4671,6 @@ envoy_cc_library(
         "//conditions:default": [],
     }),
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_ip_address_family",
@@ -4754,7 +4683,6 @@ envoy_cc_library(
     name = "quiche_common_platform_server_stats",
     hdrs = ["quiche/common/platform/api/quiche_server_stats.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_server_stats_impl_lib",
     ],
@@ -4773,7 +4701,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_stack_trace.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
         "@envoy//source/common/quic/platform:quiche_stack_trace_impl_lib",
@@ -4786,7 +4713,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_containers.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_default_quiche_platform_impl_containers_impl_lib",
         ":quiche_common_platform_export",
@@ -4819,7 +4745,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_testvalue.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_export",
     ],
@@ -4836,7 +4761,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_time_utils.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform_bug_tracker",
         ":quiche_common_platform_default_quiche_platform_impl_command_line_flags_impl_lib",
@@ -4908,7 +4832,6 @@ envoy_cc_library(
         "quiche/common/platform/api/quiche_export.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "@envoy//source/common/quic/platform:quiche_export_impl_lib",
     ],
@@ -4975,7 +4898,6 @@ envoy_cc_library(
         "quiche/common/quiche_linked_hash_map.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_endian_lib",
         ":quiche_common_platform",
@@ -5026,7 +4948,6 @@ envoy_cc_library(
     srcs = ["quiche/common/structured_headers.cc"],
     hdrs = ["quiche/common/structured_headers.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_common_platform",
         ":quiche_common_platform_client_stats",
@@ -5060,7 +4981,6 @@ envoy_cc_library(
     hdrs = ["quiche/quic/load_balancer/load_balancer_server_id.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quic_core_types_lib",
         ":quic_platform_bug_tracker",
@@ -5123,7 +5043,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_enums.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [":quiche_common_platform_export"],
 )
 
@@ -5132,7 +5051,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_visitor_interface.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
         ":quiche_common_platform_export",
@@ -5144,7 +5062,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/noop_balsa_visitor.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_visitor_interface_lib",
         ":quiche_common_platform_export",
@@ -5232,7 +5149,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_headers.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
         ":quiche_balsa_header_api_lib",
@@ -5256,7 +5172,6 @@ envoy_cc_library(
     hdrs = ["quiche/balsa/balsa_frame.h"],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":quiche_balsa_balsa_enums_lib",
         ":quiche_balsa_balsa_headers_lib",
@@ -5282,7 +5197,6 @@ envoy_cc_library(
     ],
     copts = quiche_copts,
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":common_http_http_header_block_lib",
         ":quiche_common_callbacks",

--- a/bazel/external/quiche.bzl
+++ b/bazel/external/quiche.bzl
@@ -1,7 +1,6 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_cc_test",
     "envoy_cc_test_library",
 )
 load("@envoy//bazel:envoy_select.bzl", "envoy_select_enable_http3")
@@ -86,22 +85,6 @@ def envoy_quic_cc_test_library(
         name = name,
         srcs = envoy_select_enable_http3(srcs, "@envoy"),
         hdrs = envoy_select_enable_http3(hdrs, "@envoy"),
-        copts = quiche_copts,
-        repository = "@envoy",
-        tags = tags,
-        external_deps = external_deps,
-        deps = envoy_select_enable_http3(deps, "@envoy"),
-    )
-
-def envoy_quic_cc_test(
-        name,
-        srcs = [],
-        tags = [],
-        external_deps = [],
-        deps = []):
-    envoy_cc_test(
-        name = name,
-        srcs = envoy_select_enable_http3(srcs, "@envoy"),
         copts = quiche_copts,
         repository = "@envoy",
         tags = tags,

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -276,9 +276,8 @@ function bazel_envoy_api_go_build() {
 
 function build_openssl() {
     BAZEL_BUILD_OPTIONS+=("--config=openssl")
-    # shellcheck disable=SC2207
-    # Append OpenSSL compat tests, and exclude quiche tests
-    TEST_TARGETS=("//compat/openssl/test/..." $(printf "%s\n" "${TEST_TARGETS[@]}" | grep -Fxv "@quiche//:ci_tests"))
+    # Append OpenSSL compat tests
+    TEST_TARGETS=("//compat/openssl/test/..." "${TEST_TARGETS[@]}")
     setup_clang_toolchain
     echo "Bazel fastbuild build with OpenSSL..."
     bazel_envoy_binary_build fastbuild
@@ -370,7 +369,6 @@ if [[ $# -ge 1 ]]; then
   COVERAGE_TEST_TARGETS=("$@")
   TEST_TARGETS=("$@")
 else
-  # Coverage test will add QUICHE tests by itself.
   COVERAGE_TEST_TARGETS=("//test/...")
   if [[ "${CI_TARGET}" == "release" || "${CI_TARGET}" == "release.test_only" ]]; then
     # We test contrib on release only.
@@ -378,7 +376,7 @@ else
   elif [[ "${CI_TARGET}" == "msan" ]]; then
     COVERAGE_TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "-//test/extensions/...")
   fi
-  TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}" "@quiche//:ci_tests")
+  TEST_TARGETS=("${COVERAGE_TEST_TARGETS[@]}")
 fi
 
 case $CI_TARGET in

--- a/test/common/quic/quiche/BUILD
+++ b/test/common/quic/quiche/BUILD
@@ -1,0 +1,306 @@
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_test",
+    "envoy_package",
+    "envoy_select_enable_http3",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+# QUICHE test sources compiled under Envoy's real envoy_cc_test macro, which
+# injects the correct test main, PCH, sanitizer configuration, and gmock
+# strictness settings. The test sources are exposed as filegroups in
+# @quiche//:*_srcs and deps point at the corresponding @quiche// libraries.
+
+# These copts suppress warnings present in QUICHE test sources.
+quiche_test_copts = [
+    "-Wno-unused-function",
+    "-Wno-old-style-cast",
+    "-Wno-error",
+]
+
+envoy_cc_test(
+    name = "http2_adapter_event_forwarder_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_event_forwarder_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_event_forwarder",
+        "@quiche//:http2_core_protocol_lib",
+        "@quiche//:http2_test_tools_mock_spdy_framer_visitor_lib",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_header_validator_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_header_validator_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_header_validator",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_impl_comparison_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_impl_comparison_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter",
+        "@quiche//:http2_adapter_http2_protocol",
+        "@quiche//:http2_adapter_mock_http2_visitor",
+        "@quiche//:http2_adapter_recording_http2_visitor",
+        "@quiche//:http2_adapter_test_frame_sequence",
+        "@quiche//:http2_adapter_test_utils",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_nghttp2_adapter_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_nghttp2_adapter_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_http2_protocol",
+        "@quiche//:http2_adapter_http2_visitor_interface",
+        "@quiche//:http2_adapter_mock_http2_visitor",
+        "@quiche//:http2_adapter_nghttp2_adapter",
+        "@quiche//:http2_adapter_nghttp2_include",
+        "@quiche//:http2_adapter_nghttp2_test_utils",
+        "@quiche//:http2_adapter_oghttp2_util",
+        "@quiche//:http2_adapter_test_frame_sequence",
+        "@quiche//:http2_adapter_test_utils",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_nghttp2_data_provider_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_nghttp2_data_provider_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_nghttp2_data_provider",
+        "@quiche//:http2_adapter_test_utils",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_nghttp2_session_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_nghttp2_session_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter",
+        "@quiche//:http2_adapter_mock_http2_visitor",
+        "@quiche//:http2_adapter_nghttp2_callbacks",
+        "@quiche//:http2_adapter_nghttp2_util",
+        "@quiche//:http2_adapter_test_frame_sequence",
+        "@quiche//:http2_adapter_test_utils",
+        "@quiche//:quiche_common_platform_expect_bug",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_oghttp2_adapter_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_oghttp2_adapter_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_http2_protocol",
+        "@quiche//:http2_adapter_http2_visitor_interface",
+        "@quiche//:http2_adapter_mock_http2_visitor",
+        "@quiche//:http2_adapter_oghttp2_adapter",
+        "@quiche//:http2_adapter_oghttp2_util",
+        "@quiche//:http2_adapter_test_frame_sequence",
+        "@quiche//:http2_adapter_test_utils",
+        "@quiche//:quiche_common_platform_expect_bug",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_oghttp2_session_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_oghttp2_session_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_mock_http2_visitor",
+        "@quiche//:http2_adapter_oghttp2_adapter",
+        "@quiche//:http2_adapter_test_frame_sequence",
+        "@quiche//:http2_adapter_test_utils",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_oghttp2_util_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_oghttp2_util_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_http2_protocol",
+        "@quiche//:http2_adapter_oghttp2_util",
+        "@quiche//:http2_adapter_test_frame_sequence",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_recording_http2_visitor_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_recording_http2_visitor_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_http2_protocol",
+        "@quiche//:http2_adapter_http2_visitor_interface",
+        "@quiche//:http2_adapter_recording_http2_visitor",
+        "@quiche//:http2_test_tools_random",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_adapter_window_manager_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_window_manager_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_adapter_window_manager",
+        "@quiche//:http2_test_tools_random",
+        "@quiche//:quiche_common_platform_expect_bug",
+        "@quiche//:quiche_common_platform_export",
+        "@quiche//:quiche_common_platform_test",
+        "@abseil-cpp//absl/functional:bind_front",
+    ]),
+)
+
+envoy_cc_test(
+    name = "http2_platform_api_test",
+    srcs = envoy_select_enable_http3(["@quiche//:http2_platform_api_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_test_tools_random",
+        "@quiche//:quiche_common_platform",
+        "@quiche//:quiche_common_test_tools_test_utils_lib",
+    ]),
+)
+
+envoy_cc_test(
+    name = "quiche_balsa_balsa_frame_test",
+    srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_balsa_frame_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:quiche_balsa_balsa_enums_lib",
+        "@quiche//:quiche_balsa_balsa_frame_lib",
+        "@quiche//:quiche_balsa_balsa_headers_lib",
+        "@quiche//:quiche_balsa_balsa_visitor_interface_lib",
+        "@quiche//:quiche_balsa_http_validation_policy_lib",
+        "@quiche//:quiche_balsa_noop_balsa_visitor_lib",
+        "@quiche//:quiche_balsa_simple_buffer_lib",
+        "@quiche//:quiche_common_platform_expect_bug",
+        "@quiche//:quiche_common_platform_logging",
+        "@quiche//:quiche_common_platform_test",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+    ]),
+)
+
+envoy_cc_test(
+    name = "quiche_balsa_balsa_headers_test",
+    srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_balsa_headers_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:quiche_balsa_balsa_enums_lib",
+        "@quiche//:quiche_balsa_balsa_frame_lib",
+        "@quiche//:quiche_balsa_balsa_headers_lib",
+        "@quiche//:quiche_balsa_simple_buffer_lib",
+        "@quiche//:quiche_common_platform_expect_bug",
+        "@quiche//:quiche_common_platform_logging",
+        "@quiche//:quiche_common_platform_test",
+        "@quiche//:quiche_common_test_tools_test_utils_lib",
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/memory",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+    ]),
+)
+
+envoy_cc_test(
+    name = "quiche_balsa_header_properties_test",
+    srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_header_properties_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:quiche_balsa_header_properties_lib",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "quiche_balsa_simple_buffer_test",
+    srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_simple_buffer_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:quiche_balsa_simple_buffer_lib",
+        "@quiche//:quiche_common_platform_expect_bug",
+        "@quiche//:quiche_common_platform_test",
+        "@abseil-cpp//absl/strings",
+    ]),
+)
+
+envoy_cc_test(
+    name = "quiche_common_test",
+    srcs = envoy_select_enable_http3(["@quiche//:quiche_common_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:quiche_common_lib",
+        "@quiche//:quiche_common_mem_slice_storage",
+        "@quiche//:quiche_common_platform_test",
+    ]),
+)
+
+envoy_cc_test(
+    name = "quiche_http_header_block_test",
+    srcs = envoy_select_enable_http3(["@quiche//:quiche_http_header_block_test_srcs"]),
+    copts = quiche_test_copts,
+    rbe_pool = "6gig",
+    tags = ["quiche"],
+    deps = envoy_select_enable_http3([
+        "@quiche//:http2_test_tools_test_utils_lib",
+        "@quiche//:quiche_common_platform_test",
+        "@quiche//:quiche_http_header_block_lib",
+        "@abseil-cpp//absl/functional:bind_front",
+    ]),
+)

--- a/test/common/quic/quiche/BUILD
+++ b/test/common/quic/quiche/BUILD
@@ -4,6 +4,7 @@ load(
     "envoy_package",
     "envoy_select_enable_http3",
 )
+load("//bazel/external:quiche.bzl", "quiche_copts")
 
 licenses(["notice"])  # Apache 2
 
@@ -14,17 +15,10 @@ envoy_package()
 # strictness settings. The test sources are exposed as filegroups in
 # @quiche//:*_srcs and deps point at the corresponding @quiche// libraries.
 
-# These copts suppress warnings present in QUICHE test sources.
-quiche_test_copts = [
-    "-Wno-unused-function",
-    "-Wno-old-style-cast",
-    "-Wno-error",
-]
-
 envoy_cc_test(
     name = "http2_adapter_event_forwarder_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_event_forwarder_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -38,7 +32,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_header_validator_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_header_validator_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -50,7 +44,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_impl_comparison_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_impl_comparison_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -67,7 +61,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_nghttp2_adapter_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_nghttp2_adapter_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -87,7 +81,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_nghttp2_data_provider_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_nghttp2_data_provider_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -100,7 +94,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_nghttp2_session_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_nghttp2_session_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -118,7 +112,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_oghttp2_adapter_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_oghttp2_adapter_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -137,7 +131,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_oghttp2_session_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_oghttp2_session_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -152,7 +146,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_oghttp2_util_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_oghttp2_util_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -166,7 +160,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_recording_http2_visitor_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_recording_http2_visitor_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -181,7 +175,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_adapter_window_manager_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_adapter_window_manager_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -197,7 +191,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "http2_platform_api_test",
     srcs = envoy_select_enable_http3(["@quiche//:http2_platform_api_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -210,7 +204,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_balsa_balsa_frame_test",
     srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_balsa_frame_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -233,7 +227,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_balsa_balsa_headers_test",
     srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_balsa_headers_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -255,7 +249,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_balsa_header_properties_test",
     srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_header_properties_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -267,7 +261,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_balsa_simple_buffer_test",
     srcs = envoy_select_enable_http3(["@quiche//:quiche_balsa_simple_buffer_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -281,7 +275,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_common_test",
     srcs = envoy_select_enable_http3(["@quiche//:quiche_common_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([
@@ -294,7 +288,7 @@ envoy_cc_test(
 envoy_cc_test(
     name = "quiche_http_header_block_test",
     srcs = envoy_select_enable_http3(["@quiche//:quiche_http_header_block_test_srcs"]),
-    copts = quiche_test_copts,
+    copts = quiche_copts,
     rbe_pool = "6gig",
     tags = ["quiche"],
     deps = envoy_select_enable_http3([


### PR DESCRIPTION
currently we test quiche with `@quiche//...` and we define the tests using Envoy's test framework

this is not visible to quiche in bzlmod so rather than redefining all of Envoys test framework in the quiche mod pull the tests into Envoy, which is kinda where they belong anyway
