### PR TITLE
common: support yaml float literals when converting to protobuf value

### DIFF
--- a/source/common/protobuf/yaml_utility.cc
+++ b/source/common/protobuf/yaml_utility.cc
@@ -73,23 +73,30 @@ Protobuf::Value parseYamlNode(const YAML::Node& node) {
       }
       break;
     }
-    double double_value;
-    if (YAML::convert<double>::decode(node, double_value)) {
-      if (std::isfinite(double_value)) {
-        value.set_number_value(double_value);
-      } else {
-        // JSON numbers cannot encode NaN/Infinity/-Infinity, so proto3 JSON mapping represents
-        // these float/double values as the strings "NaN", "Infinity", and "-Infinity" instead.
-        if (std::isnan(double_value)) {
-          value.set_string_value("NaN");
+    // Unlike integers, plain (untagged) float/double literals are intentionally left as strings
+    // below to preserve existing behavior for configs that rely on this fallback (e.g. a string
+    // match `exact: 3.14`). Only an explicitly tagged `!!float` scalar is parsed as a number, so
+    // this is opt-in and cannot change the meaning of any existing untagged YAML.
+    if (node.Tag() == "tag:yaml.org,2002:float") {
+      double double_value;
+      if (YAML::convert<double>::decode(node, double_value)) {
+        if (std::isfinite(double_value)) {
+          value.set_number_value(double_value);
         } else {
-          value.set_string_value(double_value > 0 ? "Infinity" : "-Infinity");
+          // JSON numbers cannot encode NaN/Infinity/-Infinity, so proto3 JSON mapping represents
+          // these float/double values as the strings "NaN", "Infinity", and "-Infinity" instead.
+          if (std::isnan(double_value)) {
+            value.set_string_value("NaN");
+          } else {
+            value.set_string_value(double_value > 0 ? "Infinity" : "-Infinity");
+          }
         }
+        break;
       }
-      break;
     }
-    // Fall back on string for anything else. When protobuf parses the JSON into a message it will
-    // convert based on the type in the message definition.
+    // Fall back on string for anything else, including untagged float/double literals. When
+    // protobuf parses the JSON into a message it will convert based on the type in the message
+    // definition.
     value.set_string_value(node.as<std::string>());
     break;
   }

--- a/source/common/protobuf/yaml_utility.cc
+++ b/source/common/protobuf/yaml_utility.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <limits>
 #include <numeric>
 
@@ -72,8 +73,23 @@ Protobuf::Value parseYamlNode(const YAML::Node& node) {
       }
       break;
     }
-    // Fall back on string, including float/double case. When protobuf parse the JSON into a message
-    // it will convert based on the type in the message definition.
+    double double_value;
+    if (YAML::convert<double>::decode(node, double_value)) {
+      if (std::isfinite(double_value)) {
+        value.set_number_value(double_value);
+      } else {
+        // JSON numbers cannot encode NaN/Infinity/-Infinity, so proto3 JSON mapping represents
+        // these float/double values as the strings "NaN", "Infinity", and "-Infinity" instead.
+        if (std::isnan(double_value)) {
+          value.set_string_value("NaN");
+        } else {
+          value.set_string_value(double_value > 0 ? "Infinity" : "-Infinity");
+        }
+      }
+      break;
+    }
+    // Fall back on string for anything else. When protobuf parses the JSON into a message it will
+    // convert based on the type in the message definition.
     value.set_string_value(node.as<std::string>());
     break;
   }

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1331,6 +1331,10 @@ TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlScalar) {
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("null"), "null_value: NULL_VALUE"));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("true"), "bool_value: true"));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("1"), "number_value: 1"));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("3.14"), "number_value: 3.14"));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml(".inf"), "string_value: \"Infinity\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("-.inf"), "string_value: \"-Infinity\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml(".nan"), "string_value: \"NaN\""));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("9223372036854775807"),
                                  "string_value: \"9223372036854775807\""));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("\"foo\""), "string_value: \"foo\""));

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -1331,10 +1331,22 @@ TEST_F(ProtobufUtilityTest, ValueUtilLoadFromYamlScalar) {
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("null"), "null_value: NULL_VALUE"));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("true"), "bool_value: true"));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("1"), "number_value: 1"));
-  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("3.14"), "number_value: 3.14"));
-  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml(".inf"), "string_value: \"Infinity\""));
-  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("-.inf"), "string_value: \"-Infinity\""));
-  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml(".nan"), "string_value: \"NaN\""));
+  // Plain (untagged) float/double literals are left as strings, preserving pre-existing
+  // behavior for configs that rely on this fallback (e.g. a string match `exact: 3.14`).
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("3.14"), "string_value: \"3.14\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml(".inf"), "string_value: \".inf\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("-.inf"), "string_value: \"-.inf\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml(".nan"), "string_value: \".nan\""));
+  // An explicit `!!float` tag opts a scalar into being parsed as a JSON number.
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("!!float 3.14"), "number_value: 3.14"));
+  // "1e2" is not a valid int64 literal, so this exercises the double-decode path specifically
+  // (as opposed to "!!float 1", which the preceding int64 check would already have claimed).
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("!!float 1e2"), "number_value: 100"));
+  EXPECT_TRUE(
+      checkProtoEquality(ValueUtil::loadFromYaml("!!float .inf"), "string_value: \"Infinity\""));
+  EXPECT_TRUE(
+      checkProtoEquality(ValueUtil::loadFromYaml("!!float -.inf"), "string_value: \"-Infinity\""));
+  EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("!!float .nan"), "string_value: \"NaN\""));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("9223372036854775807"),
                                  "string_value: \"9223372036854775807\""));
   EXPECT_TRUE(checkProtoEquality(ValueUtil::loadFromYaml("\"foo\""), "string_value: \"foo\""));


