### PR TITLE
De-ossify the assumption on the ClientHello structures

### DIFF
--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_integration_test.cc
@@ -26,9 +26,9 @@ namespace {
 
 class LargeBufferListenerFilter : public Network::ListenerFilter {
 public:
-  // These differences in BUFFER_SIZE are required because BoringSSL and OpenSSL
-  // produce different sized client hello messages (514 and 394 respectively).
-  static constexpr int BUFFER_SIZE = SSL_SELECT(512, 392);
+  // Set BUFFER_SIZE to 300, which is larger than tls_inspector's initial read buffer size
+  // 256 bytes but smaller than the client hello message which is at least 350 bytes.
+  static constexpr int BUFFER_SIZE = 300;
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks&) override {
     ENVOY_LOG_MISC(debug, "LargeBufferListenerFilter::onAccept");
@@ -404,9 +404,9 @@ TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanGrow) {
   EXPECT_EQ(
       TestUtility::readSampleCount(test_server_->server().dispatcher(), *bytes_processed_histogram),
       1);
-  EXPECT_EQ(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
+  EXPECT_GT(static_cast<int>(TestUtility::readSampleSum(test_server_->server().dispatcher(),
                                                         *bytes_processed_histogram)),
-            SSL_SELECT(514, 414));
+            256);
 }
 
 TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanStartBig) {
@@ -444,7 +444,6 @@ TEST_P(TlsInspectorIntegrationTest, RequestedBufferSizeCanStartBig) {
       1);
   auto bytes_processed = static_cast<int>(
       TestUtility::readSampleSum(test_server_->server().dispatcher(), *bytes_processed_histogram));
-  EXPECT_EQ(bytes_processed, SSL_SELECT(514, 394));
   // Double check that the test is effective by ensuring that the
   // LargeBufferListenerFilter::BUFFER_SIZE is smaller than the client hello.
   EXPECT_GT(bytes_processed, LargeBufferListenerFilter::BUFFER_SIZE);

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -215,6 +215,8 @@ public:
                const std::string& hash = {}, bool expect_alpn = true);
   void testJA4(const std::string& expected_ja4, const std::string& sni = "",
                const std::string& alpn = "");
+  void testJA4(testing::Matcher<absl::string_view> expected_ja4_matcher,
+               const std::string& sni = "", const std::string& alpn = "");
 
   NiceMock<Api::MockOsSysCalls> os_sys_calls_;
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls_{&os_sys_calls_};
@@ -737,6 +739,11 @@ TEST_P(TlsInspectorTest, RequestedMaxReadSizeDoesNotGoBeyondMaxSize) {
 
 void TlsInspectorTest::testJA4(const std::string& expected_ja4, const std::string& sni,
                                const std::string& alpn) {
+  testJA4(testing::Matcher<absl::string_view>(expected_ja4), sni, alpn);
+}
+
+void TlsInspectorTest::testJA4(testing::Matcher<absl::string_view> expected_ja4_matcher,
+                               const std::string& sni, const std::string& alpn) {
   envoy::extensions::filters::listener::tls_inspector::v3::TlsInspector proto_config;
   proto_config.mutable_enable_ja4_fingerprinting()->set_value(true);
   cfg_ = std::make_shared<Config>(*store_.rootScope(), proto_config);
@@ -747,7 +754,7 @@ void TlsInspectorTest::testJA4(const std::string& expected_ja4, const std::strin
   init();
   mockSysCallForPeek(client_hello);
 
-  EXPECT_CALL(socket_, setJA4Hash(absl::string_view(expected_ja4)));
+  EXPECT_CALL(socket_, setJA4Hash(expected_ja4_matcher));
 
   if (!sni.empty()) {
     EXPECT_CALL(socket_, setRequestedServerName(absl::string_view(sni)));
@@ -859,11 +866,15 @@ TEST_P(TlsInspectorTest, JA4WithSNIAndALPN) {
   const uint16_t min_version = std::get<0>(GetParam());
   const uint16_t max_version = std::get<1>(GetParam());
 
-  std::string expected_value = (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
-                                max_version == Config::TLS_MAX_SUPPORTED_VERSION)
-                                   ? SSL_SELECT("t13d1312h2_f57a46bbacb6_ef7df7f74e48",
-                                                "t13d5511h2_54f589121d70_3cecfd2c111c")
-                                   : alpn_sni_test_version_to_ja4_.at(min_version);
+  testing::Matcher<absl::string_view> expected_value =
+      (min_version == Config::TLS_MIN_SUPPORTED_VERSION &&
+       max_version == Config::TLS_MAX_SUPPORTED_VERSION)
+          ? SSL_SELECT(testing::Matcher<absl::string_view>(
+                           testing::AnyOf(testing::Eq("t13d1312h2_f57a46bbacb6_ef7df7f74e48"),
+                                          testing::Eq("t13d1311h2_f57a46bbacb6_78e6aca7449b"))),
+                       testing::Matcher<absl::string_view>(
+                           testing::Eq("t13d5511h2_54f589121d70_3cecfd2c111c")))
+          : alpn_sni_test_version_to_ja4_.at(min_version);
 
   testJA4(expected_value, "example.com", "\x02h2\x08http/1.1");
 }


### PR DESCRIPTION
We should keep the test focused on verification of the property that the buffer only grows per demand when more data is actually received on the wire. ClientHello will continue to vary wildly across library versions as we add more post-quantum, quantum-resistant and possibly quantum-annoying ciphers.

This is motivated by the change that BoringSSL decides to stop applying the F5 workaround.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
