### PR TITLE
http: add mcp filter to well-known names

### DIFF
--- a/source/extensions/filters/http/well_known_names.h
+++ b/source/extensions/filters/http/well_known_names.h
@@ -110,6 +110,8 @@ public:
   const std::string SetMetadata = "envoy.filters.http.set_metadata";
   // Body Size Limit filter
   const std::string BodySizeLimit = "envoy.filters.http.body_size_limit";
+  // MCP filter
+  const std::string Mcp = "envoy.filters.http.mcp";
   // MCP JSON REST bridge filter
   const std::string McpJsonRestBridge = "envoy.filters.http.mcp_json_rest_bridge";
 };


### PR DESCRIPTION
Additional Description: Adds the well-known filter name constant for `envoy.filters.http.mcp` to `HttpFilterNameValues`.
This is useful to modules that need to access filter data like Dynamic Metadata, but don't need to import all the other definitions in the filter.
Risk Level: Low
Testing: format checks
Docs Changes: N/A
Release Notes: N/A"