### PR TITLE
Update QUICHE from 7bcd48d56 to 01408281e

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -1010,7 +1010,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-08-20"
+  release_date: "2026-08-24"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -537,8 +537,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "7bcd48d56214c477885a5af4f3c25f95e74214b7",
-        sha256 = "805df5cd7431004b1e146d3ee3f8ac8a881d27f153232d7a3f67662e992fcc51",
+        version = "01408281e0d4541113cd8c15185d70f30c773b36",
+        sha256 = "d2be8be3c47ccb8bcc96bde210ccddc87c12a2ab6b50cc795399e1bdbea50f0d",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/7bcd48d56..01408281e

```
$ git log 7bcd48d56..01408281e --date=short --no-merges --format="%ad %al %s"

2026-08-24 apaseltiner Remove unnecessary copy of Item when serializing without parameters
2026-08-21 rch No public description
2026-08-21 martinduke Refactor SCONE end-to-end tests.
2026-08-21 martinduke Allow SCONE packets to update the server connection ID.
2026-08-20 rch Remove obsolete comment about the return value of `HpackHeaderTable::TryAddEntry` now that it returns `void`.
2026-08-20 birenroy Removes the return value of `HpackHeaderTable::TryAddEntry` and updates tests
2026-08-20 apaseltiner Remove deprecated Item::GetString method
```