### PR TITLE
Add MCP header-based attribute extraction and validation

### DIFF
--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -66,7 +66,9 @@ message Mcp {
     // Use MCP attribute headers and verify that values parsed from the body agree.
     VERIFY = 1;
 
-    // Trust MCP attribute headers and avoid parsing the body when nothing else requires it.
+    // Trust MCP attribute headers for ``method`` and the method-specific
+    // identifier carried by ``Mcp-Name`` (``params.name``, ``params.uri``, or
+    // ``params.taskId``), and avoid parsing the body when nothing else requires it.
     HEADERS = 2;
   }
 
@@ -134,7 +136,9 @@ message Mcp {
   google.protobuf.BoolValue reject_duplicate_keys = 8;
 
   // Controls whether MCP request attributes are obtained from the request body
-  // or from MCP request headers.
+  // or from MCP request headers. Header-based extraction is limited to ``method``
+  // and the method-specific identifier carried by ``Mcp-Name``; other configured
+  // extraction rules still require body parsing.
   AttributeSource attribute_source = 9 [(validate.rules).enum = {defined_only: true}];
 }
 

--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -21,7 +21,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // [#extension: envoy.filters.http.mcp]
 
 // This filter will inspect and get attributes from MCP traffic.
-// [#next-free-field: 9]
+// [#next-free-field: 10]
 message Mcp {
   // Traffic handling mode for non-MCP traffic.
   enum TrafficMode {
@@ -57,6 +57,19 @@ message Mcp {
     // Store request attributes in both dynamic metadata and filter state.
     DYNAMIC_METADATA_AND_FILTER_STATE = 3;
   }
+
+  // Source used to obtain MCP request attributes.
+  enum AttributeSource {
+    // Parse attributes from the request body and ignore MCP attribute headers.
+    BODY = 0;
+
+    // Use MCP attribute headers and verify that values parsed from the body agree.
+    VERIFY = 1;
+
+    // Trust MCP attribute headers and avoid parsing the body when nothing else requires it.
+    HEADERS = 2;
+  }
+
 
   message TraceContextPropagationConfig {
     option (xds.annotations.v3.message_status).work_in_progress = true;
@@ -120,6 +133,10 @@ message Mcp {
   // nesting level. RFC 8259 Section 4 states that names within an object SHOULD be
   // unique. Defaults to false (last-key-wins / last-win).
   google.protobuf.BoolValue reject_duplicate_keys = 8;
+
+  // Controls whether MCP request attributes are obtained from the request body
+  // or from MCP request headers.
+  AttributeSource attribute_source = 9 [(validate.rules).enum = {defined_only: true}];
 }
 
 // Parser configuration with method-specific rules.

--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -70,7 +70,6 @@ message Mcp {
     HEADERS = 2;
   }
 
-
   message TraceContextPropagationConfig {
     option (xds.annotations.v3.message_status).work_in_progress = true;
   }

--- a/changelogs/current/new_features/mcp__header_attribute_source.rst
+++ b/changelogs/current/new_features/mcp__header_attribute_source.rst
@@ -1,0 +1,1 @@
+Added `attribute_source` support for extracting MCP request attributes from the request body, verifying request headers against the body, or using `Mcp-Method` and `Mcp-Name` headers for a body-free fast path.

--- a/changelogs/current/new_features/mcp__header_attribute_source.rst
+++ b/changelogs/current/new_features/mcp__header_attribute_source.rst
@@ -1,1 +1,1 @@
-Added `attribute_source` support for extracting MCP request attributes from the request body, verifying request headers against the body, or using `Mcp-Method` and `Mcp-Name` headers for a body-free fast path.
+Added ``attribute_source`` support for extracting MCP request attributes from the request body, verifying request headers against the body, or using ``Mcp-Method`` and ``Mcp-Name`` headers for a body-free fast path.

--- a/source/extensions/filters/common/mcp/constants.h
+++ b/source/extensions/filters/common/mcp/constants.h
@@ -67,6 +67,8 @@ constexpr absl::string_view BODY_TOO_LARGE = "mcp_body_too_large";
 // HTTP header names
 constexpr absl::string_view MCP_SESSION_ID_HEADER = "mcp-session-id";
 constexpr absl::string_view MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version";
+constexpr absl::string_view MCP_METHOD_HEADER = "mcp-method";
+constexpr absl::string_view MCP_NAME_HEADER = "mcp-name";
 
 // Method names
 namespace Methods {

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -481,6 +481,36 @@ void McpFilter::sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp
                                      statusToString(status));
 }
 
+bool McpFilter::verifyHeaderAttributes() const {
+  if (config_->attributeSource() !=
+      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY) {
+    return true;
+  }
+
+  if (!parser_) {
+    return false;
+  }
+
+  if (header_method_ != parser_->getMethod()) {
+    return false;
+  }
+
+  const std::string name_path =
+      parserConfig().getNameAttributePath(header_method_);
+
+  if (!name_path.empty()) {
+    const Protobuf::Value* body_name = parser_->getNestedValue(name_path);
+
+    if (body_name == nullptr ||
+        body_name->kind_case() != Protobuf::Value::kStringValue ||
+        body_name->string_value() != header_name_) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 Http::FilterDataStatus McpFilter::completeParsing() {
   parsing_complete_ = true;
   is_mcp_request_ = parser_->isValidMcpRequest();
@@ -497,6 +527,12 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   if (!is_mcp_request_ && shouldRejectRequest()) {
     sendErrorReply("request must be a valid JSON-RPC 2.0 message for MCP",
                    Filters::Common::Mcp::Status::NotJsonRpc);
+    return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
+  if (!verifyHeaderAttributes()) {
+    sendErrorReply("MCP header attributes do not match request body",
+                  Filters::Common::Mcp::Status::NotJsonRpc);
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -562,6 +562,22 @@ Http::FilterDataStatus McpFilter::completeParsing() {
 
   Protobuf::Struct metadata = parser_->metadata();
 
+  std::string effective_method = parser_->getMethod();
+
+  if (config_->attributeSource() == envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS) {
+    effective_method = header_method_;
+
+    if (!header_method_.empty()) {
+      (*metadata.mutable_fields())["method"].set_string_value(header_method_);
+    }
+
+    const std::string name_path = parserConfig().getNameAttributePath(header_method_);
+
+    if (!header_name_.empty() && !name_path.empty()) {
+      setNestedStringValue(metadata, name_path, header_name_);
+    }
+  }
+
   // For JSON-RPC responses (no method field), set a synthetic method so the
   // router can identify and dispatch them.
   if (is_mcp_request_ && parser_->isResponse()) {
@@ -572,7 +588,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   const ParserConfig& active_parser_config = parserConfig();
   const std::string& group_metadata_key = active_parser_config.groupMetadataKey();
   if (!group_metadata_key.empty()) {
-    std::string method_group = active_parser_config.getMethodGroup(parser_->getMethod());
+    std::string method_group = active_parser_config.getMethodGroup(effective_method);
     (*metadata.mutable_fields())[group_metadata_key].set_string_value(method_group);
     ENVOY_LOG(debug, "MCP filter set method group: {}={}", group_metadata_key, method_group);
   }
@@ -599,7 +615,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   if (should_store_metadata) {
     if (shouldStoreToFilterState()) {
       auto filter_state_obj = std::make_shared<FilterStateObject>(
-          parser_->getMethod(), metadata, is_mcp_request_, is_exceeding_limit_, status_);
+          effective_method, metadata, is_mcp_request_, is_exceeding_limit_, status_);
       decoder_callbacks_->streamInfo().filterState()->setData(
           std::string(FilterStateObject::FilterStateKey), std::move(filter_state_obj),
           StreamInfo::FilterState::LifeSpan::Request,

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -481,12 +481,7 @@ void McpFilter::sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp
                                      statusToString(status));
 }
 
-bool McpFilter::verifyHeaderAttributes() const {
-  if (config_->attributeSource() !=
-      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY) {
-    return true;
-  }
-
+bool McpFilter::headerAttributesMatch() const {
   if (!parser_) {
     return false;
   }
@@ -495,20 +490,26 @@ bool McpFilter::verifyHeaderAttributes() const {
     return false;
   }
 
-  const std::string name_path =
-      parserConfig().getNameAttributePath(header_method_);
+  const std::string name_path = parserConfig().getNameAttributePath(header_method_);
 
   if (!name_path.empty()) {
     const Protobuf::Value* body_name = parser_->getNestedValue(name_path);
 
-    if (body_name == nullptr ||
-        body_name->kind_case() != Protobuf::Value::kStringValue ||
+    if (body_name == nullptr || body_name->kind_case() != Protobuf::Value::kStringValue ||
         body_name->string_value() != header_name_) {
       return false;
     }
   }
 
   return true;
+}
+
+bool McpFilter::verifyHeaderAttributes() const {
+  if (config_->attributeSource() != envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY) {
+    return true;
+  }
+
+  return headerAttributesMatch();
 }
 
 Http::FilterDataStatus McpFilter::completeParsing() {
@@ -531,9 +532,16 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   }
 
   if (!verifyHeaderAttributes()) {
+    config_->stats().header_mismatch_.inc();
+
     sendErrorReply("MCP header attributes do not match request body",
-                  Filters::Common::Mcp::Status::NotJsonRpc);
+                   Filters::Common::Mcp::Status::NotJsonRpc);
     return Http::FilterDataStatus::StopIterationNoBuffer;
+  }
+
+  if (config_->attributeSource() == envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS &&
+      !headerAttributesMatch()) {
+    config_->stats().header_mismatch_.inc();
   }
 
   Protobuf::Struct metadata = parser_->metadata();

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -308,12 +308,26 @@ bool McpFilter::needsBody() const {
     return true;
   }
 
+  if (!hasCompleteHeaderAttributes()) {
+    return true;
+  }
+
   if (config_->propagateTraceContext().has_value() || config_->propagateBaggage().has_value() ||
       rejectDuplicateKeys()) {
     return true;
   }
 
   return false;
+}
+
+bool McpFilter::hasCompleteHeaderAttributes() const {
+  if (header_method_.empty()) {
+    return false;
+  }
+
+  const std::string name_path = parserConfig().getNameAttributePath(header_method_);
+
+  return name_path.empty() || !header_name_.empty();
 }
 
 const McpOverrideConfig* McpFilter::routeOverride() const {
@@ -556,7 +570,7 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   }
 
   if (config_->attributeSource() == envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS &&
-      !headerAttributesMatch()) {
+      hasCompleteHeaderAttributes() && !headerAttributesMatch()) {
     config_->stats().header_mismatch_.inc();
   }
 
@@ -565,9 +579,8 @@ Http::FilterDataStatus McpFilter::completeParsing() {
   std::string effective_method = parser_->getMethod();
 
   if (config_->attributeSource() == envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS) {
-    effective_method = header_method_;
-
     if (!header_method_.empty()) {
+      effective_method = header_method_;
       (*metadata.mutable_fields())["method"].set_string_value(header_method_);
     }
 

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -46,6 +46,21 @@ const Http::LowerCaseString kMcpMethod{
 const Http::LowerCaseString kMcpName{
     std::string(Filters::Common::Mcp::McpConstants::MCP_NAME_HEADER)};
 
+void setNestedStringValue(Protobuf::Struct& metadata, absl::string_view path,
+                          absl::string_view value) {
+  const std::vector<absl::string_view> segments = absl::StrSplit(path, '.');
+
+  Protobuf::Struct* current = &metadata;
+
+  for (size_t i = 0; i + 1 < segments.size(); ++i) {
+    current = (*current->mutable_fields())[std::string(segments[i])].mutable_struct_value();
+  }
+
+  if (!segments.empty()) {
+    (*current->mutable_fields())[std::string(segments.back())].set_string_value(std::string(value));
+  }
+}
+
 McpFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = absl::StrCat(prefix, "mcp.");
   return McpFilterStats{MCP_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -349,6 +364,7 @@ Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& heade
       is_mcp_request_ = true;
 
       if (!needsBody()) {
+        skip_body_parsing_ = true;
         populateMetadataFromHeaders();
         return Http::FilterHeadersStatus::Continue;
       }
@@ -376,7 +392,7 @@ Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& heade
 }
 
 Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_stream) {
-  if (!is_json_post_request_ || !is_mcp_request_) {
+  if (skip_body_parsing_ || !is_json_post_request_ || !is_mcp_request_) {
     return Http::FilterDataStatus::Continue;
   }
 
@@ -613,8 +629,9 @@ void McpFilter::populateMetadataFromHeaders() {
 
   if (!header_name_.empty()) {
     const std::string name_path = parserConfig().getNameAttributePath(header_method_);
+
     if (!name_path.empty()) {
-      (*metadata.mutable_fields())[name_path].set_string_value(header_name_);
+      setNestedStringValue(metadata, name_path, header_name_);
     }
   }
 
@@ -624,8 +641,25 @@ void McpFilter::populateMetadataFromHeaders() {
         parserConfig().getMethodGroup(header_method_));
   }
 
+  if (shouldStoreToFilterState()) {
+    auto filter_state_obj = std::make_shared<FilterStateObject>(
+        header_method_, metadata, is_mcp_request_, is_exceeding_limit_, status_);
+
+    decoder_callbacks_->streamInfo().filterState()->setData(
+        std::string(FilterStateObject::FilterStateKey), std::move(filter_state_obj),
+        StreamInfo::FilterState::LifeSpan::Request,
+        StreamInfo::StreamSharingMayImpactPooling::None);
+  }
+
   if (shouldStoreToDynamicMetadata()) {
     setDynamicMetadataStatus(std::move(metadata));
+  }
+
+  if (clearRouteCache()) {
+    if (auto cb = decoder_callbacks_->downstreamCallbacks(); cb.has_value()) {
+      cb->clearRouteCache();
+      ENVOY_LOG(debug, "MCP filter cleared route cache for metadata-based routing");
+    }
   }
 }
 

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -349,6 +349,7 @@ Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& heade
       is_mcp_request_ = true;
 
       if (!needsBody()) {
+        populateMetadataFromHeaders();
         return Http::FilterHeadersStatus::Continue;
       }
 
@@ -557,6 +558,50 @@ Http::FilterDataStatus McpFilter::completeParsing() {
     }
   }
   return Http::FilterDataStatus::Continue;
+}
+
+void McpFilter::populateMetadataFromHeaders() {
+  Protobuf::Struct metadata;
+
+  if (!header_method_.empty()) {
+    (*metadata.mutable_fields())["method"].set_string_value(header_method_);
+  }
+
+  if (!header_name_.empty()) {
+    const std::string name_path = parserConfig().getNameAttributePath(header_method_);
+    if (!name_path.empty()) {
+      (*metadata.mutable_fields())[name_path].set_string_value(header_name_);
+    }
+  }
+
+  const std::string& group_metadata_key = parserConfig().groupMetadataKey();
+  if (!group_metadata_key.empty() && !header_method_.empty()) {
+    (*metadata.mutable_fields())[group_metadata_key].set_string_value(
+        parserConfig().getMethodGroup(header_method_));
+  }
+
+  if (shouldStoreToDynamicMetadata()) {
+    setDynamicMetadataStatus(std::move(metadata));
+  }
+}
+
+bool McpFilter::headerAttributesMatchBody() const {
+  if (parser_->getMethod() != header_method_) {
+    return false;
+  }
+
+  if (header_name_.empty()) {
+    return true;
+  }
+
+  const std::string name_path = parserConfig().getNameAttributePath(header_method_);
+  if (name_path.empty()) {
+    return true;
+  }
+
+  const Protobuf::Value* body_name = parser_->getNestedValue(name_path);
+  return body_name != nullptr && body_name->kind_case() == Protobuf::Value::kStringValue &&
+         body_name->string_value() == header_name_;
 }
 
 void McpFilter::setDynamicMetadataStatus(Protobuf::Struct metadata) {

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -316,7 +316,7 @@ bool McpFilter::needsBody() const {
   const std::string name_path = parser_config.getNameAttributePath(header_method_);
 
   for (const auto& rule : parser_config.getFieldsForMethod(header_method_)) {
-    if (rule.path != name_path) {
+    if (rule.path != "method" && rule.path != name_path) {
       return true;
     }
   }

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -40,6 +40,12 @@ namespace {
 const Http::LowerCaseString kMcpSessionId{
     std::string(Filters::Common::Mcp::McpConstants::MCP_SESSION_ID_HEADER)};
 
+const Http::LowerCaseString kMcpMethod{
+    std::string(Filters::Common::Mcp::McpConstants::MCP_METHOD_HEADER)};
+
+const Http::LowerCaseString kMcpName{
+    std::string(Filters::Common::Mcp::McpConstants::MCP_NAME_HEADER)};
+
 McpFilterStats generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = absl::StrCat(prefix, "mcp.");
   return McpFilterStats{MCP_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -108,8 +114,8 @@ McpFilterConfig::McpFilterConfig(const envoy::extensions::filters::http::mcp::v3
                              ? std::make_optional(proto_config.propagate_baggage())
                              : std::nullopt),
       max_request_body_size_(proto_config.has_max_request_body_size()
-                                ? proto_config.max_request_body_size().value()
-                                : 8192),
+                                 ? proto_config.max_request_body_size().value()
+                                 : 8192), // Default: 8KB
       request_storage_mode_(proto_config.request_storage_mode()),
       attribute_source_(proto_config.attribute_source()),
       metadata_namespace_(Filters::Common::Mcp::metadataNamespace()),
@@ -282,6 +288,19 @@ bool McpFilter::rejectDuplicateKeys() const {
   return config_->rejectDuplicateKeys();
 }
 
+bool McpFilter::needsBody() const {
+  if (config_->attributeSource() != envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS) {
+    return true;
+  }
+
+  if (config_->propagateTraceContext().has_value() || config_->propagateBaggage().has_value() ||
+      rejectDuplicateKeys()) {
+    return true;
+  }
+
+  return false;
+}
+
 const McpOverrideConfig* McpFilter::routeOverride() const {
   // TODO(mkbehr): We can latch the McpOverrideConfig in order to do fewer route lookups. The
   // McpOverrideConfig has lifetime equal to the route, so we'll need to take care not to keep a
@@ -311,11 +330,27 @@ Http::FilterHeadersStatus McpFilter::decodeHeaders(Http::RequestHeaderMap& heade
   if (isValidMcpPostRequest(headers)) {
     is_json_post_request_ = true;
     ENVOY_LOG(debug, "valid MCP Post request");
+    if (config_->attributeSource() != envoy::extensions::filters::http::mcp::v3::Mcp::BODY) {
+      const auto method_headers = headers.get(kMcpMethod);
+      if (!method_headers.empty()) {
+        header_method_ = std::string(method_headers[0]->value().getStringView());
+      }
+
+      const auto name_headers = headers.get(kMcpName);
+      if (!name_headers.empty()) {
+        header_name_ = std::string(name_headers[0]->value().getStringView());
+      }
+    }
+
     if (end_stream) {
       is_mcp_request_ = false;
     } else {
       // Need to buffer the body to check for JSON-RPC 2.0
       is_mcp_request_ = true;
+
+      if (!needsBody()) {
+        return Http::FilterHeadersStatus::Continue;
+      }
 
       // Set the buffer limit.
       const uint32_t max_size = getMaxRequestBodySize();

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -663,25 +663,6 @@ void McpFilter::populateMetadataFromHeaders() {
   }
 }
 
-bool McpFilter::headerAttributesMatchBody() const {
-  if (parser_->getMethod() != header_method_) {
-    return false;
-  }
-
-  if (header_name_.empty()) {
-    return true;
-  }
-
-  const std::string name_path = parserConfig().getNameAttributePath(header_method_);
-  if (name_path.empty()) {
-    return true;
-  }
-
-  const Protobuf::Value* body_name = parser_->getNestedValue(name_path);
-  return body_name != nullptr && body_name->kind_case() == Protobuf::Value::kStringValue &&
-         body_name->string_value() == header_name_;
-}
-
 void McpFilter::setDynamicMetadataStatus(Protobuf::Struct metadata) {
   (*metadata.mutable_fields())[Filters::Common::Mcp::McpConstants::STATUS].set_string_value(
       std::string(statusToString(status_)));

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -312,6 +312,15 @@ bool McpFilter::needsBody() const {
     return true;
   }
 
+  const auto& parser_config = parserConfig();
+  const std::string name_path = parser_config.getNameAttributePath(header_method_);
+
+  for (const auto& rule : parser_config.getFieldsForMethod(header_method_)) {
+    if (rule.path != name_path) {
+      return true;
+    }
+  }
+
   if (config_->propagateTraceContext().has_value() || config_->propagateBaggage().has_value() ||
       rejectDuplicateKeys()) {
     return true;

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -108,9 +108,10 @@ McpFilterConfig::McpFilterConfig(const envoy::extensions::filters::http::mcp::v3
                              ? std::make_optional(proto_config.propagate_baggage())
                              : std::nullopt),
       max_request_body_size_(proto_config.has_max_request_body_size()
-                                 ? proto_config.max_request_body_size().value()
-                                 : 8192), // Default: 8KB
+                                ? proto_config.max_request_body_size().value()
+                                : 8192),
       request_storage_mode_(proto_config.request_storage_mode()),
+      attribute_source_(proto_config.attribute_source()),
       metadata_namespace_(Filters::Common::Mcp::metadataNamespace()),
       parser_config_(proto_config.has_parser_config()
                          ? McpParserConfig::fromProto(proto_config.parser_config())

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -197,6 +197,7 @@ private:
   std::unique_ptr<JsonPathParser> parser_;
   bool is_mcp_request_{false};
   bool is_json_post_request_{false};
+  bool skip_body_parsing_{false};
   std::string header_method_;
   std::string header_name_;
   Filters::Common::Mcp::Status status_{Filters::Common::Mcp::Status::Ok};

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -68,6 +68,9 @@ public:
 
   bool rejectDuplicateKeys() const { return parser_config_.rejectDuplicateKeys(); }
   uint32_t maxRequestBodySize() const { return max_request_body_size_; }
+  envoy::extensions::filters::http::mcp::v3::Mcp::AttributeSource attributeSource() const {
+    return attribute_source_;
+  }
   const ParserConfig& parserConfig() const { return parser_config_; }
   bool shouldStoreToDynamicMetadata() const {
     return request_storage_mode_ ==
@@ -168,6 +171,7 @@ private:
   // we assume the route does not change during the request, so it is resolved only once.
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode();
   uint32_t getMaxRequestBodySize() const;
+  bool needsBody() const;
   bool clearRouteCache() const;
   const ParserConfig& parserConfig() const;
   bool shouldStoreToDynamicMetadata() const;
@@ -188,6 +192,8 @@ private:
   std::unique_ptr<JsonPathParser> parser_;
   bool is_mcp_request_{false};
   bool is_json_post_request_{false};
+  std::string header_method_;
+  std::string header_name_;
   Filters::Common::Mcp::Status status_{Filters::Common::Mcp::Status::Ok};
 };
 

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -177,7 +177,6 @@ private:
   bool shouldStoreToDynamicMetadata() const;
   bool shouldStoreToFilterState() const;
   bool rejectDuplicateKeys() const;
-  bool headerAttributesMatchBody() const;
   const McpOverrideConfig* routeOverride() const;
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -181,6 +181,7 @@ private:
   const McpOverrideConfig* routeOverride() const;
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);
+  bool verifyHeaderAttributes() const;
   Http::FilterDataStatus completeParsing();
   void setDynamicMetadataStatus(Protobuf::Struct metadata);
   void populateMetadataFromHeaders();

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -29,7 +29,8 @@ namespace Mcp {
   COUNTER(requests_rejected)                                                                       \
   COUNTER(invalid_json)                                                                            \
   COUNTER(body_too_large)                                                                          \
-  COUNTER(duplicate_keys_rejected)
+  COUNTER(duplicate_keys_rejected)                                                                 \
+  COUNTER(header_mismatch)
 
 /**
  * Struct definition for MCP filter stats. @see stats_macros.h
@@ -176,11 +177,12 @@ private:
   bool shouldStoreToDynamicMetadata() const;
   bool shouldStoreToFilterState() const;
   bool rejectDuplicateKeys() const;
-  bool needsBody() const;
   bool headerAttributesMatchBody() const;
   const McpOverrideConfig* routeOverride() const;
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);
+  bool needsBody() const;
+  bool headerAttributesMatch() const;
   bool verifyHeaderAttributes() const;
   Http::FilterDataStatus completeParsing();
   void setDynamicMetadataStatus(Protobuf::Struct metadata);

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -95,6 +95,7 @@ private:
       propagate_baggage_;
   const uint32_t max_request_body_size_;
   const envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode request_storage_mode_;
+  const envoy::extensions::filters::http::mcp::v3::Mcp::AttributeSource attribute_source_;
   const std::string metadata_namespace_;
   ParserConfig parser_config_;
   McpFilterStats stats_;

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -181,6 +181,7 @@ private:
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);
   bool needsBody() const;
+  bool hasCompleteHeaderAttributes() const;
   bool headerAttributesMatch() const;
   bool verifyHeaderAttributes() const;
   Http::FilterDataStatus completeParsing();

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -171,17 +171,19 @@ private:
   // we assume the route does not change during the request, so it is resolved only once.
   envoy::extensions::filters::http::mcp::v3::Mcp::TrafficMode trafficMode();
   uint32_t getMaxRequestBodySize() const;
-  bool needsBody() const;
   bool clearRouteCache() const;
   const ParserConfig& parserConfig() const;
   bool shouldStoreToDynamicMetadata() const;
   bool shouldStoreToFilterState() const;
   bool rejectDuplicateKeys() const;
+  bool needsBody() const;
+  bool headerAttributesMatchBody() const;
   const McpOverrideConfig* routeOverride() const;
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);
   Http::FilterDataStatus completeParsing();
   void setDynamicMetadataStatus(Protobuf::Struct metadata);
+  void populateMetadataFromHeaders();
 
   McpFilterConfigSharedPtr config_;
   Http::StreamDecoderFilterCallbacks* decoder_callbacks_{};

--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -143,6 +143,10 @@ std::string McpParserConfig::getNameAttributePath(const std::string& method) con
     return std::string(PARAMS_NAME);
   }
 
+  if (method == RESOURCES_READ) {
+    return std::string(PARAMS_URI);
+  }
+
   if (method == TASKS_GET || method == TASKS_UPDATE || method == TASKS_CANCEL) {
     return std::string(PARAMS_TASK_ID);
   }

--- a/source/extensions/filters/http/mcp/mcp_json_parser.cc
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.cc
@@ -135,6 +135,21 @@ McpParserConfig::getFieldsForMethod(const std::string& method) const {
   return (it != method_fields_.end()) ? it->second : empty;
 }
 
+std::string McpParserConfig::getNameAttributePath(const std::string& method) const {
+  using namespace Methods;
+  using namespace Paths;
+
+  if (method == TOOLS_CALL || method == PROMPTS_GET) {
+    return std::string(PARAMS_NAME);
+  }
+
+  if (method == TASKS_GET || method == TASKS_UPDATE || method == TASKS_CANCEL) {
+    return std::string(PARAMS_TASK_ID);
+  }
+
+  return "";
+}
+
 const McpParserConfig::FieldRequirements&
 McpParserConfig::getFieldRequirementsForMethod(const std::string& method) const {
   auto it = method_requirements_.find(method);

--- a/source/extensions/filters/http/mcp/mcp_json_parser.h
+++ b/source/extensions/filters/http/mcp/mcp_json_parser.h
@@ -53,6 +53,10 @@ public:
   // Get extraction policy for a specific method
   const std::vector<AttributeExtractionRule>& getFieldsForMethod(const std::string& method) const;
 
+  // Get the attribute path corresponding to Mcp-Name for a method.
+  // Returns empty when the method has no name-like attribute.
+  std::string getNameAttributePath(const std::string& method) const;
+
   // Get merged requirements for a specific method (global + method-specific).
   const FieldRequirements& getFieldRequirementsForMethod(const std::string& method) const;
 

--- a/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
@@ -119,6 +119,107 @@ TEST_P(McpFilterIntegrationTest, ValidJsonRpcPostRequest) {
   EXPECT_TRUE(metadata_verified);
 }
 
+TEST_P(McpFilterIntegrationTest, HeadersAttributeSourceUsesHeaderMetadata) {
+  FakeAccessLogFactory factory;
+  Registry::InjectFactory<AccessLog::AccessLogInstanceFactory> factory_register(factory);
+
+  bool metadata_verified = false;
+  factory.setLogCallback(
+      [&metadata_verified](const Formatter::Context&, const StreamInfo::StreamInfo& stream_info) {
+        const auto& dynamic_metadata = stream_info.dynamicMetadata().filter_metadata();
+
+        auto it = dynamic_metadata.find("envoy.filters.http.mcp");
+        ASSERT_NE(it, dynamic_metadata.end());
+
+        const auto& metadata = it->second;
+
+        EXPECT_EQ("tasks/get", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+
+        EXPECT_EQ("header-task", params.fields().at("taskId").string_value());
+
+        metadata_verified = true;
+      });
+
+  config_helper_.addConfigModifier([](ConfigHelper::HttpConnectionManager& hcm) {
+    auto* access_log = hcm.add_access_log();
+    access_log->set_name("envoy.access_loggers.test");
+
+    test::integration::accesslog::FakeAccessLog access_log_config;
+    std::ignore = access_log->mutable_typed_config()->PackFrom(access_log_config);
+  });
+
+  initializeFilter(R"EOF(
+name: envoy.filters.http.mcp
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
+  traffic_mode: PASS_THROUGH
+  request_storage_mode: DYNAMIC_METADATA
+  attribute_source: HEADERS
+)EOF");
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"body-task"}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"mcp-method", "tasks/get"},
+                                     {"mcp-name", "header-task"}},
+      request_body);
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  EXPECT_TRUE(metadata_verified);
+}
+
+TEST_P(McpFilterIntegrationTest, VerifyRejectsHeaderBodyMismatch) {
+  initializeFilter(R"EOF(
+name: envoy.filters.http.mcp
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.mcp.v3.Mcp
+  traffic_mode: PASS_THROUGH
+  attribute_source: VERIFY
+)EOF");
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  const std::string request_body =
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"body-task"}})";
+
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"accept", "application/json"},
+                                     {"accept", "text/event-stream"},
+                                     {"content-type", "application/json"},
+                                     {"mcp-method", "tasks/get"},
+                                     {"mcp-name", "header-task"}},
+      request_body);
+
+  ASSERT_TRUE(response->waitForEndStream());
+
+  EXPECT_EQ("400", response->headers().getStatusValue());
+
+  // The upstream should NOT receive a request because the filter sends a local reply.
+  EXPECT_FALSE(upstream_request_ != nullptr);
+}
+
 // Test that an MCP request with malformed JSON is rejected with a 400.
 TEST_P(McpFilterIntegrationTest, InvalidJsonBodyRejected) {
   FakeAccessLogFactory factory;

--- a/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_integration_test.cc
@@ -217,7 +217,7 @@ typed_config:
   EXPECT_EQ("400", response->headers().getStatusValue());
 
   // The upstream should NOT receive a request because the filter sends a local reply.
-  EXPECT_FALSE(upstream_request_ != nullptr);
+  EXPECT_EQ(nullptr, upstream_request_);
 }
 
 // Test that an MCP request with malformed JSON is rejected with a 400.

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -209,6 +209,113 @@ TEST_F(McpFilterTest, HeadersAttributeSourceBuffersWhenDuplicateKeyCheckEnabled)
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 }
 
+TEST_F(McpFilterTest, VerifyRejectsMethodMismatch) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(
+      envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(
+      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+
+  config_ =
+      std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"},
+      {"content-type", "application/json"},
+      {"accept", "application/json"},
+      {"accept", "text/event-stream"},
+      {"mcp-method", "tools/call"},
+      {"mcp-name", "get_weather"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl buffer(
+      R"({"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"get_weather"}})");
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "MCP header attributes do not match request body",
+                             _, _, _));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_->decodeData(buffer, true));
+}
+
+TEST_F(McpFilterTest, VerifyRejectsNameMismatch) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(
+      envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(
+      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+
+  config_ =
+      std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"},
+      {"content-type", "application/json"},
+      {"accept", "application/json"},
+      {"accept", "text/event-stream"},
+      {"mcp-method", "tasks/get"},
+      {"mcp-name", "task-123"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl buffer(
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"task-999"}})");
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "MCP header attributes do not match request body",
+                             _, _, _));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
+            filter_->decodeData(buffer, true));
+}
+
+TEST_F(McpFilterTest, VerifyAcceptsMatchingAttributes) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(
+      envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(
+      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+
+  config_ =
+      std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"},
+      {"content-type", "application/json"},
+      {"accept", "application/json"},
+      {"accept", "text/event-stream"},
+      {"mcp-method", "tasks/get"},
+      {"mcp-name", "task-123"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl buffer(
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"task-123"}})");
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(decoder_callbacks_.stream_info_,
+              setDynamicMetadata("envoy.filters.http.mcp", _));
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue,
+            filter_->decodeData(buffer, true));
+}
+
 // Test POST request with both accept headers in single value
 TEST_F(McpFilterTest, PostWithCombinedAcceptHeader) {
   Http::TestRequestHeaderMapImpl headers{{":method", "POST"},

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -264,6 +264,14 @@ TEST_F(McpFilterTest, HeadersMismatchIsStatOnlyWhenBodyIsParsed) {
 
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
 
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_EQ("tasks/get", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+        EXPECT_EQ("task-123", params.fields().at("taskId").string_value());
+      });
+
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
 
   EXPECT_EQ(1u, config_->stats().header_mismatch_.value());

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -239,6 +239,32 @@ TEST_F(McpFilterTest, HeadersAttributeSourceBuffersWhenDuplicateKeyCheckEnabled)
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 }
 
+TEST_F(McpFilterTest, HeadersAttributeSourceBuffersForBodyOnlyExtractionRule) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+
+  auto* method_config = proto_config.mutable_parser_config()->add_methods();
+  method_config->set_method("tools/call");
+  method_config->add_extraction_rules()->set_path("params.arguments");
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tools/call"},
+                                         {"mcp-name", "get_weather"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+}
+
 TEST_F(McpFilterTest, HeadersMismatchIsStatOnlyWhenBodyIsParsed) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
   proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -360,6 +360,75 @@ TEST_F(McpFilterTest, VerifyRejectsMissingMethodHeader) {
   EXPECT_EQ(1u, config_->stats().header_mismatch_.value());
 }
 
+TEST_F(McpFilterTest, HeadersAttributeSourceFallsBackWhenMethodHeaderMissing) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data(
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"body-task"}})");
+
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_EQ("tasks/get", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+        EXPECT_EQ("body-task", params.fields().at("taskId").string_value());
+      });
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
+  EXPECT_EQ(0u, config_->stats().header_mismatch_.value());
+}
+
+TEST_F(McpFilterTest, HeadersAttributeSourceFallsBackWhenNameHeaderMissing) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tools/call"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl data(
+      R"({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"body-tool"}})");
+
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_EQ("tools/call", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+        EXPECT_EQ("body-tool", params.fields().at("name").string_value());
+      });
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
+  EXPECT_EQ(0u, config_->stats().header_mismatch_.value());
+}
+
 TEST_F(McpFilterTest, VerifyRejectsMethodMismatch) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
   proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -209,111 +209,122 @@ TEST_F(McpFilterTest, HeadersAttributeSourceBuffersWhenDuplicateKeyCheckEnabled)
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 }
 
-TEST_F(McpFilterTest, VerifyRejectsMethodMismatch) {
+TEST_F(McpFilterTest, HeadersMismatchIsStatOnlyWhenBodyIsParsed) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
-  proto_config.set_traffic_mode(
-      envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
-  proto_config.set_attribute_source(
-      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+  proto_config.mutable_reject_duplicate_keys()->set_value(true);
 
-  config_ =
-      std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
   filter_ = std::make_unique<McpFilter>(config_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   filter_->setEncoderFilterCallbacks(encoder_callbacks_);
 
-  Http::TestRequestHeaderMapImpl headers{
-      {":method", "POST"},
-      {"content-type", "application/json"},
-      {"accept", "application/json"},
-      {"accept", "text/event-stream"},
-      {"mcp-method", "tools/call"},
-      {"mcp-name", "get_weather"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tasks/get"},
+                                         {"mcp-name", "task-123"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl buffer(
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"task-999"}})");
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+
+  EXPECT_EQ(1u, config_->stats().header_mismatch_.value());
+}
+
+TEST_F(McpFilterTest, VerifyRejectsMethodMismatch) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tools/call"},
+                                         {"mcp-name", "get_weather"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 
   Buffer::OwnedImpl buffer(
       R"({"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"get_weather"}})");
 
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
-                             "MCP header attributes do not match request body",
-                             _, _, _));
+                             "MCP header attributes do not match request body", _, _, _));
 
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
-            filter_->decodeData(buffer, true));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer, true));
 }
 
 TEST_F(McpFilterTest, VerifyRejectsNameMismatch) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
-  proto_config.set_traffic_mode(
-      envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
-  proto_config.set_attribute_source(
-      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
 
-  config_ =
-      std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
   filter_ = std::make_unique<McpFilter>(config_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   filter_->setEncoderFilterCallbacks(encoder_callbacks_);
 
-  Http::TestRequestHeaderMapImpl headers{
-      {":method", "POST"},
-      {"content-type", "application/json"},
-      {"accept", "application/json"},
-      {"accept", "text/event-stream"},
-      {"mcp-method", "tasks/get"},
-      {"mcp-name", "task-123"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tasks/get"},
+                                         {"mcp-name", "task-123"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 
   Buffer::OwnedImpl buffer(
       R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"task-999"}})");
 
   EXPECT_CALL(decoder_callbacks_,
               sendLocalReply(Http::Code::BadRequest,
-                             "MCP header attributes do not match request body",
-                             _, _, _));
+                             "MCP header attributes do not match request body", _, _, _));
 
-  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer,
-            filter_->decodeData(buffer, true));
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer, true));
+
+  EXPECT_EQ(1u, config_->stats().header_mismatch_.value());
 }
 
 TEST_F(McpFilterTest, VerifyAcceptsMatchingAttributes) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
-  proto_config.set_traffic_mode(
-      envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
-  proto_config.set_attribute_source(
-      envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
 
-  config_ =
-      std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
   filter_ = std::make_unique<McpFilter>(config_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   filter_->setEncoderFilterCallbacks(encoder_callbacks_);
 
-  Http::TestRequestHeaderMapImpl headers{
-      {":method", "POST"},
-      {"content-type", "application/json"},
-      {"accept", "application/json"},
-      {"accept", "text/event-stream"},
-      {"mcp-method", "tasks/get"},
-      {"mcp-name", "task-123"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tasks/get"},
+                                         {"mcp-name", "task-123"}};
 
-  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers, false));
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 
   Buffer::OwnedImpl buffer(
       R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"task-123"}})");
 
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
-  EXPECT_CALL(decoder_callbacks_.stream_info_,
-              setDynamicMetadata("envoy.filters.http.mcp", _));
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _));
 
-  EXPECT_EQ(Http::FilterDataStatus::Continue,
-            filter_->decodeData(buffer, true));
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
 }
 
 // Test POST request with both accept headers in single value

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -126,6 +126,89 @@ TEST_F(McpFilterTest, ValidMcpPostHeaders) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
 }
 
+TEST_F(McpFilterTest, HeadersAttributeSourceUsesFastPath) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tasks/get"},
+                                         {"mcp-name", "task-123"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_)).Times(0);
+
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_THAT(
+            metadata.fields(),
+            AllOf(Contains(Pair("method", Property(&Protobuf::Value::string_value, "tasks/get"))),
+                  Contains(Pair("params.taskId",
+                                Property(&Protobuf::Value::string_value, "task-123")))));
+      });
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+TEST_F(McpFilterTest, HeadersAttributeSourceUsesNamePath) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tools/call"},
+                                         {"mcp-name", "get_weather"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_)).Times(0);
+
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_THAT(
+            metadata.fields(),
+            Contains(Pair("params.name", Property(&Protobuf::Value::string_value, "get_weather"))));
+      });
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+TEST_F(McpFilterTest, HeadersAttributeSourceBuffersWhenDuplicateKeyCheckEnabled) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+  proto_config.mutable_reject_duplicate_keys()->set_value(true);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tools/call"},
+                                         {"mcp-name", "get_weather"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+}
+
 // Test POST request with both accept headers in single value
 TEST_F(McpFilterTest, PostWithCombinedAcceptHeader) {
   Http::TestRequestHeaderMapImpl headers{{":method", "POST"},

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -186,6 +186,36 @@ TEST_F(McpFilterTest, HeadersAttributeSourceUsesNamePath) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
 }
 
+TEST_F(McpFilterTest, HeadersAttributeSourceUsesResourceUriPath) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "resources/read"},
+                                         {"mcp-name", "file:///tmp/foo"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_)).Times(0);
+
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_EQ("resources/read", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+        EXPECT_EQ("file:///tmp/foo", params.fields().at("uri").string_value());
+      });
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
 TEST_F(McpFilterTest, HeadersAttributeSourceBuffersWhenDuplicateKeyCheckEnabled) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
   proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -147,11 +147,10 @@ TEST_F(McpFilterTest, HeadersAttributeSourceUsesFastPath) {
 
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
-        EXPECT_THAT(
-            metadata.fields(),
-            AllOf(Contains(Pair("method", Property(&Protobuf::Value::string_value, "tasks/get"))),
-                  Contains(Pair("params.taskId",
-                                Property(&Protobuf::Value::string_value, "task-123")))));
+        EXPECT_EQ("tasks/get", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+        EXPECT_EQ("task-123", params.fields().at("taskId").string_value());
       });
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
@@ -178,9 +177,10 @@ TEST_F(McpFilterTest, HeadersAttributeSourceUsesNamePath) {
 
   EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
       .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
-        EXPECT_THAT(
-            metadata.fields(),
-            Contains(Pair("params.name", Property(&Protobuf::Value::string_value, "get_weather"))));
+        EXPECT_EQ("tools/call", metadata.fields().at("method").string_value());
+
+        const auto& params = metadata.fields().at("params").struct_value();
+        EXPECT_EQ("get_weather", params.fields().at("name").string_value());
       });
 
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
@@ -235,6 +235,89 @@ TEST_F(McpFilterTest, HeadersMismatchIsStatOnlyWhenBodyIsParsed) {
   EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
 
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer, true));
+
+  EXPECT_EQ(1u, config_->stats().header_mismatch_.value());
+}
+
+TEST_F(McpFilterTest, HeadersAttributeSourceStoresFilterState) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+  proto_config.set_request_storage_mode(
+      envoy::extensions::filters::http::mcp::v3::Mcp::FILTER_STATE);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tasks/get"},
+                                         {"mcp-name", "task-123"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_)).Times(0);
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+
+  auto obj = decoder_callbacks_.stream_info_.filterState()->getDataReadOnly<McpFilterStateObject>(
+      std::string(McpFilterStateObject::FilterStateKey));
+
+  ASSERT_NE(nullptr, obj);
+}
+
+TEST_F(McpFilterTest, HeadersAttributeSourceClearsRouteCache) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS);
+  proto_config.set_clear_route_cache(true);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-method", "tasks/get"},
+                                         {"mcp-name", "task-123"}};
+
+  EXPECT_CALL(decoder_callbacks_, setBufferLimit(_)).Times(0);
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(headers, false));
+}
+
+TEST_F(McpFilterTest, VerifyRejectsMissingMethodHeader) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+  filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"},
+                                         {"mcp-name", "task-123"}};
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration, filter_->decodeHeaders(headers, false));
+
+  Buffer::OwnedImpl buffer(
+      R"({"jsonrpc":"2.0","id":1,"method":"tasks/get","params":{"taskId":"task-123"}})");
+
+  EXPECT_CALL(decoder_callbacks_,
+              sendLocalReply(Http::Code::BadRequest,
+                             "MCP header attributes do not match request body", _, _, _));
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(buffer, true));
 
   EXPECT_EQ(1u, config_->stats().header_mismatch_.value());
 }

--- a/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
@@ -1568,6 +1568,7 @@ TEST(McpParserConfigTest, NameAttributePaths) {
 
   EXPECT_EQ(config.getNameAttributePath("tools/call"), "params.name");
   EXPECT_EQ(config.getNameAttributePath("prompts/get"), "params.name");
+  EXPECT_EQ(config.getNameAttributePath("resources/read"), "params.uri");
   EXPECT_EQ(config.getNameAttributePath("tasks/get"), "params.taskId");
   EXPECT_EQ(config.getNameAttributePath("tasks/update"), "params.taskId");
   EXPECT_EQ(config.getNameAttributePath("tasks/cancel"), "params.taskId");

--- a/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_json_parser_test.cc
@@ -1563,6 +1563,17 @@ TEST(McpParserConfigTest, BuiltInMethodGroups) {
   EXPECT_EQ(config.getMethodGroup("custom/extension"), "unknown");
 }
 
+TEST(McpParserConfigTest, NameAttributePaths) {
+  McpParserConfig config;
+
+  EXPECT_EQ(config.getNameAttributePath("tools/call"), "params.name");
+  EXPECT_EQ(config.getNameAttributePath("prompts/get"), "params.name");
+  EXPECT_EQ(config.getNameAttributePath("tasks/get"), "params.taskId");
+  EXPECT_EQ(config.getNameAttributePath("tasks/update"), "params.taskId");
+  EXPECT_EQ(config.getNameAttributePath("tasks/cancel"), "params.taskId");
+  EXPECT_EQ(config.getNameAttributePath("logging/setLevel"), "");
+}
+
 TEST(McpParserConfigTest, MethodGroupFromProtoWithOverrides) {
   envoy::extensions::filters::http::mcp::v3::ParserConfig proto_config;
   proto_config.set_group_metadata_key("method_group");


### PR DESCRIPTION
Commit Message: add mcp header-based attribute extraction and validation
Additional Description: Adds support for extracting MCP request attributes from the `Mcp-Method` and `Mcp-Name` headers introduced by the new MCP specification.
This change adds configurable attribute source modes to preserve the existing body-based behavior, verify header values against attributes parsed from the request body, or trust header values and avoid buffering the request body when it is not otherwise needed. Header/body mismatches are rejected in verification mode, while header mode continues using the header values without rejecting the request.
Risk Level: low
Testing: Added and updated unit and integration tests covering:
- BODY mode preserving existing behavior.
- HEADERS mode using Mcp-Method and Mcp-Name without buffering or parsing the body when not otherwise required.
- HEADERS mode continuing to use header attributes when the body is parsed for duplicate-key validation or other features.
- VERIFY mode accepting matching header/body attributes and rejecting mismatches.
- Header mismatch statistics.
- Mcp-Name mappings for tools/call, prompts/get, resources/read, and task methods.
- Dynamic metadata, filter state, and route cache behavior for header-derived attributes.
Validated with:
- //test/extensions/filters/http/mcp:mcp_json_parser_test
- //test/extensions/filters/http/mcp:mcp_filter_test
- //test/extensions/filters/http/mcp:mcp_filter_integration_test
- //test/extensions/filters/http/mcp:config_test

Docs Changes: NA
Release Notes: Added ``attribute_source`` support for extracting MCP request attributes from the request body, verifying request headers against the body, or using ``Mcp-Method`` and ``Mcp-Name`` headers for a body-free fast path.
Platform Specific Features: NA
