### PR TITLE
fix: typo on `unknown_api_key`

### DIFF
--- a/source/extensions/filters/http/api_key_auth/api_key_auth.cc
+++ b/source/extensions/filters/http/api_key_auth/api_key_auth.cc
@@ -156,7 +156,7 @@ Http::FilterHeadersStatus ApiKeyAuthFilter::decodeHeaders(Http::RequestHeaderMap
 
   const auto credential = credentials->find(key_result);
   if (credential == credentials->end()) {
-    return onDenied(Http::Code::Unauthorized, "Client authentication failed.", "unkonwn_api_key");
+    return onDenied(Http::Code::Unauthorized, "Client authentication failed.", "unknown_api_key");
   }
 
   // If route config is not null then check if the client is allowed or not based on the route

--- a/test/extensions/filters/http/api_key_auth/api_key_auth_test.cc
+++ b/test/extensions/filters/http/api_key_auth/api_key_auth_test.cc
@@ -269,7 +269,7 @@ TEST_F(FilterTest, UnkonwnApiKey) {
                                                  {":path", "/path"},
                                                  {"Authorization", "Bearer key2"}};
   EXPECT_CALL(decoder_filter_callbacks_,
-              sendLocalReply(Http::Code::Unauthorized, _, _, _, "unkonwn_api_key"));
+              sendLocalReply(Http::Code::Unauthorized, _, _, _, "unknown_api_key"));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, true));
@@ -313,7 +313,7 @@ TEST_F(FilterTest, RouteConfigOverrideCredentials) {
                                                    {":path", "/path"},
                                                    {"Authorization", "Bearer key1"}};
     EXPECT_CALL(decoder_filter_callbacks_,
-                sendLocalReply(Http::Code::Unauthorized, _, _, _, "unkonwn_api_key"));
+                sendLocalReply(Http::Code::Unauthorized, _, _, _, "unknown_api_key"));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers, true));
     EXPECT_EQ(stats_.counterFromString("stats.api_key_auth.unauthorized").value(), 1);
@@ -404,7 +404,7 @@ TEST_F(FilterTest, RouteConfigOverrideKeySourceAndCredentials) {
     Http::TestRequestHeaderMapImpl request_headers{
         {":authority", "host"}, {":method", "GET"}, {":path", "/path?api_key=key1"}};
     EXPECT_CALL(decoder_filter_callbacks_,
-                sendLocalReply(Http::Code::Unauthorized, _, _, _, "unkonwn_api_key"));
+                sendLocalReply(Http::Code::Unauthorized, _, _, _, "unknown_api_key"));
     EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
               filter_->decodeHeaders(request_headers, true));
     EXPECT_EQ(stats_.counterFromString("stats.api_key_auth.unauthorized").value(), 2);


### PR DESCRIPTION
Commit Message: fix: typo on `unknown_api_key`
Additional Description: updates `unkonwn_api_key` to `unknown_api_key` in code and test
Risk Level: low
Testing: updated existing test
Docs Changes: none
Release Notes: none
Platform Specific Features: none