### PR TITLE
dynamic_modules: add cluster host count query to cluster specifier

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-a-cluster-specifier-extension.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-a-cluster-specifier-extension.rst
@@ -4,7 +4,8 @@ upstream cluster for a request and replace the timeout, idle timeout, priority, 
 limit, cluster not found response code, retry policy, metadata match criteria and request mirroring
 policies of the matched route.
 The selection context exposes the request headers, stream info attributes, dynamic metadata, the
-route name, and the random value Envoy generated for cluster selection, and the module is invoked
+route name, the random value Envoy generated for cluster selection, and a routability query that
+reports host counts for a named cluster from the current worker, and the module is invoked
 again whenever a filter refreshes the route cluster. The Rust SDK exposes this through the
 ``cluster_specifier`` module and the ``cluster_specifier:`` arm of ``declare_all_init_functions!``.
 See

--- a/docs/root/configuration/http/cluster_specifier/dynamic_modules.rst
+++ b/docs/root/configuration/http/cluster_specifier/dynamic_modules.rst
@@ -42,6 +42,9 @@ a different point:
   attempt, so only the first selection applies to them.
 * The cluster not found response code is read only when the selected cluster does not exist, which
   ends the request, so the selection that named the missing cluster is the one that applies.
+* ``get_cluster_host_count`` reports whether a cluster is routable from the current worker and
+  returns host counts at a priority level. It uses ``getThreadLocalCluster()``, so it can return
+  false even when the cluster is configured but not yet warmed on the worker.
 
 Configuration
 -------------

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -14945,12 +14945,37 @@ bool envoy_dynamic_module_callback_cluster_specifier_get_route_name(
 uint64_t envoy_dynamic_module_callback_cluster_specifier_get_random_value(
     envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr);
 
+/**
+ * envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count retrieves the host counts
+ * for a cluster by name. This lets a module check whether a cluster is routable from the current
+ * worker before naming it with set_cluster_name.
+ *
+ * The lookup uses getThreadLocalCluster(), so false is returned when the cluster is not routable
+ * from this worker at the moment, which can happen even when the cluster is configured but not yet
+ * warmed or propagated. Healthy and degraded host counts are eventually consistent.
+ *
+ * @param context_envoy_ptr is the pointer to the cluster selection context.
+ * @param cluster_name is the name of the cluster to query owned by the module.
+ * @param priority is the priority level to query (0 for default priority).
+ * @param total_count is the pointer to store the total number of hosts. Can be null if not needed.
+ * @param healthy_count is the pointer to store the number of healthy hosts. Can be null if not
+ * needed.
+ * @param degraded_count is the pointer to store the number of degraded hosts. Can be null if not
+ * needed.
+ * @return true if the counts were retrieved successfully, false otherwise (e.g., cluster not
+ * routable from this worker).
+ */
+bool envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer cluster_name, uint32_t priority, size_t* total_count,
+    size_t* healthy_count, size_t* degraded_count);
+
 // ------------------- Cluster Specifier Callbacks - Selection -----------------
 
 /**
  * envoy_dynamic_module_callback_cluster_specifier_set_cluster_name sets the upstream cluster for
  * the request. When the cluster does not exist, the request is failed with the cluster-not-found
- * response code of the matched route.
+ * response code of the matched route. Use get_cluster_host_count to check `routability` first.
  *
  * @param context_envoy_ptr is the pointer to the cluster selection context.
  * @param cluster_name is the name of the cluster to route to. Envoy copies the buffer. An empty

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -2861,6 +2861,14 @@ __attribute__((weak)) uint64_t envoy_dynamic_module_callback_cluster_specifier_g
   return 0;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, uint32_t, size_t*, size_t*, size_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count: not "
+               "implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) bool envoy_dynamic_module_callback_cluster_specifier_get_request_header_value(
     envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
     envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_envoy_buffer*, size_t,

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster_specifier.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster_specifier.rs
@@ -6,7 +6,7 @@
 //! [`crate::NEW_CLUSTER_SPECIFIER_CONFIG_FUNCTION`] and lets a single module dispatch by
 //! `specifier_name`.
 
-use crate::{abi, EnvoyBuffer};
+use crate::{abi, ClusterHostCount, EnvoyBuffer};
 use std::ffi::c_void;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
@@ -294,6 +294,40 @@ impl ClusterSpecifierContext {
   /// used to split traffic by percentage without re-deriving a hash.
   pub fn random_value(&self) -> u64 {
     unsafe { abi::envoy_dynamic_module_callback_cluster_specifier_get_random_value(self.envoy_ptr) }
+  }
+
+  /// Get host counts for a cluster by name at the given priority level.
+  ///
+  /// Returns `None` when the cluster is not routable from the current worker at the moment, which
+  /// can happen even when the cluster is configured but not yet warmed or propagated. Healthy and
+  /// degraded host counts are eventually consistent.
+  pub fn get_cluster_host_count(
+    &self,
+    cluster_name: &str,
+    priority: u32,
+  ) -> Option<ClusterHostCount> {
+    let mut total: usize = 0;
+    let mut healthy: usize = 0;
+    let mut degraded: usize = 0;
+    let success = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+        self.envoy_ptr,
+        crate::str_to_module_buffer(cluster_name),
+        priority,
+        &mut total as *mut _,
+        &mut healthy as *mut _,
+        &mut degraded as *mut _,
+      )
+    };
+    if success {
+      Some(ClusterHostCount {
+        total,
+        healthy,
+        degraded,
+      })
+    } else {
+      None
+    }
   }
 
   /// Set the upstream cluster for the request.

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -8958,6 +8958,26 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_get_dynamic_me
 }
 
 #[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+  _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+  _cluster_name: abi::envoy_dynamic_module_type_module_buffer,
+  _priority: u32,
+  total_count: *mut usize,
+  healthy_count: *mut usize,
+  degraded_count: *mut usize,
+) -> bool {
+  if !STUB_SPECIFIER_STATE_PRESENT.load(std::sync::atomic::Ordering::SeqCst) {
+    return false;
+  }
+  unsafe {
+    *total_count = 5;
+    *healthy_count = 3;
+    *degraded_count = 1;
+  }
+  true
+}
+
+#[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_get_route_name(
   _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
   result: *mut abi::envoy_dynamic_module_type_envoy_buffer,
@@ -9267,6 +9287,10 @@ fn test_cluster_specifier_context_reads_request_state() {
     ctx.route_name().unwrap().as_slice()
   );
   assert_eq!(STUB_SPECIFIER_RANDOM_VALUE, ctx.random_value());
+  let counts = ctx.get_cluster_host_count("prod", 0).unwrap();
+  assert_eq!(5, counts.total);
+  assert_eq!(3, counts.healthy);
+  assert_eq!(1, counts.degraded);
 
   // An empty header map returns an empty vector without invoking the fill callback.
   STUB_SPECIFIER_HEADERS_EMPTY.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -9297,6 +9321,7 @@ fn test_cluster_specifier_context_reads_request_state() {
   assert!(ctx
     .get_dynamic_metadata_bool("envoy.test", "canary")
     .is_none());
+  assert!(ctx.get_cluster_host_count("prod", 0).is_none());
   assert!(ctx.route_name().is_none());
   STUB_SPECIFIER_STATE_PRESENT.store(true, std::sync::atomic::Ordering::SeqCst);
 }

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/abi_impl.cc
@@ -121,6 +121,36 @@ uint64_t envoy_dynamic_module_callback_cluster_specifier_get_random_value(
   return clusterSpecifierContext(context_envoy_ptr)->random_value;
 }
 
+bool envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer cluster_name, uint32_t priority, size_t* total_count,
+    size_t* healthy_count, size_t* degraded_count) {
+  auto* context = clusterSpecifierContext(context_envoy_ptr);
+  auto* tl_cluster = context->config.clusterManager().getThreadLocalCluster(
+      absl::string_view(cluster_name.ptr, cluster_name.length));
+  if (tl_cluster == nullptr) {
+    return false;
+  }
+  const auto& priority_set = tl_cluster->prioritySet();
+  if (priority >= priority_set.hostSetsPerPriority().size()) {
+    return false;
+  }
+  const auto& host_set = priority_set.hostSetsPerPriority()[priority];
+  if (host_set == nullptr) {
+    return false;
+  }
+  if (total_count != nullptr) {
+    *total_count = host_set->hosts().size();
+  }
+  if (healthy_count != nullptr) {
+    *healthy_count = host_set->healthyHosts().size();
+  }
+  if (degraded_count != nullptr) {
+    *degraded_count = host_set->degradedHosts().size();
+  }
+  return true;
+}
+
 void envoy_dynamic_module_callback_cluster_specifier_set_cluster_name(
     envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
     envoy_dynamic_module_type_module_buffer cluster_name) {

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
@@ -61,9 +61,9 @@ buildRouteActionOverride(const RouteActionOverrideProto& proto_override,
 DynamicModuleClusterSpecifierConfig::DynamicModuleClusterSpecifierConfig(
     absl::string_view specifier_name, absl::string_view specifier_config,
     Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-    RouteActionOverrideMap route_action_overrides)
+    RouteActionOverrideMap route_action_overrides, Upstream::ClusterManager& cluster_manager)
     : specifier_name_(specifier_name), specifier_config_(specifier_config),
-      dynamic_module_(std::move(dynamic_module)),
+      dynamic_module_(std::move(dynamic_module)), cluster_manager_(cluster_manager),
       route_action_overrides_(std::move(route_action_overrides)) {}
 
 DynamicModuleClusterSpecifierConfig::~DynamicModuleClusterSpecifierConfig() {
@@ -133,7 +133,7 @@ newDynamicModuleClusterSpecifierConfig(const DynamicModuleClusterSpecifierProto&
 
   auto config = std::make_shared<DynamicModuleClusterSpecifierConfig>(
       proto_config.specifier_name(), specifier_config, std::move(dynamic_module),
-      std::move(route_action_overrides));
+      std::move(route_action_overrides), context.clusterManager());
   config->on_config_destroy_ = on_config_destroy.value();
   config->on_select_ = on_select.value();
 

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.h
@@ -63,7 +63,8 @@ public:
   DynamicModuleClusterSpecifierConfig(absl::string_view specifier_name,
                                       absl::string_view specifier_config,
                                       Extensions::DynamicModules::DynamicModulePtr dynamic_module,
-                                      RouteActionOverrideMap route_action_overrides);
+                                      RouteActionOverrideMap route_action_overrides,
+                                      Upstream::ClusterManager& cluster_manager);
 
   ~DynamicModuleClusterSpecifierConfig();
 
@@ -81,6 +82,11 @@ public:
    * @return an error naming the first override that mirrors to an unknown cluster.
    */
   absl::Status validateClusters(const Upstream::ClusterManager& cluster_manager) const;
