### PR TITLE
decompressor: use unfied factory and generic factory context

### DIFF
--- a/envoy/compression/decompressor/config.h
+++ b/envoy/compression/decompressor/config.h
@@ -19,7 +19,7 @@ public:
 
   virtual DecompressorFactoryPtr
   createDecompressorFactoryFromProto(const Protobuf::Message& config,
-                                     Server::Configuration::FactoryContext& context) PURE;
+                                     Server::Configuration::GenericFactoryContext& context) PURE;
 
   std::string category() const override { return "envoy.compression.decompressor"; }
 };

--- a/source/extensions/compression/brotli/decompressor/config.cc
+++ b/source/extensions/compression/brotli/decompressor/config.cc
@@ -28,7 +28,7 @@ BrotliDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
 Envoy::Compression::Decompressor::DecompressorFactoryPtr
 BrotliDecompressorLibraryFactory::createDecompressorFactoryFromProtoTyped(
     const envoy::extensions::compression::brotli::decompressor::v3::Brotli& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   return std::make_unique<BrotliDecompressorFactory>(proto_config, context.scope());
 }
 

--- a/source/extensions/compression/brotli/decompressor/config.h
+++ b/source/extensions/compression/brotli/decompressor/config.h
@@ -51,7 +51,7 @@ public:
 private:
   Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProtoTyped(
       const envoy::extensions::compression::brotli::decompressor::v3::Brotli& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::GenericFactoryContext& context) override;
 };
 
 DECLARE_FACTORY(BrotliDecompressorLibraryFactory);

