### PR TITLE
filter: merge filter factory interface into single one 2

### DIFF
--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -398,7 +398,7 @@ public:
   }
 
   /**
-   * @return bool true if this filter is a unified filter who implements
+   * @return bool true if this filter is a unified filter that implements
    * createHttpFilterFactoryFromProto to replace createFilterFactoryFromProto completely. This is
    * used to differentiate unified filters from legacy filters.
    */

--- a/source/extensions/filters/http/adaptive_concurrency/config.h
+++ b/source/extensions/filters/http/adaptive_concurrency/config.h
@@ -14,25 +14,19 @@ namespace AdaptiveConcurrency {
  * Config registration for the adaptive concurrency limit filter. @see NamedHttpFilterConfigFactory.
  */
 class AdaptiveConcurrencyFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency> {
 public:
   AdaptiveConcurrencyFilterFactory()
-      : ExceptionFreeFactoryBase("envoy.filters.http.adaptive_concurrency") {}
+      : UnifiedFactoryBase("envoy.filters.http.adaptive_concurrency") {}
 
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
-          proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override {
-    return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
-                               context.scope());
-  }
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::adaptive_concurrency::v3::AdaptiveConcurrency&
           proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override {
-    return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
+    return createFilterFactory(proto_config, extra_context.stats_prefix, context,
+                               extra_context.scopeOr(context));
   }
 
 private:

--- a/source/extensions/filters/http/api_key_auth/config.cc
+++ b/source/extensions/filters/http/api_key_auth/config.cc
@@ -21,17 +21,12 @@ ApiKeyAuthFilterFactory::createFilterFactory(const ApiKeyAuthProto& proto_config
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> ApiKeyAuthFilterFactory::createFilterFactoryFromProtoTyped(
-    const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 ApiKeyAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const ApiKeyAuthProto& proto_config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto_config, extra_context.stats_prefix, context.scope());
+  return createFilterFactory(proto_config, extra_context.stats_prefix,
+                             extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/api_key_auth/config.h
+++ b/source/extensions/filters/http/api_key_auth/config.h
@@ -12,20 +12,17 @@ namespace HttpFilters {
 namespace ApiKeyAuth {
 
 class ApiKeyAuthFilterFactory
-    : public Common::ExceptionFreeFactoryBase<ApiKeyAuthProto, ApiKeyAuthPerRouteProto> {
+    : public Common::UnifiedFactoryBase<ApiKeyAuthProto, ApiKeyAuthPerRouteProto> {
 public:
-  ApiKeyAuthFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.api_key_auth") {}
+  ApiKeyAuthFilterFactory() : UnifiedFactoryBase("envoy.filters.http.api_key_auth") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const ApiKeyAuthProto& config, const std::string& stats_prefix,
-                                    Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const ApiKeyAuthProto& config, Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const ApiKeyAuthProto& proto_config, const std::string& stats_prefix,
                       Stats::Scope& scope);

--- a/source/extensions/filters/http/bandwidth_limit/config.cc
+++ b/source/extensions/filters/http/bandwidth_limit/config.cc
@@ -23,18 +23,12 @@ absl::StatusOr<Http::FilterFactoryCb> BandwidthLimitFilterConfig::createFilterFa
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> BandwidthLimitFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 BandwidthLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
-  return createFilterFactory(proto_config, context, context.scope());
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, context, extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/bandwidth_limit/config.h
+++ b/source/extensions/filters/http/bandwidth_limit/config.h
@@ -14,23 +14,19 @@ namespace BandwidthLimitFilter {
  * Config registration for the bandwidth limit filter. @see NamedHttpFilterConfigFactory.
  */
 class BandwidthLimitFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit> {
 public:
-  BandwidthLimitFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.bandwidth_limit") {}
+  BandwidthLimitFilterConfig() : UnifiedFactoryBase("envoy.filters.http.bandwidth_limit") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::bandwidth_limit::v3::BandwidthLimit& proto_config,
       Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);

--- a/source/extensions/filters/http/basic_auth/config.cc
+++ b/source/extensions/filters/http/basic_auth/config.cc
@@ -64,23 +64,6 @@ absl::StatusOr<UserMap> readHtpasswd(const std::string& htpasswd) {
 
 } // namespace
 
-absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createFilterFactoryFromProtoTyped(
-    const BasicAuth& proto_config, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  auto htpasswd_or =
-      Config::DataSource::read(proto_config.users(), false, context.serverFactoryContext().api());
-  RETURN_IF_NOT_OK_REF(htpasswd_or.status());
-  auto users_or = readHtpasswd(htpasswd_or.value());
-  RETURN_IF_NOT_OK_REF(users_or.status());
-  FilterConfigConstSharedPtr config = std::make_unique<FilterConfig>(
-      std::move(users_or.value()), proto_config.forward_username_header(),
-      proto_config.authentication_header(), proto_config.allow_missing(),
-      proto_config.emit_dynamic_metadata(), stats_prefix, context.scope());
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_shared<BasicAuthFilter>(config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const BasicAuth& proto_config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
@@ -91,7 +74,8 @@ absl::StatusOr<Http::FilterFactoryCb> BasicAuthFilterFactory::createHttpFilterFa
   FilterConfigConstSharedPtr config = std::make_unique<FilterConfig>(
       std::move(users_or.value()), proto_config.forward_username_header(),
       proto_config.authentication_header(), proto_config.allow_missing(),
-      proto_config.emit_dynamic_metadata(), extra_context.stats_prefix, context.scope());
+      proto_config.emit_dynamic_metadata(), extra_context.stats_prefix,
+      extra_context.scopeOr(context));
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<BasicAuthFilter>(config));
   };

--- a/source/extensions/filters/http/basic_auth/config.h
+++ b/source/extensions/filters/http/basic_auth/config.h
@@ -11,17 +11,13 @@ namespace HttpFilters {
 namespace BasicAuth {
 
 class BasicAuthFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::basic_auth::v3::BasicAuth,
           envoy::extensions::filters::http::basic_auth::v3::BasicAuthPerRoute> {
 public:
-  BasicAuthFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.basic_auth") {}
+  BasicAuthFilterFactory() : UnifiedFactoryBase("envoy.filters.http.basic_auth") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::basic_auth::v3::BasicAuth& config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/cors/config.cc
+++ b/source/extensions/filters/http/cors/config.cc
@@ -17,22 +17,12 @@ namespace Cors {
 using CorsPolicyImpl =
     Router::CorsPolicyImplBase<envoy::extensions::filters::http::cors::v3::CorsPolicy>;
 
-absl::StatusOr<Http::FilterFactoryCb> CorsFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::cors::v3::Cors&, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  CorsFilterConfigSharedPtr config =
-      std::make_shared<CorsFilterConfig>(stats_prefix, context.scope());
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<CorsFilter>(config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> CorsFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::cors::v3::Cors&,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  CorsFilterConfigSharedPtr config =
-      std::make_shared<CorsFilterConfig>(extra_context.stats_prefix, context.scope());
+  CorsFilterConfigSharedPtr config = std::make_shared<CorsFilterConfig>(
+      extra_context.stats_prefix, extra_context.scopeOr(context));
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<CorsFilter>(config));
   };

--- a/source/extensions/filters/http/cors/config.h
+++ b/source/extensions/filters/http/cors/config.h
@@ -13,15 +13,11 @@ namespace Cors {
 /**
  * Config registration for the cors filter. @see NamedHttpFilterConfigFactory.
  */
-class CorsFilterFactory : public Common::ExceptionFreeFactoryBase<
-                              envoy::extensions::filters::http::cors::v3::Cors,
-                              envoy::extensions::filters::http::cors::v3::CorsPolicy> {
+class CorsFilterFactory
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::cors::v3::Cors,
+                                        envoy::extensions::filters::http::cors::v3::CorsPolicy> {
 public:
-  CorsFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.cors") {}
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::cors::v3::Cors& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+  CorsFilterFactory() : UnifiedFactoryBase("envoy.filters.http.cors") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::cors::v3::Cors& proto_config,

--- a/source/extensions/filters/http/csrf/config.cc
+++ b/source/extensions/filters/http/csrf/config.cc
@@ -11,22 +11,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Csrf {
 
-absl::StatusOr<Http::FilterFactoryCb> CsrfFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  CsrfFilterConfigSharedPtr config = std::make_shared<CsrfFilterConfig>(
-      policy, stats_prefix, context.scope(), context.serverFactoryContext());
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_shared<CsrfFilter>(config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> CsrfFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
   CsrfFilterConfigSharedPtr config = std::make_shared<CsrfFilterConfig>(
-      policy, extra_context.stats_prefix, context.scope(), context);
+      policy, extra_context.stats_prefix, extra_context.scopeOr(context), context);
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<CsrfFilter>(config));
   };

--- a/source/extensions/filters/http/csrf/config.h
+++ b/source/extensions/filters/http/csrf/config.h
@@ -13,16 +13,12 @@ namespace Csrf {
 /**
  * Config registration for the CSRF filter. @see NamedHttpFilterConfigFactory.
  */
-class CsrfFilterFactory : public Common::ExceptionFreeFactoryBase<
-                              envoy::extensions::filters::http::csrf::v3::CsrfPolicy> {
+class CsrfFilterFactory
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::csrf::v3::CsrfPolicy> {
 public:
-  CsrfFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.csrf") {}
+  CsrfFilterFactory() : UnifiedFactoryBase("envoy.filters.http.csrf") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::csrf::v3::CsrfPolicy& policy,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/fault/config.cc
+++ b/source/extensions/filters/http/fault/config.cc
@@ -11,24 +11,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Fault {
 
-absl::StatusOr<Http::FilterFactoryCb> FaultFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::fault::v3::HTTPFault& config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-
-  FaultFilterConfigSharedPtr filter_config(
-      std::make_shared<FaultFilterConfig>(config, stats_prefix, context.scope(), server_context));
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<FaultFilter>(filter_config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> FaultFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::fault::v3::HTTPFault& config,
     Server::Configuration::ServerFactoryContext& server_context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
   FaultFilterConfigSharedPtr filter_config(std::make_shared<FaultFilterConfig>(
-      config, extra_context.stats_prefix, server_context.scope(), server_context));
+      config, extra_context.stats_prefix, extra_context.scopeOr(server_context), server_context));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<FaultFilter>(filter_config));
   };

--- a/source/extensions/filters/http/fault/config.h
+++ b/source/extensions/filters/http/fault/config.h
@@ -13,16 +13,12 @@ namespace Fault {
 /**
  * Config registration for the fault injection filter. @see NamedHttpFilterConfigFactory.
  */
-class FaultFilterFactory : public Common::ExceptionFreeFactoryBase<
-                               envoy::extensions::filters::http::fault::v3::HTTPFault> {
+class FaultFilterFactory
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::fault::v3::HTTPFault> {
 public:
-  FaultFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.fault") {}
+  FaultFilterFactory() : UnifiedFactoryBase("envoy.filters.http.fault") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::fault::v3::HTTPFault& proto_config,
       Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/gcp_authn/filter_config.cc
+++ b/source/extensions/filters/http/gcp_authn/filter_config.cc
@@ -36,16 +36,11 @@ absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactory
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createFilterFactoryFromProtoTyped(
-    const GcpAuthnFilterConfig& config, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(config, stats_prefix, context.serverFactoryContext(), context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> GcpAuthnFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const GcpAuthnFilterConfig& config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(config, extra_context.stats_prefix, context, context.scope());
+  return createFilterFactory(config, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context));
 }
 
 /**

--- a/source/extensions/filters/http/gcp_authn/filter_config.h
+++ b/source/extensions/filters/http/gcp_authn/filter_config.h
@@ -12,23 +12,19 @@ namespace HttpFilters {
 namespace GcpAuthn {
 
 class GcpAuthnFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig>,
       public Logger::Loggable<Logger::Id::filter> {
 public:
-  GcpAuthnFilterFactory() : ExceptionFreeFactoryBase(std::string(FilterName)) {}
+  GcpAuthnFilterFactory() : UnifiedFactoryBase(std::string(FilterName)) {}
 
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
 private:
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths.
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::gcp_authn::v3::GcpAuthnFilterConfig& config,
       const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/geoip/config.cc
+++ b/source/extensions/filters/http/geoip/config.cc
@@ -49,17 +49,12 @@ absl::StatusOr<Http::FilterFactoryCb> GeoipFilterFactory::createFilterFactory(
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> GeoipFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
-    const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, stat_prefix, context);
-}
-
 absl::StatusOr<Http::FilterFactoryCb> GeoipFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
+  Server::GenericFactoryContextImpl generic_context(
+      context, extra_context.scope, extra_context.visitor, extra_context.init_manager);
   return createFilterFactory(proto_config, extra_context.stats_prefix, generic_context);
 }
 

--- a/source/extensions/filters/http/geoip/config.h
+++ b/source/extensions/filters/http/geoip/config.h
@@ -15,23 +15,19 @@ namespace Geoip {
  * Config registration for the geoip filter. @see NamedHttpFilterConfigFactory.
  */
 class GeoipFilterFactory
-    : public Common::ExceptionFreeFactoryBase<envoy::extensions::filters::http::geoip::v3::Geoip> {
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::geoip::v3::Geoip> {
 public:
-  GeoipFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.geoip") {}
+  GeoipFilterFactory() : UnifiedFactoryBase("envoy.filters.http.geoip") {}
 
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
 private:
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. A GenericFactoryContext is used so the filter's scope and
-  // validation visitor stay correct for each path, while the provider driver is created with the
-  // server factory context.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. A
+  // GenericFactoryContext is used so the filter's scope and validation visitor stay correct for
+  // each path, while the provider driver is created with the server factory context.
   absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const envoy::extensions::filters::http::geoip::v3::Geoip& proto_config,
                       const std::string& stat_prefix,

--- a/source/extensions/filters/http/grpc_json_transcoder/config.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.cc
@@ -12,22 +12,6 @@ namespace HttpFilters {
 namespace GrpcJsonTranscoder {
 
 absl::StatusOr<Http::FilterFactoryCb>
-GrpcJsonTranscoderFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
-        proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  absl::Status creation_status = absl::OkStatus();
-  JsonTranscoderConfigSharedPtr filter_config = std::make_shared<JsonTranscoderConfig>(
-      proto_config, context.serverFactoryContext().api(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  auto stats = std::make_shared<GrpcJsonTranscoderFilterStats>(
-      GrpcJsonTranscoderFilterStats::generateStats(stats_prefix, context.scope()));
-  return [filter_config, stats](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<JsonTranscoderFilter>(filter_config, stats));
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 GrpcJsonTranscoderFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
         proto_config,
@@ -37,8 +21,9 @@ GrpcJsonTranscoderFilterConfig::createHttpFilterFactoryFromProtoTyped(
   JsonTranscoderConfigSharedPtr filter_config =
       std::make_shared<JsonTranscoderConfig>(proto_config, context.api(), creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
-  auto stats = std::make_shared<GrpcJsonTranscoderFilterStats>(
-      GrpcJsonTranscoderFilterStats::generateStats(extra_context.stats_prefix, context.scope()));
+  auto stats =
+      std::make_shared<GrpcJsonTranscoderFilterStats>(GrpcJsonTranscoderFilterStats::generateStats(
+          extra_context.stats_prefix, extra_context.scopeOr(context)));
   return [filter_config, stats](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<JsonTranscoderFilter>(filter_config, stats));
   };

--- a/source/extensions/filters/http/grpc_json_transcoder/config.h
+++ b/source/extensions/filters/http/grpc_json_transcoder/config.h
@@ -14,18 +14,13 @@ namespace GrpcJsonTranscoder {
  * Config registration for the gRPC JSON transcoder filter. @see NamedHttpFilterConfigFactory.
  */
 class GrpcJsonTranscoderFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder> {
 public:
   GrpcJsonTranscoderFilterConfig()
-      : ExceptionFreeFactoryBase("envoy.filters.http.grpc_json_transcoder") {}
+      : UnifiedFactoryBase("envoy.filters.http.grpc_json_transcoder") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
-          proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_json_transcoder::v3::GrpcJsonTranscoder&
           proto_config,

--- a/source/extensions/filters/http/header_to_metadata/config.cc
+++ b/source/extensions/filters/http/header_to_metadata/config.cc
@@ -28,17 +28,11 @@ absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactor
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> HeaderToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
-  return createFilterFactory(proto_config, context, context.scope());
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, context, extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/header_to_metadata/config.h
+++ b/source/extensions/filters/http/header_to_metadata/config.h
@@ -14,22 +14,19 @@ namespace HeaderToMetadataFilter {
  * Config registration for the header-to-metadata filter. @see NamedHttpFilterConfigFactory.
  */
 class HeaderToMetadataConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::header_to_metadata::v3::Config> {
 public:
-  HeaderToMetadataConfig() : ExceptionFreeFactoryBase("envoy.filters.http.header_to_metadata") {}
+  HeaderToMetadataConfig() : UnifiedFactoryBase("envoy.filters.http.header_to_metadata") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::header_to_metadata::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);

--- a/source/extensions/filters/http/health_check/config.cc
+++ b/source/extensions/filters/http/health_check/config.cc
@@ -62,20 +62,13 @@ absl::StatusOr<Http::FilterFactoryCb> HealthCheckFilterConfig::createFilterFacto
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> HealthCheckFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  return createFilterFactoryHelper(proto_config, stats_prefix, context.serverFactoryContext(),
-                                   context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 HealthCheckFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
   return createFilterFactoryHelper(proto_config, extra_context.stats_prefix, context,
-                                   context.scope());
+                                   extra_context.scopeOr(context));
 }
 
 /**

--- a/source/extensions/filters/http/health_check/config.h
+++ b/source/extensions/filters/http/health_check/config.h
@@ -11,16 +11,12 @@ namespace HttpFilters {
 namespace HealthCheck {
 
 class HealthCheckFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::health_check::v3::HealthCheck> {
 public:
-  HealthCheckFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.health_check") {}
+  HealthCheckFilterConfig() : UnifiedFactoryBase("envoy.filters.http.health_check") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::health_check::v3::HealthCheck& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/ip_tagging/config.cc
+++ b/source/extensions/filters/http/ip_tagging/config.cc
@@ -13,31 +13,15 @@ namespace Extensions {
 namespace HttpFilters {
 namespace IpTagging {
 
-absl::StatusOr<Http::FilterFactoryCb> IpTaggingFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
-    const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
-
-  absl::StatusOr<IpTaggingFilterConfigSharedPtr> config = IpTaggingFilterConfig::create(
-      proto_config, stat_prefix, context.serverFactoryContext().singletonManager(), context.scope(),
-      context.serverFactoryContext().runtime(), context.serverFactoryContext().api(),
-      context.serverFactoryContext().threadLocal(),
-      context.serverFactoryContext().mainThreadDispatcher(), context.messageValidationVisitor());
-  RETURN_IF_NOT_OK_REF(config.status());
-  return
-      [config = std::move(config.value())](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-        callbacks.addStreamDecoderFilter(std::make_shared<IpTaggingFilter>(config));
-      };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> IpTaggingFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
 
   absl::StatusOr<IpTaggingFilterConfigSharedPtr> config = IpTaggingFilterConfig::create(
-      proto_config, extra_context.stats_prefix, context.singletonManager(), context.scope(),
-      context.runtime(), context.api(), context.threadLocal(), context.mainThreadDispatcher(),
-      context.messageValidationVisitor());
+      proto_config, extra_context.stats_prefix, context.singletonManager(),
+      extra_context.scopeOr(context), context.runtime(), context.api(), context.threadLocal(),
+      context.mainThreadDispatcher(), extra_context.visitor);
   RETURN_IF_NOT_OK_REF(config.status());
   return
       [config = std::move(config.value())](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/ip_tagging/config.h
+++ b/source/extensions/filters/http/ip_tagging/config.h
@@ -13,16 +13,12 @@ namespace IpTagging {
 /**
  * Config registration for the router filter. @see NamedHttpFilterConfigFactory.
  */
-class IpTaggingFilterFactory : public Common::ExceptionFreeFactoryBase<
+class IpTaggingFilterFactory : public Common::UnifiedFactoryBase<
                                    envoy::extensions::filters::http::ip_tagging::v3::IPTagging> {
 public:
-  IpTaggingFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.ip_tagging") {}
+  IpTaggingFilterFactory() : UnifiedFactoryBase("envoy.filters.http.ip_tagging") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ip_tagging::v3::IPTagging& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/json_to_metadata/config.cc
+++ b/source/extensions/filters/http/json_to_metadata/config.cc
@@ -24,17 +24,11 @@ absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactory(
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> JsonToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
-  return createFilterFactory(proto_config, context, context.scope());
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, context, extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/json_to_metadata/config.h
+++ b/source/extensions/filters/http/json_to_metadata/config.h
@@ -13,22 +13,19 @@ namespace HttpFilters {
 namespace JsonToMetadata {
 
 class JsonToMetadataConfig
-    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata> {
 public:
-  JsonToMetadataConfig() : ExceptionFreeFactoryBase("envoy.filters.http.json_to_metadata") {}
+  JsonToMetadataConfig() : UnifiedFactoryBase("envoy.filters.http.json_to_metadata") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata&,
-      const std::string&, Server::Configuration::FactoryContext&) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata&,
       Server::Configuration::ServerFactoryContext&,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::json_to_metadata::v3::JsonToMetadata& proto_config,
       Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);

--- a/source/extensions/filters/http/local_ratelimit/config.cc
+++ b/source/extensions/filters/http/local_ratelimit/config.cc
@@ -12,28 +12,15 @@ namespace Extensions {
 namespace HttpFilters {
 namespace LocalRateLimitFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> LocalRateLimitFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-
-  absl::Status creation_status = absl::OkStatus();
-  FilterConfigSharedPtr filter_config = std::make_shared<FilterConfig>(
-      proto_config, context.serverFactoryContext(), context.scope(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(filter_config));
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 LocalRateLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
   absl::Status creation_status = absl::OkStatus();
-  FilterConfigSharedPtr filter_config =
-      std::make_shared<FilterConfig>(proto_config, context, context.scope(), creation_status);
+  FilterConfigSharedPtr filter_config = std::make_shared<FilterConfig>(
+      proto_config, context, extra_context.scopeOr(context), creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Filter>(filter_config));

--- a/source/extensions/filters/http/local_ratelimit/config.h
+++ b/source/extensions/filters/http/local_ratelimit/config.h
@@ -14,15 +14,12 @@ namespace LocalRateLimitFilter {
  * Config registration for the local rate limit filter. @see NamedHttpFilterConfigFactory.
  */
 class LocalRateLimitFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit> {
 public:
-  LocalRateLimitFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.local_ratelimit") {}
+  LocalRateLimitFilterConfig() : UnifiedFactoryBase("envoy.filters.http.local_ratelimit") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::local_ratelimit::v3::LocalRateLimit& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/mcp_router/config.cc
+++ b/source/extensions/filters/http/mcp_router/config.cc
@@ -23,19 +23,12 @@ absl::StatusOr<Http::FilterFactoryCb> McpRouterFilterConfigFactory::createFilter
 }
 
 absl::StatusOr<Http::FilterFactoryCb>
-McpRouterFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
-                             context.scope());
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 McpRouterFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context));
 }
 
 /**

--- a/source/extensions/filters/http/mcp_router/config.h
+++ b/source/extensions/filters/http/mcp_router/config.h
@@ -14,10 +14,10 @@ namespace McpRouter {
  * Config factory for MCP router filter.
  */
 class McpRouterFilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::mcp_router::v3::McpRouter> {
 public:
-  McpRouterFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.mcp_router") {}
+  McpRouterFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.mcp_router") {}
 
 private:
   bool
@@ -25,16 +25,13 @@ private:
                                Server::Configuration::ServerFactoryContext&) override {
     return true;
   }
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::mcp_router::v3::McpRouter& proto_config,
       const std::string& stats_prefix, Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -169,19 +169,12 @@ OAuth2Config::createFilterFactory(const envoy::extensions::filters::http::oauth2
       };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto, stats_prefix, context.serverFactoryContext(), context.scope(),
-                             context.initManager());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> OAuth2Config::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::oauth2::v3::OAuth2& proto,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto, extra_context.stats_prefix, context, context.scope(),
-                             extra_context.init_manager);
+  return createFilterFactory(proto, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context), extra_context.init_manager);
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/oauth2/config.h
+++ b/source/extensions/filters/http/oauth2/config.h
@@ -12,16 +12,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Oauth2 {
 
-class OAuth2Config : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+class OAuth2Config : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
                          envoy::extensions::filters::http::oauth2::v3::OAuth2,
                          envoy::extensions::filters::http::oauth2::v3::OAuth2PerRoute> {
 public:
-  OAuth2Config() : ExceptionFreeFactoryBase("envoy.filters.http.oauth2") {}
-
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const envoy::extensions::filters::http::oauth2::v3::OAuth2&,
-                                    const std::string&,
-                                    Server::Configuration::FactoryContext&) override;
+  OAuth2Config() : UnifiedFactoryBase("envoy.filters.http.oauth2") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::oauth2::v3::OAuth2&,

--- a/source/extensions/filters/http/proto_api_scrubber/config.cc
+++ b/source/extensions/filters/http/proto_api_scrubber/config.cc
@@ -14,7 +14,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ProtoApiScrubber {
 
-FilterFactoryCreator::FilterFactoryCreator() : ExceptionFreeFactoryBase(kFilterName) {}
+FilterFactoryCreator::FilterFactoryCreator() : UnifiedFactoryBase(kFilterName) {}
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb> FilterFactoryCreator::createFilterFactory(
     const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
@@ -31,20 +31,12 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb> FilterFactoryCreator::createFilterF
 }
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
-FilterFactoryCreator::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
-        proto_config,
-    const std::string&, Envoy::Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
-}
-
-absl::StatusOr<Envoy::Http::FilterFactoryCb>
 FilterFactoryCreator::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
         proto_config,
     Envoy::Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
-  return createFilterFactory(proto_config, context, context.scope());
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, context, extra_context.scopeOr(context));
 }
 
 REGISTER_FACTORY(FilterFactoryCreator, Envoy::Server::Configuration::NamedHttpFilterConfigFactory);

--- a/source/extensions/filters/http/proto_api_scrubber/config.h
+++ b/source/extensions/filters/http/proto_api_scrubber/config.h
@@ -16,25 +16,20 @@ namespace HttpFilters {
 namespace ProtoApiScrubber {
 
 class FilterFactoryCreator
-    : public Envoy::Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Envoy::Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig> {
 public:
   FilterFactoryCreator();
 
 private:
-  absl::StatusOr<Envoy::Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
-          proto_config,
-      const std::string&, Envoy::Server::Configuration::FactoryContext&) override;
-
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
           proto_config,
       Envoy::Server::Configuration::ServerFactoryContext&,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Envoy::Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::proto_api_scrubber::v3::ProtoApiScrubberConfig&
           proto_config,

--- a/source/extensions/filters/http/ratelimit/config.cc
+++ b/source/extensions/filters/http/ratelimit/config.cc
@@ -43,17 +43,11 @@ absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactory
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext(), context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> RateLimitFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
-  return createFilterFactory(proto_config, context, context.scope());
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  return createFilterFactory(proto_config, context, extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/ratelimit/config.h
+++ b/source/extensions/filters/http/ratelimit/config.h
@@ -15,23 +15,20 @@ namespace RateLimitFilter {
  * Config registration for the rate limit filter. @see NamedHttpFilterConfigFactory.
  */
 class RateLimitFilterConfig
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::ratelimit::v3::RateLimit,
           envoy::extensions::filters::http::ratelimit::v3::RateLimitPerRoute> {
 public:
-  RateLimitFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.ratelimit") {}
+  RateLimitFilterConfig() : UnifiedFactoryBase("envoy.filters.http.ratelimit") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. The FilterConfig stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. The
+  // FilterConfig stats are scoped to the given scope.
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactory(
       const envoy::extensions::filters::http::ratelimit::v3::RateLimit& proto_config,
       Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);

--- a/source/extensions/filters/http/rbac/config.cc
+++ b/source/extensions/filters/http/rbac/config.cc
@@ -12,28 +12,14 @@ namespace HttpFilters {
 namespace RBACFilter {
 
 absl::StatusOr<Http::FilterFactoryCb>
-RoleBasedAccessControlFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-
-  auto config = std::make_shared<RoleBasedAccessControlFilterConfig>(
-      proto_config, stats_prefix, context.scope(), context.serverFactoryContext(),
-      context.messageValidationVisitor());
-
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(std::make_shared<RoleBasedAccessControlFilter>(config));
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 RoleBasedAccessControlFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
 
   auto config = std::make_shared<RoleBasedAccessControlFilterConfig>(
-      proto_config, extra_context.stats_prefix, context.scope(), context,
-      context.messageValidationVisitor());
+      proto_config, extra_context.stats_prefix, extra_context.scopeOr(context), context,
+      extra_context.visitor);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(std::make_shared<RoleBasedAccessControlFilter>(config));

--- a/source/extensions/filters/http/rbac/config.h
+++ b/source/extensions/filters/http/rbac/config.h
@@ -14,18 +14,12 @@ namespace RBACFilter {
  * Config registration for the RBAC filter. @see NamedHttpFilterConfigFactory.
  */
 class RoleBasedAccessControlFilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<
-          envoy::extensions::filters::http::rbac::v3::RBAC,
-          envoy::extensions::filters::http::rbac::v3::RBACPerRoute> {
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::rbac::v3::RBAC,
+                                        envoy::extensions::filters::http::rbac::v3::RBACPerRoute> {
 public:
-  RoleBasedAccessControlFilterConfigFactory()
-      : ExceptionFreeFactoryBase("envoy.filters.http.rbac") {}
+  RoleBasedAccessControlFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.rbac") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/set_metadata/config.cc
+++ b/source/extensions/filters/http/set_metadata/config.cc
@@ -14,24 +14,12 @@ namespace Extensions {
 namespace HttpFilters {
 namespace SetMetadataFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> SetMetadataConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  ConfigSharedPtr filter_config(
-      std::make_shared<Config>(proto_config, context.scope(), stats_prefix));
-
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamDecoderFilter(
-        Http::StreamDecoderFilterSharedPtr{new SetMetadataFilter(filter_config)});
-  };
-}
-
 absl::StatusOr<Http::FilterFactoryCb> SetMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
     Server::Configuration::ServerFactoryContext& server_context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  ConfigSharedPtr filter_config(
-      std::make_shared<Config>(proto_config, server_context.scope(), extra_context.stats_prefix));
+  ConfigSharedPtr filter_config(std::make_shared<Config>(
+      proto_config, extra_context.scopeOr(server_context), extra_context.stats_prefix));
 
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(

--- a/source/extensions/filters/http/set_metadata/config.h
+++ b/source/extensions/filters/http/set_metadata/config.h
@@ -13,16 +13,12 @@ namespace SetMetadataFilter {
 /**
  * Config registration for the header-to-metadata filter. @see NamedHttpFilterConfigFactory.
  */
-class SetMetadataConfig : public Common::ExceptionFreeFactoryBase<
+class SetMetadataConfig : public Common::UnifiedFactoryBase<
                               envoy::extensions::filters::http::set_metadata::v3::Config> {
 public:
-  SetMetadataConfig() : ExceptionFreeFactoryBase("envoy.filters.http.set_metadata") {}
+  SetMetadataConfig() : UnifiedFactoryBase("envoy.filters.http.set_metadata") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::set_metadata::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext& server_context,

--- a/source/extensions/filters/http/stateful_session/config.cc
+++ b/source/extensions/filters/http/stateful_session/config.cc
@@ -12,23 +12,13 @@ namespace HttpFilters {
 namespace StatefulSession {
 
 absl::StatusOr<Http::FilterFactoryCb>
-StatefulSessionFactoryConfig::createFilterFactoryFromProtoTyped(
-    const ProtoConfig& proto_config, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  auto filter_config(std::make_shared<StatefulSessionConfig>(proto_config, context, stats_prefix,
-                                                             context.scope()));
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new StatefulSession(filter_config)});
-  };
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 StatefulSessionFactoryConfig::createHttpFilterFactoryFromProtoTyped(
     const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
+  Server::GenericFactoryContextImpl generic_context(
+      context, extra_context.scope, extra_context.visitor, extra_context.init_manager);
   auto filter_config(std::make_shared<StatefulSessionConfig>(
-      proto_config, generic_context, extra_context.stats_prefix, context.scope()));
+      proto_config, generic_context, extra_context.stats_prefix, extra_context.scopeOr(context)));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(Http::StreamFilterSharedPtr{new StatefulSession(filter_config)});
   };

--- a/source/extensions/filters/http/stateful_session/config.h
+++ b/source/extensions/filters/http/stateful_session/config.h
@@ -15,17 +15,11 @@ namespace StatefulSession {
  * Config registration for the stateful session filter. @see NamedHttpFilterConfigFactory.
  */
 class StatefulSessionFactoryConfig
-    : public Common::ExceptionFreeFactoryBase<ProtoConfig, PerRouteProtoConfig> {
+    : public Common::UnifiedFactoryBase<ProtoConfig, PerRouteProtoConfig> {
 public:
-  StatefulSessionFactoryConfig()
-      : ExceptionFreeFactoryBase("envoy.filters.http.stateful_session") {}
+  StatefulSessionFactoryConfig() : UnifiedFactoryBase("envoy.filters.http.stateful_session") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const ProtoConfig& proto_config,
-                                    const std::string& stats_prefix,
-                                    Server::Configuration::FactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;

--- a/source/extensions/filters/http/tap/config.cc
+++ b/source/extensions/filters/http/tap/config.cc
@@ -47,19 +47,12 @@ absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createFilterFactory(
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, stats_prefix, context.serverFactoryContext(),
-                             context.scope(), context.messageValidationVisitor());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> TapFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope(),
-                             context.messageValidationVisitor());
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context), extra_context.visitor);
 }
 
 /**

--- a/source/extensions/filters/http/tap/config.h
+++ b/source/extensions/filters/http/tap/config.h
@@ -14,21 +14,18 @@ namespace TapFilter {
  * Config registration for the tap filter.
  */
 class TapFilterFactory
-    : public Common::ExceptionFreeFactoryBase<envoy::extensions::filters::http::tap::v3::Tap> {
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::tap::v3::Tap> {
 public:
-  TapFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.tap") {}
+  TapFilterFactory() : UnifiedFactoryBase("envoy.filters.http.tap") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
       Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. The FilterConfig stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. The
+  // FilterConfig stats are scoped to the given scope.
   absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const envoy::extensions::filters::http::tap::v3::Tap& proto_config,
                       const std::string& stats_prefix,

--- a/source/extensions/filters/http/thrift_to_metadata/config.cc
+++ b/source/extensions/filters/http/thrift_to_metadata/config.cc
@@ -12,28 +12,15 @@ namespace HttpFilters {
 namespace ThriftToMetadata {
 
 ThriftToMetadataConfig::ThriftToMetadataConfig()
-    : ExceptionFreeFactoryBase("envoy.filters.http.thrift_to_metadata") {}
-
-absl::StatusOr<Http::FilterFactoryCb> ThriftToMetadataConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  absl::Status creation_status = absl::OkStatus();
-  std::shared_ptr<FilterConfig> config =
-      std::make_shared<FilterConfig>(proto_config, context.scope(), creation_status);
-  RETURN_IF_NOT_OK_REF(creation_status);
-
-  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(config));
-  };
-}
+    : UnifiedFactoryBase("envoy.filters.http.thrift_to_metadata") {}
 
 absl::StatusOr<Http::FilterFactoryCb> ThriftToMetadataConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata& proto_config,
     Server::Configuration::ServerFactoryContext& context,
-    Server::Configuration::ExtraFactoryContext&) {
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   absl::Status creation_status = absl::OkStatus();
   std::shared_ptr<FilterConfig> config =
-      std::make_shared<FilterConfig>(proto_config, context.scope(), creation_status);
+      std::make_shared<FilterConfig>(proto_config, extra_context.scopeOr(context), creation_status);
   RETURN_IF_NOT_OK_REF(creation_status);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/thrift_to_metadata/config.h
+++ b/source/extensions/filters/http/thrift_to_metadata/config.h
@@ -13,16 +13,12 @@ namespace HttpFilters {
 namespace ThriftToMetadata {
 
 class ThriftToMetadataConfig
-    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata> {
 public:
   ThriftToMetadataConfig();
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
-      const std::string&, Server::Configuration::FactoryContext&) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::thrift_to_metadata::v3::ThriftToMetadata&,
       Server::Configuration::ServerFactoryContext&,

--- a/source/extensions/filters/http/transform/config.cc
+++ b/source/extensions/filters/http/transform/config.cc
@@ -22,17 +22,11 @@ absl::StatusOr<Http::FilterFactoryCb> TransformFactoryConfig::createFilterFactor
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> TransformFactoryConfig::createFilterFactoryFromProtoTyped(
-    const ProtoConfig& proto_config, const std::string& stat_prefix,
-    Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, stat_prefix, context.serverFactoryContext(),
-                             context.scope());
-}
-
 absl::StatusOr<Http::FilterFactoryCb> TransformFactoryConfig::createHttpFilterFactoryFromProtoTyped(
     const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/transform/config.h
+++ b/source/extensions/filters/http/transform/config.h
@@ -14,21 +14,17 @@ namespace Transform {
 /**
  * Config registration for the stateful session filter. @see NamedHttpFilterConfigFactory.
  */
-class TransformFactoryConfig : public Common::ExceptionFreeFactoryBase<ProtoConfig> {
+class TransformFactoryConfig : public Common::UnifiedFactoryBase<ProtoConfig> {
 public:
-  TransformFactoryConfig() : ExceptionFreeFactoryBase("envoy.filters.http.transform") {}
+  TransformFactoryConfig() : UnifiedFactoryBase("envoy.filters.http.transform") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const ProtoConfig& proto_config,
-                                    const std::string& stats_prefix,
-                                    Server::Configuration::FactoryContext& context) override;
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;
 
-  // Shared factory creation used by both the downstream (FactoryContext) and route/vhost-level
-  // (ServerFactoryContext) paths. Stats are scoped to the given scope.
+  // Shared factory creation used by the listener/cluster and route/vhost-level paths. Stats are
+  // scoped to the given scope.
   static absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactory(const ProtoConfig& proto_config, const std::string& stats_prefix,
                       Server::Configuration::ServerFactoryContext& context, Stats::Scope& scope);

--- a/test/extensions/filters/http/geoip/config_test.cc
+++ b/test/extensions/filters/http/geoip/config_test.cc
@@ -80,7 +80,7 @@ TEST(GeoipFilterConfigTest, GeoipFilterDefaultValues) {
   GeoipFilterConfig filter_config;
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor()).Times(2);
+  EXPECT_CALL(context, messageValidationVisitor());
   GeoipFilterFactory factory;
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(filter_config, "geoip", context).value();
@@ -105,7 +105,7 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigWithCorrectProto) {
   GeoipFilterConfig filter_config;
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor()).Times(2);
+  EXPECT_CALL(context, messageValidationVisitor());
   GeoipFilterFactory factory;
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(filter_config, "geoip", context).value();
@@ -131,10 +131,8 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigWithCorrectProto2) {
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GeoipFilterFactory factory;
-  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{
       context.server_factory_context_.messageValidationVisitor(), "geoip"};
-  EXPECT_CALL(context.server_factory_context_, messageValidationVisitor()).Times(2);
   Http::FilterFactoryCb cb = factory
                                  .createHttpFilterFactoryFromProto(
                                      filter_config, context.server_factory_context_, extra_context)
@@ -171,6 +169,8 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigUnknownProvider) {
   std::string filter_config_yaml = R"EOF(
     provider:
         name: "envoy.geoip_providers.unknown"
+        typed_config:
+          "@type": type.googleapis.com/google.protobuf.Struct
   )EOF";
   GeoipFilterConfig filter_config;
 
@@ -178,10 +178,10 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigUnknownProvider) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GeoipFilterFactory factory;
   EXPECT_THROW_WITH_MESSAGE(
-      factory.createFilterFactoryFromProtoTyped(filter_config, "geoip", context).IgnoreError(),
+      factory.createFilterFactoryFromProto(filter_config, "geoip", context).IgnoreError(),
       Envoy::EnvoyException,
       "Didn't find a registered implementation for 'envoy.geoip_providers.unknown' with type URL: "
-      "''");
+      "'google.protobuf.Struct'");
 }
 
 TEST(GeoipFilterConfigTest, GeoipFilterConfigWithIpAddressHeader) {
@@ -199,7 +199,7 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigWithIpAddressHeader) {
   GeoipFilterConfig filter_config;
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
-  EXPECT_CALL(context, messageValidationVisitor()).Times(2);
+  EXPECT_CALL(context, messageValidationVisitor());
   GeoipFilterFactory factory;
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(filter_config, "geoip", context).value();
@@ -227,7 +227,7 @@ TEST(GeoipFilterConfigTest, GeoipFilterConfigMutualExclusionXffAndIpAddressHeade
   TestUtility::loadFromYaml(filter_config_yaml, filter_config);
   NiceMock<Server::Configuration::MockFactoryContext> context;
   GeoipFilterFactory factory;
-  auto status_or = factory.createFilterFactoryFromProtoTyped(filter_config, "geoip", context);
+  auto status_or = factory.createFilterFactoryFromProto(filter_config, "geoip", context);
   EXPECT_THAT(status_or,
               HasStatusMessage(
                   "Only one of xff_config or custom_header_config can be set in the geoip filter "

--- a/test/extensions/filters/http/oauth2/config_test.cc
+++ b/test/extensions/filters/http/oauth2/config_test.cc
@@ -504,7 +504,7 @@ TEST(ConfigTest, CreateFilterMissingConfig) {
 
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
   const auto result =
-      config.createFilterFactoryFromProtoTyped(proto_config, "whatever", factory_context);
+      config.createFilterFactoryFromProto(proto_config, "whatever", factory_context);
   // Empty config is valid, config can be provided at route level.
   EXPECT_OK(result);
 }


### PR DESCRIPTION
Commit Message: filter: merge filter factory interface into single one 2
Additional Description:

Continuous work of https://github.com/envoyproxy/envoy/pull/46835. With the new `createHttpFilterFactoryFromProto` we could unify all our downstream/upstream/route HTTP filter factory creation into single method.

Also, no behavior change, won't break any existing extensions.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.