### PR TITLE
contrib: upgrade the http filter factory to unified http filter factory

### DIFF
--- a/contrib/checksum/filters/http/source/config.cc
+++ b/contrib/checksum/filters/http/source/config.cc
@@ -12,11 +12,11 @@ namespace Extensions {
 namespace HttpFilters {
 namespace ChecksumFilter {
 
-absl::StatusOr<Http::FilterFactoryCb> ChecksumFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> ChecksumFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig& proto_config,
-    const std::string&, Server::Configuration::FactoryContext& context) {
-  ChecksumFilterConfigSharedPtr filter_config(
-      new ChecksumFilterConfig(proto_config, context.serverFactoryContext()));
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
+  ChecksumFilterConfigSharedPtr filter_config(new ChecksumFilterConfig(proto_config, context));
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<ChecksumFilter>(filter_config));
   };

--- a/contrib/checksum/filters/http/source/config.h
+++ b/contrib/checksum/filters/http/source/config.h
@@ -14,15 +14,16 @@ namespace ChecksumFilter {
  * Config registration for the checksum filter.
  */
 class ChecksumFilterFactory
-    : public Common::ExceptionFreeFactoryBase<
+    : public Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig> {
 public:
-  ChecksumFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.checksum") {}
+  ChecksumFilterFactory() : UnifiedFactoryBase("envoy.filters.http.checksum") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::checksum::v3alpha::ChecksumConfig& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 using UpstreamChecksumFilterFactory = ChecksumFilterFactory;

--- a/contrib/dynamo/filters/http/source/config.cc
+++ b/contrib/dynamo/filters/http/source/config.cc
@@ -13,14 +13,15 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Dynamo {
 
-absl::StatusOr<Http::FilterFactoryCb> DynamoFilterConfig::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::dynamo::v3::Dynamo&, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context) {
-  auto stats = std::make_shared<DynamoStats>(context.scope(), stats_prefix);
+absl::StatusOr<Http::FilterFactoryCb> DynamoFilterConfig::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::dynamo::v3::Dynamo&,
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
+  auto stats =
+      std::make_shared<DynamoStats>(extra_context.scopeOr(context), extra_context.stats_prefix);
   return [&context, stats](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(
-        std::make_shared<Dynamo::DynamoFilter>(context.serverFactoryContext().runtime(), stats,
-                                               context.serverFactoryContext().timeSource()));
+        std::make_shared<Dynamo::DynamoFilter>(context.runtime(), stats, context.timeSource()));
   };
 }
 

--- a/contrib/dynamo/filters/http/source/config.h
+++ b/contrib/dynamo/filters/http/source/config.h
@@ -17,15 +17,16 @@ namespace Dynamo {
 /**
  * Config registration for http dynamodb filter.
  */
-class DynamoFilterConfig : public Common::ExceptionFreeFactoryBase<
-                               envoy::extensions::filters::http::dynamo::v3::Dynamo> {
+class DynamoFilterConfig
+    : public Common::UnifiedFactoryBase<envoy::extensions::filters::http::dynamo::v3::Dynamo> {
 public:
-  DynamoFilterConfig() : ExceptionFreeFactoryBase("envoy.filters.http.dynamo") {}
+  DynamoFilterConfig() : UnifiedFactoryBase("envoy.filters.http.dynamo") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::dynamo::v3::Dynamo& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace Dynamo

--- a/contrib/golang/filters/http/source/BUILD
+++ b/contrib/golang/filters/http/source/BUILD
@@ -67,6 +67,7 @@ envoy_cc_contrib_extension(
         "//envoy/server:filter_config_interface",
         "//envoy/server:lifecycle_notifier_interface",
         "//source/extensions/filters/http/common:factory_base_lib",
+        "//source/server:generic_factory_context_lib",
         "@envoy_api//contrib/envoy/extensions/filters/http/golang/v3alpha:pkg_cc_proto",
     ],
 )

--- a/contrib/golang/filters/http/source/config.cc
+++ b/contrib/golang/filters/http/source/config.cc
@@ -5,6 +5,7 @@
 #include "envoy/registry/registry.h"
 
 #include "source/common/common/fmt.h"
+#include "source/server/generic_factory_context.h"
 
 #include "contrib/golang/common/dso/dso.h"
 #include "contrib/golang/filters/http/source/golang_filter.h"
@@ -14,9 +15,10 @@ namespace Extensions {
 namespace HttpFilters {
 namespace Golang {
 
-absl::StatusOr<Http::FilterFactoryCb> GolangFilterConfig::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> GolangFilterConfig::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
 
   ENVOY_LOG_MISC(debug, "load golang library at parse config: {} {}", proto_config.library_id(),
                  proto_config.library_path());
@@ -32,8 +34,10 @@ absl::StatusOr<Http::FilterFactoryCb> GolangFilterConfig::createFilterFactoryFro
                                                   proto_config.library_path()));
   }
 
+  Server::GenericFactoryContextImpl generic_context(
+      context, extra_context.scope, extra_context.visitor, extra_context.init_manager);
   FilterConfigSharedPtr config = std::make_shared<FilterConfig>(
-      proto_config, dso_lib, fmt::format("{}golang.", stats_prefix), context);
+      proto_config, dso_lib, fmt::format("{}golang.", extra_context.stats_prefix), generic_context);
   RETURN_IF_NOT_OK(config->newGoPluginConfig());
   return [config, dso_lib](Http::FilterChainFactoryCallbacks& callbacks) {
     const std::string& worker_name = callbacks.dispatcher().name();

--- a/contrib/golang/filters/http/source/config.h
+++ b/contrib/golang/filters/http/source/config.h
@@ -18,19 +18,19 @@ constexpr char CanonicalName[] = "envoy.filters.http.golang";
  * Config registration for the golang extensions  filter. @see
  * NamedHttpFilterConfigFactory.
  */
-class GolangFilterConfig : public Common::ExceptionFreeFactoryBase<
+class GolangFilterConfig : public Common::UnifiedFactoryBase<
                                envoy::extensions::filters::http::golang::v3alpha::Config,
                                envoy::extensions::filters::http::golang::v3alpha::ConfigsPerRoute> {
 public:
-  GolangFilterConfig() : ExceptionFreeFactoryBase(CanonicalName) {}
+  GolangFilterConfig() : UnifiedFactoryBase(CanonicalName) {}
 
 private:
   Server::ServerLifecycleNotifier::HandlePtr handler_;
 
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
-      const std::string& stats_prefix,
-      Server::Configuration::FactoryContext& factory_context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   absl::StatusOr<Router::RouteSpecificFilterConfigConstSharedPtr>
   createRouteSpecificFilterConfigTyped(

--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -1791,7 +1791,7 @@ uint64_t Filter::getMergedConfigId() {
 FilterConfig::FilterConfig(
     const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
     Dso::HttpFilterDsoPtr dso_lib, const std::string& stats_prefix,
-    Server::Configuration::FactoryContext& context)
+    Server::Configuration::GenericFactoryContext& context)
     : plugin_name_(proto_config.plugin_name()), so_id_(proto_config.library_id()),
       so_path_(proto_config.library_path()), plugin_config_(proto_config.plugin_config()),
       concurrency_(context.serverFactoryContext().options().concurrency()),
@@ -2069,7 +2069,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
 
 SecretReader::SecretReader(
     const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
-    Server::Configuration::FactoryContext& context) {
+    Server::Configuration::GenericFactoryContext& context) {
   if (proto_config.generic_secrets_size() > 0) {
     auto& server_context = context.serverFactoryContext();
     auto& init_manager = context.initManager();

--- a/contrib/golang/filters/http/source/golang_filter.h
+++ b/contrib/golang/filters/http/source/golang_filter.h
@@ -63,7 +63,7 @@ struct httpConfigInternal;
 class SecretReader {
 public:
   SecretReader(const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
-               Server::Configuration::FactoryContext& context);
+               Server::Configuration::GenericFactoryContext& context);
   std::optional<const std::string> secret(const std::string& name) const;
 
 private:
@@ -78,7 +78,7 @@ class FilterConfig : public std::enable_shared_from_this<FilterConfig>,
 public:
   FilterConfig(const envoy::extensions::filters::http::golang::v3alpha::Config& proto_config,
                Dso::HttpFilterDsoPtr dso_lib, const std::string& stats_prefix,
-               Server::Configuration::FactoryContext& context);
+               Server::Configuration::GenericFactoryContext& context);
   ~FilterConfig();
 
   const std::string& soId() const { return so_id_; }

--- a/contrib/istio/filters/http/alpn/source/config.cc
+++ b/contrib/istio/filters/http/alpn/source/config.cc
@@ -9,10 +9,10 @@ using istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig;
 namespace Envoy {
 namespace Http {
 namespace Alpn {
-absl::StatusOr<Http::FilterFactoryCb> AlpnConfigFactory::createFilterFactoryFromProtoTyped(
-    const FilterConfig& proto_config, const std::string&,
-    Server::Configuration::FactoryContext& context) {
-  return createFilterFactory(proto_config, context.serverFactoryContext().clusterManager());
+absl::StatusOr<Http::FilterFactoryCb> AlpnConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const FilterConfig& proto_config, Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext&) {
+  return createFilterFactory(proto_config, context.clusterManager());
 }
 
 Http::FilterFactoryCb

--- a/contrib/istio/filters/http/alpn/source/config.h
+++ b/contrib/istio/filters/http/alpn/source/config.h
@@ -12,15 +12,16 @@ namespace Alpn {
 /**
  * Config registration for the alpn filter.
  */
-class AlpnConfigFactory : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+class AlpnConfigFactory : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
                               istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig> {
 public:
-  AlpnConfigFactory() : ExceptionFreeFactoryBase("istio.alpn") {}
+  AlpnConfigFactory() : UnifiedFactoryBase("istio.alpn") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig& proto_config,
-      const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 
   Http::FilterFactoryCb createFilterFactory(
       const istio::envoy::config::filter::http::alpn::v2alpha1::FilterConfig& config_pb,

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.cc
@@ -274,7 +274,7 @@ std::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo:
 }
 
 FilterConfig::FilterConfig(const io::istio::http::peer_metadata::Config& config,
-                           Server::Configuration::FactoryContext& factory_context)
+                           Server::Configuration::ServerFactoryContext& factory_context)
     : shared_with_upstream_(config.shared_with_upstream()),
       downstream_discovery_(buildDiscoveryMethods(config.downstream_discovery(),
                                                   buildAdditionalLabels(config.additional_labels()),
@@ -293,20 +293,18 @@ std::vector<DiscoveryMethodPtr> FilterConfig::buildDiscoveryMethods(
     const Protobuf::RepeatedPtrField<io::istio::http::peer_metadata::Config::DiscoveryMethod>&
         config,
     const absl::flat_hash_set<std::string>& additional_labels, bool downstream,
-    Server::Configuration::FactoryContext& factory_context) const {
+    Server::Configuration::ServerFactoryContext& factory_context) const {
   std::vector<DiscoveryMethodPtr> methods;
   methods.reserve(config.size());
   for (const auto& method : config) {
     switch (method.method_specifier_case()) {
     case io::istio::http::peer_metadata::Config::DiscoveryMethod::MethodSpecifierCase::
         kWorkloadDiscovery:
-      methods.push_back(
-          std::make_unique<XDSMethod>(downstream, factory_context.serverFactoryContext()));
+      methods.push_back(std::make_unique<XDSMethod>(downstream, factory_context));
       break;
     case io::istio::http::peer_metadata::Config::DiscoveryMethod::MethodSpecifierCase::
         kIstioHeaders:
-      methods.push_back(std::make_unique<MXMethod>(downstream, additional_labels,
-                                                   factory_context.serverFactoryContext()));
+      methods.push_back(std::make_unique<MXMethod>(downstream, additional_labels, factory_context));
       break;
     case io::istio::http::peer_metadata::Config::DiscoveryMethod::MethodSpecifierCase::kBaggage:
       if (downstream) {
@@ -337,20 +335,19 @@ std::vector<PropagationMethodPtr> FilterConfig::buildPropagationMethods(
     const Protobuf::RepeatedPtrField<io::istio::http::peer_metadata::Config::PropagationMethod>&
         config,
     const absl::flat_hash_set<std::string>& additional_labels, bool downstream,
-    Server::Configuration::FactoryContext& factory_context) const {
+    Server::Configuration::ServerFactoryContext& factory_context) const {
   std::vector<PropagationMethodPtr> methods;
   methods.reserve(config.size());
   for (const auto& method : config) {
     switch (method.method_specifier_case()) {
     case io::istio::http::peer_metadata::Config::PropagationMethod::MethodSpecifierCase::
         kIstioHeaders:
-      methods.push_back(
-          std::make_unique<MXPropagationMethod>(downstream, factory_context.serverFactoryContext(),
-                                                additional_labels, method.istio_headers()));
+      methods.push_back(std::make_unique<MXPropagationMethod>(
+          downstream, factory_context, additional_labels, method.istio_headers()));
       break;
     case io::istio::http::peer_metadata::Config::PropagationMethod::MethodSpecifierCase::kBaggage:
-      methods.push_back(std::make_unique<BaggagePropagationMethod>(
-          factory_context.serverFactoryContext(), method.baggage()));
+      methods.push_back(
+          std::make_unique<BaggagePropagationMethod>(factory_context, method.baggage()));
       break;
     default:
       break;
@@ -479,9 +476,10 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
   return Http::FilterHeadersStatus::Continue;
 }
 
-absl::StatusOr<Http::FilterFactoryCb> FilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const io::istio::http::peer_metadata::Config& config, const std::string&,
-    Server::Configuration::FactoryContext& factory_context) {
+absl::StatusOr<Http::FilterFactoryCb> FilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const io::istio::http::peer_metadata::Config& config,
+    Server::Configuration::ServerFactoryContext& factory_context,
+    Server::Configuration::ExtraFactoryContext&) {
   auto filter_config = std::make_shared<FilterConfig>(config, factory_context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) {
     auto filter = std::make_shared<Filter>(filter_config);

--- a/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
+++ b/contrib/istio/filters/http/peer_metadata/source/peer_metadata.h
@@ -113,7 +113,7 @@ public:
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {
 public:
   FilterConfig(const io::istio::http::peer_metadata::Config&,
-               Server::Configuration::FactoryContext&);
+               Server::Configuration::ServerFactoryContext&);
   void discoverDownstream(StreamInfo::StreamInfo&, Http::RequestHeaderMap&, Context&) const;
   void discoverUpstream(StreamInfo::StreamInfo&, Http::ResponseHeaderMap&, Context&) const;
   void injectDownstream(const StreamInfo::StreamInfo&, Http::ResponseHeaderMap&, Context&) const;
@@ -130,11 +130,11 @@ private:
   std::vector<DiscoveryMethodPtr> buildDiscoveryMethods(
       const Protobuf::RepeatedPtrField<io::istio::http::peer_metadata::Config::DiscoveryMethod>&,
       const absl::flat_hash_set<std::string>& additional_labels, bool downstream,
-      Server::Configuration::FactoryContext&) const;
+      Server::Configuration::ServerFactoryContext&) const;
   std::vector<PropagationMethodPtr> buildPropagationMethods(
       const Protobuf::RepeatedPtrField<io::istio::http::peer_metadata::Config::PropagationMethod>&,
       const absl::flat_hash_set<std::string>& additional_labels, bool downstream,
-      Server::Configuration::FactoryContext&) const;
+      Server::Configuration::ServerFactoryContext&) const;
   absl::flat_hash_set<std::string>
   buildAdditionalLabels(const Protobuf::RepeatedPtrField<std::string>&) const;
   StreamInfo::StreamSharingMayImpactPooling sharedWithUpstream() const {
@@ -165,15 +165,15 @@ private:
 };
 
 class FilterConfigFactory
-    : public Common::ExceptionFreeFactoryBase<io::istio::http::peer_metadata::Config> {
+    : public Common::UnifiedFactoryBase<io::istio::http::peer_metadata::Config> {
 public:
-  FilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.peer_metadata") {}
+  FilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.peer_metadata") {}
 
 private:
   absl::StatusOr<Http::FilterFactoryCb>
-  createFilterFactoryFromProtoTyped(const io::istio::http::peer_metadata::Config& proto_config,
-                                    const std::string&,
-                                    Server::Configuration::FactoryContext&) override;
+  createHttpFilterFactoryFromProtoTyped(const io::istio::http::peer_metadata::Config& proto_config,
+                                        Server::Configuration::ServerFactoryContext&,
+                                        Server::Configuration::ExtraFactoryContext&) override;
 };
 
 } // namespace PeerMetadata

--- a/contrib/language/filters/http/source/config.cc
+++ b/contrib/language/filters/http/source/config.cc
@@ -17,9 +17,10 @@ struct LocaleHash {
   }
 };
 
-absl::StatusOr<Http::FilterFactoryCb> LanguageFilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> LanguageFilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::language::v3alpha::Language& proto_config,
-    const std::string& stats_prefix, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   const auto default_locale = icu::Locale(proto_config.default_language().data());
 
   if (default_locale.isBogus()) {
@@ -57,7 +58,7 @@ absl::StatusOr<Http::FilterFactoryCb> LanguageFilterFactory::createFilterFactory
 
   auto config = std::make_shared<LanguageFilterConfigImpl>(
       std::make_shared<icu::Locale>(default_locale), locale_matcher,
-      proto_config.clear_route_cache(), stats_prefix, context.scope());
+      proto_config.clear_route_cache(), extra_context.stats_prefix, extra_context.scopeOr(context));
 
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter = std::make_shared<LanguageFilter>(config);

--- a/contrib/language/filters/http/source/config.h
+++ b/contrib/language/filters/http/source/config.h
@@ -13,14 +13,15 @@ namespace Language {
 /**
  * Config registration for the language detection filter (i18n). @see NamedHttpFilterConfigFactory.
  */
-class LanguageFilterFactory : public Common::ExceptionFreeFactoryBase<
+class LanguageFilterFactory : public Common::UnifiedFactoryBase<
                                   envoy::extensions::filters::http::language::v3alpha::Language> {
 public:
-  LanguageFilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.language") {}
+  LanguageFilterFactory() : UnifiedFactoryBase("envoy.filters.http.language") {}
 
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::language::v3alpha::Language& proto_config,
-      const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 DECLARE_FACTORY(LanguageFilterFactory);

--- a/contrib/language/filters/http/test/language_config_test.cc
+++ b/contrib/language/filters/http/test/language_config_test.cc
@@ -22,8 +22,7 @@ public:
     envoy::extensions::filters::http::language::v3alpha::Language proto_config;
     TestUtility::loadFromYaml(yaml, proto_config);
 
-    return factory_.createFilterFactoryFromProtoTyped(proto_config, "stats", factory_context_)
-        .status();
+    return factory_.createFilterFactoryFromProto(proto_config, "stats", factory_context_).status();
   }
 
 private:

--- a/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.cc
+++ b/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.cc
@@ -10,9 +10,9 @@ namespace HttpFilters {
 namespace PeakEwma {
 
 absl::StatusOr<Http::FilterFactoryCb>
-PeakEwmaFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig&, const std::string&,
-    Server::Configuration::FactoryContext&) {
+PeakEwmaFilterConfigFactory::createHttpFilterFactoryFromProtoTyped(
+    const envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig&,
+    Server::Configuration::ServerFactoryContext&, Server::Configuration::ExtraFactoryContext&) {
   return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<PeakEwmaRttFilter>());
   };

--- a/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.h
+++ b/contrib/peak_ewma/filters/http/source/peak_ewma_filter_config.h
@@ -11,15 +11,16 @@ namespace HttpFilters {
 namespace PeakEwma {
 
 class PeakEwmaFilterConfigFactory
-    : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+    : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
           envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig> {
 public:
-  PeakEwmaFilterConfigFactory() : ExceptionFreeFactoryBase("envoy.filters.http.peak_ewma") {}
+  PeakEwmaFilterConfigFactory() : UnifiedFactoryBase("envoy.filters.http.peak_ewma") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::peak_ewma::v3alpha::PeakEwmaConfig& proto_config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 } // namespace PeakEwma

--- a/contrib/sxg/filters/http/source/config.cc
+++ b/contrib/sxg/filters/http/source/config.cc
@@ -23,7 +23,7 @@ namespace {
 Secret::GenericSecretConfigProviderSharedPtr
 secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretConfig& config,
                 Server::Configuration::ServerFactoryContext& server_context,
-                Init::Manager& init_manager) {
+                OptRef<Init::Manager> init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
         config.sds_config(), config.name(), server_context, init_manager);
@@ -33,21 +33,21 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
 }
 } // namespace
 
-absl::StatusOr<Http::FilterFactoryCb> FilterFactory::createFilterFactoryFromProtoTyped(
+absl::StatusOr<Http::FilterFactoryCb> FilterFactory::createHttpFilterFactoryFromProtoTyped(
     const envoy::extensions::filters::http::sxg::v3alpha::SXG& proto_config,
-    const std::string& stat_prefix, Server::Configuration::FactoryContext& context) {
+    Server::Configuration::ServerFactoryContext& server_context,
+    Server::Configuration::ExtraFactoryContext& extra_context) {
   const auto& certificate = proto_config.certificate();
   const auto& private_key = proto_config.private_key();
 
-  auto& server_context = context.serverFactoryContext();
-
+  // The SDS secrets are warmed up through the init manager of the enclosing configuration, if any.
   auto secret_provider_certificate =
-      secretsProvider(certificate, server_context, context.initManager());
+      secretsProvider(certificate, server_context, extra_context.init_manager);
   if (secret_provider_certificate == nullptr) {
     return absl::InvalidArgumentError("invalid certificate secret configuration");
   }
   auto secret_provider_private_key =
-      secretsProvider(private_key, server_context, context.initManager());
+      secretsProvider(private_key, server_context, extra_context.init_manager);
   if (secret_provider_private_key == nullptr) {
     return absl::InvalidArgumentError("invalid private_key secret configuration");
   }
@@ -56,7 +56,8 @@ absl::StatusOr<Http::FilterFactoryCb> FilterFactory::createFilterFactoryFromProt
       std::move(secret_provider_certificate), std::move(secret_provider_private_key),
       server_context.threadLocal(), server_context.api());
   auto config = std::make_shared<FilterConfig>(proto_config, server_context.timeSource(),
-                                               secret_reader, stat_prefix, context.scope());
+                                               secret_reader, extra_context.stats_prefix,
+                                               extra_context.scopeOr(server_context));
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     const EncoderPtr encoder = std::make_unique<EncoderImpl>(config);
     callbacks.addStreamFilter(std::make_shared<Filter>(config, encoder));

--- a/contrib/sxg/filters/http/source/config.h
+++ b/contrib/sxg/filters/http/source/config.h
@@ -12,15 +12,16 @@ namespace Extensions {
 namespace HttpFilters {
 namespace SXG {
 
-class FilterFactory : public Extensions::HttpFilters::Common::ExceptionFreeFactoryBase<
+class FilterFactory : public Extensions::HttpFilters::Common::UnifiedFactoryBase<
                           envoy::extensions::filters::http::sxg::v3alpha::SXG> {
 public:
-  FilterFactory() : ExceptionFreeFactoryBase("envoy.filters.http.sxg") {}
+  FilterFactory() : UnifiedFactoryBase("envoy.filters.http.sxg") {}
 
 private:
-  absl::StatusOr<Http::FilterFactoryCb> createFilterFactoryFromProtoTyped(
+  absl::StatusOr<Http::FilterFactoryCb> createHttpFilterFactoryFromProtoTyped(
       const envoy::extensions::filters::http::sxg::v3alpha::SXG& config,
-      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+      Server::Configuration::ServerFactoryContext& context,
+      Server::Configuration::ExtraFactoryContext& extra_context) override;
 };
 
 DECLARE_FACTORY(FilterFactory);

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -50,7 +50,7 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
   EXPECT_CALL(context, scope());
   EXPECT_CALL(context.server_factory_context_, timeSource());
   EXPECT_CALL(context.server_factory_context_, api());
-  EXPECT_CALL(context, initManager()).Times(2);
+  EXPECT_CALL(context, initManager());
   Http::FilterFactoryCb cb =
       factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
   Http::MockFilterChainFactoryCallbacks filter_callback;


### PR DESCRIPTION
Commit Message: contrib: upgrade the http filter factory to unified http filter factory
Additional Description:
Continuous work of https://github.com/envoyproxy/envoy/pull/46835. With the new createHttpFilterFactoryFromProto we could unify all our downstream/upstream/route HTTP filter factory creation into single method.

Also, no behavior change, won't break any existing extensions.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.