+
+  /**
+   * @return the cluster manager used to look up clusters during selection.
+   */
+  Upstream::ClusterManager& clusterManager() const { return cluster_manager_; }
 
   // The corresponding in-module cluster specifier configuration.
   envoy_dynamic_module_type_cluster_specifier_config_module_ptr in_module_config_{nullptr};
@@ -100,6 +106,7 @@ private:
   const std::string specifier_name_;
   const std::string specifier_config_;
   const Extensions::DynamicModules::DynamicModulePtr dynamic_module_;
+  Upstream::ClusterManager& cluster_manager_;
   // Const after construction so that the pointers routeActionOverride() hands out stay valid.
   const RouteActionOverrideMap route_action_overrides_;
 };

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1806,6 +1806,9 @@ WEAK_STUB(ClusterSpecifierGetDynamicMetadataNumber,
               nullptr, {nullptr, 0}, {nullptr, 0}, nullptr))
 WEAK_STUB(ClusterSpecifierGetRandomValue,
           envoy_dynamic_module_callback_cluster_specifier_get_random_value(nullptr))
+WEAK_STUB(ClusterSpecifierGetClusterHostCount,
+          envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+              nullptr, {nullptr, 0}, 0, nullptr, nullptr, nullptr))
 WEAK_STUB(ClusterSpecifierGetRequestHeaderValue,
           envoy_dynamic_module_callback_cluster_specifier_get_request_header_value(
               nullptr, {nullptr, 0}, nullptr, 0, nullptr))

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
@@ -116,6 +116,19 @@ fn read_echoed_value(ctx: &ClusterSpecifierContext, name: &[u8]) -> String {
       .map_or_else(|| ABSENT.to_owned(), |value| value.to_string()),
     b"route-name" => buffer_to_string_or_absent(ctx.route_name()),
     b"random-value" => ctx.random_value().to_string(),
+    b"cluster-host-count" => {
+      let cluster_name = ctx
+        .get_request_header("x-query-cluster")
+        .map(buffer_to_string)
+        .unwrap_or_default();
+      let priority = read_u64_header(ctx, "x-query-priority").unwrap_or(0) as u32;
+      ctx
+        .get_cluster_host_count(&cluster_name, priority)
+        .map_or_else(
+          || ABSENT.to_owned(),
+          |counts| format!("{}/{}/{}", counts.total, counts.healthy, counts.degraded),
+        )
+    },
     _ => ABSENT.to_owned(),
   }
 }

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
@@ -32,6 +32,7 @@ envoy_extension_cc_test(
         "//test/mocks/router:router_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
+        "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
         "@abseil-cpp//absl/strings",

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
@@ -5,6 +5,7 @@
 
 #include "source/common/common/fmt.h"
 #include "source/common/protobuf/utility.h"
+#include "source/extensions/dynamic_modules/abi/abi.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/router/cluster_specifiers/dynamic_modules/config.h"
 
@@ -12,6 +13,8 @@
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/upstream/cluster_manager.h"
+#include "test/mocks/upstream/thread_local_cluster.h"
 #include "test/test_common/logging.h"
 #include "test/test_common/utility.h"
 
@@ -822,6 +825,81 @@ route_action_overrides:
   EXPECT_EQ(matched_route_criteria, entry->metadataMatchCriteria());
   // The retry policy still comes from the override, so the entry itself was selected.
   EXPECT_EQ(7, entry->retryPolicy()->numRetries());
+}
+
+class DynamicModuleClusterSpecifierHostCountAbiTest : public testing::Test {
+public:
+  DynamicModuleClusterSpecifierHostCountAbiTest() {
+    TestEnvironment::setEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
+                               TestEnvironment::substitute(
+                                   "{{ test_rundir }}/test/extensions/dynamic_modules/test_data/c"),
+                               1);
+    EXPECT_CALL(context_, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager_));
+  }
+
+  DynamicModuleClusterSpecifierConfigSharedPtr makeConfig() {
+    auto dynamic_module = Extensions::DynamicModules::newDynamicModule(
+        Extensions::DynamicModules::testSharedObjectPath("cluster_specifier_no_op", "c"),
+        /*do_not_close=*/true);
+    EXPECT_TRUE(dynamic_module.ok());
+    auto config_or_error = newDynamicModuleClusterSpecifierConfig(
+        protoConfig("cluster_specifier_no_op", "test_cluster_specifier"),
+        std::move(dynamic_module.value()), context_);
+    EXPECT_TRUE(config_or_error.ok());
+    return config_or_error.value();
+  }
+
+  ClusterSpecifierContext makeContext(DynamicModuleClusterSpecifierConfigSharedPtr config) {
+    return ClusterSpecifierContext{*config, headers_, stream_info_, route_name_, /*random=*/0, {}};
+  }
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  Upstream::MockClusterManager cluster_manager_;
+  NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
+  Http::TestRequestHeaderMapImpl headers_;
+  const std::string route_name_{"named-route"};
+};
+
+TEST_F(DynamicModuleClusterSpecifierHostCountAbiTest, UnknownClusterReturnsFalse) {
+  auto config = makeConfig();
+  auto context = makeContext(config);
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(absl::string_view("absent")))
+      .WillOnce(testing::Return(nullptr));
+  size_t total = 0;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+      static_cast<void*>(&context), {"absent", 6}, 0, &total, nullptr, nullptr));
+}
+
+TEST_F(DynamicModuleClusterSpecifierHostCountAbiTest, HostCountsReturnedForKnownCluster) {
+  auto config = makeConfig();
+  auto context = makeContext(config);
+  EXPECT_CALL(cluster_manager_, getThreadLocalCluster(absl::string_view("present")))
+      .WillOnce(testing::Return(&thread_local_cluster_));
+  auto* mock_host_set = thread_local_cluster_.cluster_.priority_set_.getMockHostSet(0);
+  mock_host_set->hosts_.resize(4);
+  mock_host_set->healthy_hosts_.resize(2);
+  mock_host_set->degraded_hosts_.resize(1);
+
+  size_t total = 0;
+  size_t healthy = 0;
+  size_t degraded = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count(
+      static_cast<void*>(&context), {"present", 7}, 0, &total, &healthy, &degraded));
+  EXPECT_EQ(4, total);
+  EXPECT_EQ(2, healthy);
+  EXPECT_EQ(1, degraded);
+}
+
+TEST_F(DynamicModuleClusterSpecifierReadTest, ClusterHostCountReadable) {
+  setUpPlugin();
+  EXPECT_CALL(context_.cluster_manager_, getThreadLocalCluster(absl::string_view("cluster_0")))
+      .WillOnce(testing::Return(nullptr));
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"},
+                                         {"env", "prod"},
+                                         {"x-echo", "cluster-host-count"},
+                                         {"x-query-cluster", "cluster_0"}};
+  EXPECT_EQ("absent", echoedValue(headers, "cluster-host-count"));
 }
 
 } // namespace


### PR DESCRIPTION
## Description

This PR adds `envoy_dynamic_module_callback_cluster_specifier_get_cluster_host_count` so modules can check cluster routability from the worker thread before selecting a cluster.

---

**Commit Message:** dynamic_modules: add cluster host count query to cluster specifier
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A