### PR TITLE
Istio: WorkloadMetadataObject Immutable shared_ptr

### DIFF
--- a/contrib/istio/filters/common/source/metadata_object.cc
+++ b/contrib/istio/filters/common/source/metadata_object.cc
@@ -305,18 +305,18 @@ Envoy::Protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataOb
 }
 
 // Convert struct to a metadata object.
-std::unique_ptr<WorkloadMetadataObject>
+WorkloadMetadataObjectConstSharedPtr
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata) {
   return convertStructToWorkloadMetadata(metadata, {});
 }
 
-std::unique_ptr<WorkloadMetadataObject>
+WorkloadMetadataObjectConstSharedPtr
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels) {
   return convertStructToWorkloadMetadata(metadata, additional_labels, {});
 }
 
-std::unique_ptr<WorkloadMetadataObject>
+WorkloadMetadataObjectConstSharedPtr
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels,
                                 const std::optional<envoy::config::core::v3::Locality> locality) {
@@ -376,7 +376,7 @@ convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
       locality_zone = locality->zone();
     }
   }
-  auto obj = std::make_unique<WorkloadMetadataObject>(
+  auto obj = std::make_shared<WorkloadMetadataObject>(
       instance, cluster, namespace_name, workload, canonical_name, canonical_revision, app_name,
       app_version, parseOwner(owner, workload), identity, locality_region, locality_zone);
   obj->setLabels(labels);
@@ -450,13 +450,12 @@ WorkloadMetadataObject::getField(absl::string_view field_name) const {
   return {};
 }
 
-std::unique_ptr<WorkloadMetadataObject>
-convertBaggageToWorkloadMetadata(absl::string_view baggage) {
+WorkloadMetadataObjectConstSharedPtr convertBaggageToWorkloadMetadata(absl::string_view baggage) {
   return convertBaggageToWorkloadMetadata(baggage, "");
 }
 
-std::unique_ptr<WorkloadMetadataObject>
-convertBaggageToWorkloadMetadata(absl::string_view data, absl::string_view identity) {
+WorkloadMetadataObjectConstSharedPtr convertBaggageToWorkloadMetadata(absl::string_view data,
+                                                                      absl::string_view identity) {
   absl::string_view instance;
   absl::string_view cluster;
   absl::string_view workload;
@@ -528,7 +527,7 @@ convertBaggageToWorkloadMetadata(absl::string_view data, absl::string_view ident
       }
     }
   }
-  return std::make_unique<WorkloadMetadataObject>(
+  return std::make_shared<const WorkloadMetadataObject>(
       instance, cluster, namespace_name, workload, canonical_name, canonical_revision, app_name,
       app_version, workload_type, identity, region, zone);
 }

--- a/contrib/istio/filters/common/source/metadata_object.h
+++ b/contrib/istio/filters/common/source/metadata_object.h
@@ -160,14 +160,14 @@ WorkloadType parseOwner(absl::string_view owner, absl::string_view workload);
 Envoy::Protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataObject& obj);
 
 // Convert struct to a metadata object.
-std::unique_ptr<WorkloadMetadataObject>
+WorkloadMetadataObjectConstSharedPtr
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata);
 
-std::unique_ptr<WorkloadMetadataObject>
+WorkloadMetadataObjectConstSharedPtr
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels);
 
-std::unique_ptr<WorkloadMetadataObject>
+WorkloadMetadataObjectConstSharedPtr
 convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels,
                                 const std::optional<envoy::config::core::v3::Locality> locality);
@@ -181,9 +181,9 @@ std::optional<WorkloadMetadataObject> convertEndpointMetadata(const std::string&
 std::string serializeToStringDeterministic(const Envoy::Protobuf::Struct& metadata);
 
 // Convert from baggage encoding.
-std::unique_ptr<WorkloadMetadataObject> convertBaggageToWorkloadMetadata(absl::string_view data);
-std::unique_ptr<WorkloadMetadataObject>
-convertBaggageToWorkloadMetadata(absl::string_view baggage, absl::string_view identity);
+WorkloadMetadataObjectConstSharedPtr convertBaggageToWorkloadMetadata(absl::string_view data);
+WorkloadMetadataObjectConstSharedPtr convertBaggageToWorkloadMetadata(absl::string_view baggage,
+                                                                      absl::string_view identity);
 
 } // namespace Common
 } // namespace Istio

