### PR TITLE
ext_proc: skiping close the gRPC stream after ImmediateResponse

### DIFF
--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1959,8 +1959,9 @@ void Filter::onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& r) {
         on_processing_response_->afterReceivingImmediateResponse(
             response->immediate_response(), absl::OkStatus(), decoder_callbacks_->streamInfo());
       }
+      stats_.stream_msgs_received_.inc();
       sendImmediateResponse(response->immediate_response());
-      processing_status = absl::OkStatus();
+      return;
     }
     break;
   default:
@@ -1973,6 +1974,8 @@ void Filter::onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& r) {
 
   if (processing_status.ok()) {
     stats_.stream_msgs_received_.inc();
+    // Close the gRPC stream if no more external processing needed.
+    closeGrpcStreamIfLastRespReceived(*response, eos_seen_in_body);
   } else if (absl::IsFailedPrecondition(processing_status)) {
     // Processing code uses this specific error code in the case that a
     // message was received out of order.
@@ -2002,9 +2005,6 @@ void Filter::onReceiveMessage(Grpc::ResponsePtr<ProcessingResponse>&& r) {
     stats_.stream_msgs_received_.inc();
     handleErrorResponse(processing_status);
   }
-
-  // Close the gRPC stream if no more external processing needed.
-  closeGrpcStreamIfLastRespReceived(*response, eos_seen_in_body);
 }
 
 absl::Status Filter::handleStreamingImmediateResponse(


### PR DESCRIPTION
No need to try to call the stream close : 1) If ImmediateResponse is sent, since the gRPC stream is closed automatically during filter destruction. 2) or the stream is closed already due to spurious response message handling.
