### PR TITLE
tls: fix stray dispatcher exit in ssl_socket_test

### DIFF
--- a/test/common/tls/ssl_socket_test.cc
+++ b/test/common/tls/ssl_socket_test.cc
@@ -7692,7 +7692,16 @@ protected:
     dispatcher_->run(Event::Dispatcher::RunType::Block);
 
     EXPECT_CALL(*read_filter_, onNewConnection());
-    EXPECT_CALL(*read_filter_, onData(_, _)).Times(testing::AnyNumber());
+    // The read buffer must be drained as it is delivered. Leaving it full keeps the server read
+    // buffer above its high watermark, which read disables the connection permanently: once
+    // read_disable_count_ is non-zero onReadReady() returns without calling doRead(), so the
+    // close below would never be observed and disconnect() would block forever.
+    EXPECT_CALL(*read_filter_, onData(_, _))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly(Invoke([&](Buffer::Instance& data, bool) -> Network::FilterStatus {
+          data.drain(data.length());
+          return Network::FilterStatus::StopIteration;
+        }));
 
     std::string data_to_write(bytes_to_write, 'a');
     Buffer::OwnedImpl buffer_to_write(data_to_write);
@@ -7700,12 +7709,17 @@ protected:
     EXPECT_CALL(*client_write_buffer, move(_))
         .WillRepeatedly(DoAll(AddBufferToStringWithoutDraining(&data_written),
                               Invoke(client_write_buffer, &MockWatermarkBuffer::baseMove)));
+    // Two drains are expected: the first from the SSL write below, and the second from
+    // ConnectionImpl::closeSocket() in disconnect(). Only the first may exit the dispatcher.
+    // closeSocket() is reached synchronously from close(), so exiting on the second drain arms a
+    // loop exit while no loop is running, which then terminates disconnect()'s run before the
+    // server connection has observed the close.
     EXPECT_CALL(*client_write_buffer, drain(_))
-        .Times(2)
-        .WillRepeatedly(Invoke([&](uint64_t n) -> void {
+        .WillOnce(Invoke([&](uint64_t n) -> void {
           client_write_buffer->baseDrain(n);
           dispatcher_->exit();
-        }));
+        }))
+        .WillOnce(Invoke([&](uint64_t n) -> void { client_write_buffer->baseDrain(n); }));
     client_connection_->write(buffer_to_write, false);
     dispatcher_->run(Event::Dispatcher::RunType::Block);
     EXPECT_EQ(data_to_write, data_written);


### PR DESCRIPTION
singleWriteTest exited the dispatcher on the drain from closeSocket(), arming a loop exit while no loop ran and ending disconnect()'s run before the server saw the close. Also drain the read buffer so the server is not left permanently read disabled.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