### PR DESCRIPTION
### Fixes - https://github.com/envoyproxy/envoy/issues/45678

### Description

ValueUtil::loadFromYaml previously fell through to string_value for any scalar that wasn't null/bool/int64, including float/double literals (e.g. 3.14). This adds a decode path for scalars explicitly tagged !!float: finite values are set as number_value, while non-finite values (NaN, Infinity, -Infinity) are encoded as their proto3 JSON string equivalents ("NaN", "Infinity", "-Infinity"), since JSON numbers can't represent them.

Plain (untagged) float/double literals (e.g. 3.14, .inf) are left as strings, unchanged from existing behavior.  This preserves configs that rely on the string fallback (e.g. a string match exact: 3.14).

### Testing

<details>

<summary>golang filter config</summary>

```yaml
# envoy demo with golang extension enabled
static_resources:
  listeners:
  - name: listener_0
    address:
      socket_address:
        address: 0.0.0.0
        port_value: 10000
    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          stat_prefix: ingress_http
          http_filters:
          - name: envoy.filters.http.golang
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.golang.v3alpha.Config
              library_id: simple
              library_path: "lib/simple.so"
              plugin_name: simple
              plugin_config:
                "@type": type.googleapis.com/xds.type.v3.TypedStruct
                value:
                  prefix_localreply_body: "Configured local reply from go"
                  float_value: !!float 0.001
          - name: envoy.filters.http.router
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
          route_config:
            name: local_route
            virtual_hosts:
            - name: local_service
              domains: ["*"]
              routes:
              - match:
                  prefix: "/"
                route:
                  cluster: helloworld_service_cluster
  clusters:
  - name: helloworld_service_cluster
    type: STRICT_DNS
    lb_policy: ROUND_ROBIN
    load_assignment:
      cluster_name: helloworld_service_cluster
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: 127.0.0.1
                port_value: 10001


```

</details>


<details>

<summary>config.go</summary>

```golang
package main

import (
	"errors"
	"fmt"

	xds "github.com/cncf/xds/go/xds/type/v3"
	"google.golang.org/protobuf/types/known/anypb"

	"github.com/envoyproxy/envoy/contrib/golang/common/go/api"
	"github.com/envoyproxy/envoy/contrib/golang/filters/http/source/go/pkg/http"
)

const Name = "simple"

func init() {
	http.RegisterHttpFilterFactoryAndConfigParser(Name, filterFactory, &parser{})
}

type config struct {
	echoBody string
	// other fields
}

type parser struct {
}

// Parse the filter configuration. We can call the ConfigCallbackHandler to control the filter's
// behavior
func (p *parser) Parse(any *anypb.Any, callbacks api.ConfigCallbackHandler) (interface{}, error) {
	configStruct := &xds.TypedStruct{}
	if err := any.UnmarshalTo(configStruct); err != nil {
		return nil, err
	}

	v := configStruct.Value
	conf := &config{}
	prefix, ok := v.AsMap()["prefix_localreply_body"]
	float_value, ok := v.AsMap()["float_value"]
	if !ok {
		return nil, errors.New("missing prefix_localreply_body")
	}
	if _, ok := prefix.(string); ok {
		if f_val, ok := float_value.(float64); ok {
			conf.echoBody = fmt.Sprintf("float %f", f_val)
		} else if str_float, ok := float_value.(string); ok {
			conf.echoBody = fmt.Sprintf("str float %s", str_float)
		} else {
			conf.echoBody = "no float"
		}
	} else {
		return nil, fmt.Errorf("prefix_localreply_body: expect string while got %T %v", prefix)
	}
	return conf, nil
}

// Merge configuration from the inherited parent configuration
func (p *parser) Merge(parent interface{}, child interface{}) interface{} {
	parentConfig := parent.(*config)
	childConfig := child.(*config)

	// copy one, do not update parentConfig directly.
	newConfig := *parentConfig
	if childConfig.echoBody != "" {
		newConfig.echoBody = childConfig.echoBody
	}
	return &newConfig
}

func filterFactory(c interface{}, callbacks api.FilterCallbackHandler) api.StreamFilter {
	conf, ok := c.(*config)
	if !ok {
		panic("unexpected config type")
	}
	return &filter{
		callbacks: callbacks,
		config:    conf,
	}
}

func main() {}

```

</details>