--- a/source/extensions/compression/common/decompressor/factory_base.h
+++ b/source/extensions/compression/common/decompressor/factory_base.h
@@ -12,9 +12,9 @@ template <class ConfigProto>
 class DecompressorLibraryFactoryBase
     : public Envoy::Compression::Decompressor::NamedDecompressorLibraryConfigFactory {
 public:
-  Envoy::Compression::Decompressor::DecompressorFactoryPtr
-  createDecompressorFactoryFromProto(const Protobuf::Message& proto_config,
-                                     Server::Configuration::FactoryContext& context) override {
+  Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProto(
+      const Protobuf::Message& proto_config,
+      Server::Configuration::GenericFactoryContext& context) override {
     return createDecompressorFactoryFromProtoTyped(
         MessageUtil::downcastAndValidate<const ConfigProto&>(proto_config,
                                                              context.messageValidationVisitor()),
@@ -32,8 +32,8 @@ protected:
 
 private:
   virtual Envoy::Compression::Decompressor::DecompressorFactoryPtr
-  createDecompressorFactoryFromProtoTyped(const ConfigProto& proto_config,
-                                          Server::Configuration::FactoryContext& context) PURE;
+  createDecompressorFactoryFromProtoTyped(
+      const ConfigProto& proto_config, Server::Configuration::GenericFactoryContext& context) PURE;
 
   const std::string name_;
 };

--- a/source/extensions/compression/gzip/decompressor/config.cc
+++ b/source/extensions/compression/gzip/decompressor/config.cc
@@ -35,7 +35,7 @@ GzipDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
 Envoy::Compression::Decompressor::DecompressorFactoryPtr
 GzipDecompressorLibraryFactory::createDecompressorFactoryFromProtoTyped(
     const envoy::extensions::compression::gzip::decompressor::v3::Gzip& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   return std::make_unique<GzipDecompressorFactory>(proto_config, context.scope());
 }
 

--- a/source/extensions/compression/gzip/decompressor/config.h
+++ b/source/extensions/compression/gzip/decompressor/config.h
@@ -51,7 +51,7 @@ public:
 private:
   Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProtoTyped(
       const envoy::extensions::compression::gzip::decompressor::v3::Gzip& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::GenericFactoryContext& context) override;
 };
 
 DECLARE_FACTORY(GzipDecompressorLibraryFactory);

--- a/source/extensions/compression/zstd/decompressor/config.cc
+++ b/source/extensions/compression/zstd/decompressor/config.cc
@@ -28,7 +28,7 @@ ZstdDecompressorFactory::createDecompressor(const std::string& stats_prefix) {
 Envoy::Compression::Decompressor::DecompressorFactoryPtr
 ZstdDecompressorLibraryFactory::createDecompressorFactoryFromProtoTyped(
     const envoy::extensions::compression::zstd::decompressor::v3::Zstd& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   auto& server_context = context.serverFactoryContext();
   return std::make_unique<ZstdDecompressorFactory>(
       proto_config, context.scope(), server_context.mainThreadDispatcher(), server_context.api(),

--- a/source/extensions/compression/zstd/decompressor/config.h
+++ b/source/extensions/compression/zstd/decompressor/config.h
@@ -51,7 +51,7 @@ public:
 private:
   Envoy::Compression::Decompressor::DecompressorFactoryPtr createDecompressorFactoryFromProtoTyped(
       const envoy::extensions::compression::zstd::decompressor::v3::Zstd& proto_config,
-      Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::GenericFactoryContext& context) override;
 };
 
 DECLARE_FACTORY(ZstdDecompressorLibraryFactory);

--- a/source/extensions/filters/http/decompressor/BUILD
+++ b/source/extensions/filters/http/decompressor/BUILD
@@ -38,6 +38,7 @@ envoy_cc_extension(
         "//envoy/compression/decompressor:decompressor_config_interface",
         "//source/common/config:utility_lib",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/server:generic_factory_context_lib",
         "@envoy_api//envoy/extensions/filters/http/decompressor/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/decompressor/config.cc
+++ b/source/extensions/filters/http/decompressor/config.cc
@@ -4,15 +4,20 @@
 
 #include "source/common/config/utility.h"
 #include "source/extensions/filters/http/decompressor/decompressor_filter.h"
+#include "source/server/generic_factory_context.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Decompressor {
 
-absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb>
+DecompressorFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::decompressor::v3::Decompressor& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  Server::GenericFactoryContextImpl generic_context(
+      context, extra_context.scope, extra_context.visitor, extra_context.init_manager);
   const std::string decompressor_library_type{TypeUtil::typeUrlToDescriptorFullName(
       proto_config.decompressor_library().typed_config().type_url())};
   Compression::Decompressor::NamedDecompressorLibraryConfigFactory* const
@@ -24,12 +29,12 @@ absl::StatusOr<Http::FilterFactoryCb> DecompressorFilterFactory::createFilterFac
         "Didn't find a registered implementation for type: '{}'", decompressor_library_type));
   }
   ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
-      proto_config.decompressor_library().typed_config(), context.messageValidationVisitor(),
+      proto_config.decompressor_library().typed_config(), extra_context.visitor,
       *decompressor_library_factory);
   Compression::Decompressor::DecompressorFactoryPtr decompressor_factory =
-      decompressor_library_factory->createDecompressorFactoryFromProto(*message, context);
+      decompressor_library_factory->createDecompressorFactoryFromProto(*message, generic_context);
   DecompressorFilterConfigSharedPtr filter_config = std::make_shared<DecompressorFilterConfig>(
-      proto_config, stats_prefix, context.scope(), context.serverFactoryContext().runtime(),
+      proto_config, extra_context.stats_prefix, extra_context.scopeOr(context), context.runtime(),
       std::move(decompressor_factory));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<DecompressorFilter>(filter_config));

--- a/source/extensions/filters/http/decompressor/config.h
+++ b/source/extensions/filters/http/decompressor/config.h
@@ -14,15 +14,16 @@ namespace Decompressor {
  * Config registration for the decompressor filter. @see NamedHttpFilterConfigFactory.
  */
 class DecompressorFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::decompressor::v3::Decompressor> {
 public:
-  DecompressorFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.decompressor") {}
+  DecompressorFilterFactory() : UnifiedFactoryBase("envoy.filters.http.decompressor") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::decompressor::v3::Decompressor& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 DECLARE_FACTORY(DecompressorFilterFactory);


### PR DESCRIPTION
Commit Message: decompressor: use unfied factory and generic factory context
Additional Description:

Continuous work of https://github.com/envoyproxy/envoy/pull/46835. With the new createHttpFilterFactoryFromProto we could unify all our downstream/upstream/route HTTP filter factory creation into single method.

Also, no behavior change, won't break any existing extensions.

Risk Level: n/a.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.