### PR TITLE
filter: clean up unnecessary redundancy

### DIFF
--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -253,6 +253,62 @@ struct ExtraFactoryContext {
   // owns the filter configuration is warmed up, so factories may register init targets with it but
   // must never store the reference.
   OptRef<Init::Manager> init_manager = std::nullopt;
+  // Optional stats scope that the filter configuration should use to create its own stats. May be
+  // nullopt for contexts where no specific scope is available, such as route specific filter
+  // configurations. When it is nullopt, factories that need a scope should fall back to the scope
+  // of the ServerFactoryContext.
+  OptRef<Stats::Scope> scope = std::nullopt;
+  // Whether the filter is being created for an upstream filter chain rather than a downstream one.
+  // Only dual filters, that is filters that can be configured in both the downstream and the
+  // upstream filter chains, need to care about this. It is always false for contexts that can only
+  // ever be downstream, such as route specific filter configurations.
+  bool is_upstream = false;
+
+  /**
+   * @return the scope to use for stats: this context's own scope if it has one, otherwise the scope
+   *         of the given server factory context. Filters should prefer this over reading scope
+   *         directly so that they work on both the listener/cluster and the route/embedded paths.
+   */
+  template <class ContextType> Stats::Scope& scopeOr(ContextType& context) const {
+    return scope.has_value() ? scope.ref() : context.scope();
+  }
+
+  /**
+   * Create an extra factory context for a downstream (listener) filter chain.
+   *
+   * NOTE: the returned struct only holds references to the arguments, so both the context and the
+   * stat prefix must outlive the returned struct.
+   *
+   * @param context the downstream factory context.
+   * @param stats_prefix prefix for stat logging.
+   * @return ExtraFactoryContext the extra factory context.
+   */
+  static ExtraFactoryContext create(FactoryContext& context, const std::string& stats_prefix) {
+    ExtraFactoryContext extra_context{context.messageValidationVisitor(), stats_prefix};
+    extra_context.init_manager = context.initManager();
+    extra_context.scope = context.scope();
+    return extra_context;
+  }
+
+  /**
+   * Create an extra factory context for an upstream (cluster) filter chain.
+   *
+   * NOTE: the returned struct only holds references to the arguments, so both the context and the
+   * stat prefix must outlive the returned struct.
+   *
+   * @param context the upstream factory context.
+   * @param stats_prefix prefix for stat logging.
+   * @return ExtraFactoryContext the extra factory context.
+   */
+  static ExtraFactoryContext create(UpstreamFactoryContext& context,
+                                    const std::string& stats_prefix) {
+    ExtraFactoryContext extra_context{context.serverFactoryContext().messageValidationVisitor(),
+                                      stats_prefix};
+    extra_context.init_manager = context.initManager();
+    extra_context.scope = context.scope();
+    extra_context.is_upstream = true;
+    return extra_context;
+  }
 };
 
 /**
@@ -340,6 +396,13 @@ public:
                                        Server::Configuration::ServerFactoryContext&) {
     return false;
   }
+
+  /**
+   * @return bool true if this filter is a unified filter who implements
+   * createHttpFilterFactoryFromProto but does not implement createFilterFactoryFromProto. This is
+   * used to differentiate unified filters from legacy filters.
+   */
+  virtual bool isUnifiedFilter() { return false; }
 };
 
 class NamedHttpFilterConfigFactory : public virtual HttpFilterConfigFactoryBase {
@@ -420,7 +483,63 @@ public:
   virtual absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
                                Server::Configuration::UpstreamFactoryContext& context) PURE;
+
+  /**
+   * Create a particular http filter factory implementation. If the implementation is unable to
+   * produce a factory with the provided parameters, it should return an error status.
+   * The returned callback should always be initialized.
+   *
+   * NOTE: for backwards compatibility, this method will default to calling
+   * createFilterFactoryFromProtoWithServerContext, which will throw an exception if not
+   * implemented. This new method will be used to replace
+   * createFilterFactoryFromProtoWithServerContext in the future and this delegation will be
+   * removed.
+   *
+   * @param config supplies the general Protobuf message to be marshaled into a filter-specific
+   * configuration.
+   * @param context supplies the filter's context.
+   * @param extra_context supplies the filter's extra context.
+   * @return Http::FilterFactoryCb the factory creation function.
+   */
+  virtual absl::StatusOr<Http::FilterFactoryCb>
+  createHttpFilterFactoryFromProto(const Protobuf::Message& config,
+                                   Server::Configuration::ServerFactoryContext& context,
+                                   ExtraFactoryContext& extra_context) {
+    UNREFERENCED_PARAMETER(config);
+    UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(extra_context);
+    return absl::UnimplementedError(
+        "createHttpFilterFactoryFromProto is not implemented for this filter");
+  }
 };
+
+/**
+ * Helper to create the HTTP filter factory creation function from the given filter config factory.
+ *
+ * Unified filters only implement createHttpFilterFactoryFromProto() and will always return an
+ * error for createFilterFactoryFromProto(), so the call must be dispatched based on
+ * isUnifiedFilter(). All the callers that create HTTP filters from a FactoryContext or an
+ * UpstreamFactoryContext should use this helper rather than calling the factory directly.
+ *
+ * @param factory the HTTP filter config factory. It could be a NamedHttpFilterConfigFactory for
+ * the downstream filter chain or an UpstreamHttpFilterConfigFactory for the upstream filter chain.
+ * @param config supplies the general Protobuf message to be marshaled into a filter-specific
+ * configuration.
+ * @param stats_prefix prefix for stat logging.
+ * @param context the FactoryContext (downstream) or UpstreamFactoryContext (upstream).
+ * @return Http::FilterFactoryCb the factory creation function.
+ */
+template <class FactoryType, class ContextType>
+absl::StatusOr<Http::FilterFactoryCb>
+createHttpFilterFactory(FactoryType& factory, const Protobuf::Message& config,
+                        const std::string& stats_prefix, ContextType& context) {
+  if (factory.isUnifiedFilter()) {
+    ExtraFactoryContext extra_context = ExtraFactoryContext::create(context, stats_prefix);
+    return factory.createHttpFilterFactoryFromProto(config, context.serverFactoryContext(),
+                                                    extra_context);
+  }
+  return factory.createFilterFactoryFromProto(config, stats_prefix, context);
+}
 
 } // namespace Configuration
 } // namespace Server

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -399,7 +399,7 @@ public:
 
   /**
    * @return bool true if this filter is a unified filter who implements
-   * createHttpFilterFactoryFromProto but does not implement createFilterFactoryFromProto. This is
+   * createHttpFilterFactoryFromProto to replace createFilterFactoryFromProto completely. This is
    * used to differentiate unified filters from legacy filters.
    */
   virtual bool isUnifiedFilter() { return false; }
