### PR TITLE
load balancer: exclude draining hosts from panic mode AllHosts source

### DIFF
--- a/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
+++ b/source/extensions/load_balancing_policies/common/load_balancer_impl.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/load_balancing_policies/common/load_balancer_impl.h"
 
+#include <algorithm>
 #include <atomic>
 #include <bitset>
 #include <cstdint>
@@ -1076,7 +1077,21 @@ void EdfLoadBalancerBase::refresh(uint32_t priority) {
   };
   // Populate EdfSchedulers for each valid HostsSource value for the host set at this priority.
   const auto& host_set = priority_set_.hostSetsPerPriority()[priority];
-  add_hosts_source(HostsSource(priority, HostsSource::SourceType::AllHosts), host_set->hosts());
+  // Populate AllHosts with hosts minus excluded hosts, so that panic mode
+  // does not route traffic to hosts that were excluded from the panic
+  // threshold calculation (e.g. EDS DRAINING endpoints).
+  {
+    const auto& hosts = host_set->hosts();
+    const auto& excluded = host_set->excludedHosts();
+    HostVector all_hosts;
+    all_hosts.reserve(hosts.size() - std::min(excluded.size(), hosts.size()));
+    for (const auto& host : hosts) {
+      if (std::find(excluded.begin(), excluded.end(), host) == excluded.end()) {
+        all_hosts.push_back(host);
+      }
+    }
+    add_hosts_source(HostsSource(priority, HostsSource::SourceType::AllHosts), all_hosts);
+  }
   add_hosts_source(HostsSource(priority, HostsSource::SourceType::HealthyHosts),
                    host_set->healthyHosts());
   add_hosts_source(HostsSource(priority, HostsSource::SourceType::DegradedHosts),


### PR DESCRIPTION
### Description

Panic mode subtracts excluded hosts from the panic **threshold** calculation, but once panic engages it selects from the full `host_set.hosts()` -- the unfiltered membership -- so those same excluded hosts do receive traffic. For `EDS_STATUS_DRAINING` this means an endpoint the control plane explicitly marked as draining receives **new** requests.

The two decisions contradict each other: if a host is not capacity for the purpose of deciding whether we are in panic, it should not become capacity once we are in panic.

### Root Cause

`LoadBalancerBase::isHostSetInPanic` correctly excludes `excludedHosts()` from the denominator:

```
const auto host_count = host_set.hosts().size() - host_set.excludedHosts().size();
```

But `EdfLoadBalancerBase::refresh()` populates the `AllHosts` source with the full unfiltered `host_set->hosts()`, which includes hosts that were excluded from the panic calculation.

### Fix

Exclude the same hosts from the `AllHosts` source that were excluded from the panic threshold calculation, by filtering out `excludedHosts()`.

### Related Issue

Fixes #46800

### DCO

Signed-off-by: waterWang <waterwang@proton.me>