### PR TITLE
admin: Streaming version of /config_dump

### DIFF
--- a/source/common/json/BUILD
+++ b/source/common/json/BUILD
@@ -60,6 +60,17 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "proto_streamer_lib",
+    srcs = ["proto_streamer.cc"],
+    hdrs = ["proto_streamer.h"],
+    deps = [
+        ":json_streamer_lib",
+        "//source/common/common:base64_lib",
+        "//source/common/protobuf:utility_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "constants_lib",
     hdrs = ["constants.h"],
     deps = [

--- a/source/common/json/proto_streamer.cc
+++ b/source/common/json/proto_streamer.cc
@@ -15,6 +15,7 @@ namespace {
 using Field = Protobuf::FieldDescriptor;
 
 // Returns the value of `field`, from element `index` if the field is repeated.
+// Pass a negative `index` to get the whole field.
 #define REFLECTION_GET(Type, field, index)                                                         \
   (index < 0 ? reflection.Get##Type(message, &field)                                               \
              : reflection.GetRepeated##Type(message, &field, index))
@@ -36,7 +37,7 @@ bool hasSpecialRepresentation(const Protobuf::Message& message) {
 
 constexpr absl::string_view RedactedText = "[redacted]";
 
-const std::string& redactedBytes() {
+const std::string& redactedBase64() {
   CONSTRUCT_ON_FIRST_USE(std::string, Base64::encode(RedactedText));
 }
 
@@ -64,7 +65,7 @@ bool isTypedStruct(const Protobuf::Descriptor& descriptor) {
   return name == "xds.type.v3.TypedStruct" || name == "udpa.type.v1.TypedStruct";
 }
 
-// Converts map key `field` to a string.
+// Render map key 'field's value as a string.
 absl::string_view mapKeyToString(const Protobuf::Message& entry, const Field& field,
                                  std::string& scratch) {
   const Protobuf::Reflection& reflection = *entry.GetReflection();
@@ -169,9 +170,12 @@ void MessageStreamer::nextElement(Frame& frame) {
     return;
   }
 
-  // Keys are left alone, redacting them would collapse the map onto one key.
+  // A repeated field's level is always BufferStreamer::Array, unless it is a map,
+  // in which case it is BufferStreamer::Map, so the static_cast is safe.
+  // The level is created in MessageStreamer::startField.
   BufferStreamer::Map& entries = static_cast<BufferStreamer::Map&>(*frame.elements_);
   const Protobuf::Message& entry = reflection.GetRepeatedMessage(frame.message_, &field, index);
+  // Keys are left alone, redacting them would collapse the map onto one key.
   entries.addKey(mapKeyToString(entry, *field.message_type()->map_key(), scratch_));
   emitValue(entry, *field.message_type()->map_value(), -1, entries, frame.field_is_sensitive_);
 }
@@ -188,6 +192,8 @@ void MessageStreamer::startField(Frame& frame) {
   }
 
   frame.map_->addKey(json_names_ ? field.json_name() : field.name());
+  // is_map implies is_repeated, so handle it first.
+  // https://protobuf.dev/programming-guides/proto3/#backwards
   if (field.is_map()) {
     frame.elements_ = frame.map_->addMap();
     return;
@@ -259,7 +265,7 @@ void MessageStreamer::emitValue(const Protobuf::Message& message, const Field& f
   }
   case Field::CPPTYPE_STRING: {
     if (is_sensitive) {
-      level.addString(field.type() == Field::TYPE_BYTES ? absl::string_view(redactedBytes())
+      level.addString(field.type() == Field::TYPE_BYTES ? absl::string_view(redactedBase64())
                                                         : RedactedText);
       return;
     }

--- a/source/common/json/proto_streamer.cc
+++ b/source/common/json/proto_streamer.cc
@@ -1,0 +1,306 @@
+#include "source/common/json/proto_streamer.h"
+
+#include <cmath>
+
+#include "source/common/common/base64.h"
+#include "source/common/protobuf/utility.h"
+#include "source/common/protobuf/visitor_helper.h"
+
+namespace Envoy {
+namespace Json {
+
+namespace {
+
+using Field = Protobuf::FieldDescriptor;
+
+// Returns the value of `field`, from element `index` if the field is repeated.
+#define REFLECTION_GET(Type, field, index)                                                         \
+  (index < 0 ? reflection.Get##Type(message, &field)                                               \
+             : reflection.GetRepeated##Type(message, &field, index))
+
+// Whether ProtoJSON gives `message` a special representation rather than an object of its fields,
+// which is every `well_known_type()` other than Any. Any is excluded, this streamer expands it into
+// a frame.
+//
+// TODO(filipcacky): Struct, Value and ListValue should be streamed, see json_utility.cc
+bool hasSpecialRepresentation(const Protobuf::Message& message) {
+  switch (message.GetDescriptor()->well_known_type()) {
+  case Protobuf::Descriptor::WELLKNOWNTYPE_UNSPECIFIED:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_ANY:
+    return false;
+  default:
+    return true;
+  }
+}
+
+// Converts map key `field` to a string.
+absl::string_view mapKeyToString(const Protobuf::Message& entry, const Field& field,
+                                 std::string& scratch) {
+  const Protobuf::Reflection& reflection = *entry.GetReflection();
+  switch (field.cpp_type()) {
+  case Field::CPPTYPE_BOOL:
+    return reflection.GetBool(entry, &field) ? "true" : "false";
+  case Field::CPPTYPE_INT32:
+    scratch.clear();
+    absl::StrAppend(&scratch, reflection.GetInt32(entry, &field));
+    return scratch;
+  case Field::CPPTYPE_INT64:
+    scratch.clear();
+    absl::StrAppend(&scratch, reflection.GetInt64(entry, &field));
+    return scratch;
+  case Field::CPPTYPE_UINT32:
+    scratch.clear();
+    absl::StrAppend(&scratch, reflection.GetUInt32(entry, &field));
+    return scratch;
+  case Field::CPPTYPE_UINT64:
+    scratch.clear();
+    absl::StrAppend(&scratch, reflection.GetUInt64(entry, &field));
+    return scratch;
+  default:
+    return reflection.GetStringReference(entry, &field, &scratch);
+  }
+}
+
+} // namespace
+
+MessageStreamer::MessageStreamer(const Protobuf::Message& message, BufferStreamer::Level& level,
+                                 TypeUrl type_url, FieldNames field_names)
+    : json_names_(field_names == FieldNames::LowerCamelCase) {
+  const std::string name =
+      type_url == TypeUrl::Emit
+          ? TypeUtil::descriptorFullNameToTypeUrl(message.GetDescriptor()->full_name())
+          : "";
+  emitNamedMessage(message, level, name);
+}
+
+void MessageStreamer::emitNamedMessage(const Protobuf::Message& message,
+                                       BufferStreamer::Level& level, absl::string_view type_url,
+                                       ProtobufTypes::MessagePtr owned) {
+  // ProtoJSON pairs a special representation with its `@type` under `value`.
+  if (!type_url.empty() && hasSpecialRepresentation(message)) {
+    BufferStreamer::MapPtr map = level.addMap();
+    map->addKey("@type");
+    map->addString(type_url);
+    map->addKey("value");
+    emitSpecialRepresentation(message, *map);
+    return;
+  }
+
+  Frame& frame = pushFrame(message, level);
+  frame.owned_ = std::move(owned);
+  if (!type_url.empty()) {
+    frame.map_->addKey("@type");
+    frame.map_->addString(type_url);
+  }
+}
+
+MessageStreamer::~MessageStreamer() {
+  while (!stack_.empty()) {
+    stack_.pop_back();
+  }
+}
+
+bool MessageStreamer::next() {
+  if (stack_.empty()) {
+    return false;
+  }
+
+  Frame& frame = stack_.back();
+  if (frame.elements_ != nullptr) {
+    nextElement(frame);
+    return true;
+  }
+
+  if (frame.next_field_ >= frame.fields_.size()) {
+    stack_.pop_back();
+    return !stack_.empty();
+  }
+
+  startField(frame);
+  return true;
+}
+
+void MessageStreamer::nextElement(Frame& frame) {
+  const Protobuf::Reflection& reflection = *frame.message_.GetReflection();
+  const Field& field = *frame.fields_[frame.next_field_];
+
+  if (frame.next_element_ >= reflection.FieldSize(frame.message_, &field)) {
+    frame.elements_.reset();
+    frame.next_element_ = 0;
+    ++frame.next_field_;
+    return;
+  }
+
+  const int index = frame.next_element_++;
+  if (!field.is_map()) {
+    emitValue(frame.message_, field, index, *frame.elements_);
+    return;
+  }
+
+  BufferStreamer::Map& entries = static_cast<BufferStreamer::Map&>(*frame.elements_);
+  const Protobuf::Message& entry = reflection.GetRepeatedMessage(frame.message_, &field, index);
+  entries.addKey(mapKeyToString(entry, *field.message_type()->map_key(), scratch_));
+  emitValue(entry, *field.message_type()->map_value(), -1, entries);
+}
+
+void MessageStreamer::startField(Frame& frame) {
+  const Field& field = *frame.fields_[frame.next_field_];
+
+  frame.map_->addKey(json_names_ ? field.json_name() : field.name());
+  if (field.is_map()) {
+    frame.elements_ = frame.map_->addMap();
+    return;
+  }
+  if (field.is_repeated()) {
+    frame.elements_ = frame.map_->addArray();
+    return;
+  }
+  ++frame.next_field_;
+  emitValue(frame.message_, field, -1, *frame.map_);
+}
+
+void MessageStreamer::emitValue(const Protobuf::Message& message, const Field& field, int index,
+                                BufferStreamer::Level& level) {
+  const Protobuf::Reflection& reflection = *message.GetReflection();
+  switch (field.cpp_type()) {
+  case Field::CPPTYPE_INT32:
+    level.addNumber(static_cast<int64_t>(REFLECTION_GET(Int32, field, index)));
+    return;
+  case Field::CPPTYPE_UINT32:
+    level.addNumber(static_cast<uint64_t>(REFLECTION_GET(UInt32, field, index)));
+    return;
+  case Field::CPPTYPE_INT64:
+    // ProtoJSON spells 64 bit integers as decimal strings.
+    // https://protobuf.dev/programming-guides/json/#int64-strings
+    scratch_.clear();
+    absl::StrAppend(&scratch_, REFLECTION_GET(Int64, field, index));
+    level.addString(scratch_);
+    return;
+  case Field::CPPTYPE_UINT64:
+    scratch_.clear();
+    absl::StrAppend(&scratch_, REFLECTION_GET(UInt64, field, index));
+    level.addString(scratch_);
+    return;
+  case Field::CPPTYPE_BOOL:
+    level.addBool(REFLECTION_GET(Bool, field, index));
+    return;
+  case Field::CPPTYPE_DOUBLE:
+  case Field::CPPTYPE_FLOAT: {
+    const double number = field.cpp_type() == Field::CPPTYPE_DOUBLE
+                              ? REFLECTION_GET(Double, field, index)
+                              : REFLECTION_GET(Float, field, index);
+    if (std::isfinite(number)) {
+      level.addNumber(number);
+    } else if (std::isnan(number)) {
+      level.addString("NaN");
+    } else {
+      level.addString(number > 0 ? "Infinity" : "-Infinity");
+    }
+    return;
+  }
+  case Field::CPPTYPE_ENUM: {
+    // An enum is its name, unless it holds a number we have no name for.
+    const int number = REFLECTION_GET(EnumValue, field, index);
+    const Protobuf::EnumValueDescriptor* value = field.enum_type()->FindValueByNumber(number);
+    if (value == nullptr) {
+      level.addNumber(static_cast<int64_t>(number));
+    } else {
+      level.addString(value->name());
+    }
+    return;
+  }
+  case Field::CPPTYPE_STRING: {
+    scratch_.clear();
+    const std::string& value =
+        index < 0 ? reflection.GetStringReference(message, &field, &scratch_)
+                  : reflection.GetRepeatedStringReference(message, &field, index, &scratch_);
+    // ProtoJSON spells bytes as base64.
+    level.addString(field.type() == Field::TYPE_BYTES ? Base64::encode(value) : value);
+    return;
+  }
+  case Field::CPPTYPE_MESSAGE:
+    emitMessage(REFLECTION_GET(Message, field, index), level);
+    return;
+  }
+}
+
+void MessageStreamer::emitMessage(const Protobuf::Message& message, BufferStreamer::Level& level) {
+  const Protobuf::Descriptor& descriptor = *message.GetDescriptor();
+  switch (descriptor.well_known_type()) {
+  case Protobuf::Descriptor::WELLKNOWNTYPE_UNSPECIFIED:
+    pushFrame(message, level);
+    return;
+  case Protobuf::Descriptor::WELLKNOWNTYPE_ANY:
+    emitAny(message, level);
+    return;
+  case Protobuf::Descriptor::WELLKNOWNTYPE_DOUBLEVALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_FLOATVALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_INT64VALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_UINT64VALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_INT32VALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_UINT32VALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_STRINGVALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_BYTESVALUE:
+  case Protobuf::Descriptor::WELLKNOWNTYPE_BOOLVALUE:
+    // A wrapper is spelled as the value of its only field.
+    emitValue(message, *descriptor.field(0), -1, level);
+    return;
+  case Protobuf::Descriptor::WELLKNOWNTYPE_DURATION:
+    if (const auto* duration = Protobuf::DynamicCastMessage<Protobuf::Duration>(&message)) {
+      level.addString(Protobuf::util::TimeUtil::ToString(*duration));
+    } else {
+      emitSpecialRepresentation(message, level);
+    }
+    return;
+  case Protobuf::Descriptor::WELLKNOWNTYPE_TIMESTAMP:
+    if (const auto* timestamp = Protobuf::DynamicCastMessage<Protobuf::Timestamp>(&message)) {
+      level.addString(Protobuf::util::TimeUtil::ToString(*timestamp));
+    } else {
+      emitSpecialRepresentation(message, level);
+    }
+    return;
+  default:
+    emitSpecialRepresentation(message, level);
+    return;
+  }
+}
+
+void MessageStreamer::emitAny(const Protobuf::Message& message, BufferStreamer::Level& level) {
+  const Protobuf::Any* any = Protobuf::DynamicCastMessage<Protobuf::Any>(&message);
+  Protobuf::Any copy;
+  if (any == nullptr) {
+    copy.CopyFrom(message);
+    any = &copy;
+  }
+
+  ProtobufTypes::MessagePtr packed = ProtobufMessage::Helper::typeUrlToMessage(any->type_url());
+  if (packed == nullptr || !MessageUtil::unpackTo(*any, *packed).ok()) {
+    BufferStreamer::MapPtr map = level.addMap();
+    map->addKey("@type");
+    map->addString(any->type_url());
+    return;
+  }
+
+  const Protobuf::Message& payload = *packed;
+  emitNamedMessage(payload, level, any->type_url(), std::move(packed));
+}
+
+void MessageStreamer::emitSpecialRepresentation(const Protobuf::Message& message,
+                                                BufferStreamer::Level& level) {
+  const absl::StatusOr<std::string> json = MessageUtil::getJsonStringFromMessage(message);
+  if (json.ok()) {
+    level.addRawJson(*json);
+  } else {
+    level.addNull();
+  }
+}
+
+MessageStreamer::Frame& MessageStreamer::pushFrame(const Protobuf::Message& message,
+                                                   BufferStreamer::Level& level) {
+  return stack_.emplace_back(message, level.addMap());
+}
+
+#undef REFLECTION_GET
+
+} // namespace Json
+} // namespace Envoy

--- a/source/common/json/proto_streamer.cc
+++ b/source/common/json/proto_streamer.cc
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "source/common/common/base64.h"
+#include "source/common/common/macros.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/protobuf/visitor_helper.h"
 
@@ -31,6 +32,36 @@ bool hasSpecialRepresentation(const Protobuf::Message& message) {
   default:
     return true;
   }
+}
+
+constexpr absl::string_view RedactedText = "[redacted]";
+
+const std::string& redactedBytes() {
+  CONSTRUCT_ON_FIRST_USE(std::string, Base64::encode(RedactedText));
+}
+
+// Whether redaction clears `field` instead of replacing it, which it does to everything but
+// messages and text.
+bool redactionClears(const Field& field) {
+  return field.cpp_type() != Field::CPPTYPE_MESSAGE && field.type() != Field::TYPE_STRING &&
+         field.type() != Field::TYPE_BYTES;
+}
+
+ProtobufTypes::MessagePtr redactedCopy(const Protobuf::Message& message,
+                                       bool ancestor_is_sensitive) {
+  ProtobufTypes::MessagePtr copy(message.New());
+  copy->CopyFrom(message);
+  if (ancestor_is_sensitive) {
+    MessageUtil::redactAll(*copy);
+  } else {
+    MessageUtil::redact(*copy);
+  }
+  return copy;
+}
+
+bool isTypedStruct(const Protobuf::Descriptor& descriptor) {
+  const absl::string_view name = descriptor.full_name();
+  return name == "xds.type.v3.TypedStruct" || name == "udpa.type.v1.TypedStruct";
 }
 
 // Converts map key `field` to a string.
@@ -64,30 +95,31 @@ absl::string_view mapKeyToString(const Protobuf::Message& entry, const Field& fi
 } // namespace
 
 MessageStreamer::MessageStreamer(const Protobuf::Message& message, BufferStreamer::Level& level,
-                                 TypeUrl type_url, FieldNames field_names)
-    : json_names_(field_names == FieldNames::LowerCamelCase) {
+                                 TypeUrl type_url, FieldNames field_names, Sensitive sensitive)
+    : json_names_(field_names == FieldNames::LowerCamelCase),
+      redact_(sensitive == Sensitive::Redact) {
   const std::string name =
       type_url == TypeUrl::Emit
           ? TypeUtil::descriptorFullNameToTypeUrl(message.GetDescriptor()->full_name())
           : "";
-  emitNamedMessage(message, level, name);
+  emitNamedMessage(message, level, name, false);
 }
 
 void MessageStreamer::emitNamedMessage(const Protobuf::Message& message,
                                        BufferStreamer::Level& level, absl::string_view type_url,
-                                       ProtobufTypes::MessagePtr owned) {
+                                       bool is_sensitive, ProtobufTypes::MessagePtr owned) {
   // ProtoJSON pairs a special representation with its `@type` under `value`.
   if (!type_url.empty() && hasSpecialRepresentation(message)) {
     BufferStreamer::MapPtr map = level.addMap();
     map->addKey("@type");
     map->addString(type_url);
     map->addKey("value");
-    emitSpecialRepresentation(message, *map);
+    emitSpecialRepresentation(message, *map, is_sensitive);
     return;
   }
 
-  Frame& frame = pushFrame(message, level);
-  frame.owned_ = std::move(owned);
+  Frame& frame = owned == nullptr ? pushFrame(message, level, is_sensitive)
+                                  : pushOwnedFrame(std::move(owned), level, is_sensitive);
   if (!type_url.empty()) {
     frame.map_->addKey("@type");
     frame.map_->addString(type_url);
@@ -133,18 +165,27 @@ void MessageStreamer::nextElement(Frame& frame) {
 
   const int index = frame.next_element_++;
   if (!field.is_map()) {
-    emitValue(frame.message_, field, index, *frame.elements_);
+    emitValue(frame.message_, field, index, *frame.elements_, frame.field_is_sensitive_);
     return;
   }
 
+  // Keys are left alone, redacting them would collapse the map onto one key.
   BufferStreamer::Map& entries = static_cast<BufferStreamer::Map&>(*frame.elements_);
   const Protobuf::Message& entry = reflection.GetRepeatedMessage(frame.message_, &field, index);
   entries.addKey(mapKeyToString(entry, *field.message_type()->map_key(), scratch_));
-  emitValue(entry, *field.message_type()->map_value(), -1, entries);
+  emitValue(entry, *field.message_type()->map_value(), -1, entries, frame.field_is_sensitive_);
 }
 
 void MessageStreamer::startField(Frame& frame) {
   const Field& field = *frame.fields_[frame.next_field_];
+
+  frame.field_is_sensitive_ =
+      redact_ && (frame.ancestor_is_sensitive_ || MessageUtil::isSensitiveField(field));
+  // A cleared field is unset, so it drops out of the output instead of printing a default.
+  if (frame.field_is_sensitive_ && redactionClears(field)) {
+    ++frame.next_field_;
+    return;
+  }
 
   frame.map_->addKey(json_names_ ? field.json_name() : field.name());
   if (field.is_map()) {
@@ -156,12 +197,19 @@ void MessageStreamer::startField(Frame& frame) {
     return;
   }
   ++frame.next_field_;
-  emitValue(frame.message_, field, -1, *frame.map_);
+  emitValue(frame.message_, field, -1, *frame.map_, frame.field_is_sensitive_);
 }
 
 void MessageStreamer::emitValue(const Protobuf::Message& message, const Field& field, int index,
-                                BufferStreamer::Level& level) {
+                                BufferStreamer::Level& level, bool is_sensitive) {
   const Protobuf::Reflection& reflection = *message.GetReflection();
+  // A map entry and a wrapper print their value even when unset, and startField cannot drop either,
+  // it never sees the value field. Redaction clears it, so the default comes off an empty message.
+  if (is_sensitive && redactionClears(field)) {
+    const ProtobufTypes::MessagePtr cleared(message.New());
+    emitValue(*cleared, field, -1, level, false);
+    return;
+  }
   switch (field.cpp_type()) {
   case Field::CPPTYPE_INT32:
     level.addNumber(static_cast<int64_t>(REFLECTION_GET(Int32, field, index)));
@@ -210,6 +258,11 @@ void MessageStreamer::emitValue(const Protobuf::Message& message, const Field& f
     return;
   }
   case Field::CPPTYPE_STRING: {
+    if (is_sensitive) {
+      level.addString(field.type() == Field::TYPE_BYTES ? absl::string_view(redactedBytes())
+                                                        : RedactedText);
+      return;
+    }
     scratch_.clear();
     const std::string& value =
         index < 0 ? reflection.GetStringReference(message, &field, &scratch_)
@@ -219,19 +272,24 @@ void MessageStreamer::emitValue(const Protobuf::Message& message, const Field& f
     return;
   }
   case Field::CPPTYPE_MESSAGE:
-    emitMessage(REFLECTION_GET(Message, field, index), level);
+    emitMessage(REFLECTION_GET(Message, field, index), level, is_sensitive);
     return;
   }
 }
 
-void MessageStreamer::emitMessage(const Protobuf::Message& message, BufferStreamer::Level& level) {
+void MessageStreamer::emitMessage(const Protobuf::Message& message, BufferStreamer::Level& level,
+                                  bool is_sensitive) {
   const Protobuf::Descriptor& descriptor = *message.GetDescriptor();
   switch (descriptor.well_known_type()) {
   case Protobuf::Descriptor::WELLKNOWNTYPE_UNSPECIFIED:
-    pushFrame(message, level);
+    if (redact_ && isTypedStruct(descriptor)) {
+      pushOwnedFrame(redactedCopy(message, is_sensitive), level, false);
+      return;
+    }
+    pushFrame(message, level, is_sensitive);
     return;
   case Protobuf::Descriptor::WELLKNOWNTYPE_ANY:
-    emitAny(message, level);
+    emitAny(message, level, is_sensitive);
     return;
   case Protobuf::Descriptor::WELLKNOWNTYPE_DOUBLEVALUE:
   case Protobuf::Descriptor::WELLKNOWNTYPE_FLOATVALUE:
@@ -243,29 +301,34 @@ void MessageStreamer::emitMessage(const Protobuf::Message& message, BufferStream
   case Protobuf::Descriptor::WELLKNOWNTYPE_BYTESVALUE:
   case Protobuf::Descriptor::WELLKNOWNTYPE_BOOLVALUE:
     // A wrapper is spelled as the value of its only field.
-    emitValue(message, *descriptor.field(0), -1, level);
+    emitValue(message, *descriptor.field(0), -1, level, is_sensitive);
     return;
   case Protobuf::Descriptor::WELLKNOWNTYPE_DURATION:
-    if (const auto* duration = Protobuf::DynamicCastMessage<Protobuf::Duration>(&message)) {
-      level.addString(Protobuf::util::TimeUtil::ToString(*duration));
-    } else {
-      emitSpecialRepresentation(message, level);
+    if (!is_sensitive) {
+      if (const auto* duration = Protobuf::DynamicCastMessage<Protobuf::Duration>(&message)) {
+        level.addString(Protobuf::util::TimeUtil::ToString(*duration));
+        return;
+      }
     }
+    emitSpecialRepresentation(message, level, is_sensitive);
     return;
   case Protobuf::Descriptor::WELLKNOWNTYPE_TIMESTAMP:
-    if (const auto* timestamp = Protobuf::DynamicCastMessage<Protobuf::Timestamp>(&message)) {
-      level.addString(Protobuf::util::TimeUtil::ToString(*timestamp));
-    } else {
-      emitSpecialRepresentation(message, level);
+    if (!is_sensitive) {
+      if (const auto* timestamp = Protobuf::DynamicCastMessage<Protobuf::Timestamp>(&message)) {
+        level.addString(Protobuf::util::TimeUtil::ToString(*timestamp));
+        return;
+      }
     }
+    emitSpecialRepresentation(message, level, is_sensitive);
     return;
   default:
-    emitSpecialRepresentation(message, level);
+    emitSpecialRepresentation(message, level, is_sensitive);
     return;
   }
 }
 
-void MessageStreamer::emitAny(const Protobuf::Message& message, BufferStreamer::Level& level) {
+void MessageStreamer::emitAny(const Protobuf::Message& message, BufferStreamer::Level& level,
+                              bool is_sensitive) {
   const Protobuf::Any* any = Protobuf::DynamicCastMessage<Protobuf::Any>(&message);
   Protobuf::Any copy;
   if (any == nullptr) {
@@ -282,12 +345,15 @@ void MessageStreamer::emitAny(const Protobuf::Message& message, BufferStreamer::
   }
 
   const Protobuf::Message& payload = *packed;
-  emitNamedMessage(payload, level, any->type_url(), std::move(packed));
+  emitNamedMessage(payload, level, any->type_url(), is_sensitive, std::move(packed));
 }
 
 void MessageStreamer::emitSpecialRepresentation(const Protobuf::Message& message,
-                                                BufferStreamer::Level& level) {
-  const absl::StatusOr<std::string> json = MessageUtil::getJsonStringFromMessage(message);
+                                                BufferStreamer::Level& level, bool is_sensitive) {
+  // Protobuf prints the whole message, so it has to be handed a redacted copy.
+  const ProtobufTypes::MessagePtr redacted = is_sensitive ? redactedCopy(message, true) : nullptr;
+  const absl::StatusOr<std::string> json =
+      MessageUtil::getJsonStringFromMessage(redacted == nullptr ? message : *redacted);
   if (json.ok()) {
     level.addRawJson(*json);
   } else {
@@ -296,8 +362,19 @@ void MessageStreamer::emitSpecialRepresentation(const Protobuf::Message& message
 }
 
 MessageStreamer::Frame& MessageStreamer::pushFrame(const Protobuf::Message& message,
-                                                   BufferStreamer::Level& level) {
-  return stack_.emplace_back(message, level.addMap());
+                                                   BufferStreamer::Level& level,
+                                                   bool ancestor_is_sensitive) {
+  Frame& frame = stack_.emplace_back(message, level.addMap());
+  frame.ancestor_is_sensitive_ = ancestor_is_sensitive;
+  return frame;
+}
+
+MessageStreamer::Frame& MessageStreamer::pushOwnedFrame(ProtobufTypes::MessagePtr message,
+                                                        BufferStreamer::Level& level,
+                                                        bool ancestor_is_sensitive) {
+  Frame& frame = pushFrame(*message, level, ancestor_is_sensitive);
+  frame.owned_ = std::move(message);
+  return frame;
 }
 
 #undef REFLECTION_GET

--- a/source/common/json/proto_streamer.h
+++ b/source/common/json/proto_streamer.h
@@ -21,9 +21,13 @@ public:
   // https://protobuf.dev/programming-guides/json/#field-names
   enum class FieldNames { Proto, LowerCamelCase };
 
+  // Whether the fields the API marks sensitive are emitted, or replaced the way
+  // MessageUtil::redact replaces them.
+  enum class Sensitive { Emit, Redact };
+
   // Emits `message` as an object opened in `level`, which must be expecting a value.
   MessageStreamer(const Protobuf::Message& message, BufferStreamer::Level& level, TypeUrl type_url,
-                  FieldNames field_names);
+                  FieldNames field_names, Sensitive sensitive);
   ~MessageStreamer();
 
   /**
@@ -50,8 +54,12 @@ private:
     BufferStreamer::MapPtr map_;
     // An array or a map, holding the elements of the repeated field being emitted.
     BufferStreamer::LevelPtr elements_;
-    // Non-null when the frame owns `message_`, which only an Any's unpacked payload is.
+    // Non-null when the frame owns `message_`.
     ProtobufTypes::MessagePtr owned_;
+    // Set when the field this frame was reached through is sensitive, so all of it is.
+    bool ancestor_is_sensitive_{false};
+    // Whether fields_[next_field_] is sensitive, held so its elements can read it back.
+    bool field_is_sensitive_{false};
   };
 
   void nextElement(Frame& frame);
@@ -64,29 +72,38 @@ private:
   // which takes `owned` over when the streamer is the one holding the message.
   // https://protobuf.dev/programming-guides/json/#any
   void emitNamedMessage(const Protobuf::Message& message, BufferStreamer::Level& level,
-                        absl::string_view type_url, ProtobufTypes::MessagePtr owned = nullptr);
+                        absl::string_view type_url, bool is_sensitive,
+                        ProtobufTypes::MessagePtr owned = nullptr);
 
   // Pushes a frame emitting `message` as an object opened in `level`.
-  Frame& pushFrame(const Protobuf::Message& message, BufferStreamer::Level& level);
+  Frame& pushFrame(const Protobuf::Message& message, BufferStreamer::Level& level,
+                   bool ancestor_is_sensitive);
+
+  Frame& pushOwnedFrame(ProtobufTypes::MessagePtr message, BufferStreamer::Level& level,
+                        bool ancestor_is_sensitive);
 
   // Emits one value of `field`, or pushes a frame for it. `index` is which element of a repeated
   // field to emit, or -1 for a field that is not repeated.
   void emitValue(const Protobuf::Message& message, const Protobuf::FieldDescriptor& field,
-                 int index, BufferStreamer::Level& level);
+                 int index, BufferStreamer::Level& level, bool is_sensitive);
 
   // Emits the value of a message-typed field, which is either a special representation or a new
   // frame.
-  void emitMessage(const Protobuf::Message& message, BufferStreamer::Level& level);
+  void emitMessage(const Protobuf::Message& message, BufferStreamer::Level& level,
+                   bool is_sensitive);
 
   // Emits an Any as its type url and the message it packs, or the type url alone when the payload
   // cannot be unpacked.
-  void emitAny(const Protobuf::Message& message, BufferStreamer::Level& level);
+  void emitAny(const Protobuf::Message& message, BufferStreamer::Level& level, bool is_sensitive);
 
   // Emits the special representation of a well known type through protobuf's printer.
-  void emitSpecialRepresentation(const Protobuf::Message& message, BufferStreamer::Level& level);
+  void emitSpecialRepresentation(const Protobuf::Message& message, BufferStreamer::Level& level,
+                                 bool is_sensitive);
 
   // Whether the keys are json_name(), for the whole walk.
   const bool json_names_;
+  // Whether sensitive fields are redacted, for the whole walk.
+  const bool redact_;
   std::deque<Frame> stack_;
   std::string scratch_;
 };

--- a/source/common/json/proto_streamer.h
+++ b/source/common/json/proto_streamer.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <deque>
+
+#include "source/common/json/json_streamer.h"
+#include "source/common/protobuf/protobuf.h"
+
+namespace Envoy {
+namespace Json {
+
+/**
+ * Emits a protobuf message in ProtoJSON (see https://protobuf.dev/programming-guides/json/) one
+ * piece at a time, walking it with reflection and an explicit stack.
+ */
+class MessageStreamer {
+public:
+  // Whether to emit a leading @type naming the message.
+  enum class TypeUrl { Omit, Emit };
+
+  // Whether the keys are the proto field names or the lowerCamelCase ProtoJSON defaults to.
+  // https://protobuf.dev/programming-guides/json/#field-names
+  enum class FieldNames { Proto, LowerCamelCase };
+
+  // Emits `message` as an object opened in `level`, which must be expecting a value.
+  MessageStreamer(const Protobuf::Message& message, BufferStreamer::Level& level, TypeUrl type_url,
+                  FieldNames field_names);
+  ~MessageStreamer();
+
+  /**
+   * Emits the next piece of the message: one scalar field, one element of a repeated field, or the
+   * opening or closing of a nested object or array.
+   * @return false once the whole message has been emitted.
+   */
+  bool next();
+
+private:
+  struct Frame {
+    Frame(const Protobuf::Message& message, BufferStreamer::MapPtr map)
+        : message_(message), map_(std::move(map)) {
+      message_.GetReflection()->ListFields(message, &fields_);
+    }
+
+    const Protobuf::Message& message_;
+    // The set fields of `message_`, in field number order.
+    std::vector<const Protobuf::FieldDescriptor*> fields_;
+    uint32_t next_field_{0};
+    // Which element of the current repeated field or map comes next.
+    int next_element_{0};
+    // The object the frame emits its fields into.
+    BufferStreamer::MapPtr map_;
+    // An array or a map, holding the elements of the repeated field being emitted.
+    BufferStreamer::LevelPtr elements_;
+    // Non-null when the frame owns `message_`, which only an Any's unpacked payload is.
+    ProtobufTypes::MessagePtr owned_;
+  };
+
+  void nextElement(Frame& frame);
+
+  // Starts the next field, opening a level for it when it is repeated or a map.
+  void startField(Frame& frame);
+
+  // Emits `message` in `level` under `@type` if `type_url` is not empty.
+  // A message with a special representation goes under `value`, anything else creates a new frame,
+  // which takes `owned` over when the streamer is the one holding the message.
+  // https://protobuf.dev/programming-guides/json/#any
+  void emitNamedMessage(const Protobuf::Message& message, BufferStreamer::Level& level,
+                        absl::string_view type_url, ProtobufTypes::MessagePtr owned = nullptr);
+
+  // Pushes a frame emitting `message` as an object opened in `level`.
+  Frame& pushFrame(const Protobuf::Message& message, BufferStreamer::Level& level);
+
+  // Emits one value of `field`, or pushes a frame for it. `index` is which element of a repeated
+  // field to emit, or -1 for a field that is not repeated.
+  void emitValue(const Protobuf::Message& message, const Protobuf::FieldDescriptor& field,
+                 int index, BufferStreamer::Level& level);
+
+  // Emits the value of a message-typed field, which is either a special representation or a new
+  // frame.
+  void emitMessage(const Protobuf::Message& message, BufferStreamer::Level& level);
+
+  // Emits an Any as its type url and the message it packs, or the type url alone when the payload
+  // cannot be unpacked.
+  void emitAny(const Protobuf::Message& message, BufferStreamer::Level& level);
+
+  // Emits the special representation of a well known type through protobuf's printer.
+  void emitSpecialRepresentation(const Protobuf::Message& message, BufferStreamer::Level& level);
+
+  // Whether the keys are json_name(), for the whole walk.
+  const bool json_names_;
+  std::deque<Frame> stack_;
+  std::string scratch_;
+};
+
+} // namespace Json
+} // namespace Envoy

--- a/source/common/protobuf/utility.cc
+++ b/source/common/protobuf/utility.cc
@@ -593,8 +593,8 @@ void redact(Protobuf::Message* message, bool ancestor_is_sensitive) {
     const auto* field_descriptor = descriptor->field(i);
 
     // Redact if this field or any of its ancestors have the `sensitive` option set.
-    const bool sensitive = ancestor_is_sensitive ||
-                           field_descriptor->options().GetExtension(udpa::annotations::sensitive);
+    const bool sensitive =
+        ancestor_is_sensitive || MessageUtil::isSensitiveField(*field_descriptor);
 
     if (field_descriptor->type() == Protobuf::FieldDescriptor::TYPE_MESSAGE) {
       // Recursive case: traverse message fields.
@@ -650,6 +650,14 @@ void redact(Protobuf::Message* message, bool ancestor_is_sensitive) {
 
 void MessageUtil::redact(Protobuf::Message& message) {
   ::Envoy::redact(&message, /* ancestor_is_sensitive = */ false);
+}
+
+void MessageUtil::redactAll(Protobuf::Message& message) {
+  ::Envoy::redact(&message, /* ancestor_is_sensitive = */ true);
+}
+
+bool MessageUtil::isSensitiveField(const Protobuf::FieldDescriptor& field) {
+  return field.options().GetExtension(udpa::annotations::sensitive);
 }
 
 std::string MessageUtil::toTextProto(const Protobuf::Message& message) {

--- a/source/common/protobuf/utility.h
+++ b/source/common/protobuf/utility.h
@@ -630,6 +630,16 @@ public:
   static void redact(Protobuf::Message& message);
 
   /**
+   * Redacts every field of `message`.
+   */
+  static void redactAll(Protobuf::Message& message);
+
+  /**
+   * Whether `field` is annotated `udpa.annotations.sensitive`.
+   */
+  static bool isSensitiveField(const Protobuf::FieldDescriptor& field);
+
+  /**
    * Sanitizes a string to contain only valid UTF-8. Invalid UTF-8 characters will be replaced. If
    * the input string is valid UTF-8, it will be returned unmodified.
    */

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -367,6 +367,8 @@ envoy_cc_library(
         "//source/common/common:statusor_lib",
         "//source/common/http:codes_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/json:proto_streamer_lib",
+        "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -132,20 +132,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
                       MAKE_ADMIN_HANDLER(clusters_handler_.handlerClusters), false, false,
                       {{Admin::ParamDescriptor::Type::String, "filter",
                         "Regular expression (Google re2) for filtering clusters by name"}}),
-          makeHandler(
-              "/config_dump", "dump current Envoy configs",
-              MAKE_ADMIN_HANDLER(config_dump_handler_.handlerConfigDump), false, false,
-              {{Admin::ParamDescriptor::Type::String, "resource", "The resource to dump"},
-               {Admin::ParamDescriptor::Type::String, "mask",
-                "The mask to apply. When both resource and mask are specified, "
-                "the mask is applied to every element in the desired repeated field so that only a "
-                "subset of fields are returned. The mask is parsed as a Protobuf::FieldMask"},
-               {Admin::ParamDescriptor::Type::String, "name_regex",
-                "Dump only the currently loaded configurations whose names match the specified "
-                "regex. Can be used with both resource and mask query parameters."},
-               {Admin::ParamDescriptor::Type::Boolean, "include_eds",
-                "Dump currently loaded configuration including EDS. See the response definition "
-                "for more information"}}),
+          config_dump_handler_.handlerConfigDumpStreamed(),
           makeHandler("/init_dump", "dump current Envoy init manager information (experimental)",
                       MAKE_ADMIN_HANDLER(init_dump_handler_.handlerInitDump), false, false,
                       {{Admin::ParamDescriptor::Type::String, "mask",

--- a/source/server/admin/config_dump_handler.cc
+++ b/source/server/admin/config_dump_handler.cc
@@ -1,14 +1,16 @@
 #include "source/server/admin/config_dump_handler.h"
 
+#include <algorithm>
+
 #include "envoy/config/core/v3/health_check.pb.h"
 #include "envoy/config/endpoint/v3/endpoint.pb.h"
 
 #include "source/common/common/matchers.h"
 #include "source/common/common/regex.h"
-#include "source/common/common/statusor.h"
 #include "source/common/http/headers.h"
-#include "source/common/http/utility.h"
+#include "source/common/json/proto_streamer.h"
 #include "source/common/network/utility.h"
+#include "source/common/protobuf/utility.h"
 #include "source/server/admin/utils.h"
 
 namespace Envoy {
@@ -16,15 +18,24 @@ namespace Server {
 
 namespace {
 
+constexpr absl::string_view EndpointsComponentName = "endpoint";
+
+bool fieldMaskFits(const Protobuf::FieldMask& field_mask, const Protobuf::Descriptor& descriptor) {
+  for (const auto& path : field_mask.paths()) {
+    if (!ProtobufUtil::FieldMaskUtil::GetFieldDescriptors(&descriptor, path, nullptr)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Validates that `field_mask` is valid for `message` and applies `TrimMessage`.
 // Necessary because TrimMessage crashes if `field_mask` is invalid.
 // Returns `true` on success.
 bool checkFieldMaskAndTrimMessage(const Protobuf::FieldMask& field_mask,
                                   Protobuf::Message& message) {
-  for (const auto& path : field_mask.paths()) {
-    if (!ProtobufUtil::FieldMaskUtil::GetFieldDescriptors(message.GetDescriptor(), path, nullptr)) {
-      return false;
-    }
+  if (!fieldMaskFits(field_mask, *message.GetDescriptor())) {
+    return false;
   }
   ProtobufUtil::FieldMaskUtil::TrimMessage(field_mask, &message);
   return true;
@@ -126,6 +137,12 @@ bool shouldIncludeEdsInDump(const Http::Utility::QueryParamsMulti& params) {
   return params.getFirstValue("include_eds").has_value();
 }
 
+// The cluster's name, or its eds service name if it has one
+const std::string& dumpedClusterName(const Upstream::ClusterInfo& cluster_info) {
+  return cluster_info.edsServiceName().empty() ? cluster_info.name()
+                                               : cluster_info.edsServiceName();
+}
+
 absl::StatusOr<Matchers::StringMatcherPtr>
 buildNameMatcher(const Http::Utility::QueryParamsMulti& params, Regex::Engine& engine) {
   const auto name_regex = params.getFirstValue("name_regex");
@@ -149,136 +166,144 @@ buildNameMatcher(const Http::Utility::QueryParamsMulti& params, Regex::Engine& e
 ConfigDumpHandler::ConfigDumpHandler(ConfigTracker& config_tracker, Server::Instance& server)
     : HandlerContextBase(server), config_tracker_(config_tracker) {}
 
-Http::Code ConfigDumpHandler::handlerConfigDump(Http::ResponseHeaderMap& response_headers,
-                                                Buffer::Instance& response,
-                                                AdminStream& admin_stream) const {
+Admin::UrlHandler ConfigDumpHandler::handlerConfigDumpStreamed() {
+  return {"/config_dump",
+          "dump current Envoy configs",
+          [this](AdminStream& admin_stream) { return makeRequest(admin_stream); },
+          false,
+          false,
+          {{Admin::ParamDescriptor::Type::String, "resource", "The resource to dump"},
+           {Admin::ParamDescriptor::Type::String, "mask",
+            "The mask to apply. When both resource and mask are specified, "
+            "the mask is applied to every element in the desired repeated field so that only a "
+            "subset of fields are returned. The mask is parsed as a Protobuf::FieldMask"},
+           {Admin::ParamDescriptor::Type::String, "name_regex",
+            "Dump only the currently loaded configurations whose names match the specified "
+            "regex. Can be used with both resource and mask query parameters."},
+           {Admin::ParamDescriptor::Type::Boolean, "include_eds",
+            "Dump currently loaded configuration including EDS. See the response definition "
+            "for more information"}}};
+}
+
+Admin::RequestPtr ConfigDumpHandler::makeRequest(AdminStream& admin_stream) const {
   Http::Utility::QueryParamsMulti query_params = admin_stream.queryParams();
   const std::optional<std::string> resource = Utility::nonEmptyQueryParam(query_params, "resource");
   const std::optional<std::string> mask = Utility::nonEmptyQueryParam(query_params, "mask");
-  const bool include_eds = shouldIncludeEdsInDump(query_params);
-  const absl::StatusOr<Matchers::StringMatcherPtr> name_matcher =
+
+  absl::StatusOr<Matchers::StringMatcherPtr> name_matcher =
       buildNameMatcher(query_params, server_.regexEngine());
   if (!name_matcher.ok()) {
-    response.add(name_matcher.status().ToString());
-    response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Text);
-    return Http::Code::BadRequest;
+    return Admin::makeStaticTextRequest(name_matcher.status().ToString(), Http::Code::BadRequest);
   }
 
-  envoy::admin::v3::ConfigDump dump;
+  const bool include_eds = shouldIncludeEdsInDump(query_params);
 
-  std::optional<std::pair<Http::Code, std::string>> err;
+  ConfigDumpRequest::Dump dump{
+      std::move(name_matcher.value()),
+      componentNames(include_eds),
+      include_eds,
+  };
+
   if (resource.has_value()) {
-    err = addResourceToDump(dump, mask, resource.value(), **name_matcher, include_eds);
-  } else {
-    err = addAllConfigToDump(dump, mask, **name_matcher, include_eds);
+    absl::StatusOr<ResourceField> resource_field = findResource(
+        resource.value(), mask, dump.component_names_, dump.include_eds_, *dump.name_matcher_);
+    if (!resource_field.ok()) {
+      return Admin::makeStaticTextRequest(
+          resource_field.status().message(),
+          resource_field.status().code() == absl::StatusCode::kNotFound ? Http::Code::NotFound
+                                                                        : Http::Code::BadRequest);
+    }
+    dump.resource_ = std::move(resource_field.value());
+  } else if (mask.has_value()) {
+    ProtobufUtil::FieldMaskUtil::FromString(mask.value(), &dump.field_mask_.emplace());
+    dump.pending_config_ = firstMaskedConfig(*dump.field_mask_, dump.component_names_,
+                                             dump.include_eds_, *dump.name_matcher_);
+    if (dump.pending_config_ == nullptr) {
+      return Admin::makeStaticTextRequest(
+          absl::StrCat("FieldMask ", mask.value(),
+                       " could not be successfully applied to any configs."),
+          Http::Code::BadRequest);
+    }
   }
-  if (err.has_value()) {
-    response_headers.addReference(Http::Headers::get().XContentTypeOptions,
-                                  Http::Headers::get().XContentTypeOptionValues.Nosniff);
-    response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Text);
-    response.add(err.value().second);
-    return err.value().first;
-  }
-  MessageUtil::redact(dump);
 
-  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
-  response.add(MessageUtil::getJsonStringFromMessageOrError(dump, true)); // pretty-print
-  return Http::Code::OK;
+  return std::make_unique<ConfigDumpRequest>(*this, std::move(dump));
 }
 
-std::optional<std::pair<Http::Code, std::string>> ConfigDumpHandler::addResourceToDump(
-    envoy::admin::v3::ConfigDump& dump, const std::optional<std::string>& mask,
-    const std::string& resource, const Matchers::StringMatcher& name_matcher,
-    bool include_eds) const {
-  Envoy::Server::ConfigTracker::CbsMap callbacks_map = config_tracker_.getCallbacksMap();
-  if (include_eds) {
-    // TODO(mattklein123): Add ability to see warming clusters in admin output.
-    if (server_.clusterManager().hasActiveClusters()) {
-      callbacks_map.emplace("endpoint", [this](const Matchers::StringMatcher& name_matcher) {
-        return dumpEndpointConfigs(name_matcher);
-      });
+std::deque<std::string> ConfigDumpHandler::componentNames(bool include_eds) const {
+  std::deque<std::string> names;
+  for (const auto& callback : config_tracker_.getCallbacksMap()) {
+    names.push_back(callback.first);
+  }
+  // TODO(mattklein123): Add ability to see warming clusters in admin output.
+  if (include_eds && server_.clusterManager().hasActiveClusters()) {
+    const std::string endpoints_name(EndpointsComponentName);
+    const auto at = std::lower_bound(names.begin(), names.end(), endpoints_name);
+    if (at == names.end() || *at != endpoints_name) {
+      names.insert(at, endpoints_name);
     }
   }
+  return names;
+}
 
-  for (const auto& [name, callback] : callbacks_map) {
-    UNREFERENCED_PARAMETER(name);
-    ProtobufTypes::MessagePtr message = callback(name_matcher);
-    ASSERT(message);
+bool ConfigDumpHandler::dumpsEndpoints(const std::string& name, bool include_eds) const {
+  return include_eds && name == EndpointsComponentName &&
+         !config_tracker_.getCallbacksMap().contains(name);
+}
 
-    auto field_descriptor = message->GetDescriptor()->FindFieldByName(resource);
-    const Protobuf::Reflection* reflection = message->GetReflection();
-    if (!field_descriptor) {
-      continue;
-    } else if (!field_descriptor->is_repeated()) {
-      return std::optional<std::pair<Http::Code, std::string>>{std::make_pair(
-          Http::Code::BadRequest,
-          fmt::format("{} is not a repeated field. Use ?mask={} to get only this field",
-                      field_descriptor->name(), field_descriptor->name()))};
-    }
+std::optional<envoy::config::endpoint::v3::ClusterLoadAssignment>
+ConfigDumpHandler::buildClusterLoadAssignment(const Upstream::Cluster& cluster,
+                                              const Matchers::StringMatcher& name_matcher) const {
+  envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
+  Upstream::ClusterInfoConstSharedPtr cluster_info = cluster.info();
 
-    auto repeated = reflection->GetRepeatedPtrField<Protobuf::Message>(*message, field_descriptor);
-    for (Protobuf::Message& msg : repeated) {
-      if (mask.has_value()) {
-        Protobuf::FieldMask field_mask;
-        ProtobufUtil::FieldMaskUtil::FromString(mask.value(), &field_mask);
-        if (!trimResourceMessage(field_mask, msg)) {
-          return std::optional<std::pair<Http::Code, std::string>>{std::make_pair(
-              Http::Code::BadRequest, absl::StrCat("FieldMask ", field_mask.DebugString(),
-                                                   " could not be successfully used."))};
-        }
-      }
-      auto* config = dump.add_configs();
-      std::ignore = config->PackFrom(msg);
-    }
-
-    // We found the desired resource so there is no need to continue iterating over
-    // the other keys.
+  cluster_load_assignment.set_cluster_name(dumpedClusterName(*cluster_info));
+  if (!name_matcher.match(cluster_load_assignment.cluster_name())) {
     return std::nullopt;
   }
+  auto& policy = *cluster_load_assignment.mutable_policy();
 
-  return std::optional<std::pair<Http::Code, std::string>>{
-      std::make_pair(Http::Code::NotFound, fmt::format("{} not found in config dump", resource))};
-}
-
-std::optional<std::pair<Http::Code, std::string>> ConfigDumpHandler::addAllConfigToDump(
-    envoy::admin::v3::ConfigDump& dump, const std::optional<std::string>& mask,
-    const Matchers::StringMatcher& name_matcher, bool include_eds) const {
-  Envoy::Server::ConfigTracker::CbsMap callbacks_map = config_tracker_.getCallbacksMap();
-  if (include_eds) {
-    // TODO(mattklein123): Add ability to see warming clusters in admin output.
-    if (server_.clusterManager().hasActiveClusters()) {
-      callbacks_map.emplace("endpoint", [this](const Matchers::StringMatcher& name_matcher) {
-        return dumpEndpointConfigs(name_matcher);
-      });
-    }
+  // Using MILLION as denominator in config dump.
+  float value = cluster.dropOverload().value() * 1000000;
+  if (value > 0) {
+    auto* drop_overload = policy.add_drop_overloads();
+    drop_overload->set_category(cluster.dropCategory());
+    auto* percent = drop_overload->mutable_drop_percentage();
+    percent->set_denominator(envoy::type::v3::FractionalPercent::MILLION);
+    percent->set_numerator(uint32_t(value));
   }
 
-  for (const auto& [name, callback] : callbacks_map) {
-    UNREFERENCED_PARAMETER(name);
-    ProtobufTypes::MessagePtr message = callback(name_matcher);
-    ASSERT(message);
+  for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
+    policy.mutable_overprovisioning_factor()->set_value(host_set->overprovisioningFactor());
 
-    if (mask.has_value()) {
-      Protobuf::FieldMask field_mask;
-      ProtobufUtil::FieldMaskUtil::FromString(mask.value(), &field_mask);
-      // We don't use trimMessage() above here since masks don't support
-      // indexing through repeated fields. We don't return error on failure
-      // because different callback return types will have different valid
-      // field masks.
-      if (!checkFieldMaskAndTrimMessage(field_mask, *message)) {
-        continue;
+    if (!host_set->hostsPerLocality().get().empty()) {
+      for (int index = 0; index < static_cast<int>(host_set->hostsPerLocality().get().size());
+           index++) {
+        auto locality_host_set = host_set->hostsPerLocality().get()[index];
+
+        if (!locality_host_set.empty()) {
+          auto& locality_lb_endpoint = *cluster_load_assignment.mutable_endpoints()->Add();
+          locality_lb_endpoint.mutable_locality()->MergeFrom(locality_host_set[0]->locality());
+          locality_lb_endpoint.set_priority(locality_host_set[0]->priority());
+          if (host_set->localityWeights() != nullptr && !host_set->localityWeights()->empty()) {
+            locality_lb_endpoint.mutable_load_balancing_weight()->set_value(
+                (*host_set->localityWeights())[index]);
+          }
+
+          for (auto& host : locality_host_set) {
+            addLbEndpoint(host, locality_lb_endpoint);
+          }
+        }
+      }
+    } else {
+      for (auto& host : host_set->hosts()) {
+        auto& locality_lb_endpoint = *cluster_load_assignment.mutable_endpoints()->Add();
+        locality_lb_endpoint.mutable_locality()->MergeFrom(host->locality());
+        locality_lb_endpoint.set_priority(host->priority());
+        addLbEndpoint(host, locality_lb_endpoint);
       }
     }
-
-    auto* config = dump.add_configs();
-    std::ignore = config->PackFrom(*message);
   }
-  if (dump.configs().empty() && mask.has_value()) {
-    return std::optional<std::pair<Http::Code, std::string>>{std::make_pair(
-        Http::Code::BadRequest,
-        absl::StrCat("FieldMask ", *mask, " could not be successfully applied to any configs."))};
-  }
-  return std::nullopt;
+  return cluster_load_assignment;
 }
 
 ProtobufTypes::MessagePtr
@@ -286,69 +311,160 @@ ConfigDumpHandler::dumpEndpointConfigs(const Matchers::StringMatcher& name_match
   auto endpoint_config_dump = std::make_unique<envoy::admin::v3::EndpointsConfigDump>();
   // TODO(mattklein123): Add ability to see warming clusters in admin output.
   server_.clusterManager().forEachActiveCluster([&](const Upstream::Cluster& cluster) {
-    Upstream::ClusterInfoConstSharedPtr cluster_info = cluster.info();
-    envoy::config::endpoint::v3::ClusterLoadAssignment cluster_load_assignment;
-
-    if (!cluster_info->edsServiceName().empty()) {
-      cluster_load_assignment.set_cluster_name(cluster_info->edsServiceName());
-    } else {
-      cluster_load_assignment.set_cluster_name(cluster_info->name());
-    }
-    if (!name_matcher.match(cluster_load_assignment.cluster_name())) {
+    std::optional<envoy::config::endpoint::v3::ClusterLoadAssignment> cluster_load_assignment =
+        buildClusterLoadAssignment(cluster, name_matcher);
+    if (!cluster_load_assignment) {
       return;
     }
-    auto& policy = *cluster_load_assignment.mutable_policy();
 
-    // Using MILLION as denominator in config dump.
-    float value = cluster.dropOverload().value() * 1000000;
-    if (value > 0) {
-      auto* drop_overload = policy.add_drop_overloads();
-      drop_overload->set_category(cluster.dropCategory());
-      auto* percent = drop_overload->mutable_drop_percentage();
-      percent->set_denominator(envoy::type::v3::FractionalPercent::MILLION);
-      percent->set_numerator(uint32_t(value));
-    }
-
-    for (auto& host_set : cluster.prioritySet().hostSetsPerPriority()) {
-      policy.mutable_overprovisioning_factor()->set_value(host_set->overprovisioningFactor());
-
-      if (!host_set->hostsPerLocality().get().empty()) {
-        for (int index = 0; index < static_cast<int>(host_set->hostsPerLocality().get().size());
-             index++) {
-          auto locality_host_set = host_set->hostsPerLocality().get()[index];
-
-          if (!locality_host_set.empty()) {
-            auto& locality_lb_endpoint = *cluster_load_assignment.mutable_endpoints()->Add();
-            locality_lb_endpoint.mutable_locality()->MergeFrom(locality_host_set[0]->locality());
-            locality_lb_endpoint.set_priority(locality_host_set[0]->priority());
-            if (host_set->localityWeights() != nullptr && !host_set->localityWeights()->empty()) {
-              locality_lb_endpoint.mutable_load_balancing_weight()->set_value(
-                  (*host_set->localityWeights())[index]);
-            }
-
-            for (auto& host : locality_host_set) {
-              addLbEndpoint(host, locality_lb_endpoint);
-            }
-          }
-        }
-      } else {
-        for (auto& host : host_set->hosts()) {
-          auto& locality_lb_endpoint = *cluster_load_assignment.mutable_endpoints()->Add();
-          locality_lb_endpoint.mutable_locality()->MergeFrom(host->locality());
-          locality_lb_endpoint.set_priority(host->priority());
-          addLbEndpoint(host, locality_lb_endpoint);
-        }
-      }
-    }
-    if (cluster_info->addedViaApi()) {
+    if (cluster.info()->addedViaApi()) {
       auto& dynamic_endpoint = *endpoint_config_dump->mutable_dynamic_endpoint_configs()->Add();
-      std::ignore = dynamic_endpoint.mutable_endpoint_config()->PackFrom(cluster_load_assignment);
+      std::ignore = dynamic_endpoint.mutable_endpoint_config()->PackFrom(*cluster_load_assignment);
     } else {
       auto& static_endpoint = *endpoint_config_dump->mutable_static_endpoint_configs()->Add();
-      std::ignore = static_endpoint.mutable_endpoint_config()->PackFrom(cluster_load_assignment);
+      std::ignore = static_endpoint.mutable_endpoint_config()->PackFrom(*cluster_load_assignment);
     }
   });
   return endpoint_config_dump;
+}
+
+absl::StatusOr<ResourceField>
+ConfigDumpHandler::findResource(const std::string& resource, const std::optional<std::string>& mask,
+                                std::deque<std::string>& component_names, bool include_eds,
+                                const Matchers::StringMatcher& name_matcher) const {
+  Protobuf::FieldMask field_mask;
+  if (mask.has_value()) {
+    ProtobufUtil::FieldMaskUtil::FromString(mask.value(), &field_mask);
+  }
+  // Dumping the endpoints walks every cluster, so check for the field before paying for it.
+  const bool endpoints_can_hold_resource =
+      envoy::admin::v3::EndpointsConfigDump::descriptor()->FindFieldByName(resource) != nullptr;
+
+  while (!component_names.empty()) {
+    const std::string name = std::move(component_names.front());
+    component_names.pop_front();
+    // Skipped without dumping, since EndpointsConfigDump has no field by that name.
+    if (!endpoints_can_hold_resource && dumpsEndpoints(name, include_eds)) {
+      continue;
+    }
+
+    ProtobufTypes::MessagePtr message = dumpComponent(name, include_eds, name_matcher);
+    if (message == nullptr) {
+      continue;
+    }
+
+    const Protobuf::FieldDescriptor* field = message->GetDescriptor()->FindFieldByName(resource);
+    if (field == nullptr) {
+      continue;
+    }
+    if (!field->is_repeated()) {
+      return absl::InvalidArgumentError(
+          fmt::format("{} is not a repeated field. Use ?mask={} to get only this field",
+                      field->name(), field->name()));
+    }
+    if (field->cpp_type() != Protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+      return absl::InvalidArgumentError(
+          fmt::format("{} is not a repeated message field", field->name()));
+    }
+
+    if (mask.has_value()) {
+      // Whether the mask applies depends on the element, so every element is trimmed now, while a
+      // failure can still be the response code.
+      const Protobuf::Reflection* reflection = message->GetReflection();
+      const int size = reflection->FieldSize(*message, field);
+      for (int i = 0; i < size; ++i) {
+        if (!trimResourceMessage(field_mask,
+                                 *reflection->MutableRepeatedMessage(message.get(), field, i))) {
+          return absl::InvalidArgumentError(absl::StrCat("FieldMask ", field_mask.DebugString(),
+                                                         " could not be successfully used."));
+        }
+      }
+    }
+
+    return ResourceField{std::move(message), field};
+  }
+
+  return absl::NotFoundError(fmt::format("{} not found in config dump", resource));
+}
+
+ProtobufTypes::MessagePtr
+ConfigDumpHandler::firstMaskedConfig(const Protobuf::FieldMask& field_mask,
+                                     std::deque<std::string>& component_names, bool include_eds,
+                                     const Matchers::StringMatcher& name_matcher) const {
+  // Dumping the endpoints walks every cluster, so check up front whether the mask fits
+  // EndpointsConfigDump at all.
+  const bool endpoints_fit_mask =
+      fieldMaskFits(field_mask, *envoy::admin::v3::EndpointsConfigDump::descriptor());
+
+  while (!component_names.empty()) {
+    const std::string name = std::move(component_names.front());
+    component_names.pop_front();
+    if (!endpoints_fit_mask && dumpsEndpoints(name, include_eds)) {
+      continue;
+    }
+
+    ProtobufTypes::MessagePtr message = dumpComponent(name, include_eds, name_matcher);
+    if (message != nullptr && checkFieldMaskAndTrimMessage(field_mask, *message)) {
+      return message;
+    }
+  }
+  return nullptr;
+}
+
+std::deque<EndpointCluster>
+ConfigDumpHandler::snapshotEndpointClusters(const Matchers::StringMatcher& name_matcher) const {
+  std::deque<EndpointCluster> clusters;
+  // TODO(mattklein123): Add ability to see warming clusters in admin output.
+  server_.clusterManager().forEachActiveCluster([&](const Upstream::Cluster& cluster) {
+    Upstream::ClusterInfoConstSharedPtr cluster_info = cluster.info();
+    if (!name_matcher.match(dumpedClusterName(*cluster_info))) {
+      return;
+    }
+    clusters.push_back({cluster_info->name(), cluster_info->addedViaApi()});
+  });
+  std::stable_partition(clusters.begin(), clusters.end(),
+                        [](const EndpointCluster& cluster) { return !cluster.dynamic_; });
+  return clusters;
+}
+
+std::unique_ptr<envoy::config::endpoint::v3::ClusterLoadAssignment>
+ConfigDumpHandler::dumpClusterLoadAssignment(const EndpointCluster& endpoint_cluster,
+                                             const Matchers::StringMatcher& name_matcher) const {
+  const OptRef<const Upstream::Cluster> cluster =
+      server_.clusterManager().getActiveCluster(endpoint_cluster.name_);
+  if (!cluster.has_value()) {
+    return nullptr;
+  }
+  std::optional<envoy::config::endpoint::v3::ClusterLoadAssignment> cluster_load_assignment =
+      buildClusterLoadAssignment(*cluster, name_matcher);
+  if (!cluster_load_assignment.has_value()) {
+    return nullptr;
+  }
+  return std::make_unique<envoy::config::endpoint::v3::ClusterLoadAssignment>(
+      std::move(*cluster_load_assignment));
+}
+
+ProtobufTypes::MessagePtr
+ConfigDumpHandler::trackedConfig(const std::string& name,
+                                 const Matchers::StringMatcher& name_matcher) const {
+  const ConfigTracker::CbsMap& callbacks = config_tracker_.getCallbacksMap();
+  // The find can miss because the entry was destroyed after snapshot.
+  const auto callback = callbacks.find(name);
+  if (callback == callbacks.end()) {
+    return nullptr;
+  }
+  ProtobufTypes::MessagePtr message = callback->second(name_matcher);
+  ASSERT(message != nullptr);
+  return message;
+}
+
+ProtobufTypes::MessagePtr
+ConfigDumpHandler::dumpComponent(const std::string& name, bool include_eds,
+                                 const Matchers::StringMatcher& name_matcher) const {
+  if (dumpsEndpoints(name, include_eds)) {
+    return dumpEndpointConfigs(name_matcher);
+  }
+  return trackedConfig(name, name_matcher);
 }
 
 void ConfigDumpHandler::addLbEndpoint(
@@ -392,6 +508,215 @@ void ConfigDumpHandler::addLbEndpoint(
   if (host->healthCheckAddress()->asString() != host->address()->asString()) {
     health_check_config.set_port_value(host->healthCheckAddress()->ip()->port());
   }
+}
+
+class ConfigDumpRequest::Document {
+public:
+  explicit Document(Buffer::Instance& response)
+      : streamer_(response), root_map_(streamer_.makeRootMap()) {
+    root_map_->addKey("configs");
+    configs_array_ = root_map_->addArray();
+  }
+
+  // Whether a config is only partly emitted.
+  bool streaming() const { return config_ != nullptr; }
+
+  /**
+   * Emits the next piece of the config.
+   * @return false if no config was being walked.
+   */
+  bool advance() {
+    if (config_ == nullptr) {
+      return false;
+    }
+    if (!config_->streamer_->next()) {
+      config_.reset();
+    }
+    return true;
+  }
+
+  // Starts emitting `config` as an entry of `configs`.
+  void streamConfig(const Protobuf::Message& config) { streamInto(config, *configs_array_); }
+
+  // Starts emitting `config` as an entry of `configs`.
+  void streamConfig(ProtobufTypes::MessagePtr config) {
+    streamInto(*config, *configs_array_);
+    config_->owned_ = std::move(config);
+  }
+
+  // Whether an entry is still being filled in.
+  bool entryOpen() const { return entry_map_ != nullptr; }
+
+  // Opens an entry of `configs` naming `type_url`.
+  void openEntry(absl::string_view type_url) {
+    ASSERT(!entryOpen());
+    entry_map_ = configs_array_->addMap();
+    entry_map_->addKey("@type");
+    entry_map_->addString(type_url);
+  }
+
+  // Starts emitting `config` under `field` of a new element in the array named `array`. Elements of
+  // one array must be added consecutively.
+  void streamInEntry(absl::string_view array, absl::string_view field,
+                     ProtobufTypes::MessagePtr config) {
+    ASSERT(entryOpen());
+    if (entry_array_key_ != array) {
+      // Release the previous array first, or the new one opens inside it.
+      entry_array_.reset();
+      entry_map_->addKey(array);
+      entry_array_ = entry_map_->addArray();
+      entry_array_key_ = array;
+    }
+    Json::BufferStreamer::MapPtr element = entry_array_->addMap();
+    element->addKey(field);
+    streamInto(*config, *element);
+    config_->owned_ = std::move(config);
+    config_->element_ = std::move(element);
+  }
+
+  void closeEntry() {
+    ASSERT(entryOpen() && !streaming());
+    entry_array_.reset();
+    entry_map_.reset();
+    entry_array_key_.clear();
+  }
+
+private:
+  // A config being emitted, and what has to stay alive until it is whole.
+  struct StreamedConfig {
+    ProtobufTypes::MessagePtr owned_;
+    Json::BufferStreamer::MapPtr element_;
+    std::unique_ptr<Json::MessageStreamer> streamer_;
+  };
+
+  void streamInto(const Protobuf::Message& config, Json::BufferStreamer::Level& level) {
+    ASSERT(!streaming());
+    config_ = std::make_unique<StreamedConfig>();
+    config_->streamer_ = std::make_unique<Json::MessageStreamer>(
+        config, level, Json::MessageStreamer::TypeUrl::Emit,
+        Json::MessageStreamer::FieldNames::Proto, Json::MessageStreamer::Sensitive::Redact);
+  }
+
+  Json::BufferStreamer streamer_;
+  Json::BufferStreamer::MapPtr root_map_;
+  Json::BufferStreamer::ArrayPtr configs_array_;
+  Json::BufferStreamer::MapPtr entry_map_;
+  Json::BufferStreamer::ArrayPtr entry_array_;
+  std::string entry_array_key_;
+  std::unique_ptr<StreamedConfig> config_;
+};
+
+ConfigDumpRequest::ConfigDumpRequest(const ConfigDumpHandler& handler, Dump dump)
+    : handler_(handler), dump_(std::move(dump)) {}
+
+ConfigDumpRequest::~ConfigDumpRequest() = default;
+
+Http::Code ConfigDumpRequest::start(Http::ResponseHeaderMap& response_headers) {
+  document_ = std::make_unique<Document>(response_);
+  response_headers.setReferenceContentType(Http::Headers::get().ContentTypeValues.Json);
+  return Http::Code::OK;
+}
+
+bool ConfigDumpRequest::nextChunk(Buffer::Instance& response) {
+  bool more = true;
+  while (more && response_.length() < chunk_size_) {
+    more = serializeNextConfig();
+  }
+  if (!more) {
+    ASSERT(!document_->streaming() && !document_->entryOpen());
+    document_.reset();
+  }
+  response.move(response_);
+
+  return more;
+}
+
+bool ConfigDumpRequest::serializeNextResourceElement() {
+  const ProtobufTypes::MessagePtr& resource = dump_.resource_->config_;
+  const Protobuf::FieldDescriptor* field = dump_.resource_->field_;
+
+  const Protobuf::Reflection* reflection = resource->GetReflection();
+  if (next_resource_element_ >= reflection->FieldSize(*resource, field)) {
+    return false;
+  }
+  document_->streamConfig(
+      reflection->GetRepeatedMessage(*resource, field, next_resource_element_++));
+  return true;
+}
+
+bool ConfigDumpRequest::serializeNextConfig() {
+  if (document_->advance()) {
+    return true;
+  }
+
+  if (document_->entryOpen()) {
+    serializeNextEndpoint();
+    return true;
+  }
+
+  if (dump_.resource_.has_value()) {
+    return serializeNextResourceElement();
+  }
+
+  if (dump_.field_mask_.has_value()) {
+    ProtobufTypes::MessagePtr message = nextMaskedConfig();
+    if (message == nullptr) {
+      return false;
+    }
+    document_->streamConfig(std::move(message));
+    return true;
+  }
+
+  while (!dump_.component_names_.empty()) {
+    const std::string name = std::move(dump_.component_names_.front());
+    dump_.component_names_.pop_front();
+
+    // The endpoints component is emitted a cluster at a time, so it only opens its entry here.
+    if (handler_.dumpsEndpoints(name, dump_.include_eds_)) {
+      endpoint_clusters_ = handler_.snapshotEndpointClusters(*dump_.name_matcher_);
+      document_->openEntry(TypeUtil::descriptorFullNameToTypeUrl(
+          envoy::admin::v3::EndpointsConfigDump::descriptor()->full_name()));
+      return true;
+    }
+
+    ProtobufTypes::MessagePtr message = handler_.trackedConfig(name, *dump_.name_matcher_);
+    // The component can be gone by now, in which case the next name is tried.
+    if (message != nullptr) {
+      document_->streamConfig(std::move(message));
+      return true;
+    }
+  }
+
+  return false;
+}
+
+ProtobufTypes::MessagePtr ConfigDumpRequest::nextMaskedConfig() {
+  // The config makeRequest had to dump to decide the response code is emitted before the rest.
+  if (dump_.pending_config_ != nullptr) {
+    return std::move(dump_.pending_config_);
+  }
+  return handler_.firstMaskedConfig(*dump_.field_mask_, dump_.component_names_, dump_.include_eds_,
+                                    *dump_.name_matcher_);
+}
+
+void ConfigDumpRequest::serializeNextEndpoint() {
+  ASSERT(document_->entryOpen());
+  while (!endpoint_clusters_.empty()) {
+    const EndpointCluster cluster = std::move(endpoint_clusters_.front());
+    endpoint_clusters_.pop_front();
+
+    ProtobufTypes::MessagePtr config =
+        handler_.dumpClusterLoadAssignment(cluster, *dump_.name_matcher_);
+    // The cluster can be gone by now
+    if (config == nullptr) {
+      continue;
+    }
+    document_->streamInEntry(cluster.dynamic_ ? "dynamic_endpoint_configs"
+                                              : "static_endpoint_configs",
+                             "endpoint_config", std::move(config));
+    return;
+  }
+  document_->closeEntry();
 }
 
 } // namespace Server

--- a/source/server/admin/config_dump_handler.h
+++ b/source/server/admin/config_dump_handler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <deque>
+
 #include "envoy/admin/v3/config_dump.pb.h"
 #include "envoy/buffer/buffer.h"
 #include "envoy/config/endpoint/v3/endpoint_components.pb.h"
@@ -8,35 +10,45 @@
 #include "envoy/server/admin.h"
 #include "envoy/server/instance.h"
 
-#include "source/server/admin/config_tracker_impl.h"
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/statusor.h"
 #include "source/server/admin/handler_ctx.h"
-
-#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Server {
+
+// A dump is `{"configs":[...]}`, one Any per component: bootstrap, clusters, listeners and the
+// rest, each packing that component's ConfigDump message. `?resource=` names a repeated field
+// inside one of those messages, `?mask=` trims the fields of its elements.
+
+// A cluster the endpoints component covers. `dynamic_` is set for a cluster added via the API,
+// which is dumped under dynamic_endpoint_configs rather than static_endpoint_configs.
+struct EndpointCluster {
+  std::string name_;
+  bool dynamic_;
+};
+
+// A single component and the repeated field in it that `?resource=` named.
+struct ResourceField {
+  ProtobufTypes::MessagePtr config_;
+  const Protobuf::FieldDescriptor* field_;
+};
 
 class ConfigDumpHandler : public HandlerContextBase {
 
 public:
   ConfigDumpHandler(ConfigTracker& config_tracker, Server::Instance& server);
 
-  Http::Code handlerConfigDump(Http::ResponseHeaderMap& response_headers,
-                               Buffer::Instance& response, AdminStream&) const;
+  Admin::UrlHandler handlerConfigDumpStreamed();
+
+  Admin::RequestPtr makeRequest(AdminStream& admin_stream) const;
 
 private:
-  std::optional<std::pair<Http::Code, std::string>>
-  addAllConfigToDump(envoy::admin::v3::ConfigDump& dump, const std::optional<std::string>& mask,
-                     const Matchers::StringMatcher& name_matcher, bool include_eds) const;
-  /**
-   * Add the config matching the passed resource to the passed config dump.
-   * @return std::nullopt on success, else the Http::Code and an error message that should be added
-   * to the admin response.
-   */
-  std::optional<std::pair<Http::Code, std::string>>
-  addResourceToDump(envoy::admin::v3::ConfigDump& dump, const std::optional<std::string>& mask,
-                    const std::string& resource, const Matchers::StringMatcher& name_matcher,
-                    bool include_eds) const;
+  friend class ConfigDumpRequest;
+
+  std::deque<std::string> componentNames(bool include_eds) const;
+
+  bool dumpsEndpoints(const std::string& name, bool include_eds) const;
 
   /**
    * Helper methods to add endpoints config
@@ -44,9 +56,100 @@ private:
   void addLbEndpoint(const Upstream::HostSharedPtr& host,
                      envoy::config::endpoint::v3::LocalityLbEndpoints& locality_lb_endpoint) const;
 
+  /**
+   * Builds the ClusterLoadAssignment dumped for one cluster.
+   * @return ClusterLoadAssignment if `name_matcher` matches the cluster name, nullopt otherwise
+   */
+  std::optional<envoy::config::endpoint::v3::ClusterLoadAssignment>
+  buildClusterLoadAssignment(const Upstream::Cluster& cluster,
+                             const Matchers::StringMatcher& name_matcher) const;
+
   ProtobufTypes::MessagePtr dumpEndpointConfigs(const Matchers::StringMatcher& name_matcher) const;
 
+  std::deque<EndpointCluster>
+  snapshotEndpointClusters(const Matchers::StringMatcher& name_matcher) const;
+
+  /**
+   * @return the ClusterLoadAssignment or nullptr if that cluster is no longer active
+   */
+  std::unique_ptr<envoy::config::endpoint::v3::ClusterLoadAssignment>
+  dumpClusterLoadAssignment(const EndpointCluster& endpoint_cluster,
+                            const Matchers::StringMatcher& name_matcher) const;
+
+  // Dumps the config the ConfigTracker holds under `name`, or nullptr if it holds none.
+  ProtobufTypes::MessagePtr trackedConfig(const std::string& name,
+                                          const Matchers::StringMatcher& name_matcher) const;
+
+  // The config dumped under `name`, or nullptr if nothing is dumped under it any more.
+  ProtobufTypes::MessagePtr dumpComponent(const std::string& name, bool include_eds,
+                                          const Matchers::StringMatcher& name_matcher) const;
+
+  /**
+   * Finds the component with a repeated field named `resource` and applies `mask` to its elements.
+   * Pops the names of the components it dumps looking for it.
+   * @return that component and its `resource` field, or the error to answer with.
+   */
+  absl::StatusOr<ResourceField> findResource(const std::string& resource,
+                                             const std::optional<std::string>& mask,
+                                             std::deque<std::string>& component_names,
+                                             bool include_eds,
+                                             const Matchers::StringMatcher& name_matcher) const;
+
+  /**
+   * Dumps components, popping their names, until `field_mask` applies to one.
+   * @return that component, or nullptr if the mask applied to none of them.
+   */
+  ProtobufTypes::MessagePtr firstMaskedConfig(const Protobuf::FieldMask& field_mask,
+                                              std::deque<std::string>& component_names,
+                                              bool include_eds,
+                                              const Matchers::StringMatcher& name_matcher) const;
+
   ConfigTracker& config_tracker_;
+};
+
+class ConfigDumpRequest : public Admin::Request {
+public:
+  static constexpr uint64_t DefaultChunkSize = 64 * 1024;
+
+  struct Dump {
+    Matchers::StringMatcherPtr name_matcher_;
+    std::deque<std::string> component_names_;
+    bool include_eds_{false};
+    std::optional<Protobuf::FieldMask> field_mask_;
+    ProtobufTypes::MessagePtr pending_config_;
+    std::optional<ResourceField> resource_;
+  };
+
+  ConfigDumpRequest(const ConfigDumpHandler& handler, Dump dump);
+  ~ConfigDumpRequest() override;
+
+  // Admin::Request
+  Http::Code start(Http::ResponseHeaderMap& response_headers) override;
+  bool nextChunk(Buffer::Instance& response) override;
+
+  void setChunkSize(uint64_t chunk_size) { chunk_size_ = chunk_size; }
+
+private:
+  class Document;
+
+  bool serializeNextConfig();
+
+  bool serializeNextResourceElement();
+
+  // Dumps components until the mask applies to one, or nullptr once none are left.
+  ProtobufTypes::MessagePtr nextMaskedConfig();
+
+  // Emits one cluster of the endpoints component, closing it once none are left.
+  void serializeNextEndpoint();
+
+  const ConfigDumpHandler& handler_;
+  Dump dump_;
+  Buffer::OwnedImpl response_;
+  std::unique_ptr<Document> document_;
+  int next_resource_element_{0};
+  // The clusters whose endpoints are left to emit
+  std::deque<EndpointCluster> endpoint_clusters_;
+  uint64_t chunk_size_{DefaultChunkSize};
 };
 
 } // namespace Server

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -6,6 +6,7 @@ load(
     "envoy_cc_test_binary",
     "envoy_cc_test_library",
     "envoy_package",
+    "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
@@ -102,6 +103,24 @@ envoy_cc_test(
         "//source/common/json:json_internal_lib",
         "//source/common/json:json_streamer_lib",
         "//source/common/protobuf:utility_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "proto_streamer_test_proto",
+    srcs = ["proto_streamer_test.proto"],
+)
+
+envoy_cc_test(
+    name = "proto_streamer_test",
+    srcs = ["proto_streamer_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        ":proto_streamer_test_proto_cc_proto",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/json:proto_streamer_lib",
+        "//source/common/protobuf:utility_lib",
+        "//test/proto:sensitive_proto_cc_proto",
     ],
 )
 

--- a/test/common/json/BUILD
+++ b/test/common/json/BUILD
@@ -124,6 +124,19 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_benchmark_binary(
+    name = "proto_streamer_speed_test",
+    srcs = ["proto_streamer_speed_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/json:proto_streamer_lib",
+        "//source/common/protobuf:utility_lib",
+        "//test/proto:extraction_proto_cc_proto",
+        "//test/proto:sensitive_proto_cc_proto",
+    ],
+)
+
 envoy_cc_test(
     name = "json_utility_test",
     srcs = ["json_utility_test.cc"],

--- a/test/common/json/proto_streamer_speed_test.cc
+++ b/test/common/json/proto_streamer_speed_test.cc
@@ -1,0 +1,188 @@
+#include <map>
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/macros.h"
+#include "source/common/json/proto_streamer.h"
+#include "source/common/protobuf/utility.h"
+
+#include "test/benchmark/main.h"
+#include "test/proto/extraction.pb.h"
+#include "test/proto/sensitive.pb.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Json {
+namespace {
+
+enum class MessageType {
+  Strings,
+  Int64s,
+  Uint32s,
+  Doubles,
+  Enums,
+  Bytes,
+  Messages,
+  Maps,
+  Anys,
+};
+
+extraction::TestBucket makeBucket(uint32_t index) {
+  extraction::TestBucket bucket;
+  bucket.set_name(absl::StrCat("bucket_", index));
+  bucket.set_ratio(0.5);
+  bucket.add_objects("payload");
+  return bucket;
+}
+
+ProtobufTypes::MessagePtr makeMessage(MessageType type, uint32_t elements) {
+  switch (type) {
+  case MessageType::Strings:
+  case MessageType::Int64s:
+  case MessageType::Uint32s:
+  case MessageType::Doubles:
+  case MessageType::Enums: {
+    auto request = std::make_unique<extraction::TestRequest>();
+    for (uint32_t i = 0; i < elements; i++) {
+      switch (type) {
+      case MessageType::Strings:
+        request->add_repeated_strings(absl::StrCat("element_", i));
+        break;
+      case MessageType::Int64s:
+        request->add_repeated_int64(i);
+        break;
+      case MessageType::Uint32s:
+        request->add_repeated_uint32(i);
+        break;
+      case MessageType::Doubles:
+        request->add_repeated_double(i + 0.5);
+        break;
+      case MessageType::Enums:
+        request->add_repeated_enum(extraction::BETA);
+        break;
+      default:
+        break;
+      }
+    }
+    return request;
+  }
+  case MessageType::Bytes: {
+    auto bucket = std::make_unique<extraction::TestBucket>();
+    bucket->set_name("bytes");
+    for (uint32_t i = 0; i < elements; i++) {
+      bucket->add_objects(absl::StrCat("object_", i));
+    }
+    return bucket;
+  }
+  case MessageType::Messages: {
+    auto response = std::make_unique<extraction::TestResponse>();
+    for (uint32_t i = 0; i < elements; i++) {
+      *response->add_buckets() = makeBucket(i);
+    }
+    return response;
+  }
+  case MessageType::Maps: {
+    auto response = std::make_unique<extraction::TestResponse>();
+    for (uint32_t i = 0; i < elements; i++) {
+      (*response->mutable_sub_buckets())[absl::StrCat("key_", i)] = makeBucket(i);
+    }
+    return response;
+  }
+  case MessageType::Anys: {
+    auto any_holder = std::make_unique<envoy::test::Sensitive>();
+    for (uint32_t i = 0; i < elements; i++) {
+      std::ignore = any_holder->add_insensitive_repeated_any()->PackFrom(makeBucket(i));
+    }
+    return any_holder;
+  }
+  }
+  return nullptr;
+}
+
+using MessageCache = std::map<std::pair<MessageType, uint32_t>, ProtobufTypes::MessagePtr>;
+MessageCache& messageCache() { MUTABLE_CONSTRUCT_ON_FIRST_USE(MessageCache); }
+
+const Protobuf::Message& cachedMessage(MessageType type, uint32_t elements) {
+  MessageCache& cache = messageCache();
+  const std::pair<MessageType, uint32_t> key{type, elements};
+  const auto cached = cache.find(key);
+  if (cached != cache.end()) {
+    return *cached->second;
+  }
+  return *cache.emplace(key, makeMessage(type, elements)).first->second;
+}
+
+uint64_t streamMessage(const Protobuf::Message& message) {
+  Buffer::OwnedImpl buffer;
+  uint64_t bytes = 0;
+  {
+    BufferStreamer streamer(buffer);
+    BufferStreamer::ArrayPtr array = streamer.makeRootArray();
+    MessageStreamer message_streamer(message, *array, MessageStreamer::TypeUrl::Emit,
+                                     MessageStreamer::FieldNames::Proto);
+    while (message_streamer.next()) {
+      bytes += buffer.length();
+      buffer.drain(buffer.length());
+    }
+  }
+  return bytes + buffer.length();
+}
+
+uint64_t printMessage(const Protobuf::Message& message) {
+  return MessageUtil::getJsonStringFromMessageOrError(message).size();
+}
+
+uint32_t elementCount(const ::benchmark::State& state) {
+  const auto elements = static_cast<uint32_t>(state.range(0));
+  return benchmark::skipExpensiveBenchmarks() ? std::min(elements, 1000U) : elements;
+}
+
+void elementCounts(::benchmark::internal::Benchmark* registration) {
+  registration->Arg(1000)->Arg(10000)->Unit(::benchmark::kMicrosecond);
+}
+
+void report(::benchmark::State& state, uint64_t bytes) {
+  state.SetBytesProcessed(static_cast<int64_t>(bytes) * state.iterations());
+  state.SetItemsProcessed(static_cast<int64_t>(elementCount(state)) * state.iterations());
+  state.counters["response_bytes"] = bytes;
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+void BM_Print(::benchmark::State& state, MessageType type) {
+  const Protobuf::Message& message = cachedMessage(type, elementCount(state));
+  uint64_t bytes = 0;
+  for (auto _ : state) { // NOLINT
+    bytes = printMessage(message);
+  }
+  report(state, bytes);
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+void BM_Stream(::benchmark::State& state, MessageType type) {
+  const Protobuf::Message& message = cachedMessage(type, elementCount(state));
+  uint64_t bytes = 0;
+  for (auto _ : state) { // NOLINT
+    bytes = streamMessage(message);
+  }
+  report(state, bytes);
+}
+
+#define MESSAGE_BENCHMARKS(row_name, type)                                                         \
+  BENCHMARK_CAPTURE(BM_Print, row_name, type)->Apply(elementCounts);                               \
+  BENCHMARK_CAPTURE(BM_Stream, row_name, type)->Apply(elementCounts)
+
+MESSAGE_BENCHMARKS(strings, MessageType::Strings);
+MESSAGE_BENCHMARKS(int64s, MessageType::Int64s);
+MESSAGE_BENCHMARKS(uint32s, MessageType::Uint32s);
+MESSAGE_BENCHMARKS(doubles, MessageType::Doubles);
+MESSAGE_BENCHMARKS(enums, MessageType::Enums);
+MESSAGE_BENCHMARKS(bytes, MessageType::Bytes);
+MESSAGE_BENCHMARKS(messages, MessageType::Messages);
+MESSAGE_BENCHMARKS(maps, MessageType::Maps);
+MESSAGE_BENCHMARKS(anys, MessageType::Anys);
+
+#undef MESSAGE_BENCHMARKS
+
+} // namespace
+} // namespace Json
+} // namespace Envoy

--- a/test/common/json/proto_streamer_speed_test.cc
+++ b/test/common/json/proto_streamer_speed_test.cc
@@ -119,7 +119,8 @@ uint64_t streamMessage(const Protobuf::Message& message) {
     BufferStreamer streamer(buffer);
     BufferStreamer::ArrayPtr array = streamer.makeRootArray();
     MessageStreamer message_streamer(message, *array, MessageStreamer::TypeUrl::Emit,
-                                     MessageStreamer::FieldNames::Proto);
+                                     MessageStreamer::FieldNames::Proto,
+                                     MessageStreamer::Sensitive::Redact);
     while (message_streamer.next()) {
       bytes += buffer.length();
       buffer.drain(buffer.length());

--- a/test/common/json/proto_streamer_test.cc
+++ b/test/common/json/proto_streamer_test.cc
@@ -1,0 +1,237 @@
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/json/proto_streamer.h"
+#include "source/common/protobuf/utility.h"
+
+#include "test/common/json/proto_streamer_test.pb.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Json {
+namespace {
+
+using ::test::common::json::TestMessage;
+using ::test::common::json::TestNested;
+
+std::pair<std::string, uint32_t>
+stream(const Protobuf::Message& message,
+       MessageStreamer::FieldNames field_names = MessageStreamer::FieldNames::Proto) {
+  std::string emitted;
+  uint32_t pieces = 0;
+  Buffer::OwnedImpl buffer;
+  {
+    BufferStreamer streamer(buffer);
+    BufferStreamer::ArrayPtr array = streamer.makeRootArray();
+    MessageStreamer message_streamer(message, *array, MessageStreamer::TypeUrl::Omit, field_names);
+    while (message_streamer.next()) {
+      emitted += buffer.toString();
+      buffer.drain(buffer.length());
+      ++pieces;
+    }
+  }
+  emitted += buffer.toString();
+  return {emitted, pieces};
+}
+
+std::string printedInArray(const Protobuf::Message& message) {
+  return absl::StrCat("[", MessageUtil::getJsonStringFromMessageOrError(message), "]");
+}
+
+void expectSameJson(const Protobuf::Message& message) {
+  EXPECT_EQ(printedInArray(message), stream(message).first) << message.DebugString();
+}
+
+TEST(MessageStreamerTest, Empty) { expectSameJson(TestMessage()); }
+
+TEST(MessageStreamerTest, Scalars) {
+  TestMessage message;
+  message.set_int32_value(-1);
+  message.set_int64_value(std::numeric_limits<int64_t>::min());
+  message.set_uint32_value(1);
+  message.set_uint64_value(std::numeric_limits<uint64_t>::max());
+  message.set_sint32_value(-7);
+  message.set_sint64_value(-6);
+  message.set_fixed32_value(3);
+  message.set_fixed64_value(2);
+  message.set_sfixed32_value(-5);
+  message.set_sfixed64_value(-4);
+  message.set_double_value(1.5);
+  message.set_float_value(0.25);
+  message.set_bool_value(true);
+  message.set_string_value("\"quoted\"\n");
+  message.add_repeated_int64(std::numeric_limits<int64_t>::max());
+  message.add_repeated_uint64(std::numeric_limits<uint64_t>::max());
+  message.add_repeated_double(140);
+  message.add_repeated_strings("a");
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, Enums) {
+  TestMessage message;
+  message.set_enum_value(::test::common::json::BETA);
+  message.add_repeated_enum(::test::common::json::ALPHA);
+  message.add_repeated_enum(static_cast<::test::common::json::TestEnum>(1234));
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, BytesAreBase64) {
+  TestMessage message;
+  message.set_bytes_value(std::string("\x00\x01\xff", 3));
+  message.mutable_nested()->add_objects("padding-check");
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, NestedMessages) {
+  TestMessage message;
+  message.mutable_nested()->set_ratio(0.5);
+  message.add_repeated_nested()->set_name("first");
+  message.add_repeated_nested()->set_name("second");
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, Maps) {
+  TestMessage message;
+  (*message.mutable_bool_keyed())[true] = "bool";
+  (*message.mutable_int32_keyed())[-1] = "int32";
+  (*message.mutable_int64_keyed())[std::numeric_limits<int64_t>::min()] = "int64";
+  (*message.mutable_uint32_keyed())[1] = "uint32";
+  (*message.mutable_uint64_keyed())[std::numeric_limits<uint64_t>::max()] = "uint64";
+  (*message.mutable_string_keyed())["key"] = "string";
+  (*message.mutable_message_valued())["key"].set_name("nested");
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, Wrappers) {
+  TestMessage message;
+  message.mutable_wrapped_double()->set_value(1.5);
+  message.mutable_wrapped_float()->set_value(0.25);
+  message.mutable_wrapped_int64()->set_value(std::numeric_limits<int64_t>::min());
+  message.mutable_wrapped_uint64()->set_value(std::numeric_limits<uint64_t>::max());
+  message.mutable_wrapped_int32()->set_value(-1);
+  message.mutable_wrapped_uint32()->set_value(42);
+  message.mutable_wrapped_bool()->set_value(true);
+  message.mutable_wrapped_string()->set_value("wrapped");
+  message.mutable_wrapped_bytes()->set_value("wrapped");
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, LowerCamelCaseKeys) {
+  TestMessage message;
+  message.set_int64_value(7);
+  message.mutable_nested()->set_name("nested_name");
+  message.add_repeated_strings("foo");
+
+  const Protobuf::util::JsonPrintOptions options;
+  std::string printed;
+  ASSERT_TRUE(Protobuf::util::MessageToJsonString(message, &printed, options).ok());
+  EXPECT_EQ(absl::StrCat("[", printed, "]"),
+            stream(message, MessageStreamer::FieldNames::LowerCamelCase).first);
+}
+
+TEST(MessageStreamerTest, DurationsAndTimestamps) {
+  TestMessage message;
+  message.mutable_duration()->set_nanos(1234);
+  message.mutable_timestamp()->set_seconds(1234);
+  message.mutable_timestamp()->set_nanos(5678);
+  expectSameJson(message);
+
+  TestMessage zeroed;
+  zeroed.mutable_duration()->set_seconds(5678);
+  zeroed.mutable_timestamp();
+  expectSameJson(zeroed);
+}
+
+TEST(MessageStreamerTest, Anys) {
+  TestMessage message;
+  TestNested nested;
+  nested.set_name("nested_name");
+  nested.set_ratio(0.5);
+  std::ignore = message.mutable_any()->PackFrom(nested);
+  std::ignore = message.add_repeated_any()->PackFrom(TestNested());
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, AnyOfUnknownType) {
+  TestMessage message;
+  message.mutable_any()->set_type_url("type.googleapis.com/test.common.json.NotLinkedIn");
+  EXPECT_EQ(R"([{"any":{"@type":"type.googleapis.com/test.common.json.NotLinkedIn"}}])",
+            stream(message).first);
+}
+
+TEST(MessageStreamerTest, DynamicMessages) {
+  TestMessage generated;
+  generated.mutable_duration()->set_seconds(5);
+  generated.mutable_timestamp()->set_seconds(1755561600);
+  generated.mutable_nested()->set_name("nested_name");
+  std::ignore = generated.mutable_any()->PackFrom(TestNested());
+
+  std::string serialized;
+  ASSERT_TRUE(generated.SerializeToString(&serialized));
+
+  Protobuf::DynamicMessageFactory factory;
+  ProtobufTypes::MessagePtr dynamic(factory.GetPrototype(TestMessage::descriptor())->New());
+  ASSERT_TRUE(dynamic->ParseFromString(serialized));
+  expectSameJson(*dynamic);
+}
+
+TEST(MessageStreamerTest, Structs) {
+  TestMessage message;
+  (*message.mutable_structured()->mutable_fields())["key"].set_string_value("value");
+  (*message.mutable_structured()->mutable_fields())["number"].set_number_value(1.5);
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, MessageThePrinterRejects) {
+  TestMessage message;
+  // The printer refuses NaN in a google.protobuf.Value.
+  (*message.mutable_structured()->mutable_fields())["key"].set_number_value(
+      std::numeric_limits<double>::quiet_NaN());
+  EXPECT_EQ(R"([{"structured":null}])", stream(message).first);
+}
+
+TEST(MessageStreamerTest, NonFiniteNumbers) {
+  TestMessage message;
+  message.add_repeated_double(std::numeric_limits<double>::quiet_NaN());
+  message.add_repeated_double(std::numeric_limits<double>::infinity());
+  message.add_repeated_double(-std::numeric_limits<double>::infinity());
+  expectSameJson(message);
+}
+
+TEST(MessageStreamerTest, EmitsInPieces) {
+  TestMessage message;
+  message.mutable_nested()->set_name("nested_name");
+  message.add_repeated_strings("one");
+  message.add_repeated_strings("two");
+  message.add_repeated_strings("three");
+
+  const std::pair<std::string, uint32_t> streamed = stream(message);
+  EXPECT_EQ(printedInArray(message), streamed.first);
+  EXPECT_LT(5U, streamed.second);
+}
+
+TEST(MessageStreamerTest, DestroyedMidStream) {
+  TestMessage message;
+  message.mutable_nested()->set_name("nested_name");
+  message.add_repeated_nested()->set_name("more");
+
+  Buffer::OwnedImpl buffer;
+  {
+    BufferStreamer streamer(buffer);
+    BufferStreamer::ArrayPtr array = streamer.makeRootArray();
+    MessageStreamer message_streamer(message, *array, MessageStreamer::TypeUrl::Omit,
+                                     MessageStreamer::FieldNames::Proto,
+                                     MessageStreamer::Sensitive::Emit);
+    ASSERT_TRUE(message_streamer.next());
+    ASSERT_TRUE(message_streamer.next());
+  }
+
+  const std::string emitted = buffer.toString();
+  EXPECT_EQ('[', emitted.front());
+  EXPECT_EQ(']', emitted.back());
+}
+
+} // namespace
+} // namespace Json
+} // namespace Envoy

--- a/test/common/json/proto_streamer_test.cc
+++ b/test/common/json/proto_streamer_test.cc
@@ -3,6 +3,7 @@
 #include "source/common/protobuf/utility.h"
 
 #include "test/common/json/proto_streamer_test.pb.h"
+#include "test/proto/sensitive.pb.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -17,14 +18,16 @@ using ::test::common::json::TestNested;
 
 std::pair<std::string, uint32_t>
 stream(const Protobuf::Message& message,
-       MessageStreamer::FieldNames field_names = MessageStreamer::FieldNames::Proto) {
+       MessageStreamer::FieldNames field_names = MessageStreamer::FieldNames::Proto,
+       MessageStreamer::Sensitive sensitive = MessageStreamer::Sensitive::Emit) {
   std::string emitted;
   uint32_t pieces = 0;
   Buffer::OwnedImpl buffer;
   {
     BufferStreamer streamer(buffer);
     BufferStreamer::ArrayPtr array = streamer.makeRootArray();
-    MessageStreamer message_streamer(message, *array, MessageStreamer::TypeUrl::Omit, field_names);
+    MessageStreamer message_streamer(message, *array, MessageStreamer::TypeUrl::Omit, field_names,
+                                     sensitive);
     while (message_streamer.next()) {
       emitted += buffer.toString();
       buffer.drain(buffer.length());
@@ -197,6 +200,77 @@ TEST(MessageStreamerTest, NonFiniteNumbers) {
   message.add_repeated_double(std::numeric_limits<double>::infinity());
   message.add_repeated_double(-std::numeric_limits<double>::infinity());
   expectSameJson(message);
+}
+
+void expectSameRedactedJson(const envoy::test::Sensitive& message) {
+  envoy::test::Sensitive redacted = message;
+  MessageUtil::redact(redacted);
+  EXPECT_EQ(
+      printedInArray(redacted),
+      stream(message, MessageStreamer::FieldNames::Proto, MessageStreamer::Sensitive::Redact).first)
+      << message.DebugString();
+}
+
+TEST(MessageStreamerTest, Redacts) {
+  envoy::test::Sensitive sensitive;
+  sensitive.set_sensitive_string("secret");
+  sensitive.add_sensitive_repeated_string("secret");
+  sensitive.set_sensitive_bytes("secret");
+  sensitive.add_sensitive_repeated_bytes("secret");
+  sensitive.set_sensitive_int(1);
+  sensitive.add_sensitive_repeated_int(2);
+  (*sensitive.mutable_sensitive_string_map())["key"] = "secret";
+  (*sensitive.mutable_sensitive_int_map())["key"] = 3;
+
+  sensitive.set_insensitive_string("public");
+  sensitive.add_insensitive_repeated_string("public");
+  sensitive.set_insensitive_bytes("public");
+  sensitive.set_insensitive_int(4);
+  (*sensitive.mutable_insensitive_string_map())["key"] = "public";
+  (*sensitive.mutable_insensitive_int_map())["key"] = 5;
+  expectSameRedactedJson(sensitive);
+}
+
+TEST(MessageStreamerTest, RedactsNestedMessages) {
+  envoy::test::Sensitive sensitive;
+  // Everything under a sensitive field should be redacted.
+  sensitive.mutable_sensitive_message()->set_insensitive_string("public");
+  sensitive.mutable_sensitive_message()->set_insensitive_int(1);
+  sensitive.add_sensitive_repeated_message()->set_insensitive_string("public");
+  // Only the annotated fields of an insensitive message should be redacted.
+  sensitive.mutable_insensitive_message()->set_sensitive_string("secret");
+  sensitive.mutable_insensitive_message()->set_insensitive_string("public");
+  sensitive.add_insensitive_repeated_message()->set_sensitive_int(2);
+  expectSameRedactedJson(sensitive);
+}
+
+TEST(MessageStreamerTest, RedactsInsideAny) {
+  envoy::test::Sensitive packed;
+  packed.set_sensitive_string("secret");
+  packed.set_insensitive_string("public");
+
+  envoy::test::Sensitive sensitive;
+  std::ignore = sensitive.mutable_insensitive_any()->PackFrom(packed);
+  std::ignore = sensitive.mutable_sensitive_any()->PackFrom(packed);
+  std::ignore = sensitive.add_insensitive_repeated_any()->PackFrom(packed);
+  expectSameRedactedJson(sensitive);
+}
+
+TEST(MessageStreamerTest, RedactsInsideTypedStruct) {
+  envoy::test::Sensitive sensitive;
+  TestUtility::loadFromYaml(R"EOF(
+type_url: type.googleapis.com/envoy.test.Sensitive
+value:
+  sensitive_string: secret
+)EOF",
+                            *sensitive.mutable_insensitive_typed_struct());
+  TestUtility::loadFromYaml(R"EOF(
+type_url: type.googleapis.com/envoy.test.Sensitive
+value:
+  insensitive_string: public
+)EOF",
+                            *sensitive.mutable_sensitive_typed_struct());
+  expectSameRedactedJson(sensitive);
 }
 
 TEST(MessageStreamerTest, EmitsInPieces) {

--- a/test/common/json/proto_streamer_test.proto
+++ b/test/common/json/proto_streamer_test.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package test.common.json;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+enum TestEnum {
+  TEST_ENUM_UNSPECIFIED = 0;
+  ALPHA = 1;
+  BETA = 2;
+}
+
+message TestNested {
+  string name = 1;
+  float ratio = 2;
+  repeated bytes objects = 3;
+}
+
+message TestMessage {
+  int32 int32_value = 1;
+  int64 int64_value = 2;
+  uint32 uint32_value = 3;
+  uint64 uint64_value = 4;
+  sint32 sint32_value = 5;
+  sint64 sint64_value = 6;
+  fixed32 fixed32_value = 7;
+  fixed64 fixed64_value = 8;
+  sfixed32 sfixed32_value = 9;
+  sfixed64 sfixed64_value = 10;
+  double double_value = 11;
+  float float_value = 12;
+  bool bool_value = 13;
+  string string_value = 14;
+  bytes bytes_value = 15;
+  TestEnum enum_value = 16;
+
+  repeated int64 repeated_int64 = 20;
+  repeated uint64 repeated_uint64 = 21;
+  repeated double repeated_double = 22;
+  repeated string repeated_strings = 23;
+  repeated TestEnum repeated_enum = 24;
+
+  map<bool, string> bool_keyed = 30;
+  map<int32, string> int32_keyed = 31;
+  map<int64, string> int64_keyed = 32;
+  map<uint32, string> uint32_keyed = 33;
+  map<uint64, string> uint64_keyed = 34;
+  map<string, string> string_keyed = 35;
+  map<string, TestNested> message_valued = 36;
+
+  google.protobuf.DoubleValue wrapped_double = 40;
+  google.protobuf.FloatValue wrapped_float = 41;
+  google.protobuf.Int64Value wrapped_int64 = 42;
+  google.protobuf.UInt64Value wrapped_uint64 = 43;
+  google.protobuf.Int32Value wrapped_int32 = 44;
+  google.protobuf.UInt32Value wrapped_uint32 = 45;
+  google.protobuf.BoolValue wrapped_bool = 46;
+  google.protobuf.StringValue wrapped_string = 47;
+  google.protobuf.BytesValue wrapped_bytes = 48;
+
+  google.protobuf.Duration duration = 50;
+  google.protobuf.Timestamp timestamp = 51;
+  google.protobuf.Any any = 52;
+  repeated google.protobuf.Any repeated_any = 53;
+  google.protobuf.Struct structured = 54;
+
+  TestNested nested = 60;
+  repeated TestNested repeated_nested = 61;
+}

--- a/test/common/protobuf/utility_test.cc
+++ b/test/common/protobuf/utility_test.cc
@@ -509,6 +509,32 @@ insensitive_repeated_string:
   EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
 }
 
+// redactAll() redacts every field, annotated or not, as redact() does under a sensitive field.
+TEST_F(ProtobufUtilityTest, RedactAll) {
+  envoy::test::Sensitive actual, expected;
+  TestUtility::loadFromYaml(R"EOF(
+sensitive_string: This field should be redacted.
+insensitive_string: This field should be redacted too.
+insensitive_int: 1
+)EOF",
+                            actual);
+
+  TestUtility::loadFromYaml(R"EOF(
+sensitive_string: '[redacted]'
+insensitive_string: '[redacted]'
+)EOF",
+                            expected);
+
+  MessageUtil::redactAll(actual);
+  EXPECT_TRUE(TestUtility::protoEqual(expected, actual));
+}
+
+TEST_F(ProtobufUtilityTest, IsSensitiveField) {
+  const Protobuf::Descriptor& descriptor = *envoy::test::Sensitive::descriptor();
+  EXPECT_TRUE(MessageUtil::isSensitiveField(*descriptor.FindFieldByName("sensitive_string")));
+  EXPECT_FALSE(MessageUtil::isSensitiveField(*descriptor.FindFieldByName("insensitive_string")));
+}
+
 // Fields that are values in a sensitive map should be redacted.
 TEST_F(ProtobufUtilityTest, RedactMap) {
   envoy::test::Sensitive actual, expected;

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -207,6 +207,35 @@ envoy_cc_benchmark_binary(
 )
 
 envoy_cc_test(
+    name = "config_dump_memory_test",
+    srcs = envoy_select_admin_functionality(["config_dump_memory_test.cc"]),
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:fmt_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/network:utility_lib",
+        "//source/server/admin:admin_lib",
+        "//source/server/admin:config_tracker_lib",
+        "//test/common/memory:memory_test_utility_lib",
+        "//test/mocks/server:admin_stream_mocks",
+        "//test/mocks/server:instance_mocks",
+        "//test/mocks/upstream:cluster_manager_mocks",
+        "//test/mocks/upstream:cluster_priority_set_mocks",
+        "//test/mocks/upstream:host_mocks",
+        "//test/test_common:proto_filler_lib",
+        "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/types:span",
+        "@envoy_api//envoy/admin/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
     name = "utils_test",
     srcs = envoy_select_admin_functionality(["utils_test.cc"]),
     rbe_pool = "6gig",

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -184,6 +184,31 @@ envoy_cc_benchmark_binary(
     ],
 )
 
+envoy_cc_benchmark_binary(
+    name = "config_dump_handler_speed_test",
+    srcs = envoy_select_admin_functionality(["config_dump_handler_speed_test.cc"]),
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/event:libevent_lib",
+        "//source/common/http:header_map_lib",
+        "//source/common/protobuf:utility_lib",
+        "//source/server/admin:admin_lib",
+        "//source/server/admin:config_tracker_lib",
+        "//test/mocks/server:admin_stream_mocks",
+        "//test/mocks/server:instance_mocks",
+        "//test/test_common:proto_filler_lib",
+        "@envoy_api//envoy/admin/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/upstreams/http/v3:pkg_cc_proto",
+    ],
+)
+
 envoy_cc_test(
     name = "utils_test",
     srcs = envoy_select_admin_functionality(["utils_test.cc"]),

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -202,10 +202,7 @@ envoy_cc_benchmark_binary(
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/route/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/filters/http/router/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
-        "@envoy_api//envoy/extensions/upstreams/http/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/server/admin/config_dump_handler_speed_test.cc
+++ b/test/server/admin/config_dump_handler_speed_test.cc
@@ -1,0 +1,165 @@
+#include <map>
+
+#include "envoy/admin/v3/config_dump.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/config/route/v3/scoped_route.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/secret.pb.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/macros.h"
+#include "source/common/event/libevent.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/common/protobuf/utility.h"
+#include "source/server/admin/config_dump_handler.h"
+#include "source/server/admin/config_tracker_impl.h"
+
+#include "test/benchmark/main.h"
+#include "test/mocks/server/admin_stream.h"
+#include "test/mocks/server/instance.h"
+#include "test/test_common/proto_filler.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+namespace Server {
+
+namespace {
+
+struct ComponentSpec {
+  absl::string_view name;
+  const Protobuf::Message* dump;
+  absl::string_view entries;
+  ProtoFiller::AnyTypes any_types;
+};
+
+const std::vector<ComponentSpec>& componentSpecs() {
+  CONSTRUCT_ON_FIRST_USE(
+      std::vector<ComponentSpec>,
+      ComponentSpec{"clusters",
+                    &envoy::admin::v3::ClustersConfigDump::default_instance(),
+                    "dynamic_active_clusters",
+                    {{"cluster", &envoy::config::cluster::v3::Cluster::default_instance()}}},
+      ComponentSpec{"listeners",
+                    &envoy::admin::v3::ListenersConfigDump::default_instance(),
+                    "dynamic_listeners",
+                    {{"listener", &envoy::config::listener::v3::Listener::default_instance()}}},
+      ComponentSpec{
+          "routes",
+          &envoy::admin::v3::RoutesConfigDump::default_instance(),
+          "dynamic_route_configs",
+          {{"route_config", &envoy::config::route::v3::RouteConfiguration::default_instance()}}},
+      ComponentSpec{"route_scopes",
+                    &envoy::admin::v3::ScopedRoutesConfigDump::default_instance(),
+                    "dynamic_scoped_route_configs",
+                    {{"scoped_route_configs",
+                      &envoy::config::route::v3::ScopedRouteConfiguration::default_instance()}}},
+      ComponentSpec{
+          "secrets",
+          &envoy::admin::v3::SecretsConfigDump::default_instance(),
+          "dynamic_active_secrets",
+          {{"secret",
+            &envoy::extensions::transport_sockets::tls::v3::Secret::default_instance()}}});
+}
+
+const ComponentSpec& componentSpec(absl::string_view name) {
+  for (const ComponentSpec& spec : componentSpecs()) {
+    if (spec.name == name) {
+      return spec;
+    }
+  }
+  PANIC(absl::StrCat("no component named ", name));
+}
+
+ProtobufTypes::MessagePtr makeDump(const ComponentSpec& spec, uint32_t resources) {
+  ProtobufTypes::MessagePtr dump(spec.dump->New());
+  const Protobuf::FieldDescriptor& entries =
+      *dump->GetDescriptor()->FindFieldByName(std::string(spec.entries));
+  for (uint32_t i = 0; i < resources; i++) {
+    ProtoFiller::fill(*dump->GetReflection()->AddMessage(dump.get(), &entries),
+                      {.any_types = spec.any_types});
+  }
+  return dump;
+}
+
+using DumpCache = std::map<std::pair<absl::string_view, uint32_t>, ProtobufTypes::MessagePtr>;
+
+DumpCache& dumpCache() { MUTABLE_CONSTRUCT_ON_FIRST_USE(DumpCache); }
+
+const Protobuf::Message& dumpFor(const ComponentSpec& spec, uint32_t resources) {
+  DumpCache& cache = dumpCache();
+  const std::pair<absl::string_view, uint32_t> key{spec.name, resources};
+  const auto cached = cache.find(key);
+  if (cached != cache.end()) {
+    return *cached->second;
+  }
+  return *cache.emplace(key, makeDump(spec, resources)).first->second;
+}
+
+class ConfigDumpSpeedTest {
+public:
+  ConfigDumpSpeedTest(absl::string_view component, uint32_t resources) {
+    Event::Libevent::Global::initialize();
+    const ComponentSpec& spec = componentSpec(component);
+    const Protobuf::Message& dump = dumpFor(spec, resources);
+    entry_ = tracker_.add(std::string(spec.name), [&dump](const Matchers::StringMatcher&) {
+      ProtobufTypes::MessagePtr copy(dump.New());
+      copy->CopyFrom(dump);
+      return copy;
+    });
+  }
+
+  ConfigDumpHandler& handler() { return handler_; }
+  AdminStream& adminStream() { return admin_stream_; }
+
+private:
+  testing::NiceMock<MockInstance> server_;
+  ConfigTrackerImpl tracker_;
+  ConfigTracker::EntryOwnerPtr entry_;
+  ConfigDumpHandler handler_{tracker_, server_};
+  testing::NiceMock<MockAdminStream> admin_stream_;
+};
+
+} // namespace
+} // namespace Server
+} // namespace Envoy
+
+namespace {
+
+uint32_t resourceCount(const benchmark::State& state) {
+  const auto resources = static_cast<uint32_t>(state.range(0));
+  return Envoy::benchmark::skipExpensiveBenchmarks() ? std::min(resources, 100U) : resources;
+}
+
+void dumpSizes(benchmark::internal::Benchmark* benchmark) {
+  benchmark->Arg(100)->Arg(1000)->Arg(10000)->Unit(benchmark::kMillisecond);
+}
+
+uint64_t dump(benchmark::State& state, Envoy::Server::ConfigDumpSpeedTest& test_context) {
+  Envoy::Http::ResponseHeaderMapPtr headers = Envoy::Http::ResponseHeaderMapImpl::create();
+  Envoy::Buffer::OwnedImpl response;
+  uint64_t bytes = 0;
+  for (auto _ : state) { // NOLINT
+    test_context.handler().handlerConfigDump(*headers, response, test_context.adminStream());
+
+    state.PauseTiming();
+    bytes += response.length();
+    response.drain(response.length());
+    state.ResumeTiming();
+  }
+  return bytes;
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static void BM_ConfigDump(benchmark::State& state, absl::string_view component) {
+  Envoy::Server::ConfigDumpSpeedTest test_context(component, resourceCount(state));
+  state.SetBytesProcessed(dump(state, test_context));
+}
+BENCHMARK_CAPTURE(BM_ConfigDump, clusters, "clusters")->Apply(dumpSizes);
+BENCHMARK_CAPTURE(BM_ConfigDump, listeners, "listeners")->Apply(dumpSizes);
+BENCHMARK_CAPTURE(BM_ConfigDump, routes, "routes")->Apply(dumpSizes);
+BENCHMARK_CAPTURE(BM_ConfigDump, route_scopes, "route_scopes")->Apply(dumpSizes);
+BENCHMARK_CAPTURE(BM_ConfigDump, secrets, "secrets")->Apply(dumpSizes);
+
+} // namespace

--- a/test/server/admin/config_dump_handler_speed_test.cc
+++ b/test/server/admin/config_dump_handler_speed_test.cc
@@ -138,15 +138,23 @@ void dumpSizes(benchmark::internal::Benchmark* benchmark) {
 
 uint64_t dump(benchmark::State& state, Envoy::Server::ConfigDumpSpeedTest& test_context) {
   Envoy::Http::ResponseHeaderMapPtr headers = Envoy::Http::ResponseHeaderMapImpl::create();
-  Envoy::Buffer::OwnedImpl response;
+  Envoy::Buffer::OwnedImpl chunk;
   uint64_t bytes = 0;
   for (auto _ : state) { // NOLINT
-    test_context.handler().handlerConfigDump(*headers, response, test_context.adminStream());
+    Envoy::Server::Admin::RequestPtr request =
+        test_context.handler().makeRequest(test_context.adminStream());
+    request->start(*headers);
 
-    state.PauseTiming();
-    bytes += response.length();
-    response.drain(response.length());
-    state.ResumeTiming();
+    uint64_t response_bytes = 0;
+    for (bool more = true; more;) {
+      more = request->nextChunk(chunk);
+
+      state.PauseTiming();
+      response_bytes += chunk.length();
+      chunk.drain(chunk.length());
+      state.ResumeTiming();
+    }
+    bytes += response_bytes;
   }
   return bytes;
 }

--- a/test/server/admin/config_dump_handler_test.cc
+++ b/test/server/admin/config_dump_handler_test.cc
@@ -2,7 +2,10 @@
 #include "test/integration/filters/test_network_filter.pb.h"
 #include "test/server/admin/admin_instance.h"
 
+#include "absl/strings/str_cat.h"
+
 using testing::HasSubstr;
+using testing::Not;
 using testing::Return;
 using testing::ReturnPointee;
 using testing::ReturnRef;
@@ -13,6 +16,19 @@ namespace Server {
 INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
+
+void wireClusters(Upstream::MockClusterManager& cluster_manager,
+                  Upstream::ClusterManager::ClusterInfoMaps& maps) {
+  ON_CALL(cluster_manager, clusters()).WillByDefault(ReturnPointee(&maps));
+  ON_CALL(cluster_manager, getActiveCluster(_))
+      .WillByDefault(Invoke([&maps](absl::string_view name) -> OptRef<const Upstream::Cluster> {
+        const auto it = maps.active_clusters_.find(name);
+        if (it == maps.active_clusters_.end()) {
+          return std::nullopt;
+        }
+        return it->second.get();
+      }));
+}
 
 // helper method for adding host's info
 void addHostInfo(NiceMock<Upstream::MockHost>& host, const std::string& hostname,
@@ -69,8 +85,8 @@ TEST_P(AdminInstanceTest, ConfigDump) {
   EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
   EXPECT_EQ(Http::Code::OK,
             getCallback("/config_dump?resource=&mask=&name_regex=", header_map, response2));
-  EXPECT_EQ(expected_json, response.toString());
-  EXPECT_EQ(expected_json, response2.toString());
+  EXPECT_THAT(response.toString(), JsonStringEq(expected_json));
+  EXPECT_THAT(response2.toString(), JsonStringEq(expected_json));
 }
 
 TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
@@ -125,14 +141,14 @@ TEST_P(AdminInstanceTest, ConfigDumpMaintainsOrder) {
     Http::TestResponseHeaderMapImpl header_map;
     EXPECT_EQ(Http::Code::OK, getCallback("/config_dump", header_map, response));
     const std::string output = response.toString();
-    EXPECT_EQ(expected_json, output);
+    EXPECT_THAT(output, JsonStringEq(expected_json));
   }
 }
 
 // Test that using ?include_eds parameter adds EDS to the config dump.
 TEST_P(AdminInstanceTest, ConfigDumpWithEndpoint) {
   Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
-  ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_maps));
+  wireClusters(server_.cluster_manager_, cluster_maps);
 
   NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   cluster_maps.active_clusters_.emplace(cluster.info_->name_, cluster);
@@ -224,13 +240,13 @@ TEST_P(AdminInstanceTest, ConfigDumpWithEndpoint) {
  ]
 }
 )EOF";
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 }
 
 // Test EDS config dump while multiple localities and priorities exist
 TEST_P(AdminInstanceTest, ConfigDumpWithLocalityEndpoint) {
   Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
-  ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_maps));
+  wireClusters(server_.cluster_manager_, cluster_maps);
 
   NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
   cluster_maps.active_clusters_.emplace(cluster.info_->name_, cluster);
@@ -404,7 +420,7 @@ TEST_P(AdminInstanceTest, ConfigDumpWithLocalityEndpoint) {
  ]
 }
 )EOF";
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
   delete (hosts_per_locality);
 }
 
@@ -436,7 +452,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByResource) {
   EXPECT_EQ(Http::Code::OK,
             getCallback("/config_dump?resource=dynamic_listeners", header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 }
 
 // Test that using the resource and name_regex query parameters filter the config dump including
@@ -445,7 +461,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByResource) {
 // ?name_regex=fake_cluster_2.
 TEST_P(AdminInstanceTest, ConfigDumpWithEndpointFiltersByResourceAndName) {
   Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
-  ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_maps));
+  wireClusters(server_.cluster_manager_, cluster_maps);
 
   NiceMock<Upstream::MockClusterMockPrioritySet> cluster_1;
   cluster_maps.active_clusters_.emplace(cluster_1.info_->name_, cluster_1);
@@ -526,7 +542,7 @@ TEST_P(AdminInstanceTest, ConfigDumpWithEndpointFiltersByResourceAndName) {
  ]
 }
 )EOF";
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 
   // Check that endpoints dump uses the name_matcher.
   Buffer::OwnedImpl response2;
@@ -577,7 +593,7 @@ TEST_P(AdminInstanceTest, ConfigDumpWithEndpointFiltersByResourceAndName) {
  ]
 }
 )EOF";
-  EXPECT_EQ(expected_json2, response2.toString());
+  EXPECT_THAT(response2.toString(), JsonStringEq(expected_json2));
 }
 
 // Test that using the mask query parameter filters the config dump.
@@ -612,7 +628,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByMask) {
   EXPECT_EQ(Http::Code::OK,
             getCallback("/config_dump?mask=dynamic_listeners", header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 }
 
 TEST_P(AdminInstanceTest, ConfigDumpFiltersByNameRegex) {
@@ -646,7 +662,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByNameRegex) {
 )EOF";
   EXPECT_EQ(Http::Code::OK, getCallback("/config_dump?name_regex=.*a.*", header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 }
 
 TEST_P(AdminInstanceTest, InvalidRegexIsBadRequest) {
@@ -702,7 +718,7 @@ TEST_P(AdminInstanceTest, ConfigDumpFiltersByResourceAndMask) {
                                         "cluster.name,version_info,cluster.http2_protocol_options",
                                         header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 }
 
 // Test that BadRequest is returned if there is no intersection between the fields
@@ -745,8 +761,6 @@ TEST_P(AdminInstanceTest, ConfigDumpResourceNotRepeated) {
 }
 
 TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
-  Buffer::OwnedImpl response;
-  Http::TestResponseHeaderMapImpl header_map;
   auto clusters = admin_.getConfigTracker().add("clusters", [](const Matchers::StringMatcher&) {
     auto msg = std::make_unique<envoy::admin::v3::ClustersConfigDump>();
     auto* static_cluster = msg->add_static_clusters();
@@ -758,18 +772,20 @@ TEST_P(AdminInstanceTest, InvalidFieldMaskWithResourceDoesNotCrash) {
   });
 
   // `transport_socket_matches` is a repeated field, and cannot be indexed through in a FieldMask.
+  std::string body;
+  Http::TestResponseHeaderMapImpl header_map;
   EXPECT_EQ(Http::Code::BadRequest,
-            getCallback(
+            admin_.request(
                 "/config_dump?resource=static_clusters&mask=cluster.transport_socket_matches.name",
-                header_map, response));
+                "GET", header_map, body));
   std::string expected_mask_text = R"pb(paths: "cluster.transport_socket_matches.name")pb";
   Protobuf::FieldMask expected_mask_proto;
   std::ignore = Protobuf::TextFormat::ParseFromString(expected_mask_text, &expected_mask_proto);
   EXPECT_EQ(fmt::format("FieldMask {} could not be successfully used.",
                         expected_mask_proto.DebugString()),
-            response.toString());
+            body);
   EXPECT_EQ(header_map.ContentType()->value().getStringView(),
-            Http::Headers::get().ContentTypeValues.Text);
+            Http::Headers::get().ContentTypeValues.TextUtf8);
   EXPECT_EQ(header_map.get(Http::Headers::get().XContentTypeOptions)[0]->value(),
             Http::Headers::get().XContentTypeOptionValues.Nosniff);
 }
@@ -810,7 +826,7 @@ TEST_P(AdminInstanceTest, FieldMasksWorkWhenFetchingAllResources) {
     return msg;
   });
   EXPECT_EQ(Http::Code::OK, getCallback("/config_dump?mask=bootstrap", header_map, response));
-  EXPECT_EQ(R"EOF({
+  EXPECT_THAT(response.toString(), JsonStringEq(R"EOF({
  "configs": [
   {
    "@type": "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump",
@@ -829,8 +845,7 @@ TEST_P(AdminInstanceTest, FieldMasksWorkWhenFetchingAllResources) {
   }
  ]
 }
-)EOF",
-            response.toString());
+)EOF"));
 }
 
 ProtobufTypes::MessagePtr testDumpEcdsConfig(const Matchers::StringMatcher&) {
@@ -897,7 +912,7 @@ TEST_P(AdminInstanceTest, ConfigDumpEcds) {
   EXPECT_EQ(Http::Code::OK,
             getCallback("/config_dump?resource=ecds_filters", header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
 }
 
 TEST_P(AdminInstanceTest, ConfigDumpEcdsByResourceAndMask) {
@@ -929,7 +944,198 @@ TEST_P(AdminInstanceTest, ConfigDumpEcdsByResourceAndMask) {
                                         "ecds_filter.name,version_info",
                                         header_map, response));
   std::string output = response.toString();
-  EXPECT_EQ(expected_json, output);
+  EXPECT_THAT(output, JsonStringEq(expected_json));
+}
+
+std::string dumpWhileMutating(AdminInstanceTest& test, absl::string_view query,
+                              absl::string_view mutate_after, std::function<void()> mutate) {
+  test.request_headers_.setPath(query);
+  test.admin_filter_.decodeHeaders(test.request_headers_, false);
+
+  ConfigDumpHandler handler(test.admin_.getConfigTracker(), test.server_);
+  Admin::RequestPtr request = handler.makeRequest(test.admin_filter_);
+  dynamic_cast<ConfigDumpRequest&>(*request).setChunkSize(1);
+
+  Http::TestResponseHeaderMapImpl response_headers;
+  EXPECT_EQ(Http::Code::OK, request->start(response_headers));
+
+  Buffer::OwnedImpl chunk;
+  std::string output;
+  bool mutated = false;
+  bool more = true;
+  while (more) {
+    more = request->nextChunk(chunk);
+    output += chunk.toString();
+    chunk.drain(chunk.length());
+    if (!mutated && absl::StrContains(output, mutate_after)) {
+      mutate();
+      mutated = true;
+    }
+  }
+  EXPECT_TRUE(mutated) << mutate_after << " never reached the response";
+  return output;
+}
+
+ConfigTracker::EntryOwnerPtr addComponent(AdminInstanceTest& test, const std::string& name,
+                                          const std::string& value) {
+  return test.admin_.getConfigTracker().add(name, [value](const Matchers::StringMatcher&) {
+    auto msg = std::make_unique<Protobuf::StringValue>();
+    msg->set_value(value);
+    return msg;
+  });
+}
+
+int64_t configCount(const std::string& output) {
+  return TestUtility::jsonToStruct(output).fields().at("configs").list_value().values_size();
+}
+
+TEST_P(AdminInstanceTest, ComponentRemovedMidStream) {
+  ConfigTracker::EntryOwnerPtr component1 = addComponent(*this, "component1", "value1");
+  ConfigTracker::EntryOwnerPtr component2 = addComponent(*this, "component2", "value2");
+
+  const std::string output =
+      dumpWhileMutating(*this, "/config_dump", "value1", [&component2]() { component2.reset(); });
+  EXPECT_THAT(output, HasSubstr("value1"));
+  EXPECT_THAT(output, Not(HasSubstr("value2")));
+  EXPECT_EQ(1, configCount(output));
+}
+
+TEST_P(AdminInstanceTest, ComponentAddedMidStream) {
+  ConfigTracker::EntryOwnerPtr component1 = addComponent(*this, "component1", "value1");
+  ConfigTracker::EntryOwnerPtr component2;
+
+  const std::string output =
+      dumpWhileMutating(*this, "/config_dump", "value1", [this, &component2]() {
+        component2 = addComponent(*this, "component2", "value2");
+      });
+  EXPECT_THAT(output, HasSubstr("value1"));
+  EXPECT_THAT(output, Not(HasSubstr("value2")));
+  EXPECT_EQ(1, configCount(output));
+}
+
+TEST_P(AdminInstanceTest, ClusterRemovedMidStream) {
+  Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
+  wireClusters(server_.cluster_manager_, cluster_maps);
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+
+  // The snapshot is partitioned static first, so cluster1 is always serialized before cluster2.
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster1;
+  cluster1.info_->name_ = "cluster1";
+  ON_CALL(*cluster1.info_, addedViaApi()).WillByDefault(Return(false));
+  cluster_maps.active_clusters_.emplace(cluster1.info_->name_, cluster1);
+
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster2;
+  cluster2.info_->name_ = "cluster2";
+  ON_CALL(*cluster2.info_, addedViaApi()).WillByDefault(Return(true));
+  cluster_maps.active_clusters_.emplace(cluster2.info_->name_, cluster2);
+
+  const std::string output =
+      dumpWhileMutating(*this, "/config_dump?include_eds", "cluster1",
+                        [&cluster_maps]() { cluster_maps.active_clusters_.erase("cluster2"); });
+  EXPECT_THAT(output, HasSubstr("cluster1"));
+  EXPECT_THAT(output, Not(HasSubstr("cluster2")));
+  EXPECT_EQ(1, configCount(output));
+}
+
+TEST_P(AdminInstanceTest, ClusterAddedMidStream) {
+  Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
+  wireClusters(server_.cluster_manager_, cluster_maps);
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster1;
+  cluster1.info_->name_ = "cluster1";
+  ON_CALL(*cluster1.info_, addedViaApi()).WillByDefault(Return(false));
+  cluster_maps.active_clusters_.emplace(cluster1.info_->name_, cluster1);
+
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster2;
+  cluster2.info_->name_ = "cluster2";
+  ON_CALL(*cluster2.info_, addedViaApi()).WillByDefault(Return(true));
+
+  const std::string output = dumpWhileMutating(
+      *this, "/config_dump?include_eds", "cluster1", [&cluster_maps, &cluster2]() {
+        cluster_maps.active_clusters_.emplace(cluster2.info_->name_, cluster2);
+      });
+  EXPECT_THAT(output, HasSubstr("cluster1"));
+  EXPECT_THAT(output, Not(HasSubstr("cluster2")));
+  EXPECT_EQ(1, configCount(output));
+}
+
+TEST_P(AdminInstanceTest, ConfigDumpWithEndpointReportsHostHealth) {
+  Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
+  wireClusters(server_.cluster_manager_, cluster_maps);
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster;
+  cluster_maps.active_clusters_.emplace(cluster.info_->name_, cluster);
+
+  Upstream::MockHostSet* host_set = cluster.priority_set_.getMockHostSet(0);
+  envoy::config::core::v3::Locality locality;
+  const std::string hostname = "example.com";
+  const std::string hostname_for_healthcheck = "healthcheck.example.com";
+
+  uint32_t port = 1;
+  for (const auto health : {Upstream::Host::Health::Healthy, Upstream::Host::Health::Unhealthy,
+                            Upstream::Host::Health::Degraded}) {
+    auto host = std::make_shared<NiceMock<Upstream::MockHost>>();
+    addHostInfo(*host, hostname, absl::StrCat("tcp://1.2.3.4:", port++), {}, locality,
+                hostname_for_healthcheck, "tcp://1.2.3.5:90", 5, 6);
+    ON_CALL(*host, coarseHealth()).WillByDefault(Return(health));
+    host_set->hosts_.emplace_back(host);
+  }
+
+  Buffer::OwnedImpl response;
+  Http::TestResponseHeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::OK, getCallback("/config_dump?include_eds", header_map, response));
+  const std::string output = response.toString();
+  EXPECT_THAT(output, HasSubstr(R"("health_status":"HEALTHY")"));
+  EXPECT_THAT(output, HasSubstr(R"("health_status":"UNHEALTHY")"));
+  EXPECT_THAT(output, HasSubstr(R"("health_status":"DEGRADED")"));
+}
+
+TEST_P(AdminInstanceTest, ConfigDumpEndpointResourceHonorsNameRegex) {
+  Upstream::ClusterManager::ClusterInfoMaps cluster_maps;
+  wireClusters(server_.cluster_manager_, cluster_maps);
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster1;
+  cluster1.info_->name_ = "cluster1";
+  ON_CALL(*cluster1.info_, addedViaApi()).WillByDefault(Return(true));
+  cluster_maps.active_clusters_.emplace(cluster1.info_->name_, cluster1);
+
+  NiceMock<Upstream::MockClusterMockPrioritySet> cluster2;
+  cluster2.info_->name_ = "cluster2";
+  ON_CALL(*cluster2.info_, addedViaApi()).WillByDefault(Return(true));
+  cluster_maps.active_clusters_.emplace(cluster2.info_->name_, cluster2);
+
+  Buffer::OwnedImpl response;
+  Http::TestResponseHeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::OK,
+            getCallback("/config_dump?include_eds&resource=dynamic_endpoint_configs&name_regex="
+                        "cluster2",
+                        header_map, response));
+  const std::string output = response.toString();
+  EXPECT_THAT(output, HasSubstr(R"("cluster_name":"cluster2")"));
+  EXPECT_THAT(output, Not(HasSubstr(R"("cluster_name":"cluster1")")));
+}
+
+TEST_P(AdminInstanceTest, ConfigDumpResourceMissingFromEndpointsIsNotFound) {
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+
+  Buffer::OwnedImpl response;
+  Http::TestResponseHeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::NotFound,
+            getCallback("/config_dump?include_eds&resource=static_clusters", header_map, response));
+  EXPECT_THAT(response.toString(), HasSubstr("static_clusters not found in config dump"));
+}
+
+TEST_P(AdminInstanceTest, ConfigDumpMaskUnusableByEndpointsIsBadRequest) {
+  ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+
+  Buffer::OwnedImpl response;
+  Http::TestResponseHeaderMapImpl header_map;
+  EXPECT_EQ(Http::Code::BadRequest,
+            getCallback("/config_dump?include_eds&mask=bootstrap", header_map, response));
+  EXPECT_THAT(response.toString(), HasSubstr("could not be successfully applied"));
 }
 
 } // namespace Server

--- a/test/server/admin/config_dump_memory_test.cc
+++ b/test/server/admin/config_dump_memory_test.cc
@@ -1,0 +1,348 @@
+#include <sys/resource.h>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/admin/v3/config_dump.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
+#include "envoy/config/route/v3/route.pb.h"
+#include "envoy/extensions/transport_sockets/tls/v3/secret.pb.h"
+#include "envoy/http/query_params.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/common/fmt.h"
+#include "source/common/http/header_map_impl.h"
+#include "source/common/network/utility.h"
+#include "source/server/admin/config_dump_handler.h"
+#include "source/server/admin/config_tracker_impl.h"
+
+#include "test/common/memory/memory_test_utility.h"
+#include "test/mocks/server/admin_stream.h"
+#include "test/mocks/server/instance.h"
+#include "test/mocks/upstream/cluster_manager.h"
+#include "test/mocks/upstream/cluster_priority_set.h"
+#include "test/mocks/upstream/host.h"
+#include "test/test_common/proto_filler.h"
+
+#include "absl/strings/str_cat.h"
+#include "absl/types/span.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::Invoke;
+using testing::NiceMock;
+using testing::Return;
+using testing::ReturnPointee;
+using testing::ReturnRefOfCopy;
+
+namespace Envoy {
+namespace Server {
+namespace {
+
+std::string bytesToMiB(uint64_t bytes) {
+  return fmt::format("{:.1f}", static_cast<double>(bytes) / (1024 * 1024));
+}
+
+constexpr size_t LabelColumns = 2;
+
+void printRow(absl::Span<const std::pair<absl::string_view, std::string>> row) {
+  const auto pad = [](absl::string_view text, size_t width, bool left) {
+    return left ? fmt::format("{:<{}}", text, width) : fmt::format("{:>{}}", text, width);
+  };
+
+  std::string headings;
+  std::string rule;
+  std::string values;
+  for (size_t i = 0; i < row.size(); i++) {
+    const auto& [heading, value] = row[i];
+    const size_t width = std::max(heading.size(), value.size());
+    const bool left = i < LabelColumns;
+    absl::StrAppend(&headings, "  ", pad(heading, width, left));
+    absl::StrAppend(&rule, "  ", std::string(width, '-'));
+    absl::StrAppend(&values, "  ", pad(value, width, left));
+  }
+  std::cerr << "//" << headings << "\n//" << rule << "\n//" << values << std::endl;
+}
+
+uint64_t peakRssBytes() {
+  struct rusage usage;
+  // reports kilobytes on Linux and bytes on macOS.
+  getrusage(RUSAGE_SELF, &usage);
+#ifdef __APPLE__
+  return static_cast<uint64_t>(usage.ru_maxrss);
+#else
+  return static_cast<uint64_t>(usage.ru_maxrss) * 1024;
+#endif
+}
+
+struct Scale {
+  uint32_t static_clusters_{5};
+  uint32_t dynamic_clusters_{30000};
+  uint32_t listeners_{10};
+  uint32_t static_routes_{15000};
+  uint32_t secrets_{3000};
+  uint32_t endpoint_clusters_{500};
+  uint32_t hosts_per_cluster_{100};
+  uint32_t distinct_hosts_{512};
+  uint32_t elements_{3};
+  uint32_t max_depth_{4};
+};
+
+struct Component {
+  absl::string_view name_;
+  const Protobuf::Message* dump_;
+  std::vector<std::pair<absl::string_view, uint32_t>> entries_;
+  ProtoFiller::AnyTypes any_types_;
+};
+
+std::vector<Component> deployment(const Scale& scale) {
+  return {
+      Component{"bootstrap", &envoy::admin::v3::BootstrapConfigDump::default_instance(), {}, {}},
+      Component{"clusters",
+                &envoy::admin::v3::ClustersConfigDump::default_instance(),
+                {{"static_clusters", scale.static_clusters_},
+                 {"dynamic_active_clusters", scale.dynamic_clusters_}},
+                {{"cluster", &envoy::config::cluster::v3::Cluster::default_instance()}}},
+      Component{"listeners",
+                &envoy::admin::v3::ListenersConfigDump::default_instance(),
+                {{"dynamic_listeners", scale.listeners_}},
+                {{"listener", &envoy::config::listener::v3::Listener::default_instance()}}},
+      Component{
+          "routes",
+          &envoy::admin::v3::RoutesConfigDump::default_instance(),
+          {{"static_route_configs", scale.static_routes_}},
+          {{"route_config", &envoy::config::route::v3::RouteConfiguration::default_instance()}}},
+      Component{"secrets",
+                &envoy::admin::v3::SecretsConfigDump::default_instance(),
+                {{"dynamic_active_secrets", scale.secrets_}},
+                {{"secret",
+                  &envoy::extensions::transport_sockets::tls::v3::Secret::default_instance()}}}};
+}
+
+class ConfigDumpMemoryTest : public testing::Test {
+protected:
+  void SetUp() override {
+    Http::Utility::QueryParamsMulti query_params;
+    query_params.add("include_eds", "");
+    ON_CALL(admin_stream_, queryParams()).WillByDefault(Return(query_params));
+  }
+
+  void buildConfig(const Scale& scale) {
+    tracker_ = std::make_unique<ConfigTrackerImpl>();
+
+    for (const Component& component : deployment(scale)) {
+      const ProtoFiller::Options fill{.elements = scale.elements_,
+                                      .max_depth = scale.max_depth_,
+                                      .any_types = component.any_types_};
+      ProtobufTypes::MessagePtr config(component.dump_->New());
+      const Protobuf::Reflection& reflection = *config->GetReflection();
+      if (component.entries_.empty()) {
+        ProtoFiller::fill(*config, fill);
+      }
+      for (const auto& [field, count] : component.entries_) {
+        const Protobuf::FieldDescriptor& entries =
+            *config->GetDescriptor()->FindFieldByName(std::string(field));
+        if (count == 0) {
+          continue;
+        }
+        ProtoFiller::fill(*reflection.AddMessage(config.get(), &entries), fill);
+        const Protobuf::Message& resource = reflection.GetRepeatedMessage(*config, &entries, 0);
+        for (uint32_t i = 1; i < count; i++) {
+          reflection.AddMessage(config.get(), &entries)->CopyFrom(resource);
+        }
+      }
+      tracked_.emplace_back(component.name_, std::move(config));
+
+      const Protobuf::Message& source = *tracked_.back().second;
+      entries_.push_back(
+          tracker_->add(std::string(component.name_), [&source](const Matchers::StringMatcher&) {
+            ProtobufTypes::MessagePtr copy(source.New());
+            copy->CopyFrom(source);
+            return copy;
+          }));
+    }
+
+    wireClusterManager(scale);
+    handler_ = std::make_unique<ConfigDumpHandler>(*tracker_, server_);
+  }
+
+  struct ConfigSizes {
+    uint64_t total_{0};
+    uint64_t largest_component_{0};
+  };
+
+  ConfigSizes configSizes() const {
+    ConfigSizes sizes;
+    for (const auto& [name, config] : tracked_) {
+      const uint64_t bytes = config->ByteSizeLong();
+      sizes.total_ += bytes;
+      sizes.largest_component_ = std::max(sizes.largest_component_, bytes);
+    }
+    return sizes;
+  }
+
+  struct Streamed {
+    uint64_t peak_consumed_{0};
+    uint64_t response_bytes_{0};
+    uint64_t chunks_{0};
+  };
+
+  Streamed stream() {
+    Http::ResponseHeaderMapPtr headers = Http::ResponseHeaderMapImpl::create();
+    Buffer::OwnedImpl chunk;
+    Streamed streamed;
+
+    Memory::TestUtil::MemoryTest memory_test;
+    Admin::RequestPtr request = handler_->makeRequest(admin_stream_);
+    request->start(*headers);
+    for (bool more = true; more;) {
+      more = request->nextChunk(chunk);
+      streamed.peak_consumed_ =
+          std::max(streamed.peak_consumed_, static_cast<uint64_t>(memory_test.consumedBytes()));
+      streamed.response_bytes_ += chunk.length();
+      streamed.chunks_++;
+      chunk.drain(chunk.length());
+    }
+    return streamed;
+  }
+
+private:
+  void wireClusterManager(const Scale& scale) {
+    const std::vector<Upstream::HostSharedPtr> hosts = buildHostPool(scale);
+
+    for (uint32_t i = 0; i < scale.endpoint_clusters_; i++) {
+      auto cluster = std::make_unique<NiceMock<Upstream::MockClusterMockPrioritySet>>();
+      cluster->info_->name_ = absl::StrCat("tenant-", i, "-upstream");
+      ON_CALL(*cluster->info_, addedViaApi()).WillByDefault(Return(i % 4 != 0));
+      ON_CALL(*cluster, dropOverload()).WillByDefault(Return(UnitFloat(0.00035)));
+
+      Upstream::MockHostSet* host_set = cluster->priority_set_.getMockHostSet(0);
+      for (uint32_t j = 0; j < scale.hosts_per_cluster_; j++) {
+        host_set->hosts_.emplace_back(hosts[(i * scale.hosts_per_cluster_ + j) % hosts.size()]);
+      }
+
+      cluster_maps_.active_clusters_.emplace(cluster->info_->name_, *cluster);
+      clusters_.push_back(std::move(cluster));
+    }
+
+    ON_CALL(server_.cluster_manager_, clusters()).WillByDefault(ReturnPointee(&cluster_maps_));
+    ON_CALL(server_.cluster_manager_, hasActiveClusters()).WillByDefault(Return(true));
+    ON_CALL(server_.cluster_manager_, getActiveCluster(_))
+        .WillByDefault(Invoke([this](absl::string_view name) -> OptRef<const Upstream::Cluster> {
+          const auto at = cluster_maps_.active_clusters_.find(name);
+          if (at == cluster_maps_.active_clusters_.end()) {
+            return std::nullopt;
+          }
+          return at->second.get();
+        }));
+  }
+
+  std::vector<Upstream::HostSharedPtr> buildHostPool(const Scale& scale) {
+    std::vector<Upstream::HostSharedPtr> hosts;
+    hosts.reserve(scale.distinct_hosts_);
+    for (uint32_t i = 0; i < scale.distinct_hosts_; i++) {
+      hosts.push_back(makeHost(i, scale));
+    }
+    return hosts;
+  }
+
+  Upstream::HostSharedPtr makeHost(uint32_t index, const Scale& scale) {
+    auto host = std::make_shared<NiceMock<Upstream::MockHost>>();
+
+    const std::string hostname = absl::StrCat("backend-", index, ".example.com");
+
+    envoy::config::core::v3::Locality locality;
+    ProtoFiller::fill(locality, {.elements = scale.elements_, .max_depth = scale.max_depth_});
+
+    auto metadata = std::make_shared<envoy::config::core::v3::Metadata>();
+    ProtoFiller::fill(*metadata, {.elements = scale.elements_, .max_depth = 2});
+
+    const uint32_t high = index / 256 % 256;
+    const uint32_t low = index % 256;
+    const Network::Address::InstanceConstSharedPtr address =
+        *Network::Utility::resolveUrl(absl::StrCat("tcp://10.0.", high, ".", low, ":8443"));
+    auto address_list = std::make_shared<Upstream::HostDescription::AddressVector>();
+    address_list->push_back(address);
+    address_list->push_back(
+        *Network::Utility::resolveUrl(absl::StrCat("tcp://172.16.", high, ".", low, ":8443")));
+
+    ON_CALL(*host, locality()).WillByDefault(ReturnRefOfCopy(locality));
+    ON_CALL(*host, hostname()).WillByDefault(ReturnRefOfCopy(hostname));
+    ON_CALL(*host, hostnameForHealthChecks())
+        .WillByDefault(ReturnRefOfCopy(absl::StrCat(hostname, ".health")));
+    ON_CALL(*host, address()).WillByDefault(Return(address));
+    ON_CALL(*host, addressListOrNull()).WillByDefault(Return(address_list));
+    ON_CALL(*host, healthCheckAddress()).WillByDefault(Return(address));
+    ON_CALL(*host, metadata()).WillByDefault(Return(metadata));
+    ON_CALL(*host, weight()).WillByDefault(Return(index % 100 + 1));
+    ON_CALL(*host, priority()).WillByDefault(Return(0));
+    ON_CALL(*host, coarseHealth())
+        .WillByDefault(Return(index % 8 == 0 ? Upstream::Host::Health::Degraded
+                                             : Upstream::Host::Health::Healthy));
+
+    return host;
+  }
+
+protected:
+  NiceMock<MockInstance> server_;
+  NiceMock<MockAdminStream> admin_stream_;
+  std::unique_ptr<ConfigTrackerImpl> tracker_;
+  std::vector<std::pair<std::string, ProtobufTypes::MessagePtr>> tracked_;
+  std::vector<ConfigTracker::EntryOwnerPtr> entries_;
+  std::unique_ptr<ConfigDumpHandler> handler_;
+
+  Upstream::ClusterManager::ClusterInfoMaps cluster_maps_;
+  std::vector<std::unique_ptr<NiceMock<Upstream::MockClusterMockPrioritySet>>> clusters_;
+};
+
+TEST_F(ConfigDumpMemoryTest, BoundedMemory) {
+  // SPELLCHECKER(off)
+  // clang-format off
+  //
+  // TODO(filipcacky): remeasure this in CI, current values are from a dev VM
+  //
+  // Date        PR     clusters  listeners  routes  secrets  endpoints  elements  max_depth  config MiB  largest component MiB  chunk size  peak MiB  rss MiB  response MiB  chunks
+  // ----------  -----  --------  ---------  ------  -------  ---------  --------  ---------  ----------  ---------------------  ----------  --------  -------  ------------  ------
+  // 2026/08/27  #####     30005         10   15000     3000      50000         3          4       188.6                  104.7           -    2950.0   3564.6        1217.1       -
+  // 2026/08/27  #####     30005         10   15000     3000      50000         3          4       188.6                  104.7       65536     135.4    140.5         746.4   11941
+  //
+  // clang-format on
+  // SPELLCHECKER(on)
+
+  const Scale scale;
+  buildConfig(scale);
+  const uint64_t rss_after_config = peakRssBytes();
+
+  const Streamed streamed = stream();
+
+  const uint64_t peak_rss = peakRssBytes();
+  const ConfigSizes sizes = configSizes();
+
+  printRow({{"Date", "----------"},
+            {"PR", "#####"},
+            {"clusters", absl::StrCat(scale.static_clusters_ + scale.dynamic_clusters_)},
+            {"listeners", absl::StrCat(scale.listeners_)},
+            {"routes", absl::StrCat(scale.static_routes_)},
+            {"secrets", absl::StrCat(scale.secrets_)},
+            {"endpoints", absl::StrCat(scale.endpoint_clusters_ * scale.hosts_per_cluster_)},
+            {"elements", absl::StrCat(scale.elements_)},
+            {"max_depth", absl::StrCat(scale.max_depth_)},
+            {"config MiB", bytesToMiB(sizes.total_)},
+            {"largest component MiB", bytesToMiB(sizes.largest_component_)},
+            {"chunk size", absl::StrCat(ConfigDumpRequest::DefaultChunkSize)},
+            {"peak MiB", bytesToMiB(streamed.peak_consumed_)},
+            {"rss MiB", bytesToMiB(peak_rss - rss_after_config)},
+            {"response MiB", bytesToMiB(streamed.response_bytes_)},
+            {"chunks", absl::StrCat(streamed.chunks_)}});
+
+  EXPECT_MEMORY_LE(streamed.peak_consumed_, 2 * sizes.largest_component_);
+}
+
+} // namespace
+} // namespace Server
+} // namespace Envoy

--- a/test/test_common/BUILD
+++ b/test/test_common/BUILD
@@ -97,6 +97,17 @@ envoy_cc_library(
     ],
 )
 
+envoy_cc_library(
+    name = "proto_filler_lib",
+    srcs = ["proto_filler.cc"],
+    hdrs = ["proto_filler.h"],
+    deps = [
+        "//source/common/protobuf",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
 envoy_cc_test_library(
     name = "registry_lib",
     hdrs = ["registry.h"],

--- a/test/test_common/proto_filler.cc
+++ b/test/test_common/proto_filler.cc
@@ -1,0 +1,129 @@
+#include "test/test_common/proto_filler.h"
+
+#include "absl/strings/str_cat.h"
+
+namespace Envoy {
+namespace ProtoFiller {
+
+namespace {
+
+using Field = Protobuf::FieldDescriptor;
+
+void fillMessage(Protobuf::Message& message, const Options& options, uint32_t depth);
+
+const Protobuf::EnumValueDescriptor& nonDefaultEnumValue(const Protobuf::EnumDescriptor& enum_type,
+                                                         uint32_t index) {
+  for (int i = 0; i < enum_type.value_count(); i++) {
+    const Protobuf::EnumValueDescriptor& enum_value =
+        *enum_type.value((index + i) % enum_type.value_count());
+    if (enum_value.number() != 0) {
+      return enum_value;
+    }
+  }
+  return *enum_type.value(0);
+}
+
+bool isAny(const Field& field) {
+  return field.message_type()->full_name() == "google.protobuf.Any";
+}
+
+void packAny(Protobuf::Message& any, const Field& field, const Options& options, uint32_t depth) {
+  const auto packed_type = options.any_types.find(field.name());
+  if (packed_type == options.any_types.end()) {
+    return;
+  }
+  ProtobufTypes::MessagePtr packed(packed_type->second->New());
+  fillMessage(*packed, options, depth);
+  std::ignore = dynamic_cast<Protobuf::Any&>(any).PackFrom(*packed);
+}
+
+void fillField(Protobuf::Message& message, const Field& field, const Options& options,
+               uint32_t depth) {
+  const Protobuf::Reflection& reflection = *message.GetReflection();
+  const bool repeated = field.is_repeated();
+  const uint32_t elements = repeated ? options.elements : 1;
+  for (uint32_t index = 0; index < elements; index++) {
+    const uint32_t value = field.number() + index;
+    switch (field.cpp_type()) {
+    case Field::CPPTYPE_INT32:
+      repeated ? reflection.AddInt32(&message, &field, value)
+               : reflection.SetInt32(&message, &field, value);
+      break;
+    case Field::CPPTYPE_UINT32:
+      repeated ? reflection.AddUInt32(&message, &field, value)
+               : reflection.SetUInt32(&message, &field, value);
+      break;
+    case Field::CPPTYPE_INT64:
+      repeated ? reflection.AddInt64(&message, &field, value)
+               : reflection.SetInt64(&message, &field, value);
+      break;
+    case Field::CPPTYPE_UINT64:
+      repeated ? reflection.AddUInt64(&message, &field, value)
+               : reflection.SetUInt64(&message, &field, value);
+      break;
+    case Field::CPPTYPE_DOUBLE:
+      repeated ? reflection.AddDouble(&message, &field, value + 0.5)
+               : reflection.SetDouble(&message, &field, value + 0.5);
+      break;
+    case Field::CPPTYPE_FLOAT:
+      repeated ? reflection.AddFloat(&message, &field, value + 0.25f)
+               : reflection.SetFloat(&message, &field, value + 0.25f);
+      break;
+    case Field::CPPTYPE_BOOL:
+      repeated ? reflection.AddBool(&message, &field, true)
+               : reflection.SetBool(&message, &field, true);
+      break;
+    case Field::CPPTYPE_ENUM: {
+      const Protobuf::EnumValueDescriptor& enum_value =
+          nonDefaultEnumValue(*field.enum_type(), index);
+      repeated ? reflection.AddEnum(&message, &field, &enum_value)
+               : reflection.SetEnum(&message, &field, &enum_value);
+      break;
+    }
+    case Field::CPPTYPE_STRING: {
+      const std::string text = absl::StrCat(field.name(), "_", index);
+      repeated ? reflection.AddString(&message, &field, text)
+               : reflection.SetString(&message, &field, text);
+      break;
+    }
+    case Field::CPPTYPE_MESSAGE: {
+      if (field.is_map()) {
+        Protobuf::Message& entry = *reflection.AddMessage(&message, &field);
+        fillField(entry, *field.message_type()->map_key(), options, depth + 1);
+        fillField(entry, *field.message_type()->map_value(), options, depth + 1);
+        break;
+      }
+      Protobuf::Message& nested = repeated ? *reflection.AddMessage(&message, &field)
+                                           : *reflection.MutableMessage(&message, &field);
+      if (isAny(field)) {
+        packAny(nested, field, options, depth + 1);
+        break;
+      }
+      fillMessage(nested, options, depth + 1);
+      break;
+    }
+    }
+  }
+}
+
+void fillMessage(Protobuf::Message& message, const Options& options, uint32_t depth) {
+  if (depth >= options.max_depth) {
+    return;
+  }
+  const Protobuf::Descriptor& descriptor = *message.GetDescriptor();
+  for (int i = 0; i < descriptor.field_count(); i++) {
+    const Field& field = *descriptor.field(i);
+    // Only the first field of a oneof, as the others would overwrite it.
+    if (field.containing_oneof() != nullptr && field.index_in_oneof() != 0) {
+      continue;
+    }
+    fillField(message, field, options, depth);
+  }
+}
+
+} // namespace
+
+void fill(Protobuf::Message& message, const Options& options) { fillMessage(message, options, 0); }
+
+} // namespace ProtoFiller
+} // namespace Envoy

--- a/test/test_common/proto_filler.h
+++ b/test/test_common/proto_filler.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "source/common/protobuf/protobuf.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace Envoy {
+namespace ProtoFiller {
+
+// The message packed into an Any, keyed by that Any field's name.
+using AnyTypes = absl::flat_hash_map<std::string, const Protobuf::Message*>;
+
+struct Options {
+  // How many elements a repeated field gets, and how many entries a map gets.
+  uint32_t elements{3};
+  // How many levels of nested messages are filled.
+  uint32_t max_depth{5};
+  // Each Any is packed with its own instance of the mapped message. An Any whose field is unmapped
+  // is left empty, since no type can be inferred.
+  AnyTypes any_types;
+};
+
+/**
+ * Sets every field of `message` to a non-default value, so a test can build a message the size of
+ * a real one without naming its fields. Values derive from each field's name and number, so two
+ * messages of the same type fill alike.
+ *
+ * Only one field of each oneof is set, as the others would overwrite it.
+ */
+void fill(Protobuf::Message& message, const Options& options = {});
+
+} // namespace ProtoFiller
+} // namespace Envoy


### PR DESCRIPTION
Commit Message: admin: Streaming version of /config_dump
Additional Description:

Implements streaming version of /config_dump. Each tracked config name is snapshotted at the start and the config is materialized only when it is being serialized. The serialization is done by walking a protobuf with reflection, redacting sensitive fields as they are visited.

Compared to the previous version, this one can't do pretty printing.

Also adds `Envoy::Json::MessageStreamer` and `Envoy::ProtoFilller:fill()`. The message streamer is what implements the reflection walk and serialization to json. The `fill` utility allows for filling arbitrary protobuf objects with non-default values for performance tests.

```
Benchmark                                                Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------------
BM_ConfigDump/clusters/1000_pvalue                     0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_ConfigDump/clusters/1000_mean                      -0.7997         -0.7996           738           148           737           148
BM_ConfigDump/clusters/1000_median                    -0.7979         -0.7979           733           148           732           148
BM_ConfigDump/clusters/1000_stddev                    -0.9440         -0.9419            16             1            16             1
BM_ConfigDump/clusters/1000_cv                        -0.7204         -0.7098             0             0             0             0
BM_ConfigDump/listeners/1000_pvalue                    0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_ConfigDump/listeners/1000_mean                     -0.7831         -0.7824           841           182           837           182
BM_ConfigDump/listeners/1000_median                   -0.7833         -0.7832           833           180           832           180
BM_ConfigDump/listeners/1000_stddev                   -0.7465         -0.6384            23             6            16             6
BM_ConfigDump/listeners/1000_cv                       +0.1691         +0.6619             0             0             0             0
BM_ConfigDump/routes/1000_pvalue                       0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_ConfigDump/routes/1000_mean                        -0.7500         -0.7517          1367           342          1366           339
BM_ConfigDump/routes/1000_median                      -0.7520         -0.7520          1360           337          1360           337
BM_ConfigDump/routes/1000_stddev                      -0.3540         -0.6769            21            14            20             6
BM_ConfigDump/routes/1000_cv                          +1.5841         +0.3008             0             0             0             0
BM_ConfigDump/route_scopes/1000_pvalue                 0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_ConfigDump/route_scopes/1000_mean                  -0.7745         -0.7744          1886           425          1885           425
BM_ConfigDump/route_scopes/1000_median                -0.7744         -0.7743          1882           425          1881           425
BM_ConfigDump/route_scopes/1000_stddev                -0.8896         -0.8817            19             2            18             2
BM_ConfigDump/route_scopes/1000_cv                    -0.5105         -0.4753             0             0             0             0
BM_ConfigDump/secrets/1000_pvalue                      0.0002          0.0002      U Test, Repetitions: 10 vs 10
BM_ConfigDump/secrets/1000_mean                       -0.7998         -0.7998            39             8            39             8
BM_ConfigDump/secrets/1000_median                     -0.7991         -0.7991            39             8            39             8
BM_ConfigDump/secrets/1000_stddev                     -0.9525         -0.9498             0             0             0             0
BM_ConfigDump/secrets/1000_cv                         -0.7629         -0.7491             0             0             0             0
```

Used AI to bootstrap tests, check comments and doublecheck the ProtoJSON impl against docs, as well as the occasional simplify pass.

Risk Level: Medium, rewrites `/config_dump` admin endpoint
Testing: Unit tests in `proto_streamer_test.cc` and `config_dump_handler_test.cc`, perf tests, manual with `configs/envoy-demo.yaml`
Docs Changes: N/A
Release Notes: <TODO maybe mention the no pretty printing?>
Platform Specific Features: N/A
[Optional Runtime guard:]
Fixes #32054
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]