### PR TITLE
config: clamp overdue TTL timer duration to zero

### DIFF
--- a/source/common/config/ttl.cc
+++ b/source/common/config/ttl.cc
@@ -1,5 +1,7 @@
 #include "source/common/config/ttl.h"
 
+#include <algorithm>
+
 namespace Envoy {
 namespace Config {
 
@@ -67,7 +69,7 @@ void TtlManager::refreshTimer() {
 
   // The time until the next TTL changed, so reset the timer to match the new value.
   last_scheduled_time_ = next_ttl_expiry;
-  timer_->enableTimer(timer_duration, nullptr);
+  timer_->enableTimer(std::max(std::chrono::milliseconds::zero(), timer_duration), nullptr);
 }
 } // namespace Config
 } // namespace Envoy

--- a/test/common/config/ttl_test.cc
+++ b/test/common/config/ttl_test.cc
@@ -81,31 +81,31 @@ TEST_F(TtlManagerTest, ScopedUpdate) {
 }
 
 TEST_F(TtlManagerTest, OverdueTtl) {
-  uint32_t calls = 0;
+  std::vector<std::string> last_expired;
+  auto cb = [&](const auto& expired) {
+    last_expired = expired;
+    // Simulate time passing during callback past "second"'s expiry (5ms).
+    test_time_.advanceTimeWait(std::chrono::milliseconds(9));
+  };
   auto ttl_timer = new testing::NiceMock<Event::MockTimer>(&dispatcher_);
-  TtlManager ttl(
-      [&](const auto&) {
-        calls++;
-        test_time_.advanceTimeWait(std::chrono::milliseconds(9));
-      },
-      dispatcher_, dispatcher_.timeSource());
+  TtlManager ttl(cb, dispatcher_, dispatcher_.timeSource());
 
+  EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(1), _));
   ttl.add(std::chrono::milliseconds(1), "first");
   ttl.add(std::chrono::milliseconds(5), "second");
 
-  // Advance time to 1ms to trigger the first TTL. During the callback, time advances by 9ms
-  // past "second"'s expiry (5ms). The timer should be re-enabled with 0ms instead of negative,
-  // and "second" would be executed on the next TTL timer tick.
+  // Advance time to 1ms to trigger the first TTL.
   test_time_.advanceTimeWait(std::chrono::milliseconds(1));
+  // The callback advances time to 10ms (past "second"'s expiry of 5ms).
+  // The overdue timer must be scheduled with 0ms instead of a negative duration.
   EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(0), _));
   ttl_timer->invokeCallback();
-  EXPECT_EQ(1, calls);
+  EXPECT_EQ(last_expired, std::vector<std::string>({"first"}));
 
+  // Now trigger the 0ms timer callback for the overdue "second" entry.
+  EXPECT_CALL(*ttl_timer, disableTimer());
   ttl_timer->invokeCallback();
-  EXPECT_EQ(2, calls);
-
-  // Now there are no TTLs left, so the timer should be disabled.
-  EXPECT_FALSE(ttl_timer->enabled());
+  EXPECT_EQ(last_expired, std::vector<std::string>({"second"}));
 }
 
 } // namespace

--- a/test/common/config/ttl_test.cc
+++ b/test/common/config/ttl_test.cc
@@ -100,6 +100,12 @@ TEST_F(TtlManagerTest, OverdueTtl) {
   EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(0), _));
   ttl_timer->invokeCallback();
   EXPECT_EQ(1, calls);
+
+  ttl_timer->invokeCallback();
+  EXPECT_EQ(2, calls);
+
+  // Now there are no TTLs left, so the timer should be disabled.
+  EXPECT_FALSE(ttl_timer->enabled());
 }
 
 } // namespace

--- a/test/common/config/ttl_test.cc
+++ b/test/common/config/ttl_test.cc
@@ -81,35 +81,25 @@ TEST_F(TtlManagerTest, ScopedUpdate) {
 }
 
 TEST_F(TtlManagerTest, OverdueTtl) {
-  std::optional<std::vector<std::string>> maybe_expired;
-  auto cb = [&](const auto& expired) {
-    maybe_expired = expired;
-    // Simulate time passing during callback past the next item's expiry.
-    test_time_.setMonotonicTime(std::chrono::milliseconds(10));
-  };
-  auto ttl_timer = new Event::MockTimer(&dispatcher_);
-  TtlManager ttl(cb, dispatcher_, dispatcher_.timeSource());
+  uint32_t calls = 0;
+  auto ttl_timer = new testing::NiceMock<Event::MockTimer>(&dispatcher_);
+  TtlManager ttl(
+      [&](const auto&) {
+        calls++;
+        test_time_.advanceTimeWait(std::chrono::milliseconds(9));
+      },
+      dispatcher_, dispatcher_.timeSource());
 
-  EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(1), _));
-  EXPECT_CALL(*ttl_timer, enabled());
   ttl.add(std::chrono::milliseconds(1), "first");
