### PR TITLE
[bp/v1.39] compat/openssl: Treat CRYPTO_set_mem_functions() failure as non-fatal

### DIFF
--- a/compat/openssl/source/ossl_dlutil.c
+++ b/compat/openssl/source/ossl_dlutil.c
@@ -131,10 +131,10 @@ void ossl_dlopen(int expected_major, int expected_minor) {
     exit(ELIBACC);
   }
 
-  if (!set_mem_fn(ossl_malloc, ossl_realloc, ossl_free)) {
-    bssl_compat_error("CRYPTO_set_mem_functions() failed\n");
-    exit(ELIBACC);
-  }
+  // In some circumstances, libcrypto will perform allocations during dlopen(),
+  // in which case this CRYPTO_set_mem_functions() call will always fail, so we
+  // have to let it fail silently rather than exiting.
+  set_mem_fn(ossl_malloc, ossl_realloc, ossl_free);
 
   // Load libssl.so *after* calling CRYPTO_set_mem_functions() just in case
   // libssl.so has any library constructors that call OPENSSL_malloc().


### PR DESCRIPTION
In some circumstances, libcrypto.so will perform some initial heap allocations during dlopen(), in which case subsequently calling CRYPTO_set_mem_functions() is not allowed. We should not treat this as a fatal error.

Back port of #46826 