@@ -489,12 +489,6 @@ public:
    * produce a factory with the provided parameters, it should return an error status.
    * The returned callback should always be initialized.
    *
-   * NOTE: for backwards compatibility, this method will default to calling
-   * createFilterFactoryFromProtoWithServerContext, which will throw an exception if not
-   * implemented. This new method will be used to replace
-   * createFilterFactoryFromProtoWithServerContext in the future and this delegation will be
-   * removed.
-   *
    * @param config supplies the general Protobuf message to be marshaled into a filter-specific
    * configuration.
    * @param context supplies the filter's context.
@@ -512,34 +506,6 @@ public:
         "createHttpFilterFactoryFromProto is not implemented for this filter");
   }
 };
-
-/**
- * Helper to create the HTTP filter factory creation function from the given filter config factory.
- *
- * Unified filters only implement createHttpFilterFactoryFromProto() and will always return an
- * error for createFilterFactoryFromProto(), so the call must be dispatched based on
- * isUnifiedFilter(). All the callers that create HTTP filters from a FactoryContext or an
- * UpstreamFactoryContext should use this helper rather than calling the factory directly.
- *
- * @param factory the HTTP filter config factory. It could be a NamedHttpFilterConfigFactory for
- * the downstream filter chain or an UpstreamHttpFilterConfigFactory for the upstream filter chain.
- * @param config supplies the general Protobuf message to be marshaled into a filter-specific
- * configuration.
- * @param stats_prefix prefix for stat logging.
- * @param context the FactoryContext (downstream) or UpstreamFactoryContext (upstream).
- * @return Http::FilterFactoryCb the factory creation function.
- */
-template <class FactoryType, class ContextType>
-absl::StatusOr<Http::FilterFactoryCb>
-createHttpFilterFactory(FactoryType& factory, const Protobuf::Message& config,
-                        const std::string& stats_prefix, ContextType& context) {
-  if (factory.isUnifiedFilter()) {
-    ExtraFactoryContext extra_context = ExtraFactoryContext::create(context, stats_prefix);
-    return factory.createHttpFilterFactoryFromProto(config, context.serverFactoryContext(),
-                                                    extra_context);
-  }
-  return factory.createFilterFactoryFromProto(config, stats_prefix, context);
-}
 
 } // namespace Configuration
 } // namespace Server

--- a/source/extensions/filters/http/a2a/config.cc
+++ b/source/extensions/filters/http/a2a/config.cc
@@ -9,16 +9,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace A2a {
 
-absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  // This filter only uses the server factory context, so delegate to the server-context variant.
-  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
-                                                           stats_prefix};
-  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
-                                               extra_context);
-}
-
 absl::StatusOr<Http::FilterFactoryCb> A2aFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/a2a/config.h