--- a/contrib/istio/filters/common/source/metadata_object.h
+++ b/contrib/istio/filters/common/source/metadata_object.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include "envoy/common/hashable.h"
@@ -146,6 +147,8 @@ public:
   const std::string locality_zone_;
   std::vector<std::pair<std::string, std::string>> labels_;
 };
+
+using WorkloadMetadataObjectConstSharedPtr = std::shared_ptr<const WorkloadMetadataObject>;
 
 // Parse string workload type.
 WorkloadType fromSuffix(absl::string_view suffix);

--- a/contrib/istio/filters/common/source/workload_discovery.cc
+++ b/contrib/istio/filters/common/source/workload_discovery.cc
@@ -1,7 +1,5 @@
 #include "contrib/istio/filters/common/source/workload_discovery.h"
 
-#include <optional>
-
 #include "envoy/registry/registry.h"
 #include "envoy/server/bootstrap_extension_config.h"
 #include "envoy/server/factory_context.h"
@@ -28,7 +26,8 @@ constexpr absl::string_view DefaultNamespace = "default";
 constexpr absl::string_view DefaultServiceAccount = "default";
 constexpr absl::string_view DefaultTrustDomain = "cluster.local";
 
-Istio::Common::WorkloadMetadataObject convert(const istio::workload::Workload& workload) {
+Istio::Common::WorkloadMetadataObjectConstSharedPtr
+convert(const istio::workload::Workload& workload) {
   auto workload_type = Istio::Common::WorkloadType::Deployment;
   switch (workload.workload_type()) {
   case istio::workload::WorkloadType::CRONJOB:
@@ -61,7 +60,7 @@ Istio::Common::WorkloadMetadataObject convert(const istio::workload::Workload& w
   }
   const auto identity =
       absl::StrCat("spiffe://", trust_domain, "/ns/", ns, "/sa/", service_account);
-  return Istio::Common::WorkloadMetadataObject(
+  return std::make_shared<const Istio::Common::WorkloadMetadataObject>(
       workload.name(), workload.cluster_id(), ns, workload.workload_name(),
       workload.canonical_name(), workload.canonical_revision(), workload.canonical_name(),
       workload.canonical_revision(), workload_type, identity, workload.locality().region(),
@@ -83,7 +82,7 @@ public:
     subscription_.start();
   }
 
-  std::optional<Istio::Common::WorkloadMetadataObject>
+  Istio::Common::WorkloadMetadataObjectConstSharedPtr
   GetMetadata(const Network::Address::InstanceConstSharedPtr& address) override {
     if (address && address->ip()) {
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
@@ -99,13 +98,14 @@ public:
         return tls_->get(std::string(output.begin(), output.end()));
       }
     }
-    return {};
+    return nullptr;
   }
 
 private:
   using IdToAddress = absl::flat_hash_map<std::string, std::vector<std::string>>;
   using IdToAddressSharedPtr = std::shared_ptr<IdToAddress>;
-  using AddressToWorkload = absl::flat_hash_map<std::string, Istio::Common::WorkloadMetadataObject>;
+  using AddressToWorkload =
+      absl::flat_hash_map<std::string, Istio::Common::WorkloadMetadataObjectConstSharedPtr>;
   using AddressToWorkloadSharedPtr = std::shared_ptr<AddressToWorkload>;
 
   struct ThreadLocalProvider : public ThreadLocal::ThreadLocalObject {
@@ -127,13 +127,12 @@ private:
       }
     }
     size_t total() const { return address_to_workload_.size(); }
-    // Returns by-value since the flat map does not provide pointer stability.
-    std::optional<Istio::Common::WorkloadMetadataObject> get(const std::string& address) {
+    Istio::Common::WorkloadMetadataObjectConstSharedPtr get(const std::string& address) const {
       const auto it = address_to_workload_.find(address);
       if (it != address_to_workload_.end()) {
         return it->second;
       }
-      return {};
+      return nullptr;
     }
     IdToAddress id_to_address_;
     AddressToWorkload address_to_workload_;
@@ -162,7 +161,7 @@ private:
       for (const auto& resource : resources) {
         const auto& workload =
             dynamic_cast<const istio::workload::Workload&>(resource.get().resource());
-        const auto& metadata = convert(workload);
+        const auto metadata = convert(workload);
         for (const auto& addr : workload.addresses()) {
           index->emplace(addr, metadata);
         }
@@ -178,7 +177,7 @@ private:
       for (const auto& resource : added_resources) {
         const auto& workload =
             dynamic_cast<const istio::workload::Workload&>(resource.get().resource());
-        const auto& metadata = convert(workload);
+        const auto metadata = convert(workload);
         for (const auto& addr : workload.addresses()) {
           added_addresses->emplace(addr, metadata);
         }

--- a/contrib/istio/filters/common/source/workload_discovery.h
+++ b/contrib/istio/filters/common/source/workload_discovery.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include "envoy/network/address.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/stats/stats_macros.h"
@@ -22,7 +20,8 @@ struct WorkloadDiscoveryStats {
 class WorkloadMetadataProvider {
 public:
   virtual ~WorkloadMetadataProvider() = default;
-  virtual std::optional<Istio::Common::WorkloadMetadataObject>
+  // Returns the workload metadata for the given peer address, or nullptr if unknown.
+  virtual Istio::Common::WorkloadMetadataObjectConstSharedPtr
   // NOLINTNEXTLINE(readability-identifier-naming)
   GetMetadata(const Network::Address::InstanceConstSharedPtr& address) PURE;
 };

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -22,8 +22,7 @@ public:
       : downstream_(downstream),
         metadata_provider_(Extensions::Common::WorkloadDiscovery::GetProvider(factory_context)),
         local_info_(factory_context.localInfo()) {}
-  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                          Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&, Context&) const override;
 
 private:
   const bool downstream_;
@@ -164,8 +163,7 @@ public:
   UpstreamFilterStateMethod(
       const io::istio::http::peer_metadata::Config_UpstreamFilterState& config)
       : peer_metadata_key_(config.peer_metadata_key()) {}
-  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                          Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&, Context&) const override;
 
 private:
   std::string peer_metadata_key_;

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -1,7 +1,5 @@
 #include "contrib/istio/filters/http/peer_metadata/source/peer_metadata.h"
 
-#include <optional>
-
 #include "envoy/registry/registry.h"
 #include "envoy/server/factory_context.h"
 
@@ -24,8 +22,8 @@ public:
       : downstream_(downstream),
         metadata_provider_(Extensions::Common::WorkloadDiscovery::GetProvider(factory_context)),
         local_info_(factory_context.localInfo()) {}
-  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                         Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                          Context&) const override;
 
 private:
   const bool downstream_;
@@ -33,8 +31,8 @@ private:
   const LocalInfo::LocalInfo& local_info_;
 };
 
-std::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& info,
-                                                  Http::HeaderMap& headers, Context&) const {
+PeerInfo XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Http::HeaderMap& headers,
+                                   Context&) const {
   if (!metadata_provider_) {
     return {};
   }
@@ -110,8 +108,8 @@ MXMethod::MXMethod(bool downstream, const absl::flat_hash_set<std::string> addit
   tls_.set([](Event::Dispatcher&) { return std::make_shared<MXCache>(); });
 }
 
-std::optional<PeerInfo> MXMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
-                                                 Http::HeaderMap& headers, Context& ctx) const {
+PeerInfo MXMethod::derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap& headers,
+                                  Context& ctx) const {
   const auto peer_id_header = headers.get(Headers::get().ExchangeMetadataHeaderId);
   if (downstream_) {
     ctx.request_peer_id_received_ = !peer_id_header.empty();
@@ -135,7 +133,7 @@ void MXMethod::remove(Http::HeaderMap& headers) const {
   headers.remove(Headers::get().ExchangeMetadataHeader);
 }
 
-std::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view value) const {
+PeerInfo MXMethod::lookup(absl::string_view id, absl::string_view value) const {
   // This code is copied from:
   // https://github.com/istio/proxy/blob/release-1.18/extensions/metadata_exchange/plugin.cc#L116
   auto& cache = tls_->cache_;
@@ -148,17 +146,17 @@ std::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view
   const auto bytes = Base64::decodeWithoutPadding(value);
   Envoy::Protobuf::Struct metadata;
   if (!metadata.ParseFromString(bytes)) {
-    return {};
+    return nullptr;
   }
-  auto out = Istio::Common::convertStructToWorkloadMetadata(metadata, additional_labels_);
+  PeerInfo out = Istio::Common::convertStructToWorkloadMetadata(metadata, additional_labels_);
   if (max_peer_cache_size_ > 0 && !id.empty()) {
     // do not let the cache grow beyond max cache size.
     if (static_cast<uint32_t>(cache.size()) > max_peer_cache_size_) {
       cache.erase(cache.begin(), std::next(cache.begin(), max_peer_cache_size_ / 4));
     }
-    cache.emplace(id, *out);
+    cache.emplace(id, out);
   }
-  return *out;
+  return out;
 }
 
 class UpstreamFilterStateMethod : public DiscoveryMethod {
@@ -166,16 +164,15 @@ public:
   UpstreamFilterStateMethod(
       const io::istio::http::peer_metadata::Config_UpstreamFilterState& config)
       : peer_metadata_key_(config.peer_metadata_key()) {}
-  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                         Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                          Context&) const override;
 
 private:
   std::string peer_metadata_key_;
 };
 
-std::optional<PeerInfo>
-UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Http::HeaderMap&,
-                                          Context&) const {
+PeerInfo UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info,
+                                                   Http::HeaderMap&, Context&) const {
   const auto upstream = info.upstreamInfo();
   if (!upstream) {
     return {};
@@ -198,12 +195,7 @@ UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Ht
     return {};
   }
 
-  std::unique_ptr<PeerInfo> peer_info = ::Istio::Common::convertStructToWorkloadMetadata(obj);
-  if (!peer_info) {
-    return {};
-  }
-
-  return *peer_info;
+  return ::Istio::Common::convertStructToWorkloadMetadata(obj);
 }
 
 MXPropagationMethod::MXPropagationMethod(
@@ -258,19 +250,14 @@ void BaggagePropagationMethod::inject(const StreamInfo::StreamInfo&, Http::Heade
 
 BaggageDiscoveryMethod::BaggageDiscoveryMethod() = default;
 
-std::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
-                                                               Http::HeaderMap& headers,
-                                                               Context&) const {
+PeerInfo BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
+                                                Http::HeaderMap& headers, Context&) const {
   const auto baggage_header = headers.get(Headers::get().Baggage);
   if (baggage_header.empty()) {
     return {};
   }
   const auto baggage_value = baggage_header[0]->value().getStringView();
-  const auto workload = Istio::Common::convertBaggageToWorkloadMetadata(baggage_value);
-  if (workload) {
-    return *workload;
-  }
-  return {};
+  return Istio::Common::convertBaggageToWorkloadMetadata(baggage_value);
 }
 
 FilterConfig::FilterConfig(const io::istio::http::peer_metadata::Config& config,
@@ -383,7 +370,7 @@ void FilterConfig::discover(StreamInfo::StreamInfo& info, bool downstream, Http:
   for (const auto& method : downstream ? downstream_discovery_ : upstream_discovery_) {
     const auto result = method->derivePeerInfo(info, headers, ctx);
     if (result) {
-      setFilterState(info, downstream, *result);
+      setFilterState(info, downstream, result);
       break;
     }
   }
@@ -414,7 +401,7 @@ void FilterConfig::setFilterState(StreamInfo::StreamInfo& info, bool downstream,
       downstream ? Istio::Common::DownstreamPeerObj : Istio::Common::UpstreamPeerObj;
   if (!info.filterState()->hasDataWithName(key)) {
     // Store CelState for CEL expressions like filter_state.downstream_peer.labels['role']
-    auto pb = value.serializeAsProto();
+    auto pb = value->serializeAsProto();
     auto cel_state = std::make_unique<CelState>(FilterConfig::peerInfoPrototype());
     cel_state->setValue(absl::string_view(pb->SerializeAsString()));
     info.filterState()->setData(key, std::move(cel_state),
@@ -424,7 +411,7 @@ void FilterConfig::setFilterState(StreamInfo::StreamInfo& info, bool downstream,
     // Also store WorkloadMetadataObject under a separate key for FIELD accessor support.
     // WorkloadMetadataObject implements hasFieldSupport() + getField() for
     // formatters using %FILTER_STATE(downstream_peer_obj:FIELD:fieldname)% syntax.
-    auto workload_metadata = std::make_unique<PeerInfo>(value);
+    auto workload_metadata = std::make_unique<Istio::Common::WorkloadMetadataObject>(*value);
     info.filterState()->setData(obj_key, std::move(workload_metadata),
                                 StreamInfo::FilterState::LifeSpan::FilterChain,
                                 sharedWithUpstream());

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
@@ -49,8 +49,7 @@ class MXMethod : public DiscoveryMethod {
 public:
   MXMethod(bool downstream, const absl::flat_hash_set<std::string> additional_labels,
            Server::Configuration::ServerFactoryContext& factory_context);
-  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                          Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&, Context&) const override;
   void remove(Http::HeaderMap&) const override;
 
 private:
@@ -104,8 +103,7 @@ private:
 class BaggageDiscoveryMethod : public DiscoveryMethod, public Logger::Loggable<Logger::Id::filter> {
 public:
   BaggageDiscoveryMethod();
-  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                          Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&, Context&) const override;
 };
 
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include "source/common/singleton/const_singleton.h"
 #include "source/extensions/filters/common/expr/cel_state.h"
 #include "source/extensions/filters/http/common/factory_base.h"
@@ -29,7 +27,7 @@ struct HeaderValues {
 
 using Headers = ConstSingleton<HeaderValues>;
 
-using PeerInfo = Istio::Common::WorkloadMetadataObject;
+using PeerInfo = Istio::Common::WorkloadMetadataObjectConstSharedPtr;
 
 struct Context {
   bool request_peer_id_received_{false};
@@ -40,8 +38,8 @@ struct Context {
 class DiscoveryMethod {
 public:
   virtual ~DiscoveryMethod() = default;
-  virtual std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                                 Context&) const PURE;
+  virtual PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                  Context&) const PURE;
   virtual void remove(Http::HeaderMap&) const {}
 };
 
@@ -51,12 +49,12 @@ class MXMethod : public DiscoveryMethod {
 public:
   MXMethod(bool downstream, const absl::flat_hash_set<std::string> additional_labels,
            Server::Configuration::ServerFactoryContext& factory_context);
-  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                         Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                          Context&) const override;
   void remove(Http::HeaderMap&) const override;
 
 private:
-  std::optional<PeerInfo> lookup(absl::string_view id, absl::string_view value) const;
+  PeerInfo lookup(absl::string_view id, absl::string_view value) const;
   const bool downstream_;
   struct MXCache : public ThreadLocal::ThreadLocalObject {
     absl::flat_hash_map<std::string, PeerInfo> cache_;
@@ -106,8 +104,8 @@ private:
 class BaggageDiscoveryMethod : public DiscoveryMethod, public Logger::Loggable<Logger::Id::filter> {
 public:
   BaggageDiscoveryMethod();
-  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                         Context&) const override;
+  PeerInfo derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                          Context&) const override;
 };
 
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {

--- a/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
+++ b/contrib/istio/filters/http/peer_metadata/test/filter_test.cc
@@ -1,5 +1,3 @@
-#include <optional>
-
 #include "source/common/network/address_impl.h"
 
 #include "test/common/stream_info/test_util.h"
@@ -12,6 +10,7 @@
 #include "gtest/gtest.h"
 
 using Istio::Common::WorkloadMetadataObject;
+using Istio::Common::WorkloadMetadataObjectConstSharedPtr;
 using testing::HasSubstr;
 using testing::Invoke;
 using testing::Return;
@@ -35,7 +34,7 @@ class MockWorkloadMetadataProvider
       public Singleton::Instance {
 public:
   MockWorkloadMetadataProvider() = default;
-  MOCK_METHOD(std::optional<WorkloadMetadataObject>, GetMetadata,
+  MOCK_METHOD(WorkloadMetadataObjectConstSharedPtr, GetMetadata,
               (const Network::Address::InstanceConstSharedPtr& address));
 };
 
@@ -107,7 +106,7 @@ TEST_F(PeerMetadataTest, None) {
 }
 
 TEST_F(PeerMetadataTest, DownstreamXDSNone) {
-  EXPECT_CALL(*metadata_provider_, GetMetadata(_)).WillRepeatedly(Return(std::nullopt));
+  EXPECT_CALL(*metadata_provider_, GetMetadata(_)).WillRepeatedly(Return(nullptr));
   initialize(R"EOF(
     downstream_discovery:
       - workload_discovery: {}
@@ -119,14 +118,14 @@ TEST_F(PeerMetadataTest, DownstreamXDSNone) {
 }
 
 TEST_F(PeerMetadataTest, DownstreamXDS) {
-  const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
-                                   "");
+  const auto pod = std::make_shared<const WorkloadMetadataObject>(
+      "pod-foo-1234", "my-cluster", "default", "foo", "foo-service", "v1alpha3", "", "",
+      Istio::Common::WorkloadType::Pod, "", "", "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> std::optional<WorkloadMetadataObject> {
+                                 -> WorkloadMetadataObjectConstSharedPtr {
         if (absl::StartsWith(address->asStringView(), "127.0.0.1")) {
-          return {pod};
+          return pod;
         }
         return {};
       }));
@@ -142,14 +141,14 @@ TEST_F(PeerMetadataTest, DownstreamXDS) {
 }
 
 TEST_F(PeerMetadataTest, UpstreamXDS) {
-  const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
-                                   "");
+  const auto pod = std::make_shared<const WorkloadMetadataObject>(
+      "pod-foo-1234", "my-cluster", "foo", "foo", "foo-service", "v1alpha3", "", "",
+      Istio::Common::WorkloadType::Pod, "", "", "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> std::optional<WorkloadMetadataObject> {
+                                 -> WorkloadMetadataObjectConstSharedPtr {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) {
-          return {pod};
+          return pod;
         }
         return {};
       }));
@@ -179,14 +178,14 @@ TEST_F(PeerMetadataTest, UpstreamXDSInternal) {
   )EOF",
                             *host_metadata);
 
-  const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
-                                   "");
+  const auto pod = std::make_shared<const WorkloadMetadataObject>(
+      "pod-foo-1234", "my-cluster", "foo", "foo", "foo-service", "v1alpha3", "", "",
+      Istio::Common::WorkloadType::Pod, "", "", "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> std::optional<WorkloadMetadataObject> {
+                                 -> WorkloadMetadataObjectConstSharedPtr {
         if (absl::StartsWith(address->asStringView(), "127.0.0.100")) {
-          return {pod};
+          return pod;
         }
         return {};
       }));
@@ -249,14 +248,14 @@ TEST_F(PeerMetadataTest, DownstreamFallbackFirst) {
 }
 
 TEST_F(PeerMetadataTest, DownstreamFallbackSecond) {
-  const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
-                                   "");
+  const auto pod = std::make_shared<const WorkloadMetadataObject>(
+      "pod-foo-1234", "my-cluster", "default", "foo", "foo-service", "v1alpha3", "", "",
+      Istio::Common::WorkloadType::Pod, "", "", "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> std::optional<WorkloadMetadataObject> {
+                                 -> WorkloadMetadataObjectConstSharedPtr {
         if (absl::StartsWith(address->asStringView(), "127.0.0.1")) { // remote address
-          return {pod};
+          return pod;
         }
         return {};
       }));
@@ -285,7 +284,7 @@ TEST(MXMethod, Cache) {
       request_headers.setReference(Headers::get().ExchangeMetadataHeader, SampleIstioHeader);
       Context ctx;
       const auto result = method.derivePeerInfo(stream_info, request_headers, ctx);
-      EXPECT_TRUE(result.has_value());
+      EXPECT_NE(result, nullptr);
     }
   }
 }
@@ -333,14 +332,14 @@ TEST_F(PeerMetadataTest, UpstreamFallbackFirst) {
 }
 
 TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
-  const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
-                                   "");
+  const auto pod = std::make_shared<const WorkloadMetadataObject>(
+      "pod-foo-1234", "my-cluster", "foo", "foo", "foo-service", "v1alpha3", "", "",
+      Istio::Common::WorkloadType::Pod, "", "", "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> std::optional<WorkloadMetadataObject> {
+                                 -> WorkloadMetadataObjectConstSharedPtr {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) { // upstream host address
-          return {pod};
+          return pod;
         }
         return {};
       }));
