### PR TITLE
ratelimit quota: updated to the unified http filter factory

### DIFF
--- a/source/extensions/filters/http/rate_limit_quota/config.cc
+++ b/source/extensions/filters/http/rate_limit_quota/config.cc
@@ -28,10 +28,11 @@ namespace RateLimitQuota {
 using TlsStore = GlobalTlsStores::TlsStore;
 
 absl::StatusOr<Http::FilterFactoryCb>
-RateLimitQuotaFilterFactory::createFilterFactoryFromProtoTyped(
+RateLimitQuotaFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaFilterConfig&
         filter_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   // Filter config const object is created on the main thread and shared between
   // worker threads.
   FilterConfigConstSharedPtr config = std::make_shared<
@@ -45,7 +46,7 @@ RateLimitQuotaFilterFactory::createFilterFactoryFromProtoTyped(
   RateLimitQuotaValidationVisitor visitor;
   visitor.setSupportKeepMatching(true);
   Matcher::MatchTreeFactory<Http::HttpMatchingData, RateLimitOnMatchActionContext> matcher_factory(
-      action_context, context.serverFactoryContext(), visitor);
+      action_context, context, visitor);
 
   Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher = nullptr;
   if (config->has_bucket_matchers()) {
@@ -65,13 +66,15 @@ RateLimitQuotaFilterFactory::createFilterFactoryFromProtoTyped(
   RETURN_IF_NOT_OK_REF(tls_store_or.status());
   std::shared_ptr<TlsStore> tls_store = std::move(tls_store_or.value());
 
-  return [&, config = std::move(config), config_with_hash_key, tls_store = std::move(tls_store),
+  return [&context, &validation_visitor = extra_context.visitor, config = std::move(config),
+          config_with_hash_key, tls_store = std::move(tls_store),
           matcher = std::move(matcher)](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     std::unique_ptr<RateLimitClient> local_client =
         createLocalRateLimitClient(tls_store->global_client.get(), tls_store->buckets_tls);
 
     callbacks.addStreamFilter(std::make_shared<RateLimitQuotaFilter>(
-        config, context, std::move(local_client), config_with_hash_key, matcher));
+        config, context, validation_visitor, std::move(local_client), config_with_hash_key,
+        matcher));
   };
 }
 

--- a/source/extensions/filters/http/rate_limit_quota/config.h
+++ b/source/extensions/filters/http/rate_limit_quota/config.h
@@ -16,17 +16,18 @@ namespace RateLimitQuota {
 inline constexpr absl::string_view FilterName = "envoy.filters.http.rate_limit_quota";
 
 class RateLimitQuotaFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaFilterConfig,
           envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaOverride>,
       public Logger::Loggable<Logger::Id::rate_limit_quota> {
 public:
-  RateLimitQuotaFilterFactory() : ExceptionFreeFactoryBase(std::string(FilterName)) {}
+  RateLimitQuotaFilterFactory() : UnifiedFactoryBase(std::string(FilterName)) {}
 
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaFilterConfig&
           filter_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace RateLimitQuota

--- a/source/extensions/filters/http/rate_limit_quota/filter.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter.cc
@@ -114,7 +114,7 @@ RateLimitQuotaFilter::recordBucketUsage(const Matcher::ActionConstSharedPtr& mat
   // the request matching succeeds.
   const RateLimitOnMatchAction& match_action = matched->getTyped<RateLimitOnMatchAction>();
   absl::StatusOr<BucketId> ret =
-      match_action.generateBucketId(*data_ptr_, factory_context_, visitor_);
+      match_action.generateBucketId(*data_ptr_, validation_visitor_, visitor_);
   if (!ret.ok()) {
     // When it failed to generate the bucket id for this specific request, the
     // request is ALLOWED by default (i.e., fail-open).

--- a/source/extensions/filters/http/rate_limit_quota/filter.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter.h
@@ -49,13 +49,15 @@ class RateLimitQuotaFilter : public Http::PassThroughFilter,
                              public Logger::Loggable<Logger::Id::rate_limit_quota> {
 public:
   RateLimitQuotaFilter(FilterConfigConstSharedPtr config,
-                       Server::Configuration::FactoryContext& factory_context,
+                       Server::Configuration::ServerFactoryContext& factory_context,
+                       ProtobufMessage::ValidationVisitor& validation_visitor,
                        std::unique_ptr<RateLimitClient> local_client,
                        Grpc::GrpcServiceConfigWithHashKey config_with_hash_key,
                        Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher)
       : config_(std::move(config)), config_with_hash_key_(config_with_hash_key),
-        factory_context_(factory_context), matcher_(matcher), client_(std::move(local_client)),
-        time_source_(factory_context.serverFactoryContext().mainThreadDispatcher().timeSource()) {}
+        validation_visitor_(validation_visitor), matcher_(matcher),
+        client_(std::move(local_client)),
+        time_source_(factory_context.mainThreadDispatcher().timeSource()) {}
 
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool end_stream) override;
   void onDestroy() override;
@@ -85,7 +87,7 @@ private:
 
   FilterConfigConstSharedPtr config_;
   Grpc::GrpcServiceConfigWithHashKey config_with_hash_key_;
-  Server::Configuration::FactoryContext& factory_context_;
+  ProtobufMessage::ValidationVisitor& validation_visitor_;
   Http::StreamDecoderFilterCallbacks* callbacks_ = nullptr;
   RateLimitQuotaValidationVisitor visitor_ = {};
   Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher_;

--- a/source/extensions/filters/http/rate_limit_quota/filter_persistence.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter_persistence.cc
@@ -26,7 +26,7 @@ using TlsStore = GlobalTlsStores::TlsStore;
 // settings.
 absl::StatusOr<std::shared_ptr<TlsStore>>
 initTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
-             Server::Configuration::FactoryContext& context, absl::string_view target_address,
+             Server::Configuration::ServerFactoryContext& context, absl::string_view target_address,
              absl::string_view domain) {
   // Quota bucket & global client TLS objects are created with the config and
   // kept alive via shared_ptr to a storage struct. The local rate limit client
@@ -58,7 +58,7 @@ initTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
 // only be called during RLQS filter factory creation on the main thread.
 absl::StatusOr<std::shared_ptr<TlsStore>>
 GlobalTlsStores::getTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
-                             Server::Configuration::FactoryContext& context,
+                             Server::Configuration::ServerFactoryContext& context,
                              absl::string_view target_address, absl::string_view domain) {
   TlsStoreIndex index = std::make_pair(std::string(target_address), std::string(domain));
   // Find existing TlsStore or initialize a new one.

--- a/source/extensions/filters/http/rate_limit_quota/filter_persistence.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter_persistence.h
@@ -39,11 +39,10 @@ class GlobalTlsStores : public Logger::Loggable<Logger::Id::rate_limit_quota> {
 public:
   // Object to hold TLS slots after the factory itself has been cleaned up.
   struct TlsStore {
-    TlsStore(Server::Configuration::FactoryContext& context, absl::string_view target_address,
+    TlsStore(Server::Configuration::ServerFactoryContext& context, absl::string_view target_address,
              absl::string_view domain)
-        : buckets_tls(context.serverFactoryContext().threadLocal()),
-          target_address_(target_address), domain_(domain),
-          main_dispatcher_(context.serverFactoryContext().mainThreadDispatcher()) {}
+        : buckets_tls(context.threadLocal()), target_address_(target_address), domain_(domain),
+          main_dispatcher_(context.mainThreadDispatcher()) {}
 
     ~TlsStore() {
       // Clean up the index from the global map. This is not thread-safe, so
@@ -69,8 +68,8 @@ public:
   // Get an existing TLS store by index, or create one if not found.
   static absl::StatusOr<std::shared_ptr<TlsStore>>
   getTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
-              Server::Configuration::FactoryContext& context, absl::string_view target_address,
-              absl::string_view domain);
+              Server::Configuration::ServerFactoryContext& context,
+              absl::string_view target_address, absl::string_view domain);
 
   // Register a callback to be called when the last TLS store index is cleared.
   // This is intended primarily for test synchronization after filter deletion.

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.cc
@@ -43,21 +43,18 @@ using envoy::type::v3::RateLimitStrategy;
 
 GlobalRateLimitClientImpl::GlobalRateLimitClientImpl(
     const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
-    Server::Configuration::FactoryContext& context, absl::string_view domain_name,
+    Server::Configuration::ServerFactoryContext& context, absl::string_view domain_name,
     std::chrono::milliseconds send_reports_interval,
     Envoy::ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_tls,
     Envoy::Event::Dispatcher& main_dispatcher, absl::Status& creation_status)
     : domain_name_(domain_name), buckets_tls_(buckets_tls),
       send_reports_interval_(send_reports_interval),
-      time_source_(context.serverFactoryContext().mainThreadDispatcher().timeSource()),
-      main_dispatcher_(main_dispatcher) {
+      time_source_(context.mainThreadDispatcher().timeSource()), main_dispatcher_(main_dispatcher) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
 
   absl::StatusOr<Grpc::AsyncClientFactoryPtr> rlqs_stream_client_factory =
-      context.serverFactoryContext()
-          .clusterManager()
-          .grpcAsyncClientManager()
-          .factoryForGrpcService(config_with_hash_key.config(), context.scope(), true);
+      context.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
+          config_with_hash_key.config(), context.scope(), true);
   if (!rlqs_stream_client_factory.ok()) {
     creation_status = rlqs_stream_client_factory.status();
     return;

--- a/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
+++ b/source/extensions/filters/http/rate_limit_quota/global_client_impl.h
@@ -63,7 +63,7 @@ public:
   // Note: rlqs_client is owned directly to ensure that it does not outlive the
   // GlobalRateLimitClientImpl (as the impl provides stream callbacks).
   GlobalRateLimitClientImpl(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
-                            Server::Configuration::FactoryContext& context,
+                            Server::Configuration::ServerFactoryContext& context,
                             absl::string_view domain_name,
                             std::chrono::milliseconds send_reports_interval,
                             ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_tls,
@@ -190,12 +190,12 @@ private:
  * thread via TLS.
  */
 inline absl::StatusOr<std::unique_ptr<GlobalRateLimitClientImpl>>
-createGlobalRateLimitClientImpl(Server::Configuration::FactoryContext& context,
+createGlobalRateLimitClientImpl(Server::Configuration::ServerFactoryContext& context,
                                 absl::string_view domain_name,
                                 std::chrono::milliseconds send_reports_interval,
                                 ThreadLocal::TypedSlot<ThreadLocalBucketsCache>& buckets_tls,
                                 const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key) {
-  Envoy::Event::Dispatcher& main_dispatcher = context.serverFactoryContext().mainThreadDispatcher();
+  Envoy::Event::Dispatcher& main_dispatcher = context.mainThreadDispatcher();
   absl::Status creation_status = absl::OkStatus();
   auto client = std::make_unique<GlobalRateLimitClientImpl>(
       config_with_hash_key, context, domain_name, send_reports_interval, buckets_tls,

--- a/source/extensions/filters/http/rate_limit_quota/matcher.cc
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.cc
@@ -12,7 +12,7 @@ using ValueSpecifierCase = ::envoy::extensions::filters::http::rate_limit_quota:
 
 absl::StatusOr<BucketId>
 RateLimitOnMatchAction::generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
-                                         Server::Configuration::FactoryContext& factory_context,
+                                         ProtobufMessage::ValidationVisitor& validation_visitor,
                                          RateLimitQuotaValidationVisitor& visitor) const {
   BucketId bucket_id;
   std::unique_ptr<Matcher::MatchInputFactory<Http::HttpMatchingData>> input_factory_ptr = nullptr;
@@ -32,7 +32,7 @@ RateLimitOnMatchAction::generateBucketId(const Http::Matching::HttpMatchingDataI
       // Initialize the pointer to input factory on first use.
       if (input_factory_ptr == nullptr) {
         input_factory_ptr = std::make_unique<Matcher::MatchInputFactory<Http::HttpMatchingData>>(
-            factory_context.messageValidationVisitor(), visitor);
+            validation_visitor, visitor);
       }
       // Create `DataInput` factory callback from the config.
       Matcher::DataInputFactoryCb<Http::HttpMatchingData> data_input_cb =

--- a/source/extensions/filters/http/rate_limit_quota/matcher.h
+++ b/source/extensions/filters/http/rate_limit_quota/matcher.h
@@ -38,7 +38,7 @@ public:
       : setting_(std::move(settings)) {}
 
   absl::StatusOr<BucketId> generateBucketId(const Http::Matching::HttpMatchingDataImpl& data,
-                                            Server::Configuration::FactoryContext& factory_context,
+                                            ProtobufMessage::ValidationVisitor& validation_visitor,
                                             RateLimitQuotaValidationVisitor& visitor) const;
 
   const RateLimitQuotaBucketSettings& bucketSettings() const { return setting_; }

--- a/test/extensions/filters/http/rate_limit_quota/client_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/client_test.cc
@@ -113,8 +113,9 @@ protected:
     mock_stream_client->expectClientCreationWithFactory();
     absl::Status creation_status = absl::OkStatus();
     global_client_ = std::make_unique<GlobalRateLimitClientImpl>(
-        mock_stream_client->config_with_hash_key_, mock_stream_client->context_, mock_domain_,
-        reporting_interval_, *buckets_tls_, *mock_stream_client->dispatcher_, creation_status);
+        mock_stream_client->config_with_hash_key_,
+        mock_stream_client->context_.server_factory_context_, mock_domain_, reporting_interval_,
+        *buckets_tls_, *mock_stream_client->dispatcher_, creation_status);
     ASSERT_TRUE(creation_status.ok());
     // Set callbacks to handle asynchronous timing.
     auto callbacks = std::make_unique<GlobalClientCallbacks>();

--- a/test/extensions/filters/http/rate_limit_quota/config_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/config_test.cc
@@ -36,6 +36,7 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithCorrectProto) {
         predicate:
           single_predicate:
             input:
+              name: envoy.matching.inputs.request_headers
               typed_config:
                 "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
                 header_name: environment
@@ -65,8 +66,8 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithCorrectProto) {
 
   RateLimitQuotaFilterFactory factory;
   std::string stats_prefix = "test";
-  auto cb_or = factory.createFilterFactoryFromProtoTyped(filter_config, stats_prefix,
-                                                         mock_stream_client->context_);
+  auto cb_or = factory.createFilterFactoryFromProto(filter_config, stats_prefix,
+                                                    mock_stream_client->context_);
   ASSERT_TRUE(cb_or.ok()) << cb_or.status();
   Http::FilterFactoryCb cb = std::move(cb_or).value();
   cb(filter_callback);
@@ -112,12 +113,11 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithInvalidMatcher) {
 
   RateLimitQuotaFilterFactory factory;
   std::string stats_prefix = "test";
-  EXPECT_THROW_WITH_REGEX(factory
-                              .createFilterFactoryFromProtoTyped(filter_config, stats_prefix,
-                                                                 mock_stream_client->context_)
-                              .value(),
-                          EnvoyException,
-                          "Didn't find a registered implementation.*'input_not_found'");
+  EXPECT_THROW_WITH_REGEX(
+      factory
+          .createFilterFactoryFromProto(filter_config, stats_prefix, mock_stream_client->context_)
+          .value(),
+      EnvoyException, "Didn't find a registered implementation.*'input_not_found'");
 }
 
 TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithInvalidGrpcClient) {
@@ -133,6 +133,7 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithInvalidGrpcClient) 
         predicate:
           single_predicate:
             input:
+              name: envoy.matching.inputs.request_headers
               typed_config:
                 "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
                 header_name: environment
@@ -157,8 +158,8 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithInvalidGrpcClient) 
 
   RateLimitQuotaFilterFactory factory;
   std::string stats_prefix = "test";
-  auto cb_or = factory.createFilterFactoryFromProtoTyped(filter_config, stats_prefix,
-                                                         mock_stream_client->context_);
+  auto cb_or = factory.createFilterFactoryFromProto(filter_config, stats_prefix,
+                                                    mock_stream_client->context_);
   EXPECT_THAT(cb_or, HasStatus(absl::StatusCode::kInternal, "Mock client creation failure"));
 }
 

--- a/test/extensions/filters/http/rate_limit_quota/filter_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/filter_test.cc
@@ -121,9 +121,9 @@ public:
         Grpc::GrpcServiceConfigWithHashKey(filter_config_->rlqs_server());
 
     mock_local_client_ = new MockRateLimitClient();
-    filter_ = std::make_unique<RateLimitQuotaFilter>(filter_config_, context_,
-                                                     absl::WrapUnique(mock_local_client_),
-                                                     config_with_hash_key, match_tree_);
+    filter_ = std::make_unique<RateLimitQuotaFilter>(
+        filter_config_, context_.serverFactoryContext(), context_.messageValidationVisitor(),
+        absl::WrapUnique(mock_local_client_), config_with_hash_key, match_tree_);
     if (set_callback) {
       filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     }
@@ -164,7 +164,8 @@ public:
 
     RateLimitQuotaValidationVisitor visitor = {};
     // Generate the bucket ids.
-    auto ret = match_action->generateBucketId(filter_->matchingData(), context_, visitor);
+    auto ret = match_action->generateBucketId(filter_->matchingData(),
+                                              context_.messageValidationVisitor(), visitor);
     // Asserts that the bucket id generation succeeded and then retrieve the
     // bucket ids.
     ASSERT_OK(ret);
@@ -287,7 +288,8 @@ TEST_F(FilterTest, RequestMatchingWithInvalidOnNoMatch) {
 
   RateLimitQuotaValidationVisitor visitor = {};
   // Generate the bucket ids.
-  auto ret = match_action->generateBucketId(filter_->matchingData(), context_, visitor);
+  auto ret = match_action->generateBucketId(filter_->matchingData(),
+                                            context_.messageValidationVisitor(), visitor);
   // Bucket id generation is expected to fail, which is due to no support for
   // dynamic id generation (i.e., via custom_value with for on_no_match case.
   EXPECT_THAT(ret, HasStatusMessage("Failed to generate the id from custom value config."));
@@ -984,9 +986,9 @@ bucket_matchers:
       Grpc::GrpcServiceConfigWithHashKey(filter_config_->rlqs_server());
 
   mock_local_client_ = new MockRateLimitClient();
-  filter_ = std::make_unique<RateLimitQuotaFilter>(filter_config_, context_,
-                                                   absl::WrapUnique(mock_local_client_),
-                                                   config_with_hash_key, match_tree_);
+  filter_ = std::make_unique<RateLimitQuotaFilter>(
+      filter_config_, context_.serverFactoryContext(), context_.messageValidationVisitor(),
+      absl::WrapUnique(mock_local_client_), config_with_hash_key, match_tree_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
   // Build headers that match the config
@@ -1159,9 +1161,9 @@ matcher_list:
       Grpc::GrpcServiceConfigWithHashKey(filter_config_->rlqs_server());
 
   mock_local_client_ = new MockRateLimitClient();
-  filter_ = std::make_unique<RateLimitQuotaFilter>(filter_config_, context_,
-                                                   absl::WrapUnique(mock_local_client_),
-                                                   config_with_hash_key, match_tree_);
+  filter_ = std::make_unique<RateLimitQuotaFilter>(
+      filter_config_, context_.serverFactoryContext(), context_.messageValidationVisitor(),
+      absl::WrapUnique(mock_local_client_), config_with_hash_key, match_tree_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
 
   // Build headers that match the config


### PR DESCRIPTION
Commit Message: ratelimit quota: updated to the unified http filter factory
Additional Description:
Continuous work of https://github.com/envoyproxy/envoy/pull/46835. With the new `createHttpFilterFactoryFromProto` we could unify all our downstream/upstream/route HTTP filter factory creation into single method.

Also, no behavior change, won't break any existing extensions.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
