### PR TITLE
Add x64_windows-clang-cl platform

### DIFF
--- a/bazel/platforms/BUILD
+++ b/bazel/platforms/BUILD
@@ -111,3 +111,12 @@ platform(
         "@platforms//os:macos",
     ],
 )
+
+platform(
+    name = "x64_windows-clang-cl",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+        "@bazel_tools//tools/cpp:clang-cl",
+    ],
+)


### PR DESCRIPTION
Risk Level: none
Testing: build
Docs Changes: no
Release Notes: no
Platform Specific Features: windows only