+++ b/source/extensions/filters/http/a2a/config.h
@@ -11,15 +11,11 @@ namespace HttpFilters {
 namespace A2a {
 
 class A2aFilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<envoy::extensions::filters::http::a2a::v3::A2a> {
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::a2a::v3::A2a> {
 public:
-  A2aFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.a2a") {}
+  A2aFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.a2a") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::a2a::v3::A2a& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/alternate_protocols_cache/config.cc
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.cc
@@ -12,24 +12,6 @@ namespace HttpFilters {
 namespace AlternateProtocolsCache {
 
 absl::StatusOr<Http::FilterFactoryCb>
-AlternateProtocolsCacheFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
-        proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-
-  auto& server_context = context.serverFactoryContext();
-
-  FilterConfigSharedPtr filter_config(std::make_shared<FilterConfig>(
-      proto_config, context.serverFactoryContext().httpServerPropertiesCacheManager(),
-      server_context.mainThreadDispatcher().timeSource()));
-
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamEncoderFilter(
-        std::make_shared<Filter>(filter_config, callbacks.dispatcher()));
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 AlternateProtocolsCacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
         proto_config,

--- a/source/extensions/filters/http/alternate_protocols_cache/config.h
+++ b/source/extensions/filters/http/alternate_protocols_cache/config.h
@@ -15,18 +15,13 @@ namespace AlternateProtocolsCache {
  * Config registration for the alternate protocols cache filter.
  */
 class AlternateProtocolsCacheFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig> {
 public:
   AlternateProtocolsCacheFilterFactory()
-      : ExceptionFreeFactoryBase(HttpFilterNames::get().AlternateProtocolsCache) {}
+      : UnifiedFactoryBase(HttpFilterNames::get().AlternateProtocolsCache) {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
-          proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::alternate_protocols_cache::v3::FilterConfig&
           proto_config,

--- a/source/extensions/filters/http/body_size_limit/config.cc
+++ b/source/extensions/filters/http/body_size_limit/config.cc
@@ -21,12 +21,6 @@ Http::FilterFactoryCb createFilterFactory(
 }
 } // namespace
 
-absl::StatusOr<Http::FilterFactoryCb> BodySizeLimitFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::body_size_limit::v3::BodySizeLimit& proto_config,
-    const std::string&, DualInfo, Server::Configuration::ServerFactoryContext&) {
-  return createFilterFactory(proto_config);
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 BodySizeLimitFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::body_size_limit::v3::BodySizeLimit& proto_config,

--- a/source/extensions/filters/http/body_size_limit/config.h
+++ b/source/extensions/filters/http/body_size_limit/config.h
@@ -14,17 +14,12 @@ namespace BodySizeLimitFilter {
  * Config registration for the body size limiter filter.
  */
 class BodySizeLimitFilterFactory
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::body_size_limit::v3::BodySizeLimit> {
 public:
-  BodySizeLimitFilterFactory() : DualFactoryBase("envoy.filters.http.body_size_limit") {}
+  BodySizeLimitFilterFactory() : UnifiedFactoryBase("envoy.filters.http.body_size_limit") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::body_size_limit::v3::BodySizeLimit& proto_config,
-      const std::string& stats_prefix, DualInfo,
-      Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::body_size_limit::v3::BodySizeLimit& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/buffer/config.cc
+++ b/source/extensions/filters/http/buffer/config.cc
@@ -15,17 +15,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace BufferFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> BufferFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config, const std::string&,
-    DualInfo, Server::Configuration::ServerFactoryContext&) {
-  ASSERT(proto_config.has_max_request_bytes());
-
-  BufferFilterConfigSharedPtr filter_config(new BufferFilterConfig(proto_config));
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_shared<BufferFilter>(filter_config));
-  };
-}
-
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
 BufferFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,

--- a/source/extensions/filters/http/buffer/config.h
+++ b/source/extensions/filters/http/buffer/config.h
@@ -13,18 +13,13 @@ namespace BufferFilter {
 /**
  * Config registration for the buffer filter.
  */
-class BufferFilterFactory
-    : public Common::DualFactoryBase<envoy::extensions::filters::http::buffer::v3::Buffer,
-                                     envoy::extensions::filters::http::buffer::v3::BufferPerRoute> {
+class BufferFilterFactory : public Common::UnifiedFactoryBase<
+                                envoy::extensions::filters::http::buffer::v3::Buffer,
+                                envoy::extensions::filters::http::buffer::v3::BufferPerRoute> {
 public:
-  BufferFilterFactory() : DualFactoryBase("envoy.filters.http.buffer") {}
+  BufferFilterFactory() : UnifiedFactoryBase("envoy.filters.http.buffer") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
-      const std::string& stats_prefix, DualInfo,
-      Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::buffer::v3::Buffer& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/cache/config.cc
+++ b/source/extensions/filters/http/cache/config.cc
@@ -32,12 +32,6 @@ absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactory(
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(config, context.serverFactoryContext());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/cache/config.h
+++ b/source/extensions/filters/http/cache/config.h
@@ -10,15 +10,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Cache {
 
-class CacheFilterFactory : public Common::ExceptionFreeFactoryBase<
-                               envoy::extensions::filters::http::cache::v3::CacheConfig> {
+class CacheFilterFactory
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::cache::v3::CacheConfig> {
 public:
-  CacheFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.cache") {}
+  CacheFilterFactory() : UnifiedFactoryBase("envoy.filters.http.cache") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache::v3::CacheConfig& config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/cache_v2/config.cc
+++ b/source/extensions/filters/http/cache_v2/config.cc
@@ -39,12 +39,6 @@ absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactory(
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-    const std::string& /*stats_prefix*/, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(config, context.serverFactoryContext());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> CacheFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/cache_v2/config.h
+++ b/source/extensions/filters/http/cache_v2/config.h
@@ -10,15 +10,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace CacheV2 {
 
-class CacheFilterFactory : public Common::ExceptionFreeFactoryBase<
+class CacheFilterFactory : public Common::UnifiedFactoryBase<
                                envoy::extensions::filters::http::cache_v2::v3::CacheV2Config> {
 public:
-  CacheFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.cache_v2") {}
+  CacheFilterFactory() : UnifiedFactoryBase("envoy.filters.http.cache_v2") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cache_v2::v3::CacheV2Config& config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/cdn_loop/config.cc
+++ b/source/extensions/filters/http/cdn_loop/config.cc
@@ -21,16 +21,6 @@ using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::parseCdnId;
 using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::ParseContext;
 using ::Envoy::Extensions::HttpFilters::CdnLoop::Parser::ParsedCdnId;
 
-absl::StatusOr<Http::FilterFactoryCb> CdnLoopFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  // This filter does not use the factory context, so delegate to the server-context variant.
-  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
-                                                           stats_prefix};
-  return createHttpFilterFactoryFromProtoTyped(config, context.serverFactoryContext(),
-                                               extra_context);
-}
-
 absl::StatusOr<Http::FilterFactoryCb> CdnLoopFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
     Server::Configuration::ServerFactoryContext& /*context*/,

--- a/source/extensions/filters/http/cdn_loop/config.h
+++ b/source/extensions/filters/http/cdn_loop/config.h
@@ -14,16 +14,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace CdnLoop {
 
-class CdnLoopFilterFactory : public Common::ExceptionFreeFactoryBase<
+class CdnLoopFilterFactory : public Common::UnifiedFactoryBase<
                                  envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig> {
 public:
-  CdnLoopFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.cdn_loop") {}
+  CdnLoopFilterFactory() : UnifiedFactoryBase("envoy.filters.http.cdn_loop") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cdn_loop::v3::CdnLoopConfig& config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -256,6 +256,47 @@ private:
   }
 };
 
+template <class ConfigProto, class RouteConfigProto = ConfigProto>
+class UnifiedFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
+                           public Server::Configuration::NamedHttpFilterConfigFactory,
+                           public Server::Configuration::UpstreamHttpFilterConfigFactory {
+public:
+  UnifiedFactoryBase(const std::string& name)
+      : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
+
+  bool isUnifiedFilter() final { return true; }
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::FactoryContext& context) final {
+    auto extra_context = Server::Configuration::ExtraFactoryContext::create(context, stats_prefix);
+    return createHttpFilterFactoryFromProto(proto_config, context.serverFactoryContext(),
+                                            extra_context);
+  }
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               const std::string& stats_prefix,
+                               Server::Configuration::UpstreamFactoryContext& context) final {
+    auto extra_context = Server::Configuration::ExtraFactoryContext::create(context, stats_prefix);
+    return createHttpFilterFactoryFromProto(proto_config, context.serverFactoryContext(),
+                                            extra_context);
+  }
+
+  absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProto(
+      const Protobuf::Message& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) final {
+    return createHttpFilterFactoryFromProtoTyped(
+        MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config, extra_context.visitor),
+        context, extra_context);
+  }
+
+  virtual absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const ConfigProto& proto_config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) PURE;
+};
+
 } // namespace Common
 } // namespace HttpFilters
 } // namespace Extensions

--- a/source/extensions/filters/http/compressor/config.cc
+++ b/source/extensions/filters/http/compressor/config.cc
@@ -45,7 +45,7 @@ absl::StatusOr<Http::FilterFactoryCb> CompressorFilterFactory::createFilterFacto
     const std::string& stats_prefix, DualInfo info,
     Server::Configuration::ServerFactoryContext& context) {
   Server::GenericFactoryContextImpl generic_context(
-      context, info.scope, context.messageValidationVisitor(), &info.init_manager);
+      context, info.scope, context.messageValidationVisitor(), info.init_manager);
   return createFilterFactory(proto_config, stats_prefix, generic_context);
 }
 

--- a/source/extensions/filters/http/connect_grpc_bridge/config.cc
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.cc
@@ -12,15 +12,6 @@ namespace HttpFilters {
 namespace ConnectGrpcBridge {
 
 absl::StatusOr<Http::FilterFactoryCb>
-ConnectGrpcFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig&,
-    const std::string&, Server::Configuration::FactoryContext&) {
-  return [](Http::FilterChainFactoryCallbacks& callbacks) {
-    callbacks.addStreamFilter(std::make_shared<ConnectGrpcBridgeFilter>());
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 ConnectGrpcFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig&,
     Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {

--- a/source/extensions/filters/http/connect_grpc_bridge/config.h
+++ b/source/extensions/filters/http/connect_grpc_bridge/config.h
@@ -12,17 +12,12 @@ namespace HttpFilters {
 namespace ConnectGrpcBridge {
 
 class ConnectGrpcFilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig> {
 public:
-  ConnectGrpcFilterConfigFactory()
-      : ExceptionFreeFactoryBase("envoy.filters.http.connect_grpc_bridge") {}
+  ConnectGrpcFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.connect_grpc_bridge") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
-      const std::string&, Server::Configuration::FactoryContext&) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::connect_grpc_bridge::v3::FilterConfig& proto_config,
       Server::Configuration::ServerFactoryContext&,

--- a/source/extensions/filters/http/custom_response/factory.cc
+++ b/source/extensions/filters/http/custom_response/factory.cc
@@ -18,13 +18,6 @@ absl::StatusOr<::Envoy::Http::FilterFactoryCb> CustomResponseFilterFactory::crea
 }
 
 absl::StatusOr<::Envoy::Http::FilterFactoryCb>
-CustomResponseFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
-    const std::string& stats_prefix, Envoy::Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(config, stats_prefix, context.serverFactoryContext());
-}
-
-absl::StatusOr<::Envoy::Http::FilterFactoryCb>
 CustomResponseFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
     Envoy::Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/custom_response/factory.h
+++ b/source/extensions/filters/http/custom_response/factory.h
@@ -14,14 +14,11 @@ namespace CustomResponse {
 inline constexpr absl::string_view FilterName = "envoy.filters.http.custom_response";
 
 class CustomResponseFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::custom_response::v3::CustomResponse>,
       public Logger::Loggable<Logger::Id::filter> {
 public:
-  CustomResponseFilterFactory() : ExceptionFreeFactoryBase(std::string(FilterName)) {}
-  absl::StatusOr<::Envoy::Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  CustomResponseFilterFactory() : UnifiedFactoryBase(std::string(FilterName)) {}
   absl::StatusOr<::Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::custom_response::v3::CustomResponse& config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.cc
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.cc
@@ -34,13 +34,6 @@ absl::StatusOr<Http::FilterFactoryCb> DynamicForwardProxyFilterFactory::createFi
 }
 
 absl::StatusOr<Http::FilterFactoryCb>
-DynamicForwardProxyFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext());
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 DynamicForwardProxyFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/dynamic_forward_proxy/config.h
+++ b/source/extensions/filters/http/dynamic_forward_proxy/config.h
@@ -14,17 +14,14 @@ namespace DynamicForwardProxy {
  * Config registration for the dynamic forward proxy filter.
  */
 class DynamicForwardProxyFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig,
           envoy::extensions::filters::http::dynamic_forward_proxy::v3::PerRouteConfig> {
 public:
   DynamicForwardProxyFilterFactory()
-      : ExceptionFreeFactoryBase("envoy.filters.http.dynamic_forward_proxy") {}
+      : UnifiedFactoryBase("envoy.filters.http.dynamic_forward_proxy") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamic_forward_proxy::v3::FilterConfig& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/ext_authz/config.h
+++ b/source/extensions/filters/http/ext_authz/config.h
@@ -15,22 +15,14 @@ namespace ExtAuthz {
  * Config registration for the external authorization filter. @see NamedHttpFilterConfigFactory.
  */
 class ExtAuthzFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::ext_authz::v3::ExtAuthz,
           envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute> {
 public:
-  ExtAuthzFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.ext_authz") {}
+  ExtAuthzFilterConfig() : UnifiedFactoryBase("envoy.filters.http.ext_authz") {}
 
 private:
   static constexpr uint64_t DefaultTimeout = 200;
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
-    Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
-                                                             stats_prefix};
-    return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
-                                                 extra_context);
-  }
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ext_authz::v3::ExtAuthz& proto_config,

--- a/source/extensions/filters/http/file_system_buffer/config.cc
+++ b/source/extensions/filters/http/file_system_buffer/config.cc
@@ -16,26 +16,7 @@ using Extensions::Common::AsyncFiles::AsyncFileManager;
 using Extensions::Common::AsyncFiles::AsyncFileManagerFactory;
 
 FileSystemBufferFilterFactory::FileSystemBufferFilterFactory()
-    : ExceptionFreeFactoryBase(FileSystemBufferFilter::filterName()) {}
-
-absl::StatusOr<Http::FilterFactoryCb>
-FileSystemBufferFilterFactory::createFilterFactoryFromProtoTyped(
-    const ProtoFileSystemBufferFilterConfig& config,
-    const std::string& stats_prefix ABSL_ATTRIBUTE_UNUSED,
-    Server::Configuration::FactoryContext& context) {
-  auto factory =
-      AsyncFileManagerFactory::singleton(&context.serverFactoryContext().singletonManager());
-  auto manager = config.has_manager_config() ? factory->getAsyncFileManager(config.manager_config())
-                                             : std::shared_ptr<AsyncFileManager>();
-  absl::Status creation_status = absl::OkStatus();
-  auto filter_config = std::make_shared<FileSystemBufferFilterConfig>(
-      std::move(factory), std::move(manager), config, creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  return [filter_config =
-              std::move(filter_config)](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<FileSystemBufferFilter>(filter_config));
-  };
-}
+    : UnifiedFactoryBase(FileSystemBufferFilter::filterName()) {}
 
 absl::StatusOr<Http::FilterFactoryCb>
 FileSystemBufferFilterFactory::createHttpFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/http/file_system_buffer/config.h
+++ b/source/extensions/filters/http/file_system_buffer/config.h
@@ -18,15 +18,10 @@ namespace FileSystemBuffer {
 
 // Config registration for the file system buffer filter. @see NamedHttpFilterConfigFactory.
 class FileSystemBufferFilterFactory
-    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig> {
 public:
   FileSystemBufferFilterFactory();
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&
-          config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::file_system_buffer::v3::FileSystemBufferFilterConfig&

--- a/source/extensions/filters/http/grpc_field_extraction/config.cc
+++ b/source/extensions/filters/http/grpc_field_extraction/config.cc
@@ -17,23 +17,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcFieldExtraction {
 
-FilterFactoryCreator::FilterFactoryCreator() : ExceptionFreeFactoryBase(kFilterName) {}
-
-absl::StatusOr<Envoy::Http::FilterFactoryCb>
-FilterFactoryCreator::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
-        proto_config,
-    const std::string&, Envoy::Server::Configuration::FactoryContext& context) {
-
-  absl::Status creation_status = absl::OkStatus();
-  auto filter_config =
-      std::make_shared<FilterConfig>(proto_config, std::make_unique<ExtractorFactoryImpl>(),
-                                     context.serverFactoryContext().api(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  return [filter_config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_shared<Filter>(filter_config));
-  };
-}
+FilterFactoryCreator::FilterFactoryCreator() : UnifiedFactoryBase(kFilterName) {}
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
 FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/http/grpc_field_extraction/config.h
+++ b/source/extensions/filters/http/grpc_field_extraction/config.h
@@ -16,17 +16,12 @@ namespace HttpFilters {
 namespace GrpcFieldExtraction {
 
 class FilterFactoryCreator
-    : public Envoy::Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Envoy::Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig> {
 public:
   FilterFactoryCreator();
 
 private:
-  absl::StatusOr<Envoy::Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
-          proto_config,
-      const std::string&, Envoy::Server::Configuration::FactoryContext&) override;
-
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_field_extraction::v3::GrpcFieldExtractionConfig&
           proto_config,

--- a/source/extensions/filters/http/grpc_http1_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.cc
@@ -10,16 +10,6 @@ namespace HttpFilters {
 namespace GrpcHttp1Bridge {
 
 absl::StatusOr<Http::FilterFactoryCb>
-GrpcHttp1BridgeFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& factory_context) {
-  return [&factory_context, proto_config](Http::FilterChainFactoryCallbacks& callbacks) {
-    callbacks.addStreamFilter(std::make_shared<Http1BridgeFilter>(
-        factory_context.serverFactoryContext().grpcContext(), proto_config));
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 GrpcHttp1BridgeFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
     Server::Configuration::ServerFactoryContext& factory_context,

--- a/source/extensions/filters/http/grpc_http1_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_bridge/config.h
@@ -14,16 +14,10 @@ namespace GrpcHttp1Bridge {
  * Config registration for the grpc HTTP1 bridge filter. @see NamedHttpFilterConfigFactory.
  */
 class GrpcHttp1BridgeFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::grpc_http1_bridge::v3::Config> {
 public:
-  GrpcHttp1BridgeFilterConfig()
-      : ExceptionFreeFactoryBase("envoy.filters.http.grpc_http1_bridge") {}
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::FactoryContext& factory_context) override;
+  GrpcHttp1BridgeFilterConfig() : UnifiedFactoryBase("envoy.filters.http.grpc_http1_bridge") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_http1_bridge::v3::Config& proto_config,

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.cc
@@ -11,15 +11,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcHttp1ReverseBridge {
 
-absl::StatusOr<Http::FilterFactoryCb> Config::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
-    const std::string&, Server::Configuration::FactoryContext&) {
-  return [config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(
-        config.content_type(), config.withhold_grpc_frames(), config.response_size_header()));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> Config::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
     Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {

--- a/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
+++ b/source/extensions/filters/http/grpc_http1_reverse_bridge/config.h
@@ -12,16 +12,11 @@ namespace HttpFilters {
 namespace GrpcHttp1ReverseBridge {
 
 class Config
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig,
           envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfigPerRoute> {
 public:
-  Config() : ExceptionFreeFactoryBase("envoy.filters.http.grpc_http1_reverse_bridge") {}
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,
-      const std::string& stat_prefix,
-      Envoy::Server::Configuration::FactoryContext& context) override;
+  Config() : UnifiedFactoryBase("envoy.filters.http.grpc_http1_reverse_bridge") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_http1_reverse_bridge::v3::FilterConfig& config,

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.cc
@@ -13,21 +13,6 @@ namespace HttpFilters {
 namespace GrpcJsonReverseTranscoder {
 
 absl::StatusOr<Http::FilterFactoryCb>
-GrpcJsonReverseTranscoderFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
-        GrpcJsonReverseTranscoder& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  absl::Status creation_status = absl::OkStatus();
-  std::shared_ptr<GrpcJsonReverseTranscoderConfig> filter_config =
-      std::make_shared<GrpcJsonReverseTranscoderConfig>(
-          proto_config, context.serverFactoryContext().api(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  return [filter_config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<GrpcJsonReverseTranscoderFilter>(filter_config));
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 GrpcJsonReverseTranscoderFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
         GrpcJsonReverseTranscoder& proto_config,

--- a/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_reverse_transcoder/config.h
@@ -11,19 +11,14 @@ namespace HttpFilters {
 namespace GrpcJsonReverseTranscoder {
 
 class GrpcJsonReverseTranscoderFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
               GrpcJsonReverseTranscoder> {
 public:
   GrpcJsonReverseTranscoderFactory()
-      : ExceptionFreeFactoryBase("envoy.filters.http.grpc_json_reverse_transcoder") {}
+      : UnifiedFactoryBase("envoy.filters.http.grpc_json_reverse_transcoder") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
-          GrpcJsonReverseTranscoder& proto_config,
-      const std::string&, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_json_reverse_transcoder::v3::
           GrpcJsonReverseTranscoder& proto_config,

--- a/source/extensions/filters/http/grpc_web/config.cc
+++ b/source/extensions/filters/http/grpc_web/config.cc
@@ -9,15 +9,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcWeb {
 
-absl::StatusOr<Http::FilterFactoryCb> GrpcWebFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb&, const std::string&,
-    Server::Configuration::FactoryContext& factory_context) {
-  return [&factory_context](Http::FilterChainFactoryCallbacks& callbacks) {
-    callbacks.addStreamFilter(
-        std::make_shared<GrpcWebFilter>(factory_context.serverFactoryContext().grpcContext()));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> GrpcWebFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb&,
     Server::Configuration::ServerFactoryContext& factory_context,

--- a/source/extensions/filters/http/grpc_web/config.h
+++ b/source/extensions/filters/http/grpc_web/config.h
@@ -10,17 +10,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GrpcWeb {
 
-class GrpcWebFilterConfig : public Common::ExceptionFreeFactoryBase<
-                                envoy::extensions::filters::http::grpc_web::v3::GrpcWeb> {
+class GrpcWebFilterConfig
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::grpc_web::v3::GrpcWeb> {
 public:
-  GrpcWebFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.grpc_web") {}
+  GrpcWebFilterConfig() : UnifiedFactoryBase("envoy.filters.http.grpc_web") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::FactoryContext& factory_context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_web::v3::GrpcWeb& proto_config,
       Server::Configuration::ServerFactoryContext& factory_context,

--- a/source/extensions/filters/http/header_mutation/config.cc
+++ b/source/extensions/filters/http/header_mutation/config.cc
@@ -10,19 +10,6 @@ namespace HttpFilters {
 namespace HeaderMutation {
 
 absl::StatusOr<Http::FilterFactoryCb>
-HeaderMutationFactoryConfig::createFilterFactoryFromProtoTyped(
-    const ProtoConfig& config, const std::string&, DualInfo,
-    Server::Configuration::ServerFactoryContext& context) {
-  absl::Status creation_status = absl::OkStatus();
-  auto filter_config = std::make_shared<HeaderMutationConfig>(config, context, creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<HeaderMutation>(filter_config));
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 HeaderMutationFactoryConfig::createHttpFilterFactoryFromProtoTyped(
     const ProtoConfig& config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext&) {

--- a/source/extensions/filters/http/header_mutation/config.h
+++ b/source/extensions/filters/http/header_mutation/config.h
@@ -15,16 +15,11 @@ namespace HeaderMutation {
  * Config registration for the stateful session filter. @see NamedHttpFilterConfigFactory.
  */
 class HeaderMutationFactoryConfig
-    : public Common::DualFactoryBase<ProtoConfig, PerRouteProtoConfig> {
+    : public Common::UnifiedFactoryBase<ProtoConfig, PerRouteProtoConfig> {
 public:
-  HeaderMutationFactoryConfig() : DualFactoryBase("envoy.filters.http.header_mutation") {}
+  HeaderMutationFactoryConfig() : UnifiedFactoryBase("envoy.filters.http.header_mutation") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const ProtoConfig& proto_config,
-                                    const std::string& stats_prefix, DualInfo info,
-                                    Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;

--- a/source/extensions/filters/http/mcp/config.cc
+++ b/source/extensions/filters/http/mcp/config.cc
@@ -9,18 +9,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Mcp {
 
-absl::StatusOr<Http::FilterFactoryCb> McpFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-
-  auto config = std::make_shared<McpFilterConfig>(proto_config, stats_prefix,
-                                                  context.serverFactoryContext().scope());
-
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<McpFilter>(config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> McpFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/mcp/config.h
+++ b/source/extensions/filters/http/mcp/config.h
@@ -14,17 +14,13 @@ namespace Mcp {
 /**
  * Config factory for MCP filter.
  */
-class McpFilterConfigFactory : public Common::ExceptionFreeFactoryBase<
-                                   envoy::extensions::filters::http::mcp::v3::Mcp,
-                                   envoy::extensions::filters::http::mcp::v3::McpOverride> {
+class McpFilterConfigFactory
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::mcp::v3::Mcp,
+                                        envoy::extensions::filters::http::mcp::v3::McpOverride> {
 public:
-  McpFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.mcp") {}
+  McpFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.mcp") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp::v3::Mcp& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/mcp_json_rest_bridge/config.cc
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/config.cc
@@ -11,18 +11,6 @@ namespace HttpFilters {
 namespace McpJsonRestBridge {
 
 absl::StatusOr<Http::FilterFactoryCb>
-McpJsonRestBridgeFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
-        proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  // This filter does not use the factory context, so delegate to the server-context variant.
-  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
-                                                           stats_prefix};
-  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
-                                               extra_context);
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 McpJsonRestBridgeFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
         proto_config,

--- a/source/extensions/filters/http/mcp_json_rest_bridge/config.h
+++ b/source/extensions/filters/http/mcp_json_rest_bridge/config.h
@@ -15,18 +15,13 @@ namespace McpJsonRestBridge {
  * Config factory for MCP JSON REST bridge filter.
  */
 class McpJsonRestBridgeFilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge,
           envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridgePerRoute> {
 public:
-  McpJsonRestBridgeFilterConfigFactory() : ExceptionFreeFactoryBase(FilterName) {}
+  McpJsonRestBridgeFilterConfigFactory() : UnifiedFactoryBase(FilterName) {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
-          proto_config,
-      const std::string&, Server::Configuration::FactoryContext&) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp_json_rest_bridge::v3::McpJsonRestBridge&
           proto_config,

--- a/source/extensions/filters/http/on_demand/config.cc
+++ b/source/extensions/filters/http/on_demand/config.cc
@@ -9,26 +9,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace OnDemand {
 
-absl::StatusOr<Http::FilterFactoryCb> OnDemandFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  absl::Status creation_status = absl::OkStatus();
-  OnDemandFilterConfigSharedPtr config = std::make_shared<OnDemandFilterConfig>(
-      proto_config, context.serverFactoryContext().clusterManager(),
-      context.messageValidationVisitor(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_shared<OnDemandRouteUpdate>(config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> OnDemandFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   absl::Status creation_status = absl::OkStatus();
   OnDemandFilterConfigSharedPtr config = std::make_shared<OnDemandFilterConfig>(
-      proto_config, context.clusterManager(), context.messageValidationVisitor(), creation_status);
+      proto_config, context.clusterManager(), extra_context.visitor, creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<OnDemandRouteUpdate>(config));

--- a/source/extensions/filters/http/on_demand/config.h
+++ b/source/extensions/filters/http/on_demand/config.h
@@ -14,17 +14,13 @@ namespace OnDemand {
 /**
  * Config registration for the OnDemand filter. @see NamedHttpFilterConfigFactory.
  */
-class OnDemandFilterFactory : public Common::ExceptionFreeFactoryBase<
+class OnDemandFilterFactory : public Common::UnifiedFactoryBase<
                                   envoy::extensions::filters::http::on_demand::v3::OnDemand,
                                   envoy::extensions::filters::http::on_demand::v3::PerRouteConfig> {
 public:
-  OnDemandFilterFactory() : ExceptionFreeFactoryBase(HttpFilterNames::get().OnDemand) {}
+  OnDemandFilterFactory() : UnifiedFactoryBase(HttpFilterNames::get().OnDemand) {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
-      const std::string&, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::on_demand::v3::OnDemand& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/original_src/original_src_config_factory.cc
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.cc
@@ -12,16 +12,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace OriginalSrc {
 
-absl::StatusOr<Http::FilterFactoryCb> OriginalSrcConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  // This filter does not use the factory context, so delegate to the server-context variant.
-  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
-                                                           stats_prefix};
-  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
-                                               extra_context);
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 OriginalSrcConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,

--- a/source/extensions/filters/http/original_src/original_src_config_factory.h
+++ b/source/extensions/filters/http/original_src/original_src_config_factory.h
@@ -13,14 +13,10 @@ namespace OriginalSrc {
  * Config registration for the original_src filter.
  */
 class OriginalSrcConfigFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::original_src::v3::OriginalSrc> {
 public:
-  OriginalSrcConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.original_src") {}
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,
-      const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+  OriginalSrcConfigFactory() : UnifiedFactoryBase("envoy.filters.http.original_src") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::original_src::v3::OriginalSrc& proto_config,

--- a/source/extensions/filters/http/proto_message_extraction/config.cc
+++ b/source/extensions/filters/http/proto_message_extraction/config.cc
@@ -18,22 +18,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ProtoMessageExtraction {
 
-FilterFactoryCreator::FilterFactoryCreator() : ExceptionFreeFactoryBase(kFilterName) {}
-
-absl::StatusOr<Envoy::Http::FilterFactoryCb>
-FilterFactoryCreator::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::proto_message_extraction::v3::
-        ProtoMessageExtractionConfig& proto_config,
-    const std::string&, Envoy::Server::Configuration::FactoryContext& context) {
-  absl::Status creation_status = absl::OkStatus();
-  auto filter_config =
-      std::make_shared<FilterConfig>(proto_config, std::make_unique<ExtractorFactoryImpl>(),
-                                     context.serverFactoryContext().api(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  return [filter_config](Envoy::Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(*filter_config));
-  };
-}
+FilterFactoryCreator::FilterFactoryCreator() : UnifiedFactoryBase(kFilterName) {}
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
 FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(

--- a/source/extensions/filters/http/proto_message_extraction/config.h
+++ b/source/extensions/filters/http/proto_message_extraction/config.h
@@ -15,19 +15,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ProtoMessageExtraction {
 
-class FilterFactoryCreator
-    : public Envoy::Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
-          envoy::extensions::filters::http::proto_message_extraction::v3::
-              ProtoMessageExtractionConfig> {
+class FilterFactoryCreator : public Envoy::Extensions::HttpFilters::Common::UnifiedFactoryBase<
+                                 envoy::extensions::filters::http::proto_message_extraction::v3::
+                                     ProtoMessageExtractionConfig> {
 public:
   FilterFactoryCreator();
 
 private:
-  absl::StatusOr<Envoy::Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::proto_message_extraction::v3::
-          ProtoMessageExtractionConfig& proto_config,
-      const std::string&, Envoy::Server::Configuration::FactoryContext&) override;
-
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::proto_message_extraction::v3::
           ProtoMessageExtractionConfig& proto_config,

--- a/source/extensions/filters/http/set_filter_state/config.cc
+++ b/source/extensions/filters/http/set_filter_state/config.cc
@@ -35,19 +35,6 @@ Http::FilterHeadersStatus SetFilterState::decodeHeaders(Http::RequestHeaderMap& 
   return Http::FilterHeadersStatus::Continue;
 }
 
-absl::StatusOr<Http::FilterFactoryCb> SetFilterStateConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-
-  const auto filter_config = std::make_shared<Filters::Common::SetFilterState::Config>(
-      proto_config.on_request_headers(), StreamInfo::FilterState::LifeSpan::FilterChain, context,
-      proto_config.clear_route_cache());
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(
-        Http::StreamDecoderFilterSharedPtr{new SetFilterState(filter_config)});
-  };
-}
-
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 SetFilterStateConfig::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
@@ -63,12 +50,10 @@ SetFilterStateConfig::createRouteSpecificFilterConfigTyped(
 absl::StatusOr<Http::FilterFactoryCb> SetFilterStateConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
-  // TODO(wbpcode): these is a potential bug of message validation. The validation visitor
-  // of server context should not be used here directly. But this is bug of
-  // 'createHttpFilterFactoryFromProto' and will be fixed in the future.
-  Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
+  Server::GenericFactoryContextImpl generic_context(
+      context, extra_context.scope, extra_context.visitor, extra_context.init_manager);
 
   const auto filter_config = std::make_shared<Filters::Common::SetFilterState::Config>(
       proto_config.on_request_headers(), StreamInfo::FilterState::LifeSpan::FilterChain,

--- a/source/extensions/filters/http/set_filter_state/config.h
+++ b/source/extensions/filters/http/set_filter_state/config.h
@@ -28,16 +28,12 @@ private:
 /**
  * Config registration. @see NamedHttpFilterConfigFactory.
  */
-class SetFilterStateConfig : public Common::ExceptionFreeFactoryBase<
+class SetFilterStateConfig : public Common::UnifiedFactoryBase<
                                  envoy::extensions::filters::http::set_filter_state::v3::Config> {
 public:
-  SetFilterStateConfig() : ExceptionFreeFactoryBase("envoy.filters.http.set_filter_state") {}
+  SetFilterStateConfig() : UnifiedFactoryBase("envoy.filters.http.set_filter_state") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(
       const envoy::extensions::filters::http::set_filter_state::v3::Config& proto_config,

--- a/source/extensions/filters/http/sse_to_metadata/config.cc
+++ b/source/extensions/filters/http/sse_to_metadata/config.cc
@@ -9,16 +9,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace SseToMetadata {
 
-absl::StatusOr<Http::FilterFactoryCb> SseToMetadataConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  // This filter only uses the server factory context, so delegate to the server-context variant.
-  Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
-                                                           stats_prefix};
-  return createHttpFilterFactoryFromProtoTyped(proto_config, context.serverFactoryContext(),
-                                               extra_context);
-}
-
 absl::StatusOr<Http::FilterFactoryCb> SseToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
     Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/sse_to_metadata/config.h
+++ b/source/extensions/filters/http/sse_to_metadata/config.h
@@ -16,16 +16,12 @@ namespace SseToMetadata {
  * Config registration for the SSE to Metadata filter.
  */
 class SseToMetadataConfig
-    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata> {
 public:
-  SseToMetadataConfig() : ExceptionFreeFactoryBase("envoy.filters.http.sse_to_metadata") {}
+  SseToMetadataConfig() : UnifiedFactoryBase("envoy.filters.http.sse_to_metadata") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::sse_to_metadata::v3::SseToMetadata& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/server/generic_factory_context.cc
+++ b/source/server/generic_factory_context.cc
@@ -7,14 +7,20 @@ GenericFactoryContextImpl::GenericFactoryContextImpl(
     Server::Configuration::ServerFactoryContext& server_context,
     ProtobufMessage::ValidationVisitor& validation_visitor)
     : server_context_(server_context), stats_scope_(server_context.serverScope()),
-      validation_visitor_(validation_visitor), init_manager_(&server_context.initManager()) {}
+      validation_visitor_(validation_visitor), init_manager_(server_context.initManager()) {}
 
 GenericFactoryContextImpl::GenericFactoryContextImpl(
     Server::Configuration::GenericFactoryContext& generic_context)
     : server_context_(generic_context.serverFactoryContext()),
       stats_scope_(generic_context.scope()),
       validation_visitor_(generic_context.messageValidationVisitor()),
-      init_manager_(&generic_context.initManager()) {}
+      init_manager_(generic_context.initManager()) {}
+
+GenericFactoryContextImpl::GenericFactoryContextImpl(
+    Server::Configuration::ServerFactoryContext& server_context)
+    : server_context_(server_context), stats_scope_(server_context.serverScope()),
+      validation_visitor_(server_context.messageValidationVisitor()),
+      init_manager_(server_context.initManager()) {}
 
 // Server::Configuration::GenericFactoryContext
 Server::Configuration::ServerFactoryContext& GenericFactoryContextImpl::serverFactoryContext() {
@@ -26,7 +32,7 @@ ProtobufMessage::ValidationVisitor& GenericFactoryContextImpl::messageValidation
 
 Stats::Scope& GenericFactoryContextImpl::scope() { return stats_scope_; }
 Init::Manager& GenericFactoryContextImpl::initManager() {
-  ASSERT(init_manager_ != nullptr);
+  ASSERT(init_manager_.has_value());
   return *init_manager_;
 }
 

--- a/source/server/generic_factory_context.h
+++ b/source/server/generic_factory_context.h
@@ -12,11 +12,14 @@ public:
   GenericFactoryContextImpl(Server::Configuration::GenericFactoryContext& generic_context);
 
   GenericFactoryContextImpl(Server::Configuration::ServerFactoryContext& server_context,
-                            Stats::Scope& stats_scope,
+                            OptRef<Stats::Scope> stats_scope,
                             ProtobufMessage::ValidationVisitor& validation_visitor,
-                            Init::Manager* init_manager = nullptr)
-      : server_context_(server_context), stats_scope_(stats_scope),
-        validation_visitor_(validation_visitor), init_manager_(init_manager) {}
+                            OptRef<Init::Manager> init_manager = {})
+      : server_context_(server_context),
+        stats_scope_(stats_scope.has_value() ? *stats_scope : server_context.scope()),
+        validation_visitor_(validation_visitor),
+        init_manager_(init_manager.has_value() ? *init_manager : server_context.initManager()) {}
+  explicit GenericFactoryContextImpl(Server::Configuration::ServerFactoryContext& server_context);
 
   // Server::Configuration::GenericFactoryContext
   Server::Configuration::ServerFactoryContext& serverFactoryContext() override;
@@ -24,13 +27,13 @@ public:
   ProtobufMessage::ValidationVisitor& messageValidationVisitor() override;
   Init::Manager& initManager() override;
 
-  void setInitManager(Init::Manager& init_manager) { init_manager_ = &init_manager; }
+  void setInitManager(Init::Manager& init_manager) { init_manager_.emplace(init_manager); }
 
 private:
   Server::Configuration::ServerFactoryContext& server_context_;
   Stats::Scope& stats_scope_;
   ProtobufMessage::ValidationVisitor& validation_visitor_;
-  Init::Manager* init_manager_{};
+  OptRef<Init::Manager> init_manager_;
 };
 
 using GenericFactoryContextImplPtr = std::unique_ptr<GenericFactoryContextImpl>;

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -226,10 +226,10 @@ TEST_F(ExtAuthzFilterHttpTest, FilterWithServerContext) {
   TestUtility::loadFromYaml(ext_authz_config_yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  // Built before the expectation below so that only the factory's own calls are counted.
+  // The config is validated with the visitor of the extra context, not the one of the server
+  // context, so no expectation is set on the latter.
   Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
                                                            "stats"};
-  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
       factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;


### PR DESCRIPTION
Commit Message: filter: clean up unnecessary redundancy
Additional Description:

Another step to unify all three types of HTTP filter factories (downstream, upstream, route).

No behavior changes, won’t break out-of-tree extensions and only a purely cleanup to reduce unnecessary redundancy.
We will finally migrate all our in-tree extensions to use the `UnifiedFactoryBase`, then we could gradually deprecate the redundant interfaces. (I made a huge commit locally that has proved it works perfectly, although need some changes to `composite`. This is first piece of that)

Risk Level: low
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
