### PR TITLE
http: migrate the dual filters to use the unified http filter factory

### DIFF
--- a/source/extensions/filters/http/admission_control/config.cc
+++ b/source/extensions/filters/http/admission_control/config.cc
@@ -18,19 +18,12 @@ namespace AdmissionControl {
 static constexpr std::chrono::seconds defaultSamplingWindow{30};
 
 absl::StatusOr<Http::FilterFactoryCb>
-AdmissionControlFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& config,
-    const std::string& stats_prefix, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactory(config, stats_prefix, context, dual_info.scope);
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 AdmissionControlFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope());
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context));
 }
 
 absl::StatusOr<Http::FilterFactoryCb> AdmissionControlFilterFactory::createFilterFactory(

--- a/source/extensions/filters/http/admission_control/config.h
+++ b/source/extensions/filters/http/admission_control/config.h
@@ -14,15 +14,10 @@ namespace AdmissionControl {
  * Config registration for the adaptive concurrency limit filter. @see NamedHttpFilterConfigFactory.
  */
 class AdmissionControlFilterFactory
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::admission_control::v3::AdmissionControl> {
 public:
-  AdmissionControlFilterFactory() : DualFactoryBase("envoy.filters.http.admission_control") {}
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,
-      const std::string& stats_prefix, DualInfo dual_info,
-      Server::Configuration::ServerFactoryContext& context) override;
+  AdmissionControlFilterFactory() : UnifiedFactoryBase("envoy.filters.http.admission_control") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::admission_control::v3::AdmissionControl& proto_config,

--- a/source/extensions/filters/http/ai_protocol_manager/config.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/config.cc
@@ -11,10 +11,10 @@ namespace HttpFilters {
 namespace AiProtocolManager {
 
 absl::StatusOr<Http::FilterFactoryCb>
-AiProtocolManagerFilterConfigFactory::createFilterFactoryFromProtoTyped(
+AiProtocolManagerFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager&
         proto_config,
-    const std::string&, DualInfo, Server::Configuration::ServerFactoryContext&) {
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
   // One factory is shared by every stream on the chain. The in-memory
   // implementation is stateless, so a single shared instance is safe.
   auto buffer_factory = std::make_shared<InMemoryExternalBufferFactory>();

--- a/source/extensions/filters/http/ai_protocol_manager/config.h
+++ b/source/extensions/filters/http/ai_protocol_manager/config.h
@@ -11,19 +11,19 @@ namespace HttpFilters {
 namespace AiProtocolManager {
 
 class AiProtocolManagerFilterConfigFactory
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager,
           envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManagerPerRoute> {
 public:
   AiProtocolManagerFilterConfigFactory()
-      : DualFactoryBase("envoy.filters.http.ai_protocol_manager") {}
+      : UnifiedFactoryBase("envoy.filters.http.ai_protocol_manager") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager&
           proto_config,
-      const std::string& stats_prefix, DualInfo info,
-      Server::Configuration::ServerFactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/aws_lambda/config.cc
+++ b/source/extensions/filters/http/aws_lambda/config.cc
@@ -91,14 +91,6 @@ absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createFilterFactor
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
-    const std::string& stats_prefix, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& server_context) {
-  return createFilterFactoryFromProtoHelper(proto_config, stats_prefix, server_context,
-                                            dual_info.scope, dual_info.is_upstream);
-}
-
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
 AwsLambdaFilterFactory::createRouteSpecificFilterConfigTyped(
     const envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig& per_route_config,
@@ -139,7 +131,8 @@ absl::StatusOr<Http::FilterFactoryCb> AwsLambdaFilterFactory::createHttpFilterFa
     Server::Configuration::ServerFactoryContext& server_context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
   return createFilterFactoryFromProtoHelper(proto_config, extra_context.stats_prefix,
-                                            server_context, server_context.scope(), false);
+                                            server_context, extra_context.scopeOr(server_context),
+                                            extra_context.is_upstream);
 }
 
 /*

--- a/source/extensions/filters/http/aws_lambda/config.h
+++ b/source/extensions/filters/http/aws_lambda/config.h
@@ -17,12 +17,12 @@ namespace HttpFilters {
 namespace AwsLambdaFilter {
 
 class AwsLambdaFilterFactory
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::aws_lambda::v3::Config,
           envoy::extensions::filters::http::aws_lambda::v3::PerRouteConfig>,
       Logger::Loggable<Logger::Id::filter> {
 public:
-  AwsLambdaFilterFactory() : DualFactoryBase("envoy.filters.http.aws_lambda") {}
+  AwsLambdaFilterFactory() : UnifiedFactoryBase("envoy.filters.http.aws_lambda") {}
 
 protected:
   Extensions::Common::Aws::CredentialsProviderChainSharedPtr getCredentialsProvider(
@@ -35,11 +35,6 @@ protected:
       Stats::Scope& scope, bool is_upstream) const;
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
-      const std::string& stats_prefix, DualInfo dual_info,
-      Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::aws_lambda::v3::Config& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -45,19 +45,12 @@ AwsRequestSigningFilterFactory::createFilterFactoryFromProtoHelper(
 }
 
 absl::StatusOr<Http::FilterFactoryCb>
-AwsRequestSigningFilterFactory::createFilterFactoryFromProtoTyped(
-    const AwsRequestSigningProtoConfig& config, const std::string& stats_prefix, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& server_context) {
-  return createFilterFactoryFromProtoHelper(config, stats_prefix, server_context, dual_info.scope);
-}
-
-absl::StatusOr<Http::FilterFactoryCb>
 AwsRequestSigningFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const AwsRequestSigningProtoConfig& config,
     Server::Configuration::ServerFactoryContext& server_context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
   return createFilterFactoryFromProtoHelper(config, extra_context.stats_prefix, server_context,
-                                            server_context.scope());
+                                            extra_context.scopeOr(server_context));
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/aws_request_signing/config.h
+++ b/source/extensions/filters/http/aws_request_signing/config.h
@@ -20,10 +20,10 @@ using AwsRequestSigningProtoPerRouteConfig =
  * Config registration for the AWS request signing filter.
  */
 class AwsRequestSigningFilterFactory
-    : public Common::DualFactoryBase<AwsRequestSigningProtoConfig,
-                                     AwsRequestSigningProtoPerRouteConfig> {
+    : public Common::UnifiedFactoryBase<AwsRequestSigningProtoConfig,
+                                        AwsRequestSigningProtoPerRouteConfig> {
 public:
-  AwsRequestSigningFilterFactory() : DualFactoryBase("envoy.filters.http.aws_request_signing") {}
+  AwsRequestSigningFilterFactory() : UnifiedFactoryBase("envoy.filters.http.aws_request_signing") {}
 
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoHelper(
       const AwsRequestSigningProtoConfig& proto_config, const std::string& stats_prefix,
@@ -33,11 +33,6 @@ private:
   absl::StatusOr<Envoy::Extensions::Common::Aws::SignerPtr>
   createSigner(const AwsRequestSigningProtoConfig& config,
                Server::Configuration::ServerFactoryContext& server_context) const;
-
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const AwsRequestSigningProtoConfig& proto_config,
-                                    const std::string& stats_prefix, DualInfo dual_info,
-                                    Server::Configuration::ServerFactoryContext& context) override;
 
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const AwsRequestSigningProtoConfig& proto_config,

--- a/source/extensions/filters/http/bandwidth_share/config.cc
+++ b/source/extensions/filters/http/bandwidth_share/config.cc
@@ -107,14 +107,15 @@ protoToSharedState(const ProtoConfig& config,
 }
 } // namespace
 
-class BandwidthShareFilterFactory : public Common::DualFactoryBase<ProtoConfig, ProtoConfig> {
+class BandwidthShareFilterFactory : public Common::UnifiedFactoryBase<ProtoConfig, ProtoConfig> {
 public:
   BandwidthShareFilterFactory();
 
 private:
   absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const ProtoConfig&, const std::string& stats_prefix, DualInfo,
-                                    Server::Configuration::ServerFactoryContext&) override;
+  createHttpFilterFactoryFromProtoTyped(const ProtoConfig&,
+                                        Server::Configuration::ServerFactoryContext&,
+                                        Server::Configuration::ExtraFactoryContext&) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const ProtoConfig&,
@@ -123,12 +124,12 @@ private:
 };
 
 BandwidthShareFilterFactory::BandwidthShareFilterFactory()
-    : DualFactoryBase(BandwidthShare::filterName()) {}
+    : UnifiedFactoryBase(BandwidthShare::filterName()) {}
 
 absl::StatusOr<Http::FilterFactoryCb>
-BandwidthShareFilterFactory::createFilterFactoryFromProtoTyped(
-    const ProtoConfig& proto_config, const std::string&, DualInfo,
-    Server::Configuration::ServerFactoryContext& context) {
+BandwidthShareFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const ProtoConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   auto shared_state = protoToSharedState(proto_config, context);
   if (!shared_state.ok()) {
     return shared_state.status();

--- a/source/extensions/filters/http/compressor/config.cc
+++ b/source/extensions/filters/http/compressor/config.cc
@@ -40,21 +40,13 @@ absl::StatusOr<Http::FilterFactoryCb> CompressorFilterFactory::createFilterFacto
   };
 }
 
-absl::StatusOr<Http::FilterFactoryCb> CompressorFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
-    const std::string& stats_prefix, DualInfo info,
-    Server::Configuration::ServerFactoryContext& context) {
-  Server::GenericFactoryContextImpl generic_context(
-      context, info.scope, context.messageValidationVisitor(), info.init_manager);
-  return createFilterFactory(proto_config, stats_prefix, generic_context);
-}
-
 absl::StatusOr<Http::FilterFactoryCb>
 CompressorFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  Server::GenericFactoryContextImpl generic_context(context, context.messageValidationVisitor());
+  Server::GenericFactoryContextImpl generic_context(
+      context, extra_context.scope, extra_context.visitor, extra_context.init_manager);
   return createFilterFactory(proto_config, extra_context.stats_prefix, generic_context);
 }
 

--- a/source/extensions/filters/http/compressor/config.h
+++ b/source/extensions/filters/http/compressor/config.h
@@ -14,18 +14,13 @@ namespace Compressor {
  * Config registration for the compressor filter. @see NamedHttpFilterConfigFactory.
  */
 class CompressorFilterFactory
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::compressor::v3::Compressor,
           envoy::extensions::filters::http::compressor::v3::CompressorPerRoute> {
 public:
-  CompressorFilterFactory() : DualFactoryBase("envoy.filters.http.compressor") {}
+  CompressorFilterFactory() : UnifiedFactoryBase("envoy.filters.http.compressor") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
-      const std::string& stats_prefix, DualInfo info,
-      Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::compressor::v3::Compressor& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/credential_injector/config.cc
+++ b/source/extensions/filters/http/credential_injector/config.cc
@@ -46,23 +46,18 @@ CredentialInjectorFilterFactory::createFilterFactoryFromProtoHelper(
 }
 
 absl::StatusOr<Envoy::Http::FilterFactoryCb>
-CredentialInjectorFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector&
-        proto_config,
-    const std::string& stats_prefix, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& context) {
-  return createFilterFactoryFromProtoHelper(proto_config, stats_prefix, context, dual_info.scope,
-                                            dual_info.init_manager);
-}
-
-absl::StatusOr<Envoy::Http::FilterFactoryCb>
 CredentialInjectorFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector&
         proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
+  // The credential injector registers an init target to warm up its credential source, so fall
+  // back to the server's init manager for the contexts that do not carry one of their own.
+  Init::Manager& init_manager = extra_context.init_manager.has_value()
+                                    ? extra_context.init_manager.ref()
+                                    : context.initManager();
   return createFilterFactoryFromProtoHelper(proto_config, extra_context.stats_prefix, context,
-                                            context.scope(), context.initManager());
+                                            extra_context.scopeOr(context), init_manager);
 }
 
 REGISTER_FACTORY(CredentialInjectorFilterFactory,

--- a/source/extensions/filters/http/credential_injector/config.h
+++ b/source/extensions/filters/http/credential_injector/config.h
@@ -11,10 +11,11 @@ namespace HttpFilters {
 namespace CredentialInjector {
 
 class CredentialInjectorFilterFactory
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::credential_injector::v3::CredentialInjector> {
 public:
-  CredentialInjectorFilterFactory() : DualFactoryBase("envoy.filters.http.credential_injector") {}
+  CredentialInjectorFilterFactory()
+      : UnifiedFactoryBase("envoy.filters.http.credential_injector") {}
 
 protected:
   absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoHelper(
@@ -23,11 +24,6 @@ protected:
       Stats::Scope& scope, Init::Manager& init_manager) const;
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
-      const std::string& stats_prefix, DualInfo dual_info,
-      Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::credential_injector::v3::CredentialInjector& config,
       Server::Configuration::ServerFactoryContext& context,

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -157,8 +157,8 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb>
 DynamicModuleConfigFactory::createHttpFilterFactoryFromProtoTyped(
     const FilterConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
-  return createFilterFactory(proto_config, extra_context.stats_prefix, context, context.scope(),
-                             extra_context.init_manager);
+  return createFilterFactory(proto_config, extra_context.stats_prefix, context,
+                             extra_context.scopeOr(context), extra_context.init_manager);
 }
 
 absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>

--- a/source/extensions/filters/http/dynamic_modules/factory.h
+++ b/source/extensions/filters/http/dynamic_modules/factory.h
@@ -16,16 +16,10 @@ using RouteConfigProto =
     envoy::extensions::filters::http::dynamic_modules::v3::DynamicModuleFilterPerRoute;
 
 class DynamicModuleConfigFactory
-    : public Extensions::HttpFilters::Common::DualFactoryBase<FilterConfig, RouteConfigProto> {
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<FilterConfig, RouteConfigProto> {
 public:
-  DynamicModuleConfigFactory() : DualFactoryBase("envoy.extensions.filters.http.dynamic_modules") {}
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const FilterConfig& proto_config,
-                                    const std::string& stat_prefix, DualInfo dual_info,
-                                    Server::Configuration::ServerFactoryContext& context) override {
-    return createFilterFactory(proto_config, stat_prefix, context, dual_info.scope,
-                               dual_info.init_manager);
-  }
+  DynamicModuleConfigFactory()
+      : UnifiedFactoryBase("envoy.extensions.filters.http.dynamic_modules") {}
   absl::StatusOr<Envoy::Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const FilterConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
       Server::Configuration::ExtraFactoryContext& extra_context) override;

--- a/source/extensions/filters/http/ext_proc/config.cc
+++ b/source/extensions/filters/http/ext_proc/config.cc
@@ -73,33 +73,43 @@ absl::Status verifyFilterConfig(
 
 } // namespace
 
+absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
+ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
+    const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& proto_config,
+    Server::Configuration::ServerFactoryContext& server_context,
+    ProtobufMessage::ValidationVisitor&) {
+  return std::make_shared<FilterConfigPerRoute>(
+      proto_config, Envoy::Extensions::Filters::Common::Expr::getBuilder(server_context),
+      server_context);
+}
+
 absl::StatusOr<Http::FilterFactoryCb>
-ExternalProcessingFilterConfig::createFilterFactoryFromProtoTyped(
+ExternalProcessingFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
-    const std::string& stats_prefix, DualInfo dual_info,
-    Server::Configuration::ServerFactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   // Verify configuration before creating FilterConfig
-  absl::Status result = verifyFilterConfig(proto_config);
-  if (!result.ok()) {
-    return result;
-  }
+  RETURN_IF_NOT_OK(verifyFilterConfig(proto_config));
 
   const uint32_t message_timeout_ms =
       PROTOBUF_GET_MS_OR_DEFAULT(proto_config, message_timeout, DefaultMessageTimeoutMs);
   const uint32_t max_message_timeout_ms =
       PROTOBUF_GET_MS_OR_DEFAULT(proto_config, max_message_timeout, DefaultMaxMessageTimeoutMs);
+  // The scope outlives the filter chain, so the callback below can hold on to it. The extra
+  // context itself must not be captured: it is a stack temporary at the call site.
+  OptRef<Stats::Scope> scope = extra_context.scopeOr(context);
   absl::Status config_creation_status = absl::OkStatus();
   auto filter_config = std::make_shared<FilterConfig>(
-      proto_config, std::chrono::milliseconds(message_timeout_ms), max_message_timeout_ms,
-      dual_info.scope, stats_prefix, dual_info.is_upstream,
+      proto_config, std::chrono::milliseconds(message_timeout_ms), max_message_timeout_ms, *scope,
+      extra_context.stats_prefix, extra_context.is_upstream,
       Envoy::Extensions::Filters::Common::Expr::getBuilder(context), context,
       config_creation_status);
   RETURN_IF_NOT_OK_REF(config_creation_status);
   if (proto_config.has_grpc_service()) {
     return [filter_config = std::move(filter_config), &context,
-            dual_info](Http::FilterChainFactoryCallbacks& callbacks) {
-      auto client = createExternalProcessorClient(context.clusterManager().grpcAsyncClientManager(),
-                                                  dual_info.scope);
+            scope](Http::FilterChainFactoryCallbacks& callbacks) {
+      auto client =
+          createExternalProcessorClient(context.clusterManager().grpcAsyncClientManager(), *scope);
       callbacks.addStreamFilter(
           Http::StreamFilterSharedPtr{std::make_shared<Filter>(filter_config, std::move(client))});
     };
@@ -112,60 +122,6 @@ ExternalProcessingFilterConfig::createFilterFactoryFromProtoTyped(
             &context, headers_applicator = std::move(headers_applicator)](
                Http::FilterChainFactoryCallbacks& callbacks) {
       auto client = std::make_unique<ExtProcHttpClient>(proto_config, context, headers_applicator);
-      callbacks.addStreamFilter(
-          Http::StreamFilterSharedPtr{std::make_shared<Filter>(filter_config, std::move(client))});
-    };
-  }
-}
-
-absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
-ExternalProcessingFilterConfig::createRouteSpecificFilterConfigTyped(
-    const envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute& proto_config,
-    Server::Configuration::ServerFactoryContext& server_context,
-    ProtobufMessage::ValidationVisitor&) {
-  return std::make_shared<FilterConfigPerRoute>(
-      proto_config, Envoy::Extensions::Filters::Common::Expr::getBuilder(server_context),
-      server_context);
-}
-
-// This method will only be called when the filter is in downstream.
-absl::StatusOr<Http::FilterFactoryCb>
-ExternalProcessingFilterConfig::createHttpFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
-    Server::Configuration::ServerFactoryContext& server_context,
-    Server::Configuration::ExtraFactoryContext& extra_context) {
-  // Verify configuration before creating FilterConfig
-  RETURN_IF_NOT_OK(verifyFilterConfig(proto_config));
-
-  const uint32_t message_timeout_ms =
-      PROTOBUF_GET_MS_OR_DEFAULT(proto_config, message_timeout, DefaultMessageTimeoutMs);
-  const uint32_t max_message_timeout_ms =
-      PROTOBUF_GET_MS_OR_DEFAULT(proto_config, max_message_timeout, DefaultMaxMessageTimeoutMs);
-  absl::Status config_creation_status = absl::OkStatus();
-  auto filter_config = std::make_shared<FilterConfig>(
-      proto_config, std::chrono::milliseconds(message_timeout_ms), max_message_timeout_ms,
-      server_context.scope(), extra_context.stats_prefix, false,
-      Envoy::Extensions::Filters::Common::Expr::getBuilder(server_context), server_context,
-      config_creation_status);
-  RETURN_IF_NOT_OK_REF(config_creation_status);
-
-  if (proto_config.has_grpc_service()) {
-    return [filter_config = std::move(filter_config),
-            &server_context](Http::FilterChainFactoryCallbacks& callbacks) {
-      auto client = createExternalProcessorClient(
-          server_context.clusterManager().grpcAsyncClientManager(), server_context.scope());
-      callbacks.addStreamFilter(
-          Http::StreamFilterSharedPtr{std::make_shared<Filter>(filter_config, std::move(client))});
-    };
-  } else {
-    auto headers_applicator = Http::HttpServiceHeadersApplicator::createOrThrow(
-        proto_config.http_service().http_service(), server_context);
-    return [proto_config = std::move(proto_config), filter_config = std::move(filter_config),
-            &server_context,
-            headers_applicator = std::shared_ptr<const Http::HttpServiceHeadersApplicator>(
-                std::move(headers_applicator))](Http::FilterChainFactoryCallbacks& callbacks) {
-      auto client =
-          std::make_unique<ExtProcHttpClient>(proto_config, server_context, headers_applicator);
       callbacks.addStreamFilter(
           Http::StreamFilterSharedPtr{std::make_shared<Filter>(filter_config, std::move(client))});
     };

--- a/source/extensions/filters/http/ext_proc/config.h
+++ b/source/extensions/filters/http/ext_proc/config.h
@@ -13,21 +13,16 @@ namespace HttpFilters {
 namespace ExternalProcessing {
 
 class ExternalProcessingFilterConfig
-    : public Common::DualFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor,
           envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute> {
 
 public:
-  ExternalProcessingFilterConfig() : DualFactoryBase("envoy.filters.http.ext_proc") {}
+  ExternalProcessingFilterConfig() : UnifiedFactoryBase("envoy.filters.http.ext_proc") {}
 
 private:
   static constexpr uint64_t DefaultMessageTimeoutMs = 200;
   static constexpr uint64_t DefaultMaxMessageTimeoutMs = 0;
-
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::ext_proc::v3::ExternalProcessor& proto_config,
-      const std::string& stats_prefix, DualInfo dual_info,
-      Server::Configuration::ServerFactoryContext& context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/source/extensions/filters/http/file_server/config.cc
+++ b/source/extensions/filters/http/file_server/config.cc
@@ -57,11 +57,12 @@ absl::Status validateProto(const ProtoFileServerConfig& config) {
 } // namespace
 
 FileServerFilterFactory::FileServerFilterFactory()
-    : DualFactoryBase(FileServerFilter::filterName()) {}
+    : UnifiedFactoryBase(FileServerFilter::filterName()) {}
 
-absl::StatusOr<Http::FilterFactoryCb> FileServerFilterFactory::createFilterFactoryFromProtoTyped(
-    const ProtoFileServerConfig& config, const std::string&, DualInfo,
-    Server::Configuration::ServerFactoryContext& context) {
+absl::StatusOr<Http::FilterFactoryCb>
+FileServerFilterFactory::createHttpFilterFactoryFromProtoTyped(
+    const ProtoFileServerConfig& config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
   RETURN_IF_NOT_OK(validateProto(config));
   auto file_server_config = FileServerConfig::create(config, context);
   if (!file_server_config.ok()) {

--- a/source/extensions/filters/http/file_server/config.h
+++ b/source/extensions/filters/http/file_server/config.h
@@ -14,15 +14,14 @@ namespace FileServer {
 using ProtoFileServerConfig = envoy::extensions::filters::http::file_server::v3::FileServerConfig;
 
 class FileServerFilterFactory
-    : public Extensions::HttpFilters::Common::DualFactoryBase<ProtoFileServerConfig,
-                                                              ProtoFileServerConfig> {
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<ProtoFileServerConfig,
+                                                                 ProtoFileServerConfig> {
 public:
   FileServerFilterFactory();
 
-  absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const ProtoFileServerConfig& config,
-                                    const std::string& stats_prefix, DualInfo info,
-                                    Server::Configuration::ServerFactoryContext& context) override;
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
+      const ProtoFileServerConfig& config, Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(const ProtoFileServerConfig& config,

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -11,30 +11,15 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Lua {
 
-absl::StatusOr<Http::FilterFactoryCb> LuaFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
-    const std::string& stats_prefix, DualInfo info,
-    Server::Configuration::ServerFactoryContext& context) {
-
-  absl::Status creation_status = absl::OkStatus();
-  FilterConfigConstSharedPtr filter_config(
-      new FilterConfig{proto_config, context.threadLocal(), context.clusterManager(), context.api(),
-                       info.scope, stats_prefix, context.options().concurrency(), creation_status});
-  RETURN_IF_NOT_OK_REF(creation_status);
-  auto& time_source = context.mainThreadDispatcher().timeSource();
-  return [filter_config, &time_source](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<Filter>(filter_config, time_source));
-  };
-}
-
 absl::StatusOr<Envoy::Http::FilterFactoryCb> LuaFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
     Server::Configuration::ServerFactoryContext& context,
     Server::Configuration::ExtraFactoryContext& extra_context) {
   absl::Status creation_status = absl::OkStatus();
-  FilterConfigConstSharedPtr filter_config(new FilterConfig{
-      proto_config, context.threadLocal(), context.clusterManager(), context.api(), context.scope(),
-      extra_context.stats_prefix, context.options().concurrency(), creation_status});
+  FilterConfigConstSharedPtr filter_config(
+      new FilterConfig{proto_config, context.threadLocal(), context.clusterManager(), context.api(),
+                       extra_context.scopeOr(context), extra_context.stats_prefix,
+                       context.options().concurrency(), creation_status});
   RETURN_IF_NOT_OK_REF(creation_status);
   auto& time_source = context.mainThreadDispatcher().timeSource();
   return [filter_config, &time_source](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -14,17 +14,12 @@ namespace Lua {
  * Config registration for the Lua filter. @see NamedHttpFilterConfigFactory.
  */
 class LuaFilterConfig
-    : public Common::DualFactoryBase<envoy::extensions::filters::http::lua::v3::Lua,
-                                     envoy::extensions::filters::http::lua::v3::LuaPerRoute> {
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::lua::v3::Lua,
+                                        envoy::extensions::filters::http::lua::v3::LuaPerRoute> {
 public:
-  LuaFilterConfig() : DualFactoryBase("envoy.filters.http.lua") {}
+  LuaFilterConfig() : UnifiedFactoryBase("envoy.filters.http.lua") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
-      const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
-      const std::string& stats_prefix, DualInfo info,
-      Server::Configuration::ServerFactoryContext& context) override;
-
   absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::lua::v3::Lua& proto_config,
       Server::Configuration::ServerFactoryContext& context,

--- a/test/extensions/filters/http/admission_control/config_test.cc
+++ b/test/extensions/filters/http/admission_control/config_test.cc
@@ -48,7 +48,6 @@ public:
 protected:
   NiceMock<Runtime::MockLoader> runtime_;
   NiceMock<Server::Configuration::MockFactoryContext> context_;
-  AdmissionControlFilterFactory::DualInfo dual_info_{context_};
   Stats::IsolatedStoreImpl store_;
   Stats::Scope& scope_{*store_.rootScope()};
   NiceMock<Random::MockRandomGenerator> random_;
@@ -79,8 +78,8 @@ success_criteria:
   AdmissionControlProto proto;
   TestUtility::loadFromYamlAndValidate(yaml, proto);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  auto status_or = admission_control_filter_factory.createFilterFactoryFromProtoTyped(
-      proto, "whatever", dual_info_, factory_context.serverFactoryContext());
+  auto status_or = admission_control_filter_factory.createFilterFactoryFromProto(proto, "whatever",
+                                                                                 factory_context);
   EXPECT_THAT(status_or, HasStatusMessage("Success rate threshold cannot be less than 1.0%."));
 }
 
@@ -106,8 +105,8 @@ success_criteria:
   AdmissionControlProto proto;
   TestUtility::loadFromYamlAndValidate(yaml, proto);
   NiceMock<Server::Configuration::MockFactoryContext> factory_context;
-  auto status_or = admission_control_filter_factory.createFilterFactoryFromProtoTyped(
-      proto, "whatever", dual_info_, factory_context.serverFactoryContext());
+  auto status_or = admission_control_filter_factory.createFilterFactoryFromProto(proto, "whatever",
+                                                                                 factory_context);
   EXPECT_THAT(status_or, HasStatusMessage("Success rate threshold cannot be less than 1.0%."));
 }
 

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -109,10 +109,8 @@ TEST(HttpExtProcConfigTest, CorrectGrpcServiceConfigServerContext) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
                                                            "stats"};
-  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
       factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;
@@ -407,10 +405,8 @@ TEST(HttpExtProcConfigTest, UpstreamConfig) {
   TestUtility::loadFromYaml(yaml, *proto_config);
 
   testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  // Built before the expectation below so that only the factory's own calls are counted.
   Server::Configuration::ExtraFactoryContext extra_context{context.messageValidationVisitor(),
                                                            "stats"};
-  EXPECT_CALL(context, messageValidationVisitor());
   Http::FilterFactoryCb cb =
       factory.createHttpFilterFactoryFromProto(*proto_config, context, extra_context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;


### PR DESCRIPTION
Commit Message: http: migrate the dual filters to use the unified http filter factory
Additional Description:
Continuing work of https://github.com/envoyproxy/envoy/pull/46835. With the new createHttpFilterFactoryFromProto we can unify all our downstream/upstream/route HTTP filter factory creation into single method.

Also, no behavior change, won't break any existing extensions.
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