-
-  EXPECT_CALL(*ttl_timer, enabled());
   ttl.add(std::chrono::milliseconds(5), "second");
 
-  // Advance time to 1 ms to trigger the first TTL.
-  test_time_.setMonotonicTime(std::chrono::milliseconds(1));
-  EXPECT_CALL(*ttl_timer, enabled());
-  // The callback will advance time to 10ms (past "second"'s expiry of 5ms).
-  // The timer should be re-enabled with 0ms instead of a negative duration.
+  // Advance time to 1ms to trigger the first TTL. During the callback, time advances by 9ms
+  // past "second"'s expiry (5ms). The timer should be re-enabled with 0ms instead of negative,
+  // and "second" would be executed on the next TTL timer tick.
+  test_time_.advanceTimeWait(std::chrono::milliseconds(1));
   EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(0), _));
   ttl_timer->invokeCallback();
-  EXPECT_EQ(maybe_expired.value(), std::vector<std::string>({"first"}));
-
-  // Now invoke the callback again for the overdue "second" entry.
-  EXPECT_CALL(*ttl_timer, disableTimer());
-  ttl_timer->invokeCallback();
-  EXPECT_EQ(maybe_expired.value(), std::vector<std::string>({"second"}));
+  EXPECT_EQ(1, calls);
 }
 
 } // namespace

--- a/test/common/config/ttl_test.cc
+++ b/test/common/config/ttl_test.cc
@@ -79,6 +79,39 @@ TEST_F(TtlManagerTest, ScopedUpdate) {
     EXPECT_CALL(*ttl_timer, disableTimer());
   }
 }
+
+TEST_F(TtlManagerTest, OverdueTtl) {
+  std::optional<std::vector<std::string>> maybe_expired;
+  auto cb = [&](const auto& expired) {
+    maybe_expired = expired;
+    // Simulate time passing during callback past the next item's expiry.
+    test_time_.setMonotonicTime(std::chrono::milliseconds(10));
+  };
+  auto ttl_timer = new Event::MockTimer(&dispatcher_);
+  TtlManager ttl(cb, dispatcher_, dispatcher_.timeSource());
+
+  EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(1), _));
+  EXPECT_CALL(*ttl_timer, enabled());
+  ttl.add(std::chrono::milliseconds(1), "first");
+
+  EXPECT_CALL(*ttl_timer, enabled());
+  ttl.add(std::chrono::milliseconds(5), "second");
+
+  // Advance time to 1 ms to trigger the first TTL.
+  test_time_.setMonotonicTime(std::chrono::milliseconds(1));
+  EXPECT_CALL(*ttl_timer, enabled());
+  // The callback will advance time to 10ms (past "second"'s expiry of 5ms).
+  // The timer should be re-enabled with 0ms instead of a negative duration.
+  EXPECT_CALL(*ttl_timer, enableTimer(std::chrono::milliseconds(0), _));
+  ttl_timer->invokeCallback();
+  EXPECT_EQ(maybe_expired.value(), std::vector<std::string>({"first"}));
+
+  // Now invoke the callback again for the overdue "second" entry.
+  EXPECT_CALL(*ttl_timer, disableTimer());
+  ttl_timer->invokeCallback();
+  EXPECT_EQ(maybe_expired.value(), std::vector<std::string>({"second"}));
+}
+
 } // namespace
 } // namespace Config
 } // namespace Envoy


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: config: clamp overdue TTL timer duration to zero
Additional Description: 

When `TtlManager::refreshTimer()` recalculates the duration for the next TTL expiration, `time_source_.monotonicTime()` may have already surpassed the target expiry (e.g. due to execution time in the TTL expiration callback or thread scheduling delays).

Fixes test flake:

```
  [ RUN      ] IpVersionsClientType/NetworkExtensionDiscoveryIntegrationTest.BasicSuccessWithTtlWithDefault/1
  [2026-08-21 14:40:01.523][14653][error][envoy_bug] [./source/common/event/timer_impl.h:33] envoy bug failure: false. Details: Negative duration passed to durationToTimeval(): -1
```

This could also theoretically happen in production though IIUC.

Risk Level: Low
Testing: Added unit test `TtlManagerTest.OverdueTtl` in `test/common/config/ttl_test.cc` and verified all `//test/common/config/...` tests pass.
Docs Changes: N/A
Release Notes: N/A

I used generative AI to help make this change.