@@ -356,14 +355,14 @@ TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
 }
 
 TEST_F(PeerMetadataTest, UpstreamFallbackFirstXDS) {
-  const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "", "", Istio::Common::WorkloadType::Pod, "", "",
-                                   "");
+  const auto pod = std::make_shared<const WorkloadMetadataObject>(
+      "pod-foo-1234", "my-cluster", "foo", "foo", "foo-service", "v1alpha3", "", "",
+      Istio::Common::WorkloadType::Pod, "", "", "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
-                                 -> std::optional<WorkloadMetadataObject> {
+                                 -> WorkloadMetadataObjectConstSharedPtr {
         if (absl::StartsWith(address->asStringView(), "10.0.0.1")) { // upstream host address
-          return {pod};
+          return pod;
         }
         return {};
       }));

--- a/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.cc
+++ b/contrib/istio/filters/network/metadata_exchange/source/metadata_exchange.cc
@@ -328,7 +328,7 @@ void MetadataExchangeFilter::setMetadataNotFoundFilterState() {
         if (metadata_object) {
           ENVOY_LOG(debug, "Metadata found for upstream peer address {}",
                     upstream_peer->asString());
-          updatePeer(metadata_object.value(), FilterDirection::Upstream);
+          updatePeer(*metadata_object, FilterDirection::Upstream);
         }
       }
 
