### PR TITLE
dynamic_modules: add hash policy route action override

### DIFF
--- a/api/envoy/extensions/router/cluster_specifiers/dynamic_modules/v3/dynamic_modules.proto
+++ b/api/envoy/extensions/router/cluster_specifiers/dynamic_modules/v3/dynamic_modules.proto
@@ -53,12 +53,20 @@ message RouteActionOverride {
   // clusters are checked against the cluster manager when :ref:`validate_clusters
   // <envoy_v3_api_field_config.route.v3.RouteConfiguration.validate_clusters>` is enabled.
   repeated config.route.v3.RouteAction.RequestMirrorPolicy request_mirror_policies = 3;
+
+  // Hash policy replacing the hash policy of the matched route, used when the upstream cluster
+  // employs a hashing load balancer. If not specified, the hash policy of the matched route is used,
+  // so an entry cannot be used to remove a hash policy that the matched route configures. A
+  // cluster-level hash policy and a load-balancer-level hash policy, when configured, take precedence
+  // over this route-level policy.
+  repeated config.route.v3.RouteAction.HashPolicy hash_policy = 4;
 }
 
 // Configuration for the Dynamic Modules Cluster Specifier. This cluster specifier allows loading
 // shared object files via ``dlopen`` to select the upstream cluster for a request, and to replace
 // the timeout, idle timeout, priority, request body buffer limit, cluster not found response code,
-// retry policy, metadata match criteria and request mirroring policies of the matched route.
+// hash policy, retry policy, metadata match criteria and request mirroring policies of the matched
+// route.
 //
 // A module can be loaded by multiple cluster specifiers. It is loaded only once and shared across
 // multiple cluster specifier instances. The module is invoked while the route is being

--- a/changelogs/current/new_features/dynamic_modules__added-a-cluster-specifier-extension.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-a-cluster-specifier-extension.rst
@@ -1,8 +1,8 @@
 Added a dynamic modules cluster specifier extension
 (``envoy.router.cluster_specifier_plugin.dynamic_modules``) that lets a dynamic module select the
 upstream cluster for a request and replace the timeout, idle timeout, priority, request body buffer
-limit, cluster not found response code, retry policy, metadata match criteria and request mirroring
-policies of the matched route.
+limit, cluster not found response code, hash policy, retry policy, metadata match criteria and request
+mirroring policies of the matched route.
 The selection context exposes the request headers, stream info attributes, dynamic metadata, the
 route name, and the random value Envoy generated for cluster selection, and the module is invoked
 again whenever a filter refreshes the route cluster. The Rust SDK exposes this through the

--- a/docs/root/configuration/http/cluster_specifier/dynamic_modules.rst
+++ b/docs/root/configuration/http/cluster_specifier/dynamic_modules.rst
@@ -9,8 +9,8 @@ Overview
 The :ref:`DynamicModuleClusterSpecifier <envoy_v3_api_msg_extensions.router.cluster_specifiers.dynamic_modules.v3.DynamicModuleClusterSpecifier>`
 configuration specifies a cluster specifier backed by a :ref:`dynamic module <arch_overview_dynamic_modules>`.
 The module selects the upstream cluster for a request and may replace the timeout, idle timeout,
-priority, request body buffer limit, cluster not found response code, retry policy, metadata match
-criteria and request mirroring policies of the matched route.
+priority, request body buffer limit, cluster not found response code, hash policy, retry policy,
+metadata match criteria and request mirroring policies of the matched route.
 
 The module is invoked while the route is being resolved, so its selection is visible to the router
 without clearing the route cache. It is invoked again whenever a filter calls
@@ -40,6 +40,9 @@ a different point:
 * The idle timeout and the request body buffer limit are read while the route is resolved, and the
   timeout, the retry policy and the request mirroring policies are read before the first upstream
   attempt, so only the first selection applies to them.
+* The hash policy is read during host selection on every upstream attempt, so a later selection
+  replaces it. A cluster-level hash policy and a load-balancer-level hash policy, when configured,
+  take precedence over the route-level policy the module selects.
 * The cluster not found response code is read only when the selected cluster does not exist, which
   ends the request, so the selection that named the missing cluster is the one that applies.
 

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/BUILD
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:statusor_lib",
         "//source/common/config:well_known_names",
+        "//source/common/http:hash_policy_lib",
         "//source/common/protobuf:utility_lib",
         "//source/common/router:config_lib",
         "//source/common/router:delegating_route_lib",

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
@@ -7,6 +7,7 @@
 
 #include "source/common/common/assert.h"
 #include "source/common/config/well_known_names.h"
