### PR TITLE
router: support extension formatters in route header manipulation

### DIFF
--- a/api/envoy/config/core/v3/base.proto
+++ b/api/envoy/config/core/v3/base.proto
@@ -421,6 +421,18 @@ message HeaderValue {
   // unknown header values are replaced with the empty string instead of ``-``.
   // Header value is encoded as string. This does not work for non-utf8 characters.
   // Only one of ``value`` or ``raw_value`` can be set.
+  //
+  // .. note::
+  //
+  //   Only the built-in :ref:`command operators <config_access_log_command_operators>` are
+  //   available by default. Extension formatters (for example ``%FILE_CONTENT()%`` or
+  //   ``%REQ_WITHOUT_QUERY()%``) are *not* enabled here automatically; using one that has not been
+  //   enabled is rejected at configuration load with ``Not supported field in StreamInfo:
+  //   <COMMAND>``. To use an extension formatter in a header value, the surrounding configuration
+  //   must expose a ``formatters`` field and the extension must be listed there. For header
+  //   mutations on routes, virtual hosts and weighted clusters this is the
+  //   :ref:`RouteConfiguration.formatters
+  //   <envoy_v3_api_field_config.route.v3.RouteConfiguration.formatters>` field.
   string value = 2 [
     (validate.rules).string = {max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false},
     (udpa.annotations.field_migrate).oneof_promotion = "value_type"

--- a/api/envoy/config/route/v3/route.proto
+++ b/api/envoy/config/route/v3/route.proto
@@ -4,6 +4,7 @@ package envoy.config.route.v3;
 
 import "envoy/config/core/v3/base.proto";
 import "envoy/config/core/v3/config_source.proto";
+import "envoy/config/core/v3/extension.proto";
 import "envoy/config/route/v3/route_components.proto";
 
 import "google/protobuf/any.proto";
@@ -23,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // * Routing :ref:`architecture overview <arch_overview_http_routing>`
 // * HTTP :ref:`router filter <config_http_filters_router>`
 
-// [#next-free-field: 19]
+// [#next-free-field: 20]
 message RouteConfiguration {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.RouteConfiguration";
 
@@ -162,6 +163,18 @@ message RouteConfiguration {
   // For instance, if the metadata is intended for the Router filter,
   // the filter name should be specified as ``envoy.filters.http.router``.
   core.v3.Metadata metadata = 17;
+
+  // Specifies a collection of Formatter plugins that can be used in substitution format strings
+  // for ``request_headers_to_add`` and ``response_headers_to_add`` values at any level of the
+  // route configuration (route configuration, virtual host, route, or weighted cluster).
+  // The formatters declared here are inherited by all virtual hosts and routes within this route
+  // configuration, and are the mechanism to enable extension formatters (for example
+  // ``envoy.formatter.req_without_query``) in header values; without them only the built-in
+  // :ref:`command operators <config_access_log_command_operators>` are available. See the
+  // formatters extensions documentation and :ref:`custom request headers
+  // <config_http_conn_man_headers_custom_request_headers>` for more information.
+  // [#extension-category: envoy.formatter]
+  repeated core.v3.TypedExtensionConfig formatters = 19;
 }
 
 message Vhds {

--- a/changelogs/current/new_features/router__added-route-config-formatters.rst
+++ b/changelogs/current/new_features/router__added-route-config-formatters.rst
@@ -1,0 +1,8 @@
+Added :ref:`RouteConfiguration.formatters
+<envoy_v3_api_field_config.route.v3.RouteConfiguration.formatters>`, allowing extension
+formatters (for example ``envoy.formatter.req_without_query``) to be used in
+``request_headers_to_add`` and
+``response_headers_to_add`` values at the route configuration, virtual host, route, and weighted
+cluster levels. Previously only built-in command operators were available in header values, and
+using an extension formatter was rejected at configuration load with
+``Not supported field in StreamInfo: <COMMAND>``.

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -599,13 +599,15 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
 
   if (!route.request_headers_to_add().empty() || !route.request_headers_to_remove().empty()) {
     auto parser_or_error =
-        HeaderParser::configure(route.request_headers_to_add(), route.request_headers_to_remove());
+        HeaderParser::configure(route.request_headers_to_add(), route.request_headers_to_remove(),
+                                vhost_->globalRouteConfig().commandParsers());
     SET_AND_RETURN_IF_NOT_OK(parser_or_error.status(), creation_status);
     request_headers_parser_ = std::move(parser_or_error.value());
   }
   if (!route.response_headers_to_add().empty() || !route.response_headers_to_remove().empty()) {
-    auto parser_or_error = HeaderParser::configure(route.response_headers_to_add(),
-                                                   route.response_headers_to_remove());
+    auto parser_or_error =
+        HeaderParser::configure(route.response_headers_to_add(), route.response_headers_to_remove(),
+                                vhost_->globalRouteConfig().commandParsers());
     SET_AND_RETURN_IF_NOT_OK(parser_or_error.status(), creation_status);
     response_headers_parser_ = std::move(parser_or_error.value());
   }
@@ -635,7 +637,8 @@ RouteEntryImplBase::RouteEntryImplBase(const CommonVirtualHostSharedPtr& vhost,
   if (route.route().has_weighted_clusters()) {
     cluster_specifier_plugin_ = std::make_shared<WeightedClusterSpecifierPlugin>(
         route.route().weighted_clusters(), metadata_match_criteria_.get(), route_name_,
-        factory_context, init_manager, creation_status);
+        factory_context, init_manager, vhost_->globalRouteConfig().commandParsers(),
+        creation_status);
     RETURN_ONLY_IF_NOT_OK_REF(creation_status);
   } else if (route.route().has_inline_cluster_specifier_plugin()) {
     auto plugin_or_error = getClusterSpecifierPluginByTheProto(
@@ -1631,14 +1634,16 @@ CommonVirtualHostImpl::CommonVirtualHostImpl(
       !virtual_host.request_headers_to_remove().empty()) {
     request_headers_parser_ =
         THROW_OR_RETURN_VALUE(HeaderParser::configure(virtual_host.request_headers_to_add(),
-                                                      virtual_host.request_headers_to_remove()),
+                                                      virtual_host.request_headers_to_remove(),
+                                                      global_route_config_->commandParsers()),
                               Router::HeaderParserPtr);
   }
   if (!virtual_host.response_headers_to_add().empty() ||
       !virtual_host.response_headers_to_remove().empty()) {
     response_headers_parser_ =
         THROW_OR_RETURN_VALUE(HeaderParser::configure(virtual_host.response_headers_to_add(),
-                                                      virtual_host.response_headers_to_remove()),
+                                                      virtual_host.response_headers_to_remove(),
+                                                      global_route_config_->commandParsers()),
                               Router::HeaderParserPtr);
   }
 
@@ -2154,17 +2159,26 @@ CommonConfigImpl::CommonConfigImpl(const envoy::config::route::v3::RouteConfigur
     internal_only_headers_.push_back(Http::LowerCaseString(header));
   }
 
+  if (!config.formatters().empty()) {
+    Server::GenericFactoryContextImpl generic_context(factory_context,
+                                                      factory_context.messageValidationVisitor());
+    auto parsers_or_error = Formatter::SubstitutionFormatStringUtils::parseFormatters(
+        config.formatters(), generic_context);
+    SET_AND_RETURN_IF_NOT_OK(parsers_or_error.status(), creation_status);
+    command_parsers_ = std::move(*parsers_or_error);
+  }
+
   if (!config.request_headers_to_add().empty() || !config.request_headers_to_remove().empty()) {
-    request_headers_parser_ =
-        THROW_OR_RETURN_VALUE(HeaderParser::configure(config.request_headers_to_add(),
-                                                      config.request_headers_to_remove()),
-                              Router::HeaderParserPtr);
+    request_headers_parser_ = THROW_OR_RETURN_VALUE(
+        HeaderParser::configure(config.request_headers_to_add(), config.request_headers_to_remove(),
+                                command_parsers_),
+        Router::HeaderParserPtr);
   }
   if (!config.response_headers_to_add().empty() || !config.response_headers_to_remove().empty()) {
-    response_headers_parser_ =
-        THROW_OR_RETURN_VALUE(HeaderParser::configure(config.response_headers_to_add(),
-                                                      config.response_headers_to_remove()),
-                              Router::HeaderParserPtr);
+    response_headers_parser_ = THROW_OR_RETURN_VALUE(
+        HeaderParser::configure(config.response_headers_to_add(),
+                                config.response_headers_to_remove(), command_parsers_),
+        Router::HeaderParserPtr);
   }
 
   if (config.has_metadata()) {

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -1390,6 +1390,7 @@ public:
   }
   const envoy::config::core::v3::Metadata& metadata() const override;
   const Envoy::Config::TypedMetadata& typedMetadata() const override;
+  const Formatter::CommandParserPtrVector& commandParsers() const { return command_parsers_; }
 
 private:
   CommonConfigImpl(const envoy::config::route::v3::RouteConfiguration& config,
@@ -1397,6 +1398,7 @@ private:
                    ProtobufMessage::ValidationVisitor& validator, Init::Manager& init_manager,
                    absl::Status& creation_status);
   std::vector<Http::LowerCaseString> internal_only_headers_;
+  Formatter::CommandParserPtrVector command_parsers_;
   HeaderParserPtr request_headers_parser_;
   HeaderParserPtr response_headers_parser_;
   const std::string name_;

--- a/source/common/router/header_parser.cc
+++ b/source/common/router/header_parser.cc
@@ -142,7 +142,14 @@ absl::StatusOr<HeaderParserPtr> HeaderParser::configure(
 absl::StatusOr<HeaderParserPtr>
 HeaderParser::configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
                         const Protobuf::RepeatedPtrField<std::string>& headers_to_remove) {
-  auto parser_or_error = configure(headers_to_add);
+  return configure(headers_to_add, headers_to_remove, Formatter::CommandParserPtrVector{});
+}
+
+absl::StatusOr<HeaderParserPtr>
+HeaderParser::configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
+                        const Protobuf::RepeatedPtrField<std::string>& headers_to_remove,
+                        const Formatter::CommandParserPtrVector& command_parsers) {
+  auto parser_or_error = configure(headers_to_add, command_parsers);
   RETURN_IF_NOT_OK_REF(parser_or_error.status());
   HeaderParserPtr header_parser = std::move(parser_or_error.value());
 

--- a/source/common/router/header_parser.h
+++ b/source/common/router/header_parser.h
@@ -101,6 +101,18 @@ public:
   configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
             const Protobuf::RepeatedPtrField<std::string>& headers_to_remove);
 
+  /*
+   * @param headers_to_add defines headers to add during calls to evaluateHeaders.
+   * @param headers_to_remove defines headers to remove during calls to evaluateHeaders.
+   * @param command_parsers custom formatter command parsers for extension formatters (e.g.
+   * %SECRET()%).
+   * @return HeaderParserPtr a configured HeaderParserPtr.
+   */
+  static absl::StatusOr<HeaderParserPtr>
+  configure(const Protobuf::RepeatedPtrField<HeaderValueOption>& headers_to_add,
+            const Protobuf::RepeatedPtrField<std::string>& headers_to_remove,
+            const Formatter::CommandParserPtrVector& command_parsers);
+
   static const HeaderParser& defaultParser() {
     static HeaderParser* instance = new HeaderParser();
     return *instance;

--- a/source/common/router/weighted_cluster_specifier.cc
+++ b/source/common/router/weighted_cluster_specifier.cc
@@ -75,16 +75,19 @@ std::optional<size_t> pickClusterIndex(absl::Span<T> weighed_clusters, uint64_t 
 absl::StatusOr<std::shared_ptr<WeightedClustersConfigEntry>> WeightedClustersConfigEntry::create(
     const ClusterWeightProto& cluster, uint64_t index,
     const MetadataMatchCriteria* parent_metadata_match, absl::string_view runtime_key_prefix,
-    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
+    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager,
+    const Formatter::CommandParserPtrVector& command_parsers) {
   RETURN_IF_NOT_OK(validateWeightedClusterSpecifier(cluster));
-  return std::unique_ptr<WeightedClustersConfigEntry>(new WeightedClustersConfigEntry(
-      cluster, index, parent_metadata_match, runtime_key_prefix, context, init_manager));
+  return std::unique_ptr<WeightedClustersConfigEntry>(
+      new WeightedClustersConfigEntry(cluster, index, parent_metadata_match, runtime_key_prefix,
+                                      context, init_manager, command_parsers));
 }
 
 WeightedClustersConfigEntry::WeightedClustersConfigEntry(
     const envoy::config::route::v3::WeightedCluster::ClusterWeight& cluster, uint64_t index,
     const MetadataMatchCriteria* parent_metadata_match, absl::string_view runtime_key_prefix,
-    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager)
+    Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager,
+    const Formatter::CommandParserPtrVector& command_parsers)
     : runtime_key_(runtime_key_prefix.empty()
                        ? ""
                        : fmt::format("{}.{}", runtime_key_prefix, cluster.name())),
@@ -96,16 +99,16 @@ WeightedClustersConfigEntry::WeightedClustersConfigEntry(
       host_rewrite_(cluster.host_rewrite_literal()), cluster_name_(cluster.name()),
       cluster_header_name_(cluster.cluster_header()) {
   if (!cluster.request_headers_to_add().empty() || !cluster.request_headers_to_remove().empty()) {
-    request_headers_parser_ =
-        THROW_OR_RETURN_VALUE(HeaderParser::configure(cluster.request_headers_to_add(),
-                                                      cluster.request_headers_to_remove()),
-                              Router::HeaderParserPtr);
+    request_headers_parser_ = THROW_OR_RETURN_VALUE(
+        HeaderParser::configure(cluster.request_headers_to_add(),
+                                cluster.request_headers_to_remove(), command_parsers),
+        Router::HeaderParserPtr);
   }
   if (!cluster.response_headers_to_add().empty() || !cluster.response_headers_to_remove().empty()) {
-    response_headers_parser_ =
-        THROW_OR_RETURN_VALUE(HeaderParser::configure(cluster.response_headers_to_add(),
-                                                      cluster.response_headers_to_remove()),
-                              Router::HeaderParserPtr);
+    response_headers_parser_ = THROW_OR_RETURN_VALUE(
+        HeaderParser::configure(cluster.response_headers_to_add(),
+                                cluster.response_headers_to_remove(), command_parsers),
+        Router::HeaderParserPtr);
   }
 
   if (cluster.has_metadata_match()) {
@@ -127,7 +130,7 @@ WeightedClusterSpecifierPlugin::WeightedClusterSpecifierPlugin(
     const WeightedClusterProto& weighted_clusters,
     const MetadataMatchCriteria* parent_metadata_match, absl::string_view route_name,
     Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager,
-    absl::Status& creation_status)
+    const Formatter::CommandParserPtrVector& command_parsers, absl::Status& creation_status)
     : loader_(context.runtime()), random_value_header_(weighted_clusters.header_name()),
       use_hash_policy_(weighted_clusters.random_value_specifier_case() ==
                                WeightedClusterProto::kUseHashPolicy
@@ -145,7 +148,7 @@ WeightedClusterSpecifierPlugin::WeightedClusterSpecifierPlugin(
     auto cluster_entry =
         THROW_OR_RETURN_VALUE(WeightedClustersConfigEntry::create(
                                   cluster, weighted_clusters_.size(), parent_metadata_match,
-                                  runtime_key_prefix, context, init_manager),
+                                  runtime_key_prefix, context, init_manager, command_parsers),
                               std::shared_ptr<WeightedClustersConfigEntry>);
     weighted_clusters_.emplace_back(std::move(cluster_entry));
     total_cluster_weight += weighted_clusters_.back()->clusterWeight(loader_);

--- a/source/common/router/weighted_cluster_specifier.h
+++ b/source/common/router/weighted_cluster_specifier.h
@@ -24,7 +24,8 @@ public:
   static absl::StatusOr<std::shared_ptr<WeightedClustersConfigEntry>>
   create(const ClusterWeightProto& cluster, uint64_t index,
          const MetadataMatchCriteria* parent_metadata_match, absl::string_view runtime_key_prefix,
-         Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager);
+         Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager,
+         const Formatter::CommandParserPtrVector& command_parsers);
 
   uint64_t clusterWeight(Runtime::Loader& loader) const {
     return runtime_key_.empty() ? cluster_weight_
@@ -41,7 +42,8 @@ private:
                               const MetadataMatchCriteria* parent_metadata_match,
                               absl::string_view runtime_key_prefix,
                               Server::Configuration::ServerFactoryContext& context,
-                              Init::Manager& init_manager);
+                              Init::Manager& init_manager,
+                              const Formatter::CommandParserPtrVector& command_parsers);
 
   const std::string runtime_key_;
   const uint64_t cluster_weight_{};
@@ -67,7 +69,9 @@ public:
                                  const MetadataMatchCriteria* parent_metadata_match,
                                  absl::string_view route_name,
                                  Server::Configuration::ServerFactoryContext& context,
-                                 Init::Manager& init_manager, absl::Status& creation_status);
+                                 Init::Manager& init_manager,
+                                 const Formatter::CommandParserPtrVector& command_parsers,
+                                 absl::Status& creation_status);
 
   RouteConstSharedPtr route(RouteEntryAndRouteConstSharedPtr parent,
                             const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo&,

--- a/test/common/router/BUILD
+++ b/test/common/router/BUILD
@@ -58,6 +58,7 @@ envoy_cc_test_library(
         "//source/common/stream_info:filter_state_lib",
         "//source/common/stream_info:upstream_address_lib",
         "//source/extensions/formatter/cel:config",
+        "//test/common/formatter:command_extension_lib",
         "//test/extensions/filters/http/common:empty_http_filter_config_lib",
         "//test/fuzz:utility_lib",
         "//test/mocks/init:init_mocks",

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -23,6 +23,7 @@
 #include "source/common/stream_info/filter_state_impl.h"
 #include "source/common/stream_info/upstream_address.h"
 
+#include "test/common/formatter/command_extension.h"
 #include "test/common/router/route_fuzz.pb.h"
 #include "test/extensions/filters/http/common/empty_http_filter_config.h"
 #include "test/fuzz/utility.h"
@@ -1547,6 +1548,157 @@ virtual_hosts:
                         creation_status_);
   EXPECT_THAT(creation_status_,
               HasStatusMessage(testing::HasSubstr("Failed to create host rewrite formatter: ")));
+}
+
+// Verify that an extension formatter (CommandParserFactory) used in a route header value without
+// declaring it in the route config 'formatters' field fails with a clear error, even when the
+// extension is registered in the factory registry. Extension formatters must be explicitly
+// declared to be usable in header values.
+TEST_F(RouteMatcherTest, TestRouteHeadersExtensionFormatterUndeclared) {
+  Envoy::Formatter::TestCommandFactory test_factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
+
+  const std::string yaml = R"EOF(
+virtual_hosts:
+  - name: test
+    domains: ["*"]
+    routes:
+      - match:
+          prefix: "/"
+        route:
+          cluster: "www2"
+        request_headers_to_add:
+          - header:
+              key: x-custom
+              value: "%COMMAND_EXTENSION()%"
+)EOF";
+
+  factory_context_.cluster_manager_.initializeClusters({"www2"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_FALSE(creation_status_.ok());
+  EXPECT_TRUE(absl::StrContains(creation_status_.message(),
+                                "Not supported field in StreamInfo: COMMAND_EXTENSION"));
+}
+
+// Verify that declaring an extension formatter (CommandParserFactory) in the route config
+// 'formatters' field makes it available for use in header values at the virtual host and route
+// levels, and that it evaluates correctly.
+TEST_F(RouteMatcherTest, TestRouteHeadersWithDeclaredExtensionFormatter) {
+  Envoy::Formatter::TestCommandFactory test_factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
+
+  const std::string yaml = R"EOF(
+formatters:
+  - name: envoy.formatter.TestFormatter
+    typed_config:
+      "@type": type.googleapis.com/google.protobuf.StringValue
+virtual_hosts:
+  - name: test
+    domains: ["*"]
+    request_headers_to_add:
+      - header:
+          key: x-vhost-custom
+          value: "%COMMAND_EXTENSION()%"
+    routes:
+      - match:
+          prefix: "/"
+        route:
+          cluster: "www2"
+        request_headers_to_add:
+          - header:
+              key: x-route-custom
+              value: "%COMMAND_EXTENSION()%"
+)EOF";
+
+  factory_context_.cluster_manager_.initializeClusters({"www2"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  ASSERT_TRUE(creation_status_.ok()) << creation_status_.message();
+
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+  const RouteEntry* route_entry = config.route(headers, 0)->routeEntry();
+  const Formatter::Context formatter_context(&headers);
+  route_entry->finalizeRequestHeaders(headers, formatter_context, stream_info, true);
+
+  // The extension formatter emits a fixed token, proving it was resolved and evaluated.
+  EXPECT_EQ("TestFormatter", headers.get_("x-vhost-custom"));
+  EXPECT_EQ("TestFormatter", headers.get_("x-route-custom"));
+}
+
+// Verify that a declared extension formatter is also available for header values on weighted
+// clusters, and evaluates correctly.
+TEST_F(RouteMatcherTest, TestWeightedClusterHeadersWithDeclaredExtensionFormatter) {
+  Envoy::Formatter::TestCommandFactory test_factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
+
+  const std::string yaml = R"EOF(
+formatters:
+  - name: envoy.formatter.TestFormatter
+    typed_config:
+      "@type": type.googleapis.com/google.protobuf.StringValue
+virtual_hosts:
+  - name: test
+    domains: ["*"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            clusters:
+              - name: cluster1
+                weight: 100
+                request_headers_to_add:
+                  - header:
+                      key: x-cluster-custom
+                      value: "%COMMAND_EXTENSION()%"
+)EOF";
+
+  factory_context_.cluster_manager_.initializeClusters({"cluster1"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  ASSERT_TRUE(creation_status_.ok()) << creation_status_.message();
+
+  NiceMock<Envoy::StreamInfo::MockStreamInfo> stream_info;
+  Http::TestRequestHeaderMapImpl headers = genHeaders("www.lyft.com", "/foo", "GET");
+  // Keep the cached route alive: for weighted clusters config.route() returns a shared_ptr that
+  // owns a dynamically-created route entry.
+  RouteConstSharedPtr cached_route = config.route(headers, 0);
+  const RouteEntry* route_entry = cached_route->routeEntry();
+  EXPECT_EQ("cluster1", route_entry->clusterName());
+  const Formatter::Context formatter_context(&headers);
+  route_entry->finalizeRequestHeaders(headers, formatter_context, stream_info, true);
+
+  EXPECT_EQ("TestFormatter", headers.get_("x-cluster-custom"));
+}
+
+// Verify that an extension formatter used on a weighted cluster header without declaring it in the
+// route config 'formatters' field fails with a clear error.
+TEST_F(RouteMatcherTest, TestWeightedClusterHeadersExtensionFormatterUndeclared) {
+  Envoy::Formatter::TestCommandFactory test_factory;
+  Registry::InjectFactory<Envoy::Formatter::CommandParserFactory> register_factory(test_factory);
+
+  const std::string yaml = R"EOF(
+virtual_hosts:
+  - name: test
+    domains: ["*"]
+    routes:
+      - match: { prefix: "/" }
+        route:
+          weighted_clusters:
+            clusters:
+              - name: cluster1
+                weight: 100
+                request_headers_to_add:
+                  - header:
+                      key: x-cluster-custom
+                      value: "%COMMAND_EXTENSION()%"
+)EOF";
+
+  factory_context_.cluster_manager_.initializeClusters({"cluster1"}, {});
+  EXPECT_THROW_WITH_REGEX(TestConfigImpl(parseRouteConfigurationFromYaml(yaml), factory_context_,
+                                         true, creation_status_),
+                          EnvoyException, "Not supported field in StreamInfo: COMMAND_EXTENSION");
 }
 
 // Virtual cluster that contains neither pattern nor regex. This must be checked while pattern is


### PR DESCRIPTION
Commit Message: router: support extension formatters in route header manipulation

Additional Description:

Extension formatters (registered as `CommandParserFactory`, e.g. `envoy.formatter.req_without_query`) were rejected when used in `request_headers_to_add` / `response_headers_to_add` values on routes, virtual hosts, weighted clusters, or the route configuration, failing config load with:

```
Not supported field in StreamInfo: <COMMAND>
```

Only the built-in command operators were available to route header parsing, because extension formatters must be explicitly instantiated with a factory context. The header-manipulation documentation says header values accept "the same format specifier as used for HTTP access logging", so this was a gap for extension formatters.

This adds a `formatters` field to `RouteConfiguration`, mirroring the existing pattern used for `HttpService.formatters` and TCP proxy `TunnelingConfig.formatters`. The declared formatters are parsed once on the route configuration and the resulting command parsers are inherited by all virtual hosts, routes, and weighted clusters when building their header parsers.

Example:

```yaml
formatters:
- name: envoy.formatter.req_without_query
  typed_config:
    "@type": type.googleapis.com/envoy.extensions.formatter.req_without_query.v3.ReqWithoutQuery
virtual_hosts:
- name: local
  domains: ["*"]
  routes:
  - match: { prefix: "/" }
    route: { cluster: some_service }
    request_headers_to_add:
    - header:
        key: x-original-path
        value: "%REQ_WITHOUT_QUERY(:path)%"
```

The `config.core.v3.HeaderValue` documentation is also updated to note that extension formatters are not enabled by default in header values and must be declared via such a `formatters` field.

Risk Level: Low — additive API field; behavior is unchanged when `formatters` is not set. The new command parsers are only threaded through existing header-parser construction paths.

Testing: Unit tests added in `test/common/router/config_impl_test.cc` covering extension-formatter header values at the route and weighted-cluster levels — both successful evaluation when the formatter is declared and a clear error when it is used but not declared. Tests use the existing `command_extension` test helper (a test-local `CommandParserFactory`).

Docs Changes: Added `RouteConfiguration.formatters` field documentation and a note on `config.core.v3.HeaderValue.value` describing the extension-formatter requirement.

Release Notes: Added (new_features) — see `changelogs/current/new_features/router__added-route-config-formatters.rst`.

Platform Specific Features: n/a