@@ -350,7 +350,7 @@ void MetadataExchangeFilter::setMetadataNotFoundFilterState() {
     const auto metadata_object = config_->metadata_provider_->GetMetadata(peer_address);
     if (metadata_object) {
       ENVOY_LOG(trace, "Metadata found for peer address {}", peer_address->asString());
-      updatePeer(metadata_object.value());
+      updatePeer(*metadata_object);
       config_->stats().metadata_added_.inc();
       return;
     } else {

--- a/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/network/peer_metadata/source/peer_metadata.cc
@@ -209,7 +209,7 @@ std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
     }
   }
 
-  std::unique_ptr<::Istio::Common::WorkloadMetadataObject> metadata =
+  ::Istio::Common::WorkloadMetadataObjectConstSharedPtr metadata =
       ::Istio::Common::convertBaggageToWorkloadMetadata(baggage[0]->value().getStringView(),
                                                         identity);
 
@@ -458,7 +458,7 @@ void UpstreamFilter::populatePeerMetadataFromProto(absl::string_view serialized)
     return;
   }
 
-  std::unique_ptr<::Istio::Common::WorkloadMetadataObject> workload =
+  ::Istio::Common::WorkloadMetadataObjectConstSharedPtr workload =
       ::Istio::Common::convertStructToWorkloadMetadata(peer_metadata);
   populatePeerMetadata(*workload);
 }

