### PR TITLE
filter: use unified factory to replace the previous one

### DIFF
--- a/source/common/router/upstream_codec_filter.h
+++ b/source/common/router/upstream_codec_filter.h
@@ -107,16 +107,16 @@ private:
 };
 
 class UpstreamCodecFilterFactory
-    : public Extensions::HttpFilters::Common::CommonFactoryBase<
-          envoy::extensions::filters::http::upstream_codec::v3::UpstreamCodec>,
-      public Server::Configuration::UpstreamHttpFilterConfigFactory {
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
+          envoy::extensions::filters::http::upstream_codec::v3::UpstreamCodec> {
 public:
-  UpstreamCodecFilterFactory() : CommonFactoryBase("envoy.filters.http.upstream_codec") {}
+  UpstreamCodecFilterFactory() : UnifiedFactoryBase("envoy.filters.http.upstream_codec") {}
 
   std::string category() const override { return "envoy.filters.http.upstream"; }
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProto(const Protobuf::Message&, const std::string&,
-                               Server::Configuration::UpstreamFactoryContext&) override {
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::upstream_codec::v3::UpstreamCodec&,
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(std::make_shared<UpstreamCodecFilter>());
     };

--- a/source/extensions/filters/http/aws_eventstream_parser/config.cc
+++ b/source/extensions/filters/http/aws_eventstream_parser/config.cc
@@ -9,14 +9,16 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AwsEventstreamParser {
 
-absl::StatusOr<Http::FilterFactoryCb> AwsEventstreamParserConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+AwsEventstreamParserConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::aws_eventstream_parser::v3::AwsEventstreamParser&
         proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
   // Create shared config (which instantiates the parser from TypedExtensionConfig)
   // Note: content_parser is validated as required by proto validation rules
-  auto config = std::make_shared<FilterConfig>(proto_config, context.serverFactoryContext());
+  auto config = std::make_shared<FilterConfig>(proto_config, context);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamEncoderFilter(std::make_shared<Filter>(config));

--- a/source/extensions/filters/http/aws_eventstream_parser/config.h
+++ b/source/extensions/filters/http/aws_eventstream_parser/config.h
@@ -16,17 +16,17 @@ namespace AwsEventstreamParser {
  * Config registration for the AWS EventStream Parser filter.
  */
 class AwsEventstreamParserConfig
-    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::aws_eventstream_parser::v3::AwsEventstreamParser> {
 public:
-  AwsEventstreamParserConfig()
-      : ExceptionFreeFactoryBase("envoy.filters.http.aws_eventstream_parser") {}
+  AwsEventstreamParserConfig() : UnifiedFactoryBase("envoy.filters.http.aws_eventstream_parser") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::aws_eventstream_parser::v3::AwsEventstreamParser&
           proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace AwsEventstreamParser

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.cc
@@ -92,9 +92,8 @@ private:
 
 struct Config {
   Config(const envoy::extensions::filters::http::grpc_stats::v3::FilterConfig& proto_config,
-         Server::Configuration::FactoryContext& context)
-      : context_(context.serverFactoryContext().grpcContext()),
-        emit_filter_state_(proto_config.emit_filter_state()),
+         Server::Configuration::ServerFactoryContext& context)
+      : context_(context.grpcContext()), emit_filter_state_(proto_config.emit_filter_state()),
         enable_upstream_stats_(proto_config.enable_upstream_stats()),
         replace_dots_in_grpc_service_name_(proto_config.replace_dots_in_grpc_service_name()),
         stats_for_all_methods_(
@@ -315,11 +314,12 @@ private:
 } // namespace
 
 absl::StatusOr<Http::FilterFactoryCb>
-GrpcStatsFilterConfigFactory::createFilterFactoryFromProtoTyped(
+GrpcStatsFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::grpc_stats::v3::FilterConfig& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& factory_context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
 
-  ConfigConstSharedPtr config = std::make_shared<const Config>(proto_config, factory_context);
+  ConfigConstSharedPtr config = std::make_shared<const Config>(proto_config, context);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) {
     callbacks.addStreamFilter(std::make_shared<GrpcStatsFilter>(config));

--- a/source/extensions/filters/http/grpc_stats/grpc_stats_filter.h
+++ b/source/extensions/filters/http/grpc_stats/grpc_stats_filter.h
@@ -30,15 +30,16 @@ struct GrpcStatsObject : public StreamInfo::FilterState::Object {
 };
 
 class GrpcStatsFilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::grpc_stats::v3::FilterConfig> {
 public:
-  GrpcStatsFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.grpc_stats") {}
+  GrpcStatsFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.grpc_stats") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::grpc_stats::v3::FilterConfig& proto_config,
-      const std::string&, Server::Configuration::FactoryContext&) override;
+      Server::Configuration::ServerFactoryContext&,
+      Server::Configuration::ExtraFactoryContext&) override;
 };
 
 } // namespace GrpcStats

--- a/source/extensions/filters/http/kill_request/kill_request_config.cc
+++ b/source/extensions/filters/http/kill_request/kill_request_config.cc
@@ -11,12 +11,14 @@ namespace Extensions {
 namespace HttpFilters {
 namespace KillRequest {
 
-absl::StatusOr<Http::FilterFactoryCb> KillRequestFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+KillRequestFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   return [proto_config, &context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<KillRequestFilter>(
-        proto_config, context.serverFactoryContext().api().randomGenerator()));
+    callbacks.addStreamFilter(
+        std::make_shared<KillRequestFilter>(proto_config, context.api().randomGenerator()));
   };
 }
 

--- a/source/extensions/filters/http/kill_request/kill_request_config.h
+++ b/source/extensions/filters/http/kill_request/kill_request_config.h
@@ -14,15 +14,16 @@ namespace KillRequest {
  * Config registration for KillRequestFilter. @see NamedHttpFilterConfigFactory.
  */
 class KillRequestFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::kill_request::v3::KillRequest> {
 public:
-  KillRequestFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.kill_request") {}
+  KillRequestFilterFactory() : UnifiedFactoryBase("envoy.filters.http.kill_request") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::kill_request::v3::KillRequest& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/upstream_rbac/config.cc
+++ b/source/extensions/filters/http/upstream_rbac/config.cc
@@ -13,14 +13,10 @@ namespace HttpFilters {
 namespace UpstreamRBACFilter {
 
 absl::StatusOr<Http::FilterFactoryCb>
-UpstreamRoleBasedAccessControlFilterConfigFactory::createFilterFactoryFromProto(
-    const Protobuf::Message& proto_config, const std::string& stats_prefix,
-    Server::Configuration::UpstreamFactoryContext& context) {
-  auto& server_context = context.serverFactoryContext();
-  const auto& typed_config =
-      MessageUtil::downcastAndValidate<const envoy::extensions::filters::http::rbac::v3::RBAC&>(
-          proto_config, server_context.messageValidationVisitor());
-
+UpstreamRoleBasedAccessControlFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::rbac::v3::RBAC& typed_config,
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   // stats_prefix carries the parent's namespace ("http.<stat_prefix>." from a router,
   // "cluster.<name>." from a cluster) so RBAC counters land in the right place. This is a behavior
   // change, so it is guarded by the runtime flag; when disabled we fall back to the previous empty
@@ -28,11 +24,11 @@ UpstreamRoleBasedAccessControlFilterConfigFactory::createFilterFactoryFromProto(
   const std::string& rbac_stats_prefix =
       Runtime::runtimeFeatureEnabled(
           "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
-          ? stats_prefix
+          ? extra_context.stats_prefix
           : EMPTY_STRING;
   auto config = std::make_shared<RBACFilter::RoleBasedAccessControlFilterConfig>(
-      typed_config, rbac_stats_prefix, context.scope(), server_context,
-      server_context.messageValidationVisitor());
+      typed_config, rbac_stats_prefix, extra_context.scopeOr(context), context,
+      extra_context.visitor);
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamDecoderFilter(

--- a/source/extensions/filters/http/upstream_rbac/config.h
+++ b/source/extensions/filters/http/upstream_rbac/config.h
@@ -17,18 +17,17 @@ namespace UpstreamRBACFilter {
  * `envoy.extensions.filters.http.rbac.v3.RBAC` configuration. @see UpstreamHttpFilterConfigFactory.
  */
 class UpstreamRoleBasedAccessControlFilterConfigFactory
-    : public Common::CommonFactoryBase<envoy::extensions::filters::http::rbac::v3::RBAC>,
-      public Server::Configuration::UpstreamHttpFilterConfigFactory {
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::rbac::v3::RBAC> {
 public:
   UpstreamRoleBasedAccessControlFilterConfigFactory()
-      : CommonFactoryBase("envoy.filters.http.upstream_rbac") {}
+      : UnifiedFactoryBase("envoy.filters.http.upstream_rbac") {}
 
   std::string category() const override { return "envoy.filters.http.upstream"; }
 
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
-                               const std::string& stats_prefix,
-                               Server::Configuration::UpstreamFactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const envoy::extensions::filters::http::rbac::v3::RBAC& proto_config,
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 DECLARE_FACTORY(UpstreamRoleBasedAccessControlFilterConfigFactory);


### PR DESCRIPTION
Commit Message: filter: use unified factory to replace the previous one
Additional Description:

Continuous work of https://github.com/envoyproxy/envoy/pull/46835. With the new `createHttpFilterFactoryFromProto` we could unify all our downstream/upstream/route HTTP filter factory creation into single method.

Also, no behavior change, won't break any existing extensions.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
