### PR TITLE
test/jwt_authn: fix filter_config_test compilation

### DIFF
--- a/test/extensions/filters/http/jwt_authn/filter_config_test.cc
+++ b/test/extensions/filters/http/jwt_authn/filter_config_test.cc
@@ -607,7 +607,8 @@ rules:
 
   NiceMock<Server::Configuration::MockFactoryContext> context;
   absl::Status creation_status = absl::OkStatus();
-  FilterConfigImpl filter_conf(proto_config, "", context, creation_status);
+  FilterConfigImpl filter_conf(proto_config, "", context.server_factory_context_, context.scope(),
+                               makeOptRef<Init::Manager>(context.init_manager_), creation_status);
   ASSERT_TRUE(creation_status.ok());
 
   Http::TestRequestHeaderMapImpl headers{


### PR DESCRIPTION
Commit Message: test/jwt_authn: fix filter_config_test compilation
Additional Description:

jwt_authn/filter_config_test does not compile on main, #46858 changed the FilterConfigImpl constructor, #46586 merged first and added a test case with the old one.

Risk Level: Low
Testing: //test/extensions/filters/http/jwt_authn:filter_config_test
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