+#include "source/common/http/hash_policy.h"
 #include "source/common/protobuf/utility.h"
 #include "source/common/router/config_impl.h"
 #include "source/common/router/metadatamatchcriteria_impl.h"
@@ -45,11 +46,17 @@ buildRouteActionOverride(const RouteActionOverrideProto& proto_override,
     RETURN_IF_NOT_OK_REF(policy_or_error.status());
     entry.shadow_policies.push_back(std::move(policy_or_error.value()));
   }
+  if (!proto_override.hash_policy().empty()) {
+    auto policy_or_error =
+        Http::HashPolicyImpl::create(proto_override.hash_policy(), context.regexEngine());
+    RETURN_IF_NOT_OK_REF(policy_or_error.status());
+    entry.hash_policy = std::move(policy_or_error.value());
+  }
   // Validate what was built rather than what was configured. A metadata_match without an envoy.lb
   // entry contributes nothing, so a populated looking configuration can still build an override
   // that replaces no property, which set_route_action_override would then accept as a decision.
   if (entry.retry_policy == nullptr && entry.metadata_match_criteria == nullptr &&
-      entry.shadow_policies.empty()) {
+      entry.shadow_policies.empty() && entry.hash_policy == nullptr) {
     return absl::InvalidArgumentError(
         "Route action override must replace at least one route action property");
   }

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.h
@@ -8,6 +8,7 @@
 
 #include "envoy/extensions/router/cluster_specifiers/dynamic_modules/v3/dynamic_modules.pb.h"
 #include "envoy/http/codes.h"
+#include "envoy/http/hash_policy.h"
 #include "envoy/router/cluster_specifier_plugin.h"
 #include "envoy/server/factory_context.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -44,6 +45,7 @@ struct RouteActionOverride {
   Envoy::Router::RetryPolicyConstSharedPtr retry_policy;
   Envoy::Router::MetadataMatchCriteriaConstPtr metadata_match_criteria;
   std::vector<Envoy::Router::ShadowPolicyPtr> shadow_policies;
+  std::unique_ptr<Http::HashPolicy> hash_policy;
 };
 
 using RouteActionOverrideMap = absl::flat_hash_map<std::string, RouteActionOverride>;
@@ -197,6 +199,11 @@ public:
     return entry != nullptr && !entry->shadow_policies.empty()
                ? entry->shadow_policies
                : DelegatingRouteEntry::shadowPolicies();
+  }
+  const Http::HashPolicy* hashPolicy() const override {
+    const RouteActionOverride* entry = selection_.route_action_override;
+    return entry != nullptr && entry->hash_policy != nullptr ? entry->hash_policy.get()
+                                                             : DelegatingRouteEntry::hashPolicy();
   }
   void refreshRouteCluster(const Http::RequestHeaderMap& headers,
                            const StreamInfo::StreamInfo& stream_info) const override;

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
@@ -740,9 +740,31 @@ route_action_overrides:
   mirror_only:
     request_mirror_policies:
     - cluster: mirror-cluster
+  hash_only:
+    hash_policy:
+    - header:
+        header_name: x-hash
 )EOF");
   }
 };
+
+TEST_F(DynamicModuleRouteActionOverrideTest, HashPolicyOverrideReplacesRouteHashPolicy) {
+  setUpPluginWithOverrides();
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-override", "hash_only"}, {"x-hash", "tenant-a"}};
+  const auto* entry = resolveRouteEntry(headers);
+  ASSERT_NE(nullptr, entry->hashPolicy());
+  Http::HashPolicy::AddCookieCallback add_cookie_nop;
+  EXPECT_TRUE(entry->hashPolicy()->generateHash(headers, stream_info_, add_cookie_nop).has_value());
+}
+
+TEST_F(DynamicModuleRouteActionOverrideTest, HashPolicyOverrideDelegatesWhenNotSelected) {
+  setUpPluginWithOverrides();
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"env", "prod"}};
+  const auto* matched_hash_policy = parent_->route_entry_.hashPolicy();
+  EXPECT_CALL(parent_->route_entry_, hashPolicy()).WillOnce(Return(matched_hash_policy));
+  EXPECT_EQ(matched_hash_policy, resolveRouteEntry(headers)->hashPolicy());
+}
 
 TEST_F(DynamicModuleRouteActionOverrideTest, OverrideReplacesRouteActionProperties) {
   setUpPluginWithOverrides();


### PR DESCRIPTION
## Description

This PR adds `hash_policy` to `RouteActionOverride` so a module can select a pre-built hash policy by name. The policy is built with `HashPolicyImpl` at config load and read during host selection on every upstream attempt.

---

**Commit Message:** dynamic_modules: add hash policy route action override
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes**: Added
**Release Notes:** N/A