### PR TITLE
tracing: populate OTLP span flags in the opentelemetry tracer

### DIFF
--- a/changelogs/current/minor_behavior_changes/tracing__opentelemetry-span-flags.rst
+++ b/changelogs/current/minor_behavior_changes/tracing__opentelemetry-span-flags.rst
@@ -1,0 +1,4 @@
+tracing: the OpenTelemetry tracer now populates the ``flags`` field on exported OTLP spans. The low 8 bits carry the W3C
+trace flags of the span (currently only the sampled bit), and bits 8 and 9 record whether the span's parent context was
+remote, as defined by the OTLP specification. Previously the field was always 0, which OTLP consumers interpret as
+"trace flags not recorded".

--- a/source/extensions/tracers/opentelemetry/span_context.h
+++ b/source/extensions/tracers/opentelemetry/span_context.h
@@ -12,7 +12,8 @@ namespace OpenTelemetry {
 
 /**
  * This class represents the context of an OpenTelemetry span, including the following
- * characteristics: trace id, span id, parent id, and trace flags.
+ * characteristics: version, trace id, span id, sampled flag, tracestate, and whether the
+ * context was propagated from a remote parent.
  */
 class SpanContext {
 public:
@@ -25,9 +26,9 @@ public:
    * Constructor that creates a context object from the supplied attributes.
    */
   SpanContext(absl::string_view version, absl::string_view trace_id, absl::string_view span_id,
-              bool sampled, std::string tracestate)
+              bool sampled, std::string tracestate, bool is_remote = false)
       : version_(version), trace_id_(trace_id), span_id_(span_id), sampled_(sampled),
-        tracestate_(std::move(tracestate)) {}
+        tracestate_(std::move(tracestate)), is_remote_(is_remote) {}
 
   /**
    * @return the span's version as a hex string.
@@ -54,12 +55,18 @@ public:
    */
   const std::string& tracestate() const { return tracestate_; }
 
+  /**
+   * @return whether the context was propagated from a remote parent.
+   */
+  bool isRemote() const { return is_remote_; }
+
 private:
   std::string version_;
   std::string trace_id_;
   std::string span_id_;
   bool sampled_{false};
   std::string tracestate_;
+  bool is_remote_{false};
 };
 
 } // namespace OpenTelemetry

--- a/source/extensions/tracers/opentelemetry/span_context_extractor.cc
+++ b/source/extensions/tracers/opentelemetry/span_context_extractor.cc
@@ -92,7 +92,7 @@ absl::StatusOr<SpanContext> SpanContextExtractor::extractSpanContext() {
   const auto tracestate_values = OpenTelemetryConstants::get().TRACE_STATE.getAll(trace_context_);
 
   SpanContext parent_context(version, trace_id, span_id, sampled,
-                             absl::StrJoin(tracestate_values, ","));
+                             absl::StrJoin(tracestate_values, ","), /*is_remote=*/true);
   return parent_context;
 }
 

--- a/source/extensions/tracers/opentelemetry/tracer.cc
+++ b/source/extensions/tracers/opentelemetry/tracer.cc
@@ -23,6 +23,9 @@ namespace Tracers {
 namespace OpenTelemetry {
 
 constexpr absl::string_view kDefaultVersion = "00";
+// The sampled bit of the W3C trace flags carried in the low 8 bits of the OTLP span flags.
+// See https://www.w3.org/TR/trace-context/#sampled-flag.
+constexpr uint32_t TraceFlagsSampledMask = 0x1;
 
 using opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest;
 
@@ -77,7 +80,7 @@ Tracing::SpanPtr Span::spawnChild(const Tracing::Config&, const std::string& nam
                                   SystemTime start_time) {
   // Build span_context from the current span, then generate the child span from that context.
   SpanContext span_context(kDefaultVersion, getTraceId(), spanId(), sampled(),
-                           std::string(tracestate()));
+                           std::string(tracestate()), /*is_remote=*/false);
   return parent_tracer_.startSpan(name, stream_info_, start_time, span_context, {},
                                   ::opentelemetry::proto::trace::v1::Span::SPAN_KIND_CLIENT);
 }
@@ -86,6 +89,19 @@ void Span::finishSpan() {
   // Call into the parent tracer so we can access the shared exporter.
   span_.set_end_time_unix_nano(
       std::chrono::nanoseconds(time_source_.systemTime().time_since_epoch()).count());
+  // Bits 0-7 of the span flags carry the W3C trace flags; bits 8 and 9 encode the tri-state
+  // "is the parent context remote" (unknown/local/remote). The parent's remoteness is always
+  // known here, so the HAS_IS_REMOTE bit is set unconditionally.
+  uint32_t flags = static_cast<uint32_t>(
+      ::opentelemetry::proto::trace::v1::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK);
+  if (parent_context_is_remote_) {
+    flags |=
+        static_cast<uint32_t>(::opentelemetry::proto::trace::v1::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK);
+  }
+  if (sampled()) {
+    flags |= TraceFlagsSampledMask;
+  }
+  span_.set_flags(flags);
   if (sampled()) {
     parent_tracer_.sendSpan(span_);
   }
@@ -327,6 +343,7 @@ Tracing::SpanPtr Tracer::startSpan(const std::string& operation_name,
   // Create a new span and populate details from the span context.
   auto new_span = std::make_unique<Span>(operation_name, stream_info, start_time, time_source_,
                                          *this, span_kind, false);
+  new_span->setParentContextIsRemote(parent_context.isRemote());
   new_span->setTraceId(parent_context.traceId());
   if (!parent_context.spanId().empty()) {
     new_span->setParentId(parent_context.spanId());

--- a/source/extensions/tracers/opentelemetry/tracer.h
+++ b/source/extensions/tracers/opentelemetry/tracer.h
@@ -160,6 +160,12 @@ public:
     span_.set_parent_span_id(absl::HexStringToBytes(parent_span_id_hex));
   }
 
+  /**
+   * Records whether the span's parent context was propagated from a remote parent. Used to
+   * populate the is_remote bits of the exported span's flags field.
+   */
+  void setParentContextIsRemote(bool is_remote) { parent_context_is_remote_ = is_remote; }
+
   absl::string_view tracestate() const { return span_.trace_state(); }
 
   /**
@@ -186,6 +192,7 @@ private:
   Envoy::TimeSource& time_source_;
   bool sampled_;
   bool use_local_decision_{false};
+  bool parent_context_is_remote_{false};
 };
 
 using TracerPtr = std::unique_ptr<Tracer>;

--- a/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
+++ b/test/extensions/tracers/opentelemetry/opentelemetry_tracer_impl_test.cc
@@ -309,6 +309,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
   )";
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
   SystemTime timestamp = time_system_.systemTime();
@@ -425,6 +426,7 @@ resource_spans:
       start_time_unix_nano: {}
       end_time_unix_nano: {}
       trace_state: "test=foo"
+      flags: 769
   )";
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
   SystemTime timestamp = time_system_.systemTime();
@@ -687,6 +689,64 @@ TEST_F(OpenTelemetryDriverTest, SpawnChildSpan) {
   EXPECT_EQ(1U, stats_.counter("tracing.opentelemetry.spans_sent").value());
 }
 
+// Verifies the OTLP span flags field is populated per the OTLP spec: bits 0-7 carry the W3C
+// trace flags (bit 0: sampled), bit 8 records that the parent-remoteness is known, and bit 9
+// records whether the parent span context was remote.
+TEST_F(OpenTelemetryDriverTest, ExportOTLPSpanFlags) {
+  setupValidDriver();
+
+  constexpr uint32_t sampled_flag = 0x1;
+  constexpr uint32_t has_is_remote_flag = static_cast<uint32_t>(
+      ::opentelemetry::proto::trace::v1::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK);
+  constexpr uint32_t is_remote_flag =
+      static_cast<uint32_t>(::opentelemetry::proto::trace::v1::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK);
+
+  Tracing::TestTraceContextImpl request_headers{
+      {":authority", "test.com"}, {":path", "/"}, {":method", "GET"}};
+
+  {
+    // A sampled root span has no remote parent.
+    Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                               operation_name_, {Tracing::Reason::Sampling, true});
+    span->finishSpan();
+    EXPECT_EQ(dynamic_cast<Span*>(span.get())->spanForTest().flags(),
+              has_is_remote_flag | sampled_flag);
+  }
+  {
+    // An unsampled span still records that the parent-remoteness is known.
+    Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                               operation_name_, {Tracing::Reason::Sampling, true});
+    span->setSampled(false);
+    span->finishSpan();
+    EXPECT_EQ(dynamic_cast<Span*>(span.get())->spanForTest().flags(), has_is_remote_flag);
+  }
+  {
+    // A span spawned from another local span has a local parent.
+    Tracing::SpanPtr span = driver_->startSpan(mock_tracing_config_, request_headers, stream_info_,
+                                               operation_name_, {Tracing::Reason::Sampling, true});
+    Tracing::SpanPtr child_span =
+        span->spawnChild(mock_tracing_config_, operation_name_, time_system_.systemTime());
+    child_span->finishSpan();
+    EXPECT_EQ(dynamic_cast<Span*>(child_span.get())->spanForTest().flags(),
+              has_is_remote_flag | sampled_flag);
+  }
+  {
+    // A span continuing a trace from an extracted traceparent header has a remote parent.
+    Tracing::TestTraceContextImpl request_headers_with_parent{
+        {":authority", "test.com"},
+        {":path", "/"},
+        {":method", "GET"},
+        {"traceparent", "00-0000000000000000000000000000000a-"
+                        "000000000000000a-01"}};
+    Tracing::SpanPtr span =
+        driver_->startSpan(mock_tracing_config_, request_headers_with_parent, stream_info_,
+                           operation_name_, {Tracing::Reason::Sampling, true});
+    span->finishSpan();
+    EXPECT_EQ(dynamic_cast<Span*>(span.get())->spanForTest().flags(),
+              has_is_remote_flag | is_remote_flag | sampled_flag);
+  }
+}
+
 // Verifies the span types
 TEST_F(OpenTelemetryDriverTest, SpanType) {
   // Set up driver
@@ -855,6 +915,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
       attributes:
         - key: "first_tag_name"
           value:
@@ -925,6 +986,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
       attributes:
         - key: "http.method"
           value:
@@ -992,6 +1054,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
       attributes:
         - key: "http.method"
           value:
@@ -1062,6 +1125,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
       events:
         - name: event1
           time_unix_nano: 1000000
@@ -1137,6 +1201,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
       status:
         code: STATUS_CODE_ERROR
       attributes:
@@ -1221,6 +1286,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
       status:
         code: STATUS_CODE_ERROR
       attributes:
@@ -1503,6 +1569,7 @@ resource_spans:
       kind: SPAN_KIND_SERVER
       start_time_unix_nano: {}
       end_time_unix_nano: {}
+      flags: 257
   )";
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_proto;
   int64_t timestamp_ns = std::chrono::nanoseconds(timestamp.time_since_epoch()).count();


### PR DESCRIPTION
The OpenTelemetry tracer never set the `flags` field on exported OTLP spans, so consumers always read 0, which the OTLP spec defines as "flags not recorded". In practice this means OTLP consumers (e.g. collectors deriving the `sampled` flag from `span.flags`) cannot see the W3C trace flags of Envoy-produced spans, even though the same information is correctly propagated via the `traceparent` header.

This PR populates the field when a span finishes, per the `SpanFlags` definition (stable in `opentelemetry-proto` since v1.2.0):

- Bit 0: the W3C trace flags sampled bit.
- Bit 8 (`SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK`): set unconditionally, since the parent's remoteness is always known at export time; without it, consumers must treat the flags as unrecorded.
- Bit 9 (`SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK`): set when the parent span context was extracted from incoming request headers, and not when the span is a root span or was spawned by a local parent span.

To track parent remoteness, `SpanContext` gains an `is_remote` attribute mirroring `SpanContext.IsRemote` from the OTel API spec. The header extractor marks contexts remote, `spawnChild` marks them local. No public API or `startSpan` signature changes were needed.

## Risk Level

Low - purely additive change to exported span content so the field moves from "not recorded" (0) to spec-conformant values. Header propagation (`traceparent`) is unchanged.

## Testing

Added a unit test (`ExportOTLPSpanFlags`) covering the flag matrix. Updated existing expected-span protos in `opentelemetry_tracer_impl_test.cc` to assert the exported flags values. All tests under `//test/extensions/tracers/opentelemetry/...` pass.

## Docs Changes

None required.

## Release Notes

Added a changelog entry under `minor_behavior_changes` (area: `tracing`).

## Platform Specific Features

None.

## Runtime guard

None - the change is additive and spec-conformant. The previously emitted value of 0 meant "not recorded" rather than a behavior consumers could depend on.

## AI Disclosure
Yes - code and tests were generated with AI assistance. I have reviewed and fully understand the changes.