### PR TITLE
[bp/v1.37] ext_proc: fix an issue gRPC stream is closed when the decoding external processing is active (#45617)

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1371,9 +1371,13 @@ FilterHeadersStatus Filter::encodeHeaders(ResponseHeaderMap& headers, bool end_s
   }
 
   // If there is no external processing configured in the encoding path,
+  // and no more external processing is needed in the decoding path,
   // closing the gRPC stream if it is still open.
-  if (encoding_state_.noExternalProcess()) {
-    closeStreamMaybeGraceful();
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.ext_proc_stream_close_optimization")) {
+    if (encoding_state_.noExternalProcess() && decoding_state_.noMoreExternalProcess()) {
+      closeStreamMaybeGraceful();
+    }
   }
 
   return status;
@@ -1728,30 +1732,35 @@ void Filter::closeGrpcStreamIfLastRespReceived(const ProcessingResponse& respons
   }
 
   bool last_response = false;
+  bool last_response_for_direction = false;
   switch (response.response_case()) {
   case ProcessingResponse::ResponseCase::kRequestHeaders:
-    if (encoding_state_.noExternalProcess()) {
-      last_response = decoding_state_.isLastResponseAfterHeaderResp();
-    }
+    last_response_for_direction = decoding_state_.isLastResponseAfterHeaderResp();
+    decoding_state_.setLastResponseForDirection(last_response_for_direction);
+    last_response = last_response_for_direction && encoding_state_.noMoreExternalProcess();
     break;
   case ProcessingResponse::ResponseCase::kRequestBody:
-    if (encoding_state_.noExternalProcess()) {
-      last_response = decoding_state_.isLastResponseAfterBodyResp(eos_seen_in_body);
-    }
+    last_response_for_direction = decoding_state_.isLastResponseAfterBodyResp(eos_seen_in_body);
+    decoding_state_.setLastResponseForDirection(last_response_for_direction);
+    last_response = last_response_for_direction && encoding_state_.noMoreExternalProcess();
     break;
   case ProcessingResponse::ResponseCase::kRequestTrailers:
-    if (encoding_state_.noExternalProcess()) {
-      last_response = true;
-    }
+    decoding_state_.setLastResponseForDirection(true);
+    last_response = encoding_state_.noMoreExternalProcess();
     break;
   case ProcessingResponse::ResponseCase::kResponseHeaders:
-    last_response = encoding_state_.isLastResponseAfterHeaderResp();
+    last_response_for_direction = encoding_state_.isLastResponseAfterHeaderResp();
+    encoding_state_.setLastResponseForDirection(last_response_for_direction);
+    last_response = last_response_for_direction && decoding_state_.noMoreExternalProcess();
     break;
   case ProcessingResponse::ResponseCase::kResponseBody:
-    last_response = encoding_state_.isLastResponseAfterBodyResp(eos_seen_in_body);
+    last_response_for_direction = encoding_state_.isLastResponseAfterBodyResp(eos_seen_in_body);
+    encoding_state_.setLastResponseForDirection(last_response_for_direction);
+    last_response = last_response_for_direction && decoding_state_.noMoreExternalProcess();
     break;
   case ProcessingResponse::ResponseCase::kResponseTrailers:
-    last_response = true;
+    encoding_state_.setLastResponseForDirection(true);
+    last_response = decoding_state_.noMoreExternalProcess();
     break;
   case ProcessingResponse::ResponseCase::kStreamedImmediateResponse:
     // Streamed immediate response handling closes the stream automatically

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -122,6 +122,12 @@ public:
   void setBodyReceived(bool b) { body_received_ = b; }
   bool partialBodyProcessed() const { return partial_body_processed_; }
 
+  // Check whether external processing is configured.
+  virtual bool noExternalProcess() const {
+    return !send_headers_ && !send_trailers_ &&
+           body_mode_ == envoy::extensions::filters::http::ext_proc::v3::ProcessingMode::NONE;
+  }
+
   virtual void setProcessingMode(
       const envoy::extensions::filters::http::ext_proc::v3::ProcessingMode& mode) PURE;
 
@@ -297,6 +303,20 @@ public:
   // a body response is received and processed.
   bool isLastResponseAfterBodyResp(bool eos_seen_in_body) const;
 
+  // Check whether this is the last response from the ext_proc server for this
+  // direction.
+  bool isLastResponseForDirection() const { return last_response_for_direction_; }
+
+  void setLastResponseForDirection(bool last_response_for_direction) {
+    last_response_for_direction_ = last_response_for_direction;
+  }
+
+  // Check for this direction, the external processing is either not configured,
+  // or the last response is already received.
+  bool noMoreExternalProcess() const {
+    return (noExternalProcess() || last_response_for_direction_);
+  }
+
 protected:
   void setBodyMode(
       envoy::extensions::filters::http::ext_proc::v3::ProcessingMode_BodySendMode body_mode);
@@ -356,6 +376,8 @@ protected:
   bool send_headers_ : 1;
   // If true, the server wants to see the trailers
   bool send_trailers_ : 1;
+  // If true, this is the last response from the processor for this direction.
+  bool last_response_for_direction_ : 1 = false;
 
   // The specific mode for body handling
   envoy::extensions::filters::http::ext_proc::v3::ProcessingMode_BodySendMode body_mode_;
@@ -632,6 +654,9 @@ public:
   bool isValidTrailersCallbackState() const override;
   bool canFailOpen() const override;
   bool localResponseStarted() const { return local_response_started_; }
+  bool noExternalProcess() const override {
+    return !local_response_started_ && ProcessorState::noExternalProcess();
+  }
 
 private:
   void setProcessingModeInternal(
@@ -732,9 +757,8 @@ public:
   }
 
   // Check whether external processing is configured in the encoding path.
-  bool noExternalProcess() const {
-    return !local_response_streaming_ && !send_headers_ && !send_trailers_ &&
-           body_mode_ == envoy::extensions::filters::http::ext_proc::v3::ProcessingMode::NONE;
+  bool noExternalProcess() const override {
+    return !local_response_streaming_ && ProcessorState::noExternalProcess();
   }
 
   void setLocalResponseStreaming();

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -1916,6 +1916,103 @@ TEST_F(HttpFilterTest, GrpcFailOnRequestTrailer) {
   expectNoGrpcCall(envoy::config::core::v3::TrafficDirection::OUTBOUND);
 }
 
+// Test that ext_proc filter does not prematurely close the stream when response headers
+// are encoded (and response path requires no external process), but request path's external
+// processing is still in progress.
+TEST_F(HttpFilterTest, DoNotPrematurelyCloseStreamIfDecodingActive) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  processing_mode:
+    request_header_mode: "SKIP"
+    response_header_mode: "SKIP"
+    request_body_mode: "STREAMED"
+  )EOF");
+
+  HttpTestUtility::addDefaultHeaders(request_headers_);
+  request_headers_.setMethod("POST");
+  EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  Buffer::OwnedImpl req_data("foo");
+  EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_data, true));
+  EXPECT_TRUE(last_request_.has_protocol_config());
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
+
+  // Encode response headers. Since response processing is SKIP, but decoding path is still
+  // active (waiting for body response), the stream must NOT be closed yet.
+  response_headers_.addCopy(LowerCaseString(":status"), "200");
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
+
+  // Complete decoding path's external body processing.
+  processRequestBody(absl::nullopt, false);
+  // Now since decoding path is done and encoding has no external process, stream must be closed.
+  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+
+  filter_->onDestroy();
+}
+
+// Test that when a request body response is pending on the decoding path, and the encoding path
+// receives a response body response from the external processor, the gRPC stream is NOT closed.
+TEST_F(HttpFilterTest, DoNotCloseStreamOnResponseBodyResponseIfDecodingActive) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  processing_mode:
+    request_header_mode: "SKIP"
+    response_header_mode: "SKIP"
+    request_body_mode: "STREAMED"
+    response_body_mode: "STREAMED"
+  )EOF");
+
+  // --- Decoding Path Setup ---
+  HttpTestUtility::addDefaultHeaders(request_headers_);
+  request_headers_.setMethod("POST");
+  EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers_, false));
+
+  Buffer::OwnedImpl req_data("foo");
+  EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(req_data, true));
+  EXPECT_TRUE(last_request_.has_request_body());
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
+
+  // Save the request body message for later processing.
+  auto saved_request_body_req = last_request_;
+
+  // --- Encoding Path Setup ---
+  // Encode response headers (skipped).
+  response_headers_.addCopy(LowerCaseString(":status"), "200");
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
+
+  // Encode response body.
+  Buffer::OwnedImpl resp_data("bar");
+  EXPECT_EQ(FilterDataStatus::StopIterationNoBuffer, filter_->encodeData(resp_data, true));
+  EXPECT_TRUE(last_request_.has_response_body());
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
+
+  // --- Process Response Body Response ---
+  // Let the external processor reply to the response body request.
+  // Note: last_request_ currently holds the response body request, so processResponseBody works.
+  processResponseBody(absl::nullopt, false);
+
+  // The gRPC stream must NOT be closed because the request body's response is still pending!
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
+
+  // --- Process Request Body Response ---
+  // Restore the request body request in last_request_ before processing it.
+  last_request_ = saved_request_body_req;
+  processRequestBody(absl::nullopt, false);
+
+  // Now both decoding and encoding path processing are completed, so the stream must be closed.
+  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+
+  filter_->onDestroy();
+}
+
 // Sending gRPC calls with random latency To test max and min latency update logic.
 TEST_F(HttpFilterTest, StreamingSendDataRandomGrpcLatency) {
   initialize(R"EOF(
@@ -1966,11 +2063,11 @@ TEST_F(HttpFilterTest, StreamingSendDataRandomGrpcLatency) {
   EXPECT_EQ(0, config_->stats().streams_closed_.value());
 
   EXPECT_EQ(FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers_, false));
-  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
   Buffer::OwnedImpl resp_data("bar");
   EXPECT_EQ(FilterDataStatus::Continue, filter_->encodeData(resp_data, false));
   EXPECT_EQ(FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers_));
-  EXPECT_EQ(1, config_->stats().streams_closed_.value());
+  EXPECT_EQ(0, config_->stats().streams_closed_.value());
   filter_->onDestroy();
 
   EXPECT_EQ(1, config_->stats().streams_started_.value());


### PR DESCRIPTION
This PR is fixing an issue that when the HTTP request and response are going through external processing at same time, the gRPC stream is closed prematurely sometimes.

Both encoding and decoding processing should consider whether the other direction external processing is finished before safely close the gRPC stream.

Backport of #45617.