--- a/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
+++ b/contrib/istio/filters/network/peer_metadata/test/peer_metadata_test.cc
@@ -81,7 +81,7 @@ private:
 // Serializes peer metadata the same way the listener-side filter stores it in
 // the registry: a google.protobuf.Struct packed into an Any.
 std::string encodePeerMetadata(absl::string_view baggage, absl::string_view identity) {
-  std::unique_ptr<Istio::Common::WorkloadMetadataObject> metadata =
+  Istio::Common::WorkloadMetadataObjectConstSharedPtr metadata =
       Istio::Common::convertBaggageToWorkloadMetadata(baggage, identity);
   Protobuf::Struct data = ::Istio::Common::convertWorkloadMetadataToStruct(*metadata);
   Protobuf::Any wrapped;
@@ -100,7 +100,7 @@ decodePeerMetadata(const std::string& serialized) {
   if (!any.UnpackTo(&data)) {
     return std::nullopt;
   }
-  std::unique_ptr<Istio::Common::WorkloadMetadataObject> metadata =
+  Istio::Common::WorkloadMetadataObjectConstSharedPtr metadata =
       Istio::Common::convertStructToWorkloadMetadata(data);
   if (!metadata) {
     return std::nullopt;
@@ -447,7 +447,7 @@ public:
       return std::nullopt;
     }
 
-    std::unique_ptr<Istio::Common::WorkloadMetadataObject> peer_info =
+    Istio::Common::WorkloadMetadataObjectConstSharedPtr peer_info =
         Istio::Common::convertStructToWorkloadMetadata(obj);
     if (!peer_info) {
       return std::nullopt;


### PR DESCRIPTION
Don't copy workload metedata to tls, use shared pointer to immutable instead.

Same basic pattern as ConfigConstSharedPtr.

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
