### PR TITLE
Fix flaky test in tcp proxy integration tests

### DIFF
--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -2296,7 +2296,7 @@ TEST_P(TcpProxyIntegrationTest, ClusterBufferHighWatermarkTimeoutClosesUpstream)
   // Disable reads from the upstream to simulate a slow upstream.
   ASSERT_TRUE(fake_upstream_connection->readDisable(true));
 
-  std::string payload(256 * 1024, 'a');
+  std::string payload(2048 * 1024, 'a');
   ASSERT_TRUE(tcp_client->write(payload, false));
 
   timeSystem().advanceTimeWait(std::chrono::milliseconds(500));


### PR DESCRIPTION
tcp_proxy_integration_test.cc:  
TEST_P(TcpProxyIntegrationTest, ClusterBufferHighWatermarkTimeoutClosesUpstream)
is constantly failing in some Linux systems which has much larger kernel socket buffer, which can absorb 256KB test payload without creating back pressure.  Increasing the test payload to 2MB to reliably creating back pressure and avoid test failure.