### PR TITLE
Fix TEST_THREAD_SUPPORTED on Windows

### DIFF
--- a/source/common/common/thread.h
+++ b/source/common/common/thread.h
@@ -189,6 +189,7 @@ public:
 #if defined(__linux__) || defined(__APPLE__)
 #define TEST_THREAD_SUPPORTED 1
 #else
+// Windows does not support TestThread::isTestThread()
 #define TEST_THREAD_SUPPORTED 0
 #endif
 
@@ -236,6 +237,8 @@ public:
    * is not supported.
    */
   static bool isMainOrTestThread() { return isMainThread() || TestThread::isTestThread(); }
+#else
+  static bool isMainOrTestThread() { return isMainThread(); }
 #endif
 
   /**


### PR DESCRIPTION
Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: windows only
