### PR TITLE
lua: split StreamHandleWrapper into request/response handle types

### DIFF
--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -34,28 +34,53 @@ namespace Lua {
  */
 
 /**
- * Base macro for declaring a Lua/C function. Any function declared will need to be exported via
- * the exportedFunctions() function in BaseLuaObject. See BaseLuaObject below for more
- * information. This macro declares a static "thunk" which checks the user data, optionally checks
- * for object death (again see BaseLuaObject below for more info), and then invokes a normal
- * object method. The actual object method needs to be implemented by the class.
+ * Base macro for generating the static "thunk" of a Lua/C function: it checks the user data,
+ * optionally checks for object death (see BaseLuaObject below), and then invokes a normal object
+ * method. Generates only the thunk, not the method declaration, so it can also serve a method
+ * inherited from a shared base -- each registered type still needs its own thunk, because the
+ * metatable and the luaL_checkudata key are per type, even when the body is written once.
  * @param Class supplies the owning class name.
  * @param Name supplies the function name.
  * @param Index supplies the stack index where "this" (Lua/C userdata) is found.
  */
-#define DECLARE_LUA_FUNCTION_EX(Class, Name, Index)                                                \
+#define FORWARD_LUA_FUNCTION_EX(Class, Name, Index)                                                \
   static int static_##Name(lua_State* state) {                                                     \
     Class* object = ::Envoy::Extensions::Filters::Common::Lua::alignAndCast<Class>(                \
         luaL_checkudata(state, Index, typeid(Class).name()));                                      \
     object->checkDead(state);                                                                      \
     return object->Name(state);                                                                    \
-  }                                                                                                \
+  }
+
+/**
+ * Base macro for declaring a Lua/C function. Any function declared will need to be exported via
+ * the exportedFunctions() function in BaseLuaObject. See BaseLuaObject below for more
+ * information. Generates the thunk plus the object method declaration; the actual method needs to
+ * be implemented by the class.
+ * @param Class supplies the owning class name.
+ * @param Name supplies the function name.
+ * @param Index supplies the stack index where "this" (Lua/C userdata) is found.
+ */
+#define DECLARE_LUA_FUNCTION_EX(Class, Name, Index)                                                \
+  FORWARD_LUA_FUNCTION_EX(Class, Name, Index)                                                      \
   int Name(lua_State* state);
 
 /**
  * Declare a Lua function in which userdata is in stack slot 1. See DECLARE_LUA_FUNCTION_EX()
  */
 #define DECLARE_LUA_FUNCTION(Class, Name) DECLARE_LUA_FUNCTION_EX(Class, Name, 1)
+
+/**
+ * Generate only the thunk for a Lua function whose implementation is inherited from a shared
+ * base, with userdata in stack slot 1. Use this only where that base is itself not a
+ * BaseLuaObject and several leaf types export the same body; a class that owns its own
+ * implementation wants DECLARE_LUA_FUNCTION. See FORWARD_LUA_FUNCTION_EX()
+ */
+#define FORWARD_LUA_FUNCTION(Class, Name) FORWARD_LUA_FUNCTION_EX(Class, Name, 1)
+
+/**
+ * Same as FORWARD_LUA_FUNCTION but for closures, where userdata is in upvalue slot 1.
+ */
+#define FORWARD_LUA_CLOSURE(Class, Name) FORWARD_LUA_FUNCTION_EX(Class, Name, lua_upvalueindex(1))
 
 /**
  * Declare a Lua function in which userdata is in upvalue slot 1. See DECLARE_LUA_FUNCTION_EX()

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -38,7 +38,7 @@ namespace Lua {
  * optionally checks for object death (see BaseLuaObject below), and then invokes a normal object
  * method. Generates only the thunk, not the method declaration, so it can also serve a method
  * inherited from a shared base -- each registered type still needs its own thunk, because the
- * metatable and the luaL_checkudata key are per type, even when the body is written once.
+ * metatable and the `luaL_checkudata` key are per type, even when the body is written once.
  * @param Class supplies the owning class name.
  * @param Name supplies the function name.
  * @param Index supplies the stack index where "this" (Lua/C userdata) is found.

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -28,48 +28,45 @@ namespace Lua {
 namespace {
 
 using OptionHandler =
-    std::function<void(lua_State* state, StreamHandleWrapper::HttpCallOptions& options)>;
+    std::function<void(lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options)>;
 using OptionHandlers = std::map<absl::string_view, OptionHandler>;
 
 const OptionHandlers& optionHandlers() {
-  CONSTRUCT_ON_FIRST_USE(OptionHandlers,
-                         {
-                             {"asynchronous",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["asynchronous"] =
-                                // <boolean>} entry.
-                                options.is_async_request_ = lua_toboolean(state, -1);
-                              }},
-                             {"timeout_ms",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["timeout_ms"] = <int>}
-                                // entry.
-                                const int timeout_ms = luaL_checkint(state, -1);
-                                if (timeout_ms < 0) {
-                                  luaL_error(state, "http call timeout must be >= 0");
-                                } else {
-                                  options.request_options_.setTimeout(
-                                      std::chrono::milliseconds(timeout_ms));
-                                }
-                              }},
-                             {"trace_sampled",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                const bool sampled = lua_toboolean(state, -1);
-                                options.request_options_.setSampled(sampled);
-                              }},
-                             {"return_duplicate_headers",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["return_duplicate_headers"]
-                                // = <boolean>} entry.
-                                options.return_duplicate_headers_ = lua_toboolean(state, -1);
-                              }},
-                             {"send_xff",
-                              [](lua_State* state, StreamHandleWrapper::HttpCallOptions& options) {
-                                // Handle the case when the table has: {["send_xff"] =
-                                // <boolean>} entry.
-                                options.request_options_.setSendXff(lua_toboolean(state, -1));
-                              }},
-                         });
+  CONSTRUCT_ON_FIRST_USE(
+      OptionHandlers,
+      {
+          {"asynchronous",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             // Handle the case when the table has: {["asynchronous"] = <boolean>} entry.
+             options.is_async_request_ = lua_toboolean(state, -1);
+           }},
+          {"timeout_ms",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             // Handle the case when the table has: {["timeout_ms"] = <int>} entry.
+             const int timeout_ms = luaL_checkint(state, -1);
+             if (timeout_ms < 0) {
+               luaL_error(state, "http call timeout must be >= 0");
+             } else {
+               options.request_options_.setTimeout(std::chrono::milliseconds(timeout_ms));
+             }
+           }},
+          {"trace_sampled",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             const bool sampled = lua_toboolean(state, -1);
+             options.request_options_.setSampled(sampled);
+           }},
+          {"return_duplicate_headers",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             // Handle the case when the table has: {["return_duplicate_headers"] = <boolean>}
+             // entry.
+             options.return_duplicate_headers_ = lua_toboolean(state, -1);
+           }},
+          {"send_xff",
+           [](lua_State* state, StreamHandleWrapperBase::HttpCallOptions& options) {
+             // Handle the case when the table has: {["send_xff"] = <boolean>} entry.
+             options.request_options_.setSendXff(lua_toboolean(state, -1));
+           }},
+      });
 }
 
 constexpr int AsyncFlagIndex = 6;
@@ -82,7 +79,7 @@ using HttpResponseCodeDetails = ConstSingleton<HttpResponseCodeDetailValues>;
 
 // Parse http call options by inspecting the provided table.
 void parseOptionsFromTable(lua_State* state, int index,
-                           StreamHandleWrapper::HttpCallOptions& options) {
+                           StreamHandleWrapperBase::HttpCallOptions& options) {
   const auto& handlers = optionHandlers();
 
   lua_pushnil(state);
@@ -226,7 +223,8 @@ PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotA
   lua_state_.registerType<DynamicMetadataMapWrapper>();
   lua_state_.registerType<DynamicMetadataMapIterator>();
   lua_state_.registerType<FilterStateWrapper>();
-  lua_state_.registerType<StreamHandleWrapper>();
+  lua_state_.registerType<RequestStreamHandleWrapper>();
+  lua_state_.registerType<ResponseStreamHandleWrapper>();
   lua_state_.registerType<PublicKeyWrapper>();
   lua_state_.registerType<ConnectionStreamInfoWrapper>();
   lua_state_.registerType<ConnectionDynamicMetadataMapWrapper>();
@@ -267,10 +265,11 @@ PerLuaCodeSetup::PerLuaCodeSetup(const std::string& lua_code, ThreadLocal::SlotA
 
 PerLuaCodeSetup::~PerLuaCodeSetup() { vm_count_gauge_.sub(vm_count_delta_); }
 
-StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
-                                         Http::RequestOrResponseHeaderMap& headers, bool end_stream,
-                                         Filter& filter, FilterCallbacks& callbacks,
-                                         TimeSource& time_source)
+StreamHandleWrapperBase::StreamHandleWrapperBase(Filters::Common::Lua::Coroutine& coroutine,
+                                                 Http::RequestOrResponseHeaderMap& headers,
+                                                 bool end_stream, Filter& filter,
+                                                 FilterCallbacks& callbacks,
+                                                 TimeSource& time_source)
     : coroutine_(coroutine), headers_(headers), end_stream_(end_stream), filter_(filter),
       callbacks_(callbacks), yield_callback_([this]() -> absl::Status {
         if (state_ == State::Running) {
@@ -280,7 +279,7 @@ StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::Coroutine& corout
       }),
       time_source_(time_source) {}
 
-Http::FilterHeadersStatus StreamHandleWrapper::start(int function_ref) {
+Http::FilterHeadersStatus StreamHandleWrapperBase::start(int function_ref) {
   // We are on the top of the stack.
   coroutine_status_ = coroutine_.start(function_ref, 1, yield_callback_);
   if (!coroutine_status_.ok()) {
@@ -299,7 +298,7 @@ Http::FilterHeadersStatus StreamHandleWrapper::start(int function_ref) {
   return status;
 }
 
-Http::FilterDataStatus StreamHandleWrapper::onData(Buffer::Instance& data, bool end_stream) {
+Http::FilterDataStatus StreamHandleWrapperBase::onData(Buffer::Instance& data, bool end_stream) {
   ASSERT(!end_stream_);
   end_stream_ = end_stream;
   saw_body_ = true;
@@ -339,7 +338,7 @@ Http::FilterDataStatus StreamHandleWrapper::onData(Buffer::Instance& data, bool 
   }
 }
 
-Http::FilterTrailersStatus StreamHandleWrapper::onTrailers(Http::HeaderMap& trailers) {
+Http::FilterTrailersStatus StreamHandleWrapperBase::onTrailers(Http::HeaderMap& trailers) {
   ASSERT(!end_stream_);
   end_stream_ = true;
   trailers_ = &trailers;
@@ -376,7 +375,7 @@ Http::FilterTrailersStatus StreamHandleWrapper::onTrailers(Http::HeaderMap& trai
   return status;
 }
 
-int StreamHandleWrapper::luaRespond(lua_State* state) {
+int StreamHandleWrapperBase::luaRespond(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (headers_continued_) {
@@ -407,10 +406,10 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
   return lua_yield(state, 0);
 }
 
-int StreamHandleWrapper::luaHttpCall(lua_State* state) {
+int StreamHandleWrapperBase::luaHttpCall(lua_State* state) {
   ASSERT(state_ == State::Running);
 
-  StreamHandleWrapper::HttpCallOptions options;
+  StreamHandleWrapperBase::HttpCallOptions options;
   options.request_options_
       .setParentSpan(callbacks_.activeSpan())
       // By default, do not enforce a sampling decision on this `httpCall`'s span.
@@ -439,7 +438,7 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   return doHttpCall(state, options);
 }
 
-int StreamHandleWrapper::doHttpCall(lua_State* state, const HttpCallOptions& options) {
+int StreamHandleWrapperBase::doHttpCall(lua_State* state, const HttpCallOptions& options) {
   if (options.is_async_request_) {
     makeHttpCall(state, filter_, options.request_options_, noopCallbacks());
     return 0;
@@ -457,8 +456,8 @@ int StreamHandleWrapper::doHttpCall(lua_State* state, const HttpCallOptions& opt
   }
 }
 
-void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
-                                    Http::ResponseMessagePtr&& response) {
+void StreamHandleWrapperBase::onSuccess(const Http::AsyncClient::Request&,
+                                        Http::ResponseMessagePtr&& response) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP response complete");
   http_request_ = nullptr;
@@ -539,8 +538,8 @@ void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
   }
 }
 
-void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
-                                    Http::AsyncClient::FailureReason) {
+void StreamHandleWrapperBase::onFailure(const Http::AsyncClient::Request& request,
+                                        Http::AsyncClient::FailureReason) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP failure");
 
@@ -553,7 +552,7 @@ void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
   onSuccess(request, std::move(response_message));
 }
 
-int StreamHandleWrapper::luaHeaders(lua_State* state) {
+int StreamHandleWrapperBase::luaHeaders(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (headers_wrapper_.get() != nullptr) {
@@ -579,7 +578,7 @@ int StreamHandleWrapper::luaHeaders(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaBody(lua_State* state) {
+int StreamHandleWrapperBase::luaBody(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   bool always_wrap_body = false;
@@ -624,7 +623,7 @@ int StreamHandleWrapper::luaBody(lua_State* state) {
   }
 }
 
-int StreamHandleWrapper::luaBodyChunks(lua_State* state) {
+int StreamHandleWrapperBase::luaBodyChunks(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (saw_body_) {
@@ -632,11 +631,11 @@ int StreamHandleWrapper::luaBodyChunks(lua_State* state) {
   }
 
   // We are currently at the top of the stack. Push a closure that has us as the upvalue.
-  lua_pushcclosure(state, static_luaBodyIterator, 1);
+  lua_pushcclosure(state, bodyIteratorFn(), 1);
   return 1;
 }
 
-int StreamHandleWrapper::luaBodyIterator(lua_State* state) {
+int StreamHandleWrapperBase::luaBodyIterator(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (end_stream_) {
@@ -649,7 +648,7 @@ int StreamHandleWrapper::luaBodyIterator(lua_State* state) {
   }
 }
 
-int StreamHandleWrapper::luaTrailers(lua_State* state) {
+int StreamHandleWrapperBase::luaTrailers(lua_State* state) {
   ASSERT(state_ == State::Running);
 
   if (end_stream_ && trailers_ == nullptr) {
@@ -670,7 +669,7 @@ int StreamHandleWrapper::luaTrailers(lua_State* state) {
   }
 }
 
-int StreamHandleWrapper::luaMetadata(lua_State* state) {
+int StreamHandleWrapperBase::luaMetadata(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (metadata_wrapper_.get() != nullptr) {
     metadata_wrapper_.pushStack();
@@ -681,7 +680,7 @@ int StreamHandleWrapper::luaMetadata(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaVirtualHost(lua_State* state) {
+int StreamHandleWrapperBase::luaVirtualHost(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (virtual_host_wrapper_.get() != nullptr) {
     virtual_host_wrapper_.pushStack();
@@ -693,7 +692,7 @@ int StreamHandleWrapper::luaVirtualHost(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaRoute(lua_State* state) {
+int StreamHandleWrapperBase::luaRoute(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (route_wrapper_.get() != nullptr) {
     route_wrapper_.pushStack();
@@ -704,7 +703,7 @@ int StreamHandleWrapper::luaRoute(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaStreamInfo(lua_State* state) {
+int StreamHandleWrapperBase::luaStreamInfo(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (stream_info_wrapper_.get() != nullptr) {
     stream_info_wrapper_.pushStack();
@@ -714,7 +713,7 @@ int StreamHandleWrapper::luaStreamInfo(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaConnectionStreamInfo(lua_State* state) {
+int StreamHandleWrapperBase::luaConnectionStreamInfo(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (connection_stream_info_wrapper_.get() != nullptr) {
     connection_stream_info_wrapper_.pushStack();
@@ -725,7 +724,7 @@ int StreamHandleWrapper::luaConnectionStreamInfo(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaConnection(lua_State* state) {
+int StreamHandleWrapperBase::luaConnection(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (connection_wrapper_.get() != nullptr) {
     connection_wrapper_.pushStack();
@@ -736,7 +735,7 @@ int StreamHandleWrapper::luaConnection(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
+int StreamHandleWrapperBase::luaVerifySignature(lua_State* state) {
   // Step 1: Get hash function.
   absl::string_view hash = luaL_checkstring(state, 2);
 
@@ -771,7 +770,7 @@ int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
   return 2;
 }
 
-int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
+int StreamHandleWrapperBase::luaImportPublicKey(lua_State* state) {
   // Get byte array and the length.
   const char* str = luaL_checkstring(state, 2);
   int n = luaL_checknumber(state, 3);
@@ -802,7 +801,7 @@ int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaBase64Escape(lua_State* state) {
+int StreamHandleWrapperBase::luaBase64Escape(lua_State* state) {
   absl::string_view input = Filters::Common::Lua::getStringViewFromLuaString(state, 2);
   auto output = absl::Base64Escape(input);
   lua_pushlstring(state, output.data(), output.size());
@@ -810,7 +809,7 @@ int StreamHandleWrapper::luaBase64Escape(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaTimestamp(lua_State* state) {
+int StreamHandleWrapperBase::luaTimestamp(lua_State* state) {
   auto now = time_source_.systemTime().time_since_epoch();
 
   absl::string_view unit_parameter = luaL_optstring(state, 2, "");
@@ -831,7 +830,7 @@ int StreamHandleWrapper::luaTimestamp(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaTimestampString(lua_State* state) {
+int StreamHandleWrapperBase::luaTimestampString(lua_State* state) {
   auto now = time_source_.systemTime().time_since_epoch();
 
   absl::string_view unit_parameter = luaL_optstring(state, 2, "");
@@ -853,7 +852,7 @@ int StreamHandleWrapper::luaTimestampString(lua_State* state) {
 }
 
 enum Timestamp::Resolution
-StreamHandleWrapper::getTimestampResolution(absl::string_view unit_parameter) {
+StreamHandleWrapperBase::getTimestampResolution(absl::string_view unit_parameter) {
   auto resolution = Timestamp::Resolution::Undefined;
 
   absl::uint128 resolution_as_int_from_state = 0;
@@ -941,9 +940,11 @@ void Filter::onDestroy() {
   }
 }
 
+template <typename Wrapper>
 Http::FilterHeadersStatus
-Filter::doHeaders(StreamHandleRef& handle, Filters::Common::Lua::CoroutinePtr& coroutine,
-                  FilterCallbacks& callbacks, int function_ref, PerLuaCodeSetup* setup,
+Filter::doHeaders(Filters::Common::Lua::LuaDeathRef<Wrapper>& handle,
+                  Filters::Common::Lua::CoroutinePtr& coroutine, FilterCallbacks& callbacks,
+                  int function_ref, PerLuaCodeSetup* setup,
                   Http::RequestOrResponseHeaderMap& headers, bool end_stream) {
   if (function_ref == LUA_REFNIL) {
     return Http::FilterHeadersStatus::Continue;
@@ -951,8 +952,8 @@ Filter::doHeaders(StreamHandleRef& handle, Filters::Common::Lua::CoroutinePtr& c
   ASSERT(setup);
   coroutine = setup->createCoroutine();
 
-  handle.reset(StreamHandleWrapper::create(coroutine->luaState(), *coroutine, headers, end_stream,
-                                           *this, callbacks, time_source_),
+  handle.reset(Wrapper::create(coroutine->luaState(), *coroutine, headers, end_stream, *this,
+                               callbacks, time_source_),
                true);
 
   // The counter will increment twice if the supplied script has both request and response
@@ -971,8 +972,9 @@ Filter::doHeaders(StreamHandleRef& handle, Filters::Common::Lua::CoroutinePtr& c
   return status;
 }
 
-Http::FilterDataStatus Filter::doData(StreamHandleRef& handle, Buffer::Instance& data,
-                                      bool end_stream) {
+template <typename Wrapper>
+Http::FilterDataStatus Filter::doData(Filters::Common::Lua::LuaDeathRef<Wrapper>& handle,
+                                      Buffer::Instance& data, bool end_stream) {
   Http::FilterDataStatus status = Http::FilterDataStatus::Continue;
   if (handle.get() != nullptr) {
     handle.markLive();
@@ -989,7 +991,9 @@ Http::FilterDataStatus Filter::doData(StreamHandleRef& handle, Buffer::Instance&
   return status;
 }
 
-Http::FilterTrailersStatus Filter::doTrailers(StreamHandleRef& handle, Http::HeaderMap& trailers) {
+template <typename Wrapper>
+Http::FilterTrailersStatus Filter::doTrailers(Filters::Common::Lua::LuaDeathRef<Wrapper>& handle,
+                                              Http::HeaderMap& trailers) {
   Http::FilterTrailersStatus status = Http::FilterTrailersStatus::Continue;
   if (handle.get() != nullptr) {
     handle.markLive();
@@ -1006,6 +1010,24 @@ Http::FilterTrailersStatus Filter::doTrailers(StreamHandleRef& handle, Http::Hea
   return status;
 }
 
+// Explicit instantiations to avoid linker errors (templates defined in .cc).
+template Http::FilterHeadersStatus Filter::doHeaders<RequestStreamHandleWrapper>(
+    Filters::Common::Lua::LuaDeathRef<RequestStreamHandleWrapper>&,
+    Filters::Common::Lua::CoroutinePtr&, FilterCallbacks&, int, PerLuaCodeSetup*,
+    Http::RequestOrResponseHeaderMap&, bool);
+template Http::FilterHeadersStatus Filter::doHeaders<ResponseStreamHandleWrapper>(
+    Filters::Common::Lua::LuaDeathRef<ResponseStreamHandleWrapper>&,
+    Filters::Common::Lua::CoroutinePtr&, FilterCallbacks&, int, PerLuaCodeSetup*,
+    Http::RequestOrResponseHeaderMap&, bool);
+template Http::FilterDataStatus Filter::doData<RequestStreamHandleWrapper>(
+    Filters::Common::Lua::LuaDeathRef<RequestStreamHandleWrapper>&, Buffer::Instance&, bool);
+template Http::FilterDataStatus Filter::doData<ResponseStreamHandleWrapper>(
+    Filters::Common::Lua::LuaDeathRef<ResponseStreamHandleWrapper>&, Buffer::Instance&, bool);
+template Http::FilterTrailersStatus Filter::doTrailers<RequestStreamHandleWrapper>(
+    Filters::Common::Lua::LuaDeathRef<RequestStreamHandleWrapper>&, Http::HeaderMap&);
+template Http::FilterTrailersStatus Filter::doTrailers<ResponseStreamHandleWrapper>(
+    Filters::Common::Lua::LuaDeathRef<ResponseStreamHandleWrapper>&, Http::HeaderMap&);
+
 void Filter::scriptError(const absl::Status& status) {
   stats_.errors_.inc();
   scriptLog(spdlog::level::err, status.message());
@@ -1013,7 +1035,7 @@ void Filter::scriptError(const absl::Status& status) {
   response_stream_wrapper_.reset();
 }
 
-int StreamHandleWrapper::luaSetUpstreamOverrideHost(lua_State* state) {
+int StreamHandleWrapperBase::luaSetUpstreamOverrideHost(lua_State* state) {
   // Get the host address argument
   size_t len;
   const char* host = luaL_checklstring(state, 2, &len);
@@ -1039,12 +1061,12 @@ int StreamHandleWrapper::luaSetUpstreamOverrideHost(lua_State* state) {
   return 0;
 }
 
-int StreamHandleWrapper::luaClearRouteCache(lua_State*) {
+int StreamHandleWrapperBase::luaClearRouteCache(lua_State*) {
   callbacks_.clearRouteCache();
   return 0;
 }
 
-int StreamHandleWrapper::luaFilterContext(lua_State* state) {
+int StreamHandleWrapperBase::luaFilterContext(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (filter_context_wrapper_.get() != nullptr) {
     filter_context_wrapper_.pushStack();
@@ -1055,7 +1077,7 @@ int StreamHandleWrapper::luaFilterContext(lua_State* state) {
   return 1;
 }
 
-int StreamHandleWrapper::luaStats(lua_State* state) {
+int StreamHandleWrapperBase::luaStats(lua_State* state) {
   ASSERT(state_ == State::Running);
   if (stats_scope_wrapper_.get() != nullptr) {
     stats_scope_wrapper_.pushStack();

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -157,11 +157,17 @@ public:
 class Filter;
 
 /**
- * A wrapper for a currently running request/response. This is the primary handle passed to Lua.
- * The script interacts with Envoy entirely through this handle.
+ * Base class for request and response stream handle wrappers. Contains all state and Lua function
+ * implementations shared between the two paths. Not a BaseLuaObject itself — the concrete
+ * subclasses RequestStreamHandleWrapper and ResponseStreamHandleWrapper provide the Lua type
+ * identity and exported function tables.
  */
-class StreamHandleWrapper : public Filters::Common::Lua::BaseLuaObject<StreamHandleWrapper>,
-                            public Http::AsyncClient::Callbacks {
+class StreamHandleWrapperBase : public Http::AsyncClient::Callbacks,
+                                public Filters::Common::Lua::LuaLoggable {
+  // NOTE: BaseLuaObject also derives from LuaLoggable, so a concrete leaf reaches it by two
+  // equal-length paths. That is harmless while only this class logs -- ENVOY_LOG and scriptLog()
+  // resolve within whichever scope names them. Logging from a leaf instead needs an explicit
+  // base, since the unqualified name is ambiguous there.
 public:
   /**
    * The state machine for a stream handler. In the current implementation everything the filter
@@ -191,9 +197,9 @@ public:
     bool return_duplicate_headers_{false};
   };
 
-  StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
-                      Http::RequestOrResponseHeaderMap& headers, bool end_stream, Filter& filter,
-                      FilterCallbacks& callbacks, TimeSource& time_source);
+  StreamHandleWrapperBase(Filters::Common::Lua::Coroutine& coroutine,
+                          Http::RequestOrResponseHeaderMap& headers, bool end_stream,
+                          Filter& filter, FilterCallbacks& callbacks, TimeSource& time_source);
 
   Http::FilterHeadersStatus start(int function_ref);
   Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream);
@@ -210,6 +216,299 @@ public:
     }
     on_reset_called_ = true;
   }
+
+protected:
+  /**
+   * Perform an HTTP call to an upstream host.
+   * @param 1 (string): The name of the upstream cluster to call. This cluster must be configured.
+   * @param 2 (table): A table of HTTP headers. :method, :path, and :authority must be defined.
+   * @param 3 (string): Body. Can be nil.
+   * @param 4 (int): Timeout in milliseconds for the call.
+   * @param 5 (bool): Optional flag. If true, filter continues without waiting for HTTP response
+   * from upstream service. False/synchronous by default.
+   * @return headers (table), body (string/nil)
+   */
+  int luaHttpCall(lua_State* state);
+
+  /**
+   * Perform an inline response. This call is currently only valid on the request path. Further
+   * filter iteration will stop. No further script code will run after this call.
+   * @param 1 (table): A table of HTTP headers. :status must be defined.
+   * @param 2 (string): Body. Can be nil.
+   */
+  int luaRespond(lua_State* state);
+
+  /**
+   * @return a handle to the headers.
+   */
+  int luaHeaders(lua_State* state);
+
+  /**
+   * @return a handle to the full body or nil if there is no body. This call will cause the script
+   *         to yield until the entire body is received (or if there is no body will return nil
+   *         right away).
+   *         NOTE: This call causes Envoy to buffer the body. The max buffer size is configured
+   *         based on the currently active flow control settings.
+   */
+  int luaBody(lua_State* state);
+
+  /**
+   * @return an iterator that allows the script to iterate through all body chunks as they are
+   *         received. The iterator will yield between body chunks. Envoy *will not* buffer
+   *         the body chunks in this case, but the script can look at them as they go by.
+   */
+  int luaBodyChunks(lua_State* state);
+
+  /**
+   * @return a handle to the trailers or nil if there are no trailers. This call will cause the
+   *         script to yield if Envoy does not yet know if there are trailers or not.
+   */
+  int luaTrailers(lua_State* state);
+
+  /**
+   * @return a handle to the metadata.
+   */
+  int luaMetadata(lua_State* state);
+
+  /**
+   * @return a handle to the stream info.
+   */
+  int luaStreamInfo(lua_State* state);
+
+  /**
+   * @return a handle to the network connection.
+   */
+  int luaConnection(lua_State* state);
+
+  /**
+   * @return a handle to the network connection's stream info.
+   */
+  int luaConnectionStreamInfo(lua_State* state);
+
+  /**
+   * Verify cryptographic signatures.
+   * @param 1 (string) hash function(including SHA1, SHA224, SHA256, SHA384, SHA512)
+   * @param 2 (void*)  pointer to public key
+   * @param 3 (string) signature
+   * @param 4 (int)    length of signature
+   * @param 5 (string) clear text
+   * @param 6 (int)    length of clear text
+   * @return (bool, string) If the first element is true, the second element is empty; otherwise,
+   * the second element stores the error message
+   */
+  int luaVerifySignature(lua_State* state);
+
+  /**
+   * Import public key.
+   * @param 1 (string) keyder string
+   * @param 2 (int)    length of keyder string
+   * @return pointer to public key
+   */
+  int luaImportPublicKey(lua_State* state);
+
+  /**
+   * This is the body iterator invoked by the closure returned from luaBodyChunks().
+   */
+  int luaBodyIterator(lua_State* state);
+
+  /**
+   * Returns the concrete type's static body iterator function pointer, used by luaBodyChunks()
+   * to push the closure. Implemented by each concrete subclass via FORWARD_LUA_CLOSURE.
+   */
+  virtual lua_CFunction bodyIteratorFn() const = 0;
+
+  /**
+   * Mark this object as live (callable). Delegates to BaseLuaObject<T>::markLive() on the
+   * concrete subclass.
+   */
+  virtual void markLive() = 0;
+
+  /**
+   * Mark this object as dead (not callable). Delegates to BaseLuaObject<T>::markDead() on the
+   * concrete subclass.
+   */
+  virtual void markDead() = 0;
+
+  /**
+   * Base64 escape a string.
+   * @param1 (string) string to be base64 escaped.
+   * @return (string) base64 escaped string.
+   */
+  int luaBase64Escape(lua_State* state);
+
+  /**
+   * Timestamp.
+   * @param1 (string) optional format (e.g. milliseconds_from_epoch, nanoseconds_from_epoch).
+   * Defaults to milliseconds_from_epoch.
+   * @return timestamp
+   */
+  int luaTimestamp(lua_State* state);
+
+  /**
+   * TimestampString.
+   * @param1 (string) optional format (e.g. milliseconds_from_epoch, microseconds_from_epoch).
+   * Defaults to milliseconds_from_epoch.
+   * @return (string) timestamp.
+   */
+  int luaTimestampString(lua_State* state);
+
+  /**
+   * Set the upstream override host.
+   * @param 1 (string): The host address to override with.
+   * @param 2 (bool): Optional strict flag. Defaults to false.
+   */
+  int luaSetUpstreamOverrideHost(lua_State* state);
+
+  /**
+   * Clear the route cache explicitly.
+   */
+  int luaClearRouteCache(lua_State* state);
+
+  /**
+   * Get the filter context.
+   */
+  int luaFilterContext(lua_State* state);
+
+  /**
+   * @return a handle to the virtual host.
+   */
+  int luaVirtualHost(lua_State* state);
+
+  /**
+   * @return a handle to the route.
+   */
+  int luaRoute(lua_State* state);
+
+  /**
+   * @return a handle to the stats scope for creating custom stats.
+   */
+  int luaStats(lua_State* state);
+
+  enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
+
+  int doHttpCall(lua_State* state, const HttpCallOptions& options);
+
+  // Resumes the coroutine only if it is safe to do so. Returns the coroutine execution status;
+  // OK when resumption was skipped because the stream was reset.
+  absl::Status resumeCoroutine(int num_args,
+                               const Filters::Common::Lua::YieldCallback& yield_callback) {
+    if (!on_reset_called_) {
+      return coroutine_.resume(num_args, yield_callback);
+    }
+    return absl::OkStatus();
+  }
+
+  // Http::AsyncClient::Callbacks
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override;
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override;
+  void onBeforeFinalizeUpstreamSpan(Tracing::Span&, const Http::ResponseHeaderMap*) override {}
+
+  // Coroutine resumption MUST use resumeCoroutine.
+  Filters::Common::Lua::Coroutine& coroutine_;
+  Http::RequestOrResponseHeaderMap& headers_;
+  bool end_stream_;
+  bool headers_continued_{};
+  bool buffered_body_{};
+  bool saw_body_{};
+  bool return_duplicate_headers_{};
+  bool on_reset_called_{};
+  Filter& filter_;
+  FilterCallbacks& callbacks_;
+  Http::HeaderMap* trailers_{};
+  // None of these wrappers survive a yield; onMarkDead() resets them all. The script can
+  // request them again across yields if needed.
+  Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> headers_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::BufferWrapper> body_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> trailers_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper>
+      filter_context_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> stream_info_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<ConnectionStreamInfoWrapper> connection_stream_info_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::ConnectionWrapper> connection_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<PublicKeyWrapper> public_key_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<VirtualHostWrapper> virtual_host_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<RouteWrapper> route_wrapper_;
+  Filters::Common::Lua::LuaDeathRef<StatsScopeWrapper> stats_scope_wrapper_;
+  State state_{State::Running};
+  Filters::Common::Lua::YieldCallback yield_callback_;
+  // Set by start()/onData()/onTrailers() from the coroutine execution status; checked by the
+  // Filter after those methods return.
+  absl::Status coroutine_status_{absl::OkStatus()};
+  Http::AsyncClient::Request* http_request_{};
+  TimeSource& time_source_;
+
+  // The inserted crypto object pointers will not be removed from this map.
+  absl::flat_hash_map<std::string, Envoy::Common::Crypto::PKeyObjectPtr> public_key_storage_;
+};
+
+/**
+ * CRTP glue between StreamHandleWrapperBase and a concrete leaf handle type.
+ *
+ * The base holds the state and every Lua method body but is deliberately not a BaseLuaObject,
+ * because a Lua metatable is registered per C++ type. This layer supplies, once, everything a
+ * leaf needs that has to be spelled in terms of the leaf's own type: the per-type static thunks,
+ * and the overrides that reach BaseLuaObject<T>. A leaf only declares which of those thunks it
+ * exports, which is what lets the two paths offer different APIs over one implementation.
+ */
+template <class T>
+class StreamHandleLeaf : public StreamHandleWrapperBase,
+                         public Filters::Common::Lua::BaseLuaObject<T> {
+public:
+  using StreamHandleWrapperBase::StreamHandleWrapperBase;
+
+  lua_CFunction bodyIteratorFn() const override { return static_luaBodyIterator; }
+  void markLive() override { Filters::Common::Lua::BaseLuaObject<T>::markLive(); }
+  void markDead() override { Filters::Common::Lua::BaseLuaObject<T>::markDead(); }
+
+protected:
+  // Filters::Common::Lua::BaseLuaObject
+  // Resets every LuaDeathRef declared in StreamHandleWrapperBase, for the reason given there.
+  void onMarkDead() override {
+    headers_wrapper_.reset();
+    body_wrapper_.reset();
+    trailers_wrapper_.reset();
+    metadata_wrapper_.reset();
+    filter_context_wrapper_.reset();
+    stream_info_wrapper_.reset();
+    connection_wrapper_.reset();
+    public_key_wrapper_.reset();
+    connection_stream_info_wrapper_.reset();
+    virtual_host_wrapper_.reset();
+    route_wrapper_.reset();
+    stats_scope_wrapper_.reset();
+  }
+
+  FORWARD_LUA_FUNCTION(T, luaHeaders)
+  FORWARD_LUA_FUNCTION(T, luaBody)
+  FORWARD_LUA_FUNCTION(T, luaBodyChunks)
+  FORWARD_LUA_FUNCTION(T, luaTrailers)
+  FORWARD_LUA_FUNCTION(T, luaMetadata)
+  FORWARD_LUA_FUNCTION(T, luaHttpCall)
+  FORWARD_LUA_FUNCTION(T, luaRespond)
+  FORWARD_LUA_FUNCTION(T, luaStreamInfo)
+  FORWARD_LUA_FUNCTION(T, luaConnection)
+  FORWARD_LUA_FUNCTION(T, luaImportPublicKey)
+  FORWARD_LUA_FUNCTION(T, luaVerifySignature)
+  FORWARD_LUA_FUNCTION(T, luaBase64Escape)
+  FORWARD_LUA_FUNCTION(T, luaTimestamp)
+  FORWARD_LUA_FUNCTION(T, luaTimestampString)
+  FORWARD_LUA_FUNCTION(T, luaConnectionStreamInfo)
+  FORWARD_LUA_FUNCTION(T, luaSetUpstreamOverrideHost)
+  FORWARD_LUA_FUNCTION(T, luaClearRouteCache)
+  FORWARD_LUA_FUNCTION(T, luaFilterContext)
+  FORWARD_LUA_FUNCTION(T, luaVirtualHost)
+  FORWARD_LUA_FUNCTION(T, luaRoute)
+  FORWARD_LUA_FUNCTION(T, luaStats)
+  FORWARD_LUA_CLOSURE(T, luaBodyIterator)
+};
+
+/**
+ * Lua handle passed to envoy_on_request. Exposes the request path API.
+ */
+class RequestStreamHandleWrapper : public StreamHandleLeaf<RequestStreamHandleWrapper> {
+public:
+  using StreamHandleLeaf<RequestStreamHandleWrapper>::StreamHandleLeaf;
 
   static ExportedFunctions exportedFunctions() {
     return {{"headers", static_luaHeaders},
@@ -234,228 +533,40 @@ public:
             {"route", static_luaRoute},
             {"stats", static_luaStats}};
   }
+};
 
-private:
-  /**
-   * Perform an HTTP call to an upstream host.
-   * @param 1 (string): The name of the upstream cluster to call. This cluster must be configured.
-   * @param 2 (table): A table of HTTP headers. :method, :path, and :authority must be defined.
-   * @param 3 (string): Body. Can be nil.
-   * @param 4 (int): Timeout in milliseconds for the call.
-   * @param 5 (bool): Optional flag. If true, filter continues without waiting for HTTP response
-   * from upstream service. False/synchronous by default.
-   * @return headers (table), body (string/nil)
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaHttpCall);
+/**
+ * Lua handle passed to envoy_on_response. Exposes the same set of methods as the request handle.
+ * The two tables are identical today; they are separate types so that either path can gain or
+ * drop a method without disturbing the other.
+ */
+class ResponseStreamHandleWrapper : public StreamHandleLeaf<ResponseStreamHandleWrapper> {
+public:
+  using StreamHandleLeaf<ResponseStreamHandleWrapper>::StreamHandleLeaf;
 
-  /**
-   * Perform an inline response. This call is currently only valid on the request path. Further
-   * filter iteration will stop. No further script code will run after this call.
-   * @param 1 (table): A table of HTTP headers. :status must be defined.
-   * @param 2 (string): Body. Can be nil.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRespond);
-
-  /**
-   * @return a handle to the headers.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaHeaders);
-
-  /**
-   * @return a handle to the full body or nil if there is no body. This call will cause the script
-   *         to yield until the entire body is received (or if there is no body will return nil
-   *         right away).
-   *         NOTE: This call causes Envoy to buffer the body. The max buffer size is configured
-   *         based on the currently active flow control settings.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBody);
-
-  /**
-   * @return an iterator that allows the script to iterate through all body chunks as they are
-   *         received. The iterator will yield between body chunks. Envoy *will not* buffer
-   *         the body chunks in this case, but the script can look at them as they go by.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBodyChunks);
-
-  /**
-   * @return a handle to the trailers or nil if there are no trailers. This call will cause the
-   *         script to yield if Envoy does not yet know if there are trailers or not.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTrailers);
-
-  /**
-   * @return a handle to the metadata.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaMetadata);
-
-  /**
-   * @return a handle to the stream info.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaStreamInfo);
-
-  /**
-   * @return a handle to the network connection.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnection);
-
-  /**
-   * @return a handle to the network connection's stream info.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaConnectionStreamInfo);
-
-  /**
-   * Verify cryptographic signatures.
-   * @param 1 (string) hash function(including SHA1, SHA224, SHA256, SHA384, SHA512)
-   * @param 2 (void*)  pointer to public key
-   * @param 3 (string) signature
-   * @param 4 (int)    length of signature
-   * @param 5 (string) clear text
-   * @param 6 (int)    length of clear text
-   * @return (bool, string) If the first element is true, the second element is empty; otherwise,
-   * the second element stores the error message
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVerifySignature);
-
-  /**
-   * Import public key.
-   * @param 1 (string) keyder string
-   * @param 2 (int)    length of keyder string
-   * @return pointer to public key
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaImportPublicKey);
-
-  /**
-   * This is the closure/iterator returned by luaBodyChunks() above.
-   */
-  DECLARE_LUA_CLOSURE(StreamHandleWrapper, luaBodyIterator);
-
-  /**
-   * Base64 escape a string.
-   * @param1 (string) string to be base64 escaped.
-   * @return (string) base64 escaped string.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaBase64Escape);
-
-  /**
-   * Timestamp.
-   * @param1 (string) optional format (e.g. milliseconds_from_epoch, nanoseconds_from_epoch).
-   * Defaults to milliseconds_from_epoch.
-   * @return timestamp
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestamp);
-
-  /**
-   * TimestampString.
-   * @param1 (string) optional format (e.g. milliseconds_from_epoch, microseconds_from_epoch).
-   * Defaults to milliseconds_from_epoch.
-   * @return (string) timestamp.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaTimestampString);
-
-  /**
-   * Set the upstream override host.
-   * @param 1 (string): The host address to override with.
-   * @param 2 (bool): Optional strict flag. Defaults to false.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaSetUpstreamOverrideHost);
-
-  /**
-   * Clear the route cache explicitly.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaClearRouteCache);
-
-  /**
-   * Get the filter context.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaFilterContext);
-
-  /**
-   * @return a handle to the virtual host.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaVirtualHost);
-
-  /**
-   * @return a handle to the route.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaRoute);
-
-  /**
-   * @return a handle to the stats scope for creating custom stats.
-   */
-  DECLARE_LUA_FUNCTION(StreamHandleWrapper, luaStats);
-
-  enum Timestamp::Resolution getTimestampResolution(absl::string_view unit_parameter);
-
-  int doHttpCall(lua_State* state, const HttpCallOptions& options);
-
-  // Resumes the coroutine only if it is safe to do so. Returns the coroutine execution status;
-  // OK when resumption was skipped because the stream was reset.
-  absl::Status resumeCoroutine(int num_args,
-                               const Filters::Common::Lua::YieldCallback& yield_callback) {
-    if (!on_reset_called_) {
-      return coroutine_.resume(num_args, yield_callback);
-    }
-    return absl::OkStatus();
+  static ExportedFunctions exportedFunctions() {
+    return {{"headers", static_luaHeaders},
+            {"body", static_luaBody},
+            {"bodyChunks", static_luaBodyChunks},
+            {"trailers", static_luaTrailers},
+            {"metadata", static_luaMetadata},
+            {"httpCall", static_luaHttpCall},
+            {"respond", static_luaRespond},
+            {"streamInfo", static_luaStreamInfo},
+            {"connection", static_luaConnection},
+            {"importPublicKey", static_luaImportPublicKey},
+            {"verifySignature", static_luaVerifySignature},
+            {"base64Escape", static_luaBase64Escape},
+            {"timestamp", static_luaTimestamp},
+            {"timestampString", static_luaTimestampString},
+            {"connectionStreamInfo", static_luaConnectionStreamInfo},
+            {"setUpstreamOverrideHost", static_luaSetUpstreamOverrideHost},
+            {"clearRouteCache", static_luaClearRouteCache},
+            {"filterContext", static_luaFilterContext},
+            {"virtualHost", static_luaVirtualHost},
+            {"route", static_luaRoute},
+            {"stats", static_luaStats}};
   }
-
-  // Filters::Common::Lua::BaseLuaObject
-  void onMarkDead() override {
-    // Headers/body/trailers wrappers do not survive any yields. The user can request them
-    // again across yields if needed.
-    headers_wrapper_.reset();
-    body_wrapper_.reset();
-    trailers_wrapper_.reset();
-    metadata_wrapper_.reset();
-    filter_context_wrapper_.reset();
-    stream_info_wrapper_.reset();
-    connection_wrapper_.reset();
-    public_key_wrapper_.reset();
-    connection_stream_info_wrapper_.reset();
-    virtual_host_wrapper_.reset();
-    route_wrapper_.reset();
-    stats_scope_wrapper_.reset();
-  }
-
-  // Http::AsyncClient::Callbacks
-  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override;
-  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override;
-  void onBeforeFinalizeUpstreamSpan(Tracing::Span&, const Http::ResponseHeaderMap*) override {}
-
-  // Coroutine resumption MUST use resumeCoroutine.
-  Filters::Common::Lua::Coroutine& coroutine_;
-  Http::RequestOrResponseHeaderMap& headers_;
-  bool end_stream_;
-  bool headers_continued_{};
-  bool buffered_body_{};
-  bool saw_body_{};
-  bool return_duplicate_headers_{};
-  bool on_reset_called_{};
-  Filter& filter_;
-  FilterCallbacks& callbacks_;
-  Http::HeaderMap* trailers_{};
-  Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> headers_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::BufferWrapper> body_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<HeaderMapWrapper> trailers_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper> metadata_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::MetadataMapWrapper>
-      filter_context_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<StreamInfoWrapper> stream_info_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<ConnectionStreamInfoWrapper> connection_stream_info_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<Filters::Common::Lua::ConnectionWrapper> connection_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<PublicKeyWrapper> public_key_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<VirtualHostWrapper> virtual_host_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<RouteWrapper> route_wrapper_;
-  Filters::Common::Lua::LuaDeathRef<StatsScopeWrapper> stats_scope_wrapper_;
-  State state_{State::Running};
-  Filters::Common::Lua::YieldCallback yield_callback_;
-  // Set by start()/onData()/onTrailers() from the coroutine execution status; checked by the
-  // Filter after those methods return.
-  absl::Status coroutine_status_{absl::OkStatus()};
-  Http::AsyncClient::Request* http_request_{};
-  TimeSource& time_source_;
-
-  // The inserted crypto object pointers will not be removed from this map.
-  absl::flat_hash_map<std::string, Envoy::Common::Crypto::PKeyObjectPtr> public_key_storage_;
 };
 
 /**
@@ -671,7 +782,8 @@ private:
     Http::StreamEncoderFilterCallbacks* callbacks_{};
   };
 
-  using StreamHandleRef = Filters::Common::Lua::LuaDeathRef<StreamHandleWrapper>;
+  using RequestStreamHandleRef = Filters::Common::Lua::LuaDeathRef<RequestStreamHandleWrapper>;
+  using ResponseStreamHandleRef = Filters::Common::Lua::LuaDeathRef<ResponseStreamHandleWrapper>;
 
   PerLuaCodeSetup* getPerLuaCodeSetup() {
     if (decoder_callbacks_.callbacks_ != nullptr) {
@@ -702,13 +814,20 @@ private:
                                         : per_route_config_->filterContext();
   }
 
-  Http::FilterHeadersStatus doHeaders(StreamHandleRef& handle,
+  template <typename Wrapper>
+  Http::FilterHeadersStatus doHeaders(Filters::Common::Lua::LuaDeathRef<Wrapper>& handle,
                                       Filters::Common::Lua::CoroutinePtr& coroutine,
                                       FilterCallbacks& callbacks, int function_ref,
                                       PerLuaCodeSetup* setup,
                                       Http::RequestOrResponseHeaderMap& headers, bool end_stream);
-  Http::FilterDataStatus doData(StreamHandleRef& handle, Buffer::Instance& data, bool end_stream);
-  Http::FilterTrailersStatus doTrailers(StreamHandleRef& handle, Http::HeaderMap& trailers);
+
+  template <typename Wrapper>
+  Http::FilterDataStatus doData(Filters::Common::Lua::LuaDeathRef<Wrapper>& handle,
+                                Buffer::Instance& data, bool end_stream);
+
+  template <typename Wrapper>
+  Http::FilterTrailersStatus doTrailers(Filters::Common::Lua::LuaDeathRef<Wrapper>& handle,
+                                        Http::HeaderMap& trailers);
 
   FilterConfigConstSharedPtr config_;
   const FilterConfigPerRoute* per_route_config_{};
@@ -733,8 +852,8 @@ private:
 
   DecoderCallbacks decoder_callbacks_{*this};
   EncoderCallbacks encoder_callbacks_{*this};
-  StreamHandleRef request_stream_wrapper_;
-  StreamHandleRef response_stream_wrapper_;
+  RequestStreamHandleRef request_stream_wrapper_;
+  ResponseStreamHandleRef response_stream_wrapper_;
   bool destroyed_{};
 };
 


### PR DESCRIPTION
Groundwork for #44594. Both Lua paths share one `StreamHandleWrapper` and therefore one exported-function table, so a method added for `envoy_on_response` shows up on `envoy_on_request` too. This splits the type so each path has a table of its own, and does nothing else.

`StreamHandleWrapperBase` keeps all the state and every Lua function body. A CRTP layer `StreamHandleLeaf<T>` holds what has to be spelled in terms of the leaf's own type — the static thunks and the overrides reaching `BaseLuaObject<T>` — so each leaf is just its `exportedFunctions()`. `Filter::doHeaders` picks up a template parameter for the handle type and is otherwise the function it was.

The two new macros are in `common/lua/lua.h` rather than local to this filter because there's a second consumer: #44594 applies the same base-plus-leaves shape to `HeaderMapWrapper` in `http/lua/wrappers.h`. Rather than copy `DECLARE_LUA_FUNCTION_EX`'s thunk body a second time, I split it — `FORWARD_LUA_FUNCTION_EX` is the thunk, `DECLARE_LUA_FUNCTION_EX` is that plus the declaration. Same tokens reach the compiler.

No behavior change, including the ugly corner: both leaves still export `respond`, so calling it from `envoy_on_response` keeps failing with `respond not currently supported in the response path` rather than becoming a missing-method error. Whether the response handle *should* advertise a method it refuses is a real question, and a separate one.

## Test Plan
- `bazel test //test/extensions/filters/http/lua:lua_filter_test //test/extensions/filters/http/lua:wrappers_test`
- No test changes: `lua_filter_test` drives everything through `Filter`'s public decode/encode API rather than naming the wrapper types.
- Checked mechanically: 26 of the 29 comparable method bodies are byte-identical to their originals, `doHeaders`'s is token-identical modulo `Wrapper::create`, and both leaves' tables match main's single 21-entry table.

Risk Level: low, no behavior change
Testing: existing lua_filter_test and wrappers_test
Docs Changes: none
Release Notes: none
Platform Specific Features: none
