### PR TITLE
Move Logger::Levels enum to top level header

### DIFF
--- a/envoy/common/BUILD
+++ b/envoy/common/BUILD
@@ -162,3 +162,11 @@ envoy_cc_library(
         "@abseil-cpp//absl/types:variant",
     ],
 )
+
+envoy_cc_library(
+    name = "logger",
+    hdrs = ["logger.h"],
+    deps = [
+        "@spdlog",
+    ],
+)

--- a/envoy/common/logger.h
+++ b/envoy/common/logger.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "spdlog/spdlog.h"
+
+namespace Envoy {
+namespace Logger {
+
+/* This is simple mapping between Logger severity levels and spdlog severity levels.
+ * The only reason for this mapping is to go around the fact that spdlog defines level as err
+ * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
+ * fine spdlog::info corresponds to LOGGER.info method.
+ */
+enum class Levels {
+  trace = spdlog::level::trace,       // NOLINT(readability-identifier-naming)
+  debug = spdlog::level::debug,       // NOLINT(readability-identifier-naming)
+  info = spdlog::level::info,         // NOLINT(readability-identifier-naming)
+  warn = spdlog::level::warn,         // NOLINT(readability-identifier-naming)
+  error = spdlog::level::err,         // NOLINT(readability-identifier-naming)
+  critical = spdlog::level::critical, // NOLINT(readability-identifier-naming)
+  off = spdlog::level::off            // NOLINT(readability-identifier-naming)
+};
+
+} // namespace Logger
+} // namespace Envoy

--- a/source/common/common/BUILD
+++ b/source/common/common/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
     hdrs = ["assert.h"],
     deps = [
         ":minimal_logger_lib",
+        "//envoy/common:logger",
         "@abseil-cpp//absl/base",
         "@abseil-cpp//absl/debugging:stacktrace",
         "@abseil-cpp//absl/debugging:symbolize",
@@ -242,6 +243,7 @@ envoy_cc_library(
         ":lock_guard_lib",
         ":macros",
         ":non_copyable",
+        "//envoy/common:logger",
         "//source/common/protobuf",
         # Depend on the header-only interface, not the implementation lib, so that every commit to
         # main does not invalidate the build cache of minimal_logger_lib (and everything that

--- a/source/common/common/assert.h
+++ b/source/common/common/assert.h
@@ -2,6 +2,8 @@
 
 #include <functional>
 
+#include "envoy/common/logger.h"
+
 #include "source/common/common/logger.h"
 
 #include "absl/debugging/stacktrace.h"

--- a/source/common/common/base_logger.h
+++ b/source/common/common/base_logger.h
@@ -8,22 +8,6 @@
 
 namespace Envoy {
 namespace Logger {
-
-/* This is simple mapping between Logger severity levels and spdlog severity levels.
- * The only reason for this mapping is to go around the fact that spdlog defines level as err
- * but the method to log at err level is called LOGGER.error not LOGGER.err. All other level are
- * fine spdlog::info corresponds to LOGGER.info method.
- */
-enum class Levels {
-  trace = spdlog::level::trace,       // NOLINT(readability-identifier-naming)
-  debug = spdlog::level::debug,       // NOLINT(readability-identifier-naming)
-  info = spdlog::level::info,         // NOLINT(readability-identifier-naming)
-  warn = spdlog::level::warn,         // NOLINT(readability-identifier-naming)
-  error = spdlog::level::err,         // NOLINT(readability-identifier-naming)
-  critical = spdlog::level::critical, // NOLINT(readability-identifier-naming)
-  off = spdlog::level::off            // NOLINT(readability-identifier-naming)
-};
-
 /**
  * Logger wrapper for a spdlog logger.
  */

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/logger.h"
+
 #include "source/common/common/json_escape_string.h"
 #include "source/common/common/lock_guard.h"
 #include "source/common/version/version_string.h"

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/logger.h"
 #include "envoy/thread/thread.h"
 
 #include "source/common/common/base_logger.h"


### PR DESCRIPTION
This allows it to be used in Envoy interfaces and external code that needs to set Envoy log levels.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
