### PR TITLE
ci: select openssl presubmit tests via bazel rdeps

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -285,6 +285,22 @@ function build_openssl() {
     bazel test "${BAZEL_BUILD_OPTIONS[@]}" -c fastbuild "${TEST_TARGETS[@]}"
 }
 
+# Run a bazel query, staying quiet on success but surfacing stderr and the exit
+# code on failure, so a broken query fails the job instead of silently selecting
+# no tests. Query results go to stdout.
+function run_bazel_query() {
+    local err out rc=0
+    err="$(mktemp)"
+    out="$(bazel query "${BAZEL_QUERY_OPTIONS[@]}" "$1" 2>"$err")" || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "ERROR: bazel query failed (exit ${rc}): $1" >&2
+        cat "$err" >&2
+    fi
+    rm -f "$err"
+    printf '%s' "$out"
+    return "$rc"
+}
+
 function build_openssl_presubmit() {
     # Lightweight OpenSSL pre-submit (PRs): build the binary to catch link
     # errors, then run only the tests affected by the PR (via Bazel rdeps). The
@@ -337,9 +353,8 @@ function build_openssl_presubmit() {
     # contains their //source/... deps, so it is a sufficient rdeps universe.
     local tier1_tests=""
     if [[ ${#changed_labels[@]} -gt 0 ]]; then
-        tier1_tests="$(bazel query "${BAZEL_QUERY_OPTIONS[@]}" \
-            "kind(test, rdeps(//test/... + //compat/openssl/test/..., set(${changed_labels[*]})))" \
-            2>/dev/null || true)"
+        tier1_tests="$(run_bazel_query \
+            "kind(test, rdeps(//test/... + //compat/openssl/test/..., set(${changed_labels[*]})))")"
     fi
 
     # Tier 2 (fallback for global/build-config changes): a full //test/... run is
@@ -348,13 +363,17 @@ function build_openssl_presubmit() {
     local tier2_tests=""
     if [[ "$global_config_changed" == "true" ]]; then
         echo "Global/build-config change detected; adding OpenSSL crypto-surface tests."
-        tier2_tests="$(bazel query "${BAZEL_QUERY_OPTIONS[@]}" \
-            "kind(test, rdeps(//test/..., //source/common/tls/... + //source/extensions/transport_sockets/tls/... + //compat/openssl/...))" \
-            2>/dev/null || true)"
+        tier2_tests="$(run_bazel_query \
+            "kind(test, rdeps(//test/... + //compat/openssl/test/..., //source/common/tls/... + //source/extensions/transport_sockets/tls/... + //compat/openssl/...))")"
     fi
 
+    # Combine both tiers, dropping blanks and duplicates. A read loop (rather
+    # than mapfile) keeps this portable to bash without mapfile, e.g. macOS.
     local -a test_targets=()
-    mapfile -t test_targets < <(printf '%s\n%s\n' "$tier1_tests" "$tier2_tests" | grep -v '^$' | sort -u)
+    local target
+    while IFS= read -r target; do
+        [[ -n "$target" ]] && test_targets+=("$target")
+    done < <(printf '%s\n%s\n' "$tier1_tests" "$tier2_tests" | sort -u)
 
     if [[ ${#test_targets[@]} -eq 0 ]]; then
         echo "No affected test targets found, skipping tests."

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -286,75 +286,85 @@ function build_openssl() {
 }
 
 function build_openssl_presubmit() {
-    # Lightweight OpenSSL CI for pre-submit (PRs). Instead of running the full
-    # test suite, it builds the binary (to catch link errors) and then runs only
-    # the tests whose source files were modified in the PR. The full test suite
-    # continues to run on post-submit via the regular "openssl" target.
+    # Lightweight OpenSSL pre-submit (PRs): build the binary to catch link
+    # errors, then run only the tests affected by the PR (via Bazel rdeps). The
+    # full suite still runs on post-submit via the regular "openssl" target.
     BAZEL_BUILD_OPTIONS+=("--config=openssl")
     setup_clang_toolchain
 
-    # Build the full binary to ensure everything links with OpenSSL.
     echo "Bazel fastbuild build with OpenSSL..."
     bazel_envoy_binary_build fastbuild
 
-    # Determine the merge base for computing the PR's changed files.
-    # CI_TARGET_BRANCH is set by the CI workflow (e.g. "main") and passed into
-    # the Docker container. Fetch it since the checkout may be shallow, then use
-    # merge-base to find the fork point so we only see PR changes, not files
-    # that changed on the target branch since the PR was created.
+    # Merge base for the PR's changed files. Fetch the (possibly shallow) target
+    # branch, then merge-base to see only PR changes; fall back to diffing the
+    # target branch directly when history is too shallow.
     local merge_base
     if [[ -n "${CI_TARGET_BRANCH}" ]]; then
         git fetch origin "${CI_TARGET_BRANCH}" 2>/dev/null || true
-        # Shallow clones may lack enough history for merge-base;
-        # fall back to diffing against the target branch directly.
         merge_base="$(git merge-base "origin/${CI_TARGET_BRANCH}" HEAD 2>/dev/null || echo "origin/${CI_TARGET_BRANCH}")"
     else
         merge_base="HEAD~1"
     fi
 
-    # Map each changed file to its corresponding test target:
-    #   source/X/Y/  -> //test/X/Y/...
-    #   test/X/Y/    -> //test/X/Y/...
-    #   envoy/X/Y/   -> //test/X/Y/...   (public headers)
-    #   compat/openssl/ -> //compat/openssl/test/...
-    local -a test_targets=()
+    # Resolve each changed file to its Bazel label so tests can be selected from
+    # the real dependency graph rather than by guessing test paths from source
+    # paths (the test tree is not a 1:1 mirror of the source tree).
+    local -a changed_labels=()
+    local global_config_changed=false
     while IFS= read -r file; do
         [[ -z "$file" ]] && continue
+        [[ -e "$file" ]] || continue  # skip deleted files; they have no label
         case "$file" in
-            source/*/*)
-                local dir
-                dir="$(dirname "$file")"
-                dir="${dir#source/}"
-                test_targets+=("//test/${dir}/...")
+            # Global/build config: blast radius isn't a per-file query. Defer to
+            # the crypto-surface fallback below.
+            .bazelrc|.bazelversion|WORKSPACE|WORKSPACE.bazel|MODULE.bazel|MODULE.bazel.lock|bazel/*)
+                global_config_changed=true
                 ;;
-            test/*/*)
-                local dir
-                dir="$(dirname "$file")"
-                test_targets+=("//${dir}/...")
+            # BUILD/.bzl changes affect the whole package.
+            *BUILD|*BUILD.bazel|*.bzl)
+                changed_labels+=("//$(dirname "$file")/...")
                 ;;
-            envoy/*/*)
-                local dir
-                dir="$(dirname "$file")"
-                dir="${dir#envoy/}"
-                test_targets+=("//test/${dir}/...")
-                ;;
-            compat/openssl/*)
-                test_targets+=("//compat/openssl/test/...")
+            # Tolerate files Bazel doesn't know about (docs, unwired sources).
+            *)
+                local label
+                label="$(bazel query "${BAZEL_QUERY_OPTIONS[@]}" "$file" 2>/dev/null)" || true
+                [[ -n "$label" ]] && changed_labels+=("$label")
                 ;;
         esac
     done < <(git diff --name-only "$merge_base" HEAD 2>/dev/null)
+
+    # Tier 1: tests depending on the changed files. closure(//test/...) already
+    # contains their //source/... deps, so it is a sufficient rdeps universe.
+    local tier1_tests=""
+    if [[ ${#changed_labels[@]} -gt 0 ]]; then
+        tier1_tests="$(bazel query "${BAZEL_QUERY_OPTIONS[@]}" \
+            "kind(test, rdeps(//test/... + //compat/openssl/test/..., set(${changed_labels[*]})))" \
+            2>/dev/null || true)"
+    fi
+
+    # Tier 2 (fallback for global/build-config changes): a full //test/... run is
+    # too costly, so run tests depending on the crypto/TLS surface that differs
+    # between OpenSSL and BoringSSL.
+    local tier2_tests=""
+    if [[ "$global_config_changed" == "true" ]]; then
+        echo "Global/build-config change detected; adding OpenSSL crypto-surface tests."
+        tier2_tests="$(bazel query "${BAZEL_QUERY_OPTIONS[@]}" \
+            "kind(test, rdeps(//test/..., //source/common/tls/... + //source/extensions/transport_sockets/tls/... + //compat/openssl/...))" \
+            2>/dev/null || true)"
+    fi
+
+    local -a test_targets=()
+    mapfile -t test_targets < <(printf '%s\n%s\n' "$tier1_tests" "$tier2_tests" | grep -v '^$' | sort -u)
 
     if [[ ${#test_targets[@]} -eq 0 ]]; then
         echo "No affected test targets found, skipping tests."
         return
     fi
 
-    # Deduplicate targets (multiple files in the same directory produce duplicates).
-    # shellcheck disable=SC2207
-    mapfile -t test_targets < <(printf '%s\n' "${test_targets[@]}" | sort -u)
-
-    echo "Testing affected targets with OpenSSL: ${test_targets[*]}"
-    bazel test "${BAZEL_BUILD_OPTIONS[@]}" -c fastbuild "${test_targets[@]}"
+    echo "Testing affected targets with OpenSSL (${#test_targets[@]} targets):"
+    printf '  %s\n' "${test_targets[@]}"
+    # --keep_going so one broken/incompatible target can't abort the whole run.
+    bazel test "${BAZEL_BUILD_OPTIONS[@]}" -c fastbuild --keep_going "${test_targets[@]}"
 }
 
 shift


### PR DESCRIPTION
`build_openssl_presubmit` mapped each changed source file to a test target by rewriting its directory path (`source/X/Y` -> `//test/X/Y/...`). That assumes the test tree mirrors the source tree 1:1, which is not true. For example `source/extensions/filters/http/dynamic_modules` is tested by `test/extensions/dynamic_modules/http`, so the guessed `//test/.../...` pattern matches nothing and `bazel test` hard-fails the whole job.

Select affected tests from the real Bazel dependency graph instead: resolve each changed file to its label and run `kind(test, rdeps(...))`. As a fallback, global/build-config changes (`.bazelrc`, `bazel/**`, etc.) whose blast radius a per-file query can't capture pull in the OpenSSL crypto/TLS surface tests rather than the full (expensive) suite.

Queries use `BAZEL_QUERY_OPTIONS`, and `bazel test` runs with `--keep_going`.
