### PR TITLE
ExtProc: clarify docs on end_of_stream_without_message response field

### DIFF
--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -623,11 +623,17 @@ message StreamedBodyResponse {
   // messages sent by the client application.
   bool end_of_stream = 2;
 
-  // This field is used in ``GRPC`` body send mode when ``end_of_stream`` is ``true`` and ``body``
-  // is empty. Those values would normally indicate an empty message on the stream with the
-  // end-of-stream bit set. However, if the half-close happens after the last message on the stream
-  // was already sent, then this field will be ``true`` to indicate an end-of-stream with *no*
-  // message (as opposed to an empty message).
+  // This field is used only in ``GRPC`` body send mode. It is not used in any other body send
+  // mode.
+  //
+  // This field is used only when ``end_of_stream`` is true and ``body`` is empty.
+  // Normally, in ``GRPC`` body send mode, an empty ``body`` field indicates an empty message on
+  // the gRPC stream. However, it is possible that the gRPC client sends a half-close without
+  // actually sending a message on the stream, so we need a way to differentiate between
+  // an empty message being sent and no message being sent. If this field is true, then it
+  // indicates that no message has been sent; if it is false, then it indicates that an empty
+  // message has been sent.
+  // [#not-implemented-hide:]
   bool end_of_stream_without_message = 3;
 
   // This field is used in ``GRPC`` body send mode to indicate whether the message is compressed.


### PR DESCRIPTION
Commit Message: ExtProc: clarify docs on end_of_stream_without_message response field
Additional Description: I updated the docs on the request field in #46671 but forgot to update the response field.
Risk Level: Low
Testing: N/A
Docs Changes: Included in PR
Release Notes: N/A
Platform Specific Features: N/A

CC @yanjunxiang-google @yanavlasov 