### PR TITLE
[bp/v1.39] test: re-enable chained FULL_DUPLEX_STREAMED ext_proc integration tests

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_full_duplex_integration_test.cc
@@ -595,8 +595,7 @@ TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersInResponseProcessing) {
 }
 
 // without trailers, server fully buffers the message before sending back the response.
-// TODO(#44605): Flaky due to production bug in chained FULL_DUPLEX_STREAMED ext_proc filters.
-TEST_P(ExtProcIntegrationTest, DISABLED_TwoExtProcFiltersBothDuplexInBothDirection) {
+TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersBothDuplexInBothDirection) {
   twoExtProcFiltersFullDuplexConfig();
 
   const std::string body_sent(5 * 1024, 's');
@@ -654,8 +653,7 @@ TEST_P(ExtProcIntegrationTest, DISABLED_TwoExtProcFiltersBothDuplexInBothDirecti
 }
 
 // Without trailers,  server buffers one chunks of body before sending back the response.
-// TODO(#44605): Flaky due to production bug in chained FULL_DUPLEX_STREAMED ext_proc filters.
-TEST_P(ExtProcIntegrationTest, DISABLED_TwoExtProcFiltersBothDuplexInBothDirectionNoTrailerRandom) {
+TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersBothDuplexInBothDirectionNoTrailerRandom) {
   twoExtProcFiltersFullDuplexConfig();
 
   const std::string body_sent(10 * 1024, 's');
@@ -829,9 +827,8 @@ TEST_P(ExtProcIntegrationTest, KeepContentLengthDuplexStreamed) {
 }
 
 // With trailers, request direction, fully buffered
-// TODO(#44605): Flaky due to production bug in chained FULL_DUPLEX_STREAMED ext_proc filters.
 TEST_P(ExtProcIntegrationTest,
-       DISABLED_TwoExtProcFiltersBothDuplexInRequestDirectionWithTrailerFullyBuffered) {
+       TwoExtProcFiltersBothDuplexInRequestDirectionWithTrailerFullyBuffered) {
   two_ext_proc_filters_ = true;
   config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap&) {
     // Filter-1
@@ -902,9 +899,7 @@ TEST_P(ExtProcIntegrationTest,
 }
 
 // With trailers, both directions, server fully buffers.
-// TODO(#44605): Flaky due to production bug in chained FULL_DUPLEX_STREAMED ext_proc filters.
-TEST_P(ExtProcIntegrationTest,
-       DISABLED_TwoExtProcFiltersBothDuplexInBothDirectionWithTrailerFullyBuffered) {
+TEST_P(ExtProcIntegrationTest, TwoExtProcFiltersBothDuplexInBothDirectionWithTrailerFullyBuffered) {
   twoExtProcFiltersFullDuplexConfig();
 
   const std::string body_sent(10 * 1024, 's');


### PR DESCRIPTION
The four `TwoExtProcFiltersBothDuplex*` integration tests were disabled in #44608 because chained FULL_DUPLEX_STREAMED ext_proc filters could intermittently stall: request body chunks stopped being forwarded to the first filter's ext_proc server mid-stream, and the server timed out waiting for `ProcessingRequest` body messages (#44605).

The underlying production bug was fixed in #45617: with a single gRPC stream shared across both directions,
`closeGrpcStreamIfLastRespReceived()` could close the stream prematurely once the encoding direction finished while the decoding direction was still streaming request body, leaving queued body messages with no live stream to egress on. The fix requires both directions to be complete (`noMoreExternalProcess()`) before closing the stream, gated by the default-on
`envoy.reloadable_features.ext_proc_stream_close_optimization` runtime guard.

Verified by reproducing the exact `serverReceiveBodyDuplexStreamed` timeout at the pre-fix baseline under CPU contention, and confirming these tests pass at HEAD under the same load.

Backport of #46819.
