### PR TITLE
mobile/ios: Disable swift tests until diskspace issue is resolved

### DIFF
--- a/.github/workflows/mobile-ios_tests.yml
+++ b/.github/workflows/mobile-ios_tests.yml
@@ -69,15 +69,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Run swift library tests
-          args: >-
-            test
-            --config=ci
-            --config=mobile-rbe
-            --config=mobile-ios-swift
-            //test/swift/...
-          target: swift-tests
-          timeout-minutes: 120
+        # - name: Run swift library tests
+        #   args: >-
+        #     test
+        #     --config=ci
+        #     --config=mobile-rbe
+        #     --config=mobile-ios-swift
+        #     //test/swift/...
+        #   target: swift-tests
+        #   timeout-minutes: 120
         - name: Run Objective-C library tests
           args: >-
             test


### PR DESCRIPTION
we have requested more diskspace, but until then this should stop main/prs failing