### PR TITLE
lua: reuse a coroutine's thread instead of allocating one per handler

### DIFF
--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -42,25 +42,57 @@ void LuaLoggable::scriptLog(spdlog::level::level_enum level, absl::string_view m
   }
 }
 
-Coroutine::Coroutine(const std::pair<lua_State*, lua_State*>& new_thread_state)
-    : coroutine_state_(new_thread_state, false) {}
+Coroutine::Pool::Thread Coroutine::Pool::acquire() {
+  if (!idle_.empty()) {
+    const Thread thread = idle_.back();
+    idle_.pop_back();
+    return thread;
+  }
+
+  lua_State* state = lua_newthread(parent_state_);
+  // luaL_ref() pops the new thread and hands back a registry reference to it.
+  const int ref = luaL_ref(parent_state_, LUA_REGISTRYINDEX);
+  ASSERT(ref != LUA_REFNIL);
+  return {ref, state};
+}
+
+void Coroutine::Pool::release(Thread thread, bool reusable) {
+  if (reusable && idle_.size() < MaxSize) {
+    // Drop whatever the body left behind, so the next user starts from an empty stack and nothing
+    // the last request touched stays reachable through this thread.
+    lua_settop(thread.state, 0);
+    idle_.push_back(thread);
+    return;
+  }
+
+  luaL_unref(parent_state_, LUA_REGISTRYINDEX, thread.ref);
+}
+
+Coroutine::Coroutine(Pool::Thread thread, Pool& pool) : thread_(thread), pool_(pool) {}
+
+Coroutine::~Coroutine() {
+  // A thread that never started is pristine, and one that finished cleanly can start a fresh
+  // body. Errored cannot be resumed at all, and Yielded would resume the body it was in the
+  // middle of.
+  pool_.release(thread_, state_ == State::NotStarted || state_ == State::Finished);
+}
 
 absl::Status Coroutine::start(int function_ref, int num_args, const YieldCallback& yield_callback) {
   ASSERT(state_ == State::NotStarted);
 
   state_ = State::Yielded;
-  lua_rawgeti(coroutine_state_.get(), LUA_REGISTRYINDEX, function_ref);
-  ASSERT(lua_isfunction(coroutine_state_.get(), -1));
+  lua_rawgeti(thread_.state, LUA_REGISTRYINDEX, function_ref);
+  ASSERT(lua_isfunction(thread_.state, -1));
 
   // The function needs to come before the arguments but the arguments are already on the stack,
   // so we need to move it into position.
-  lua_insert(coroutine_state_.get(), -(num_args + 1));
+  lua_insert(thread_.state, -(num_args + 1));
   return resume(num_args, yield_callback);
 }
 
 absl::Status Coroutine::resume(int num_args, const YieldCallback& yield_callback) {
   ASSERT(state_ == State::Yielded);
-  int rc = lua_resume(coroutine_state_.get(), num_args);
+  int rc = lua_resume(thread_.state, num_args);
 
   if (0 == rc) {
     state_ = State::Finished;
@@ -71,8 +103,8 @@ absl::Status Coroutine::resume(int num_args, const YieldCallback& yield_callback
     ENVOY_LOG(debug, "coroutine yielded");
     return yield_callback();
   } else {
-    state_ = State::Finished;
-    const char* error = lua_tostring(coroutine_state_.get(), -1);
+    state_ = State::Errored;
+    const char* error = lua_tostring(thread_.state, -1);
     if (!error) {
       error = "unspecified lua error";
     }
@@ -125,8 +157,8 @@ uint64_t ThreadLocalState::registerGlobal(const std::string& global,
 }
 
 CoroutinePtr ThreadLocalState::createCoroutine() {
-  lua_State* state = tlsState().get();
-  return std::make_unique<Coroutine>(std::make_pair(lua_newthread(state), state));
+  Coroutine::Pool& pool = (*tls_slot_)->coroutine_pool_;
+  return std::make_unique<Coroutine>(pool.acquire(), pool);
 }
 
 ThreadLocalState::LuaThreadLocal::LuaThreadLocal(const std::string& code)

--- a/source/extensions/filters/common/lua/lua.cc
+++ b/source/extensions/filters/common/lua/lua.cc
@@ -72,7 +72,7 @@ Coroutine::Coroutine(Pool::Thread thread, Pool& pool) : thread_(thread), pool_(p
 
 Coroutine::~Coroutine() {
   // A thread that never started is pristine, and one that finished cleanly can start a fresh
-  // body. Errored cannot be resumed at all, and Yielded would resume the body it was in the
+  // body. `Errored` cannot be resumed at all, and `Yielded` would resume the body it was in the
   // middle of.
   pool_.release(thread_, state_ == State::NotStarted || state_ == State::Finished);
 }

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -431,13 +431,68 @@ using YieldCallback = std::function<absl::Status()>;
 /**
  * This is a wrapper for a Lua coroutine. Lua intermixes coroutine and "thread." Lua does not have
  * real threads, only cooperatively scheduled coroutines.
+ *
+ * A coroutine that ran to completion can be used again for an unrelated body. The interpreter's
+ * "cannot resume dead coroutine" rule lives in the coroutine library, not in lua_resume(), which
+ * accepts any thread with no active C frame and a status of OK or YIELD and starts it at the
+ * function on the bottom of its stack -- which is exactly how this class starts a brand new
+ * thread. So on destruction a reusable thread goes back to a pool held by the state it came from,
+ * rather than being released and rebuilt per handler per request. The destructor says which
+ * threads qualify, and Pool::release() what happens to the rest.
  */
 class Coroutine : Logger::Loggable<Logger::Id::lua> {
 public:
-  enum class State { NotStarted, Yielded, Finished };
+  /**
+   * Idle coroutine threads belonging to one Lua state, one pool per worker. Owns the registry
+   * references that keep the collector away from the threads while they wait.
+   */
+  class Pool {
+  public:
+    // Bounds retention. The pool only ever holds threads that are idle, so its natural size is
+    // the peak number of concurrent streams on this worker; the cap stops a burst from pinning
+    // that many threads for the life of the worker. It bounds the count, not the memory: LuaJIT
+    // shrinks an idle thread's stack when it traverses it, so a thread that once ran a
+    // stack-hungry script does not go on holding that stack here.
+    static constexpr size_t MaxSize = 256;
 
-  Coroutine(const std::pair<lua_State*, lua_State*>& new_thread_state);
-  lua_State* luaState() { return coroutine_state_.get(); }
+    struct Thread {
+      int ref;
+      // Held alongside the reference so that reusing a thread costs no Lua C API calls at all.
+      // The reference is what keeps the thread reachable while it waits here, and LuaJIT's
+      // collector does not move objects, so this cannot go stale.
+      lua_State* state;
+    };
+
+    explicit Pool(lua_State* parent_state) : parent_state_(parent_state) {}
+
+    // An idle thread, or a fresh one referenced from the parent state's registry.
+    Thread acquire();
+
+    // Takes a thread back. A reusable one joins the idle list while there is room for it;
+    // anything else is unreferenced and left to the collector.
+    void release(Thread thread, bool reusable);
+
+  private:
+    // The state these threads were created on. Referencing and unreferencing both go through its
+    // registry.
+    lua_State* const parent_state_;
+    std::vector<Thread> idle_;
+  };
+
+  // Errored is terminal and distinct from Finished: such a thread cannot be resumed again at all.
+  enum class State { NotStarted, Yielded, Finished, Errored };
+
+  // `pool` is where this coroutine's thread is returned on destruction, and must outlive this
+  // object -- the same requirement the parent state has always had, since the destructor has
+  // always had to reach that state's registry.
+  Coroutine(Pool::Thread thread, Pool& pool);
+  ~Coroutine();
+
+  // Owns a thread it hands back on destruction, so it cannot be copied.
+  Coroutine(const Coroutine&) = delete;
+  Coroutine& operator=(const Coroutine&) = delete;
+
+  lua_State* luaState() { return thread_.state; }
   State state() { return state_; }
 
   /**
@@ -463,7 +518,8 @@ public:
   absl::Status resume(int num_args, const YieldCallback& yield_callback);
 
 private:
-  LuaRef<lua_State> coroutine_state_;
+  const Pool::Thread thread_;
+  Pool& pool_;
   State state_{State::NotStarted};
 };
 
@@ -531,6 +587,9 @@ private:
 
     CSmartPtr<lua_State, lua_close> state_;
     std::vector<int> global_slots_;
+    // Holds registry reference ids, so there is nothing to release here: lua_close() on state_
+    // frees the registry and every thread it was keeping alive.
+    Coroutine::Pool coroutine_pool_{state_.get()};
   };
 
   CSmartPtr<lua_State, lua_close>& tlsState() { return (*tls_slot_)->state_; }

--- a/source/extensions/filters/common/lua/lua.h
+++ b/source/extensions/filters/common/lua/lua.h
@@ -450,7 +450,7 @@ public:
   public:
     // Bounds retention. The pool only ever holds threads that are idle, so its natural size is
     // the peak number of concurrent streams on this worker; the cap stops a burst from pinning
-    // that many threads for the life of the worker. It bounds the count, not the memory: LuaJIT
+    // that many threads for the life of the worker. It bounds the count, not the memory: `LuaJIT`
     // shrinks an idle thread's stack when it traverses it, so a thread that once ran a
     // stack-hungry script does not go on holding that stack here.
     static constexpr size_t MaxSize = 256;
@@ -458,7 +458,7 @@ public:
     struct Thread {
       int ref;
       // Held alongside the reference so that reusing a thread costs no Lua C API calls at all.
-      // The reference is what keeps the thread reachable while it waits here, and LuaJIT's
+      // The reference is what keeps the thread reachable while it waits here, and the `LuaJIT`
       // collector does not move objects, so this cannot go stale.
       lua_State* state;
     };
@@ -479,7 +479,8 @@ public:
     std::vector<Thread> idle_;
   };
 
-  // Errored is terminal and distinct from Finished: such a thread cannot be resumed again at all.
+  // `Errored` is terminal and distinct from `Finished`: such a thread cannot be resumed again
+  // at all.
   enum class State { NotStarted, Yielded, Finished, Errored };
 
   // `pool` is where this coroutine's thread is returned on destruction, and must outlive this

--- a/test/extensions/filters/common/lua/lua_test.cc
+++ b/test/extensions/filters/common/lua/lua_test.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 #include "source/common/thread_local/thread_local_impl.h"
 #include "source/extensions/filters/common/lua/lua.h"
@@ -9,9 +10,11 @@
 #include "test/test_common/thread_factory_for_test.h"
 #include "test/test_common/utility.h"
 
+#include "absl/container/flat_hash_set.h"
 #include "gmock/gmock.h"
 
 using testing::_;
+using testing::AnyNumber;
 using testing::InSequence;
 using testing::NiceMock;
 
@@ -52,6 +55,23 @@ public:
     state_ = std::make_unique<ThreadLocalState>(code, tls_, creation_status);
     THROW_IF_NOT_OK_REF(creation_status);
     state_->registerType<TestObject>();
+  }
+
+  // Runs a one-argument body on a fresh coroutine, expects it to complete, and returns the thread
+  // it used. The returned pointer is for identity comparison only -- the coroutine is destroyed on
+  // the way out, so the thread is back in the pool by the time the caller sees it.
+  //
+  // TestObject is a strict mock, so the object handed to the script gets an onDestroy() expectation
+  // with no count: when the collector takes it is not the point of any of these tests.
+  lua_State* expectCompletes(int function_ref) {
+    CoroutinePtr cr(state_->createCoroutine());
+    lua_State* thread = cr->luaState();
+    TestObject* object = TestObject::create(thread).first;
+    EXPECT_CALL(*object, onDestroy()).Times(AnyNumber());
+    EXPECT_CALL(*object, doTestCall(_));
+    EXPECT_TRUE(cr->start(function_ref, 1, yield_callback_).ok());
+    EXPECT_EQ(cr->state(), Coroutine::State::Finished);
+    return thread;
   }
 
   NiceMock<ThreadLocal::MockInstance> tls_;
@@ -110,6 +130,143 @@ TEST_F(LuaTest, EmptyError) {
   CoroutinePtr cr1(state_->createCoroutine());
   EXPECT_THAT(cr1->start(callMeRef, 0, yield_callback_),
               StatusHelpers::HasStatusMessage("unspecified lua error"));
+}
+
+// A coroutine that finished is reused for the next one. Without this test a pool that never hits
+// looks exactly like no pool at all, since the only observable difference is speed.
+TEST_F(LuaTest, FinishedCoroutineThreadIsReused) {
+  const std::string SCRIPT{R"EOF(
+    function callMe(object)
+      object:testCall()
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+  const int call_me_ref = state_->getGlobalRef(state_->registerGlobal("callMe", initializers_));
+  EXPECT_NE(LUA_REFNIL, call_me_ref);
+
+  EXPECT_EQ(expectCompletes(call_me_ref), expectCompletes(call_me_ref));
+}
+
+// Two coroutines alive at once get two threads, and both come back once they are done: the pool
+// has to be a pool rather than one cached thread.
+TEST_F(LuaTest, ConcurrentCoroutinesGetDistinctThreads) {
+  const std::string SCRIPT{R"EOF(
+    function callMe()
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+  const int call_me_ref = state_->getGlobalRef(state_->registerGlobal("callMe", initializers_));
+
+  std::vector<lua_State*> first_round;
+  {
+    CoroutinePtr a(state_->createCoroutine());
+    CoroutinePtr b(state_->createCoroutine());
+    EXPECT_NE(a->luaState(), b->luaState());
+    first_round = {a->luaState(), b->luaState()};
+    for (Coroutine* cr : {a.get(), b.get()}) {
+      EXPECT_TRUE(cr->start(call_me_ref, 0, yield_callback_).ok());
+    }
+  }
+
+  CoroutinePtr a(state_->createCoroutine());
+  CoroutinePtr b(state_->createCoroutine());
+  EXPECT_THAT(first_round, testing::UnorderedElementsAre(a->luaState(), b->luaState()));
+}
+
+// A coroutine whose body raised is not resumable, so it must not come back from the pool. Asserted
+// through behaviour rather than pointer identity, because a released thread's address can
+// legitimately be handed out again by the allocator.
+TEST_F(LuaTest, CoroutineAfterAnErrorStartsCleanly) {
+  const std::string SCRIPT{R"EOF(
+    function raises(object)
+      error("boom")
+    end
+    function callMe(object)
+      object:testCall()
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+  const int raises_ref = state_->getGlobalRef(state_->registerGlobal("raises", initializers_));
+  const int call_me_ref = state_->getGlobalRef(state_->registerGlobal("callMe", initializers_));
+
+  {
+    CoroutinePtr cr(state_->createCoroutine());
+    TestObject* object = TestObject::create(cr->luaState()).first;
+    EXPECT_CALL(*object, onDestroy()).Times(AnyNumber());
+    EXPECT_FALSE(cr->start(raises_ref, 1, yield_callback_).ok());
+  }
+
+  expectCompletes(call_me_ref);
+}
+
+// A coroutine abandoned mid-yield must not come back either: resuming it would continue the body
+// it was suspended in rather than start the new one.
+TEST_F(LuaTest, CoroutineAfterAnAbandonedYieldStartsCleanly) {
+  const std::string SCRIPT{R"EOF(
+    function yields(object)
+      coroutine.yield()
+      object:testCall()
+    end
+    function callMe(object)
+      object:testCall()
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+  const int yields_ref = state_->getGlobalRef(state_->registerGlobal("yields", initializers_));
+  const int call_me_ref = state_->getGlobalRef(state_->registerGlobal("callMe", initializers_));
+
+  {
+    CoroutinePtr cr(state_->createCoroutine());
+    TestObject* object = TestObject::create(cr->luaState()).first;
+    EXPECT_CALL(*object, onDestroy()).Times(AnyNumber());
+    EXPECT_CALL(on_yield_, ready());
+    EXPECT_TRUE(cr->start(yields_ref, 1, yield_callback_).ok());
+    EXPECT_EQ(cr->state(), Coroutine::State::Yielded);
+  }
+
+  expectCompletes(call_me_ref);
+}
+
+// Retention is capped, so a burst of concurrent streams does not pin a stack each for the life of
+// the worker. Two rounds of more coroutines than the cap: at least MaxSize of the second round's
+// threads have to come from the first. That is the direction the allocator cannot fake -- a
+// released thread's address can legitimately be handed out again, so asserting the 8 released ones
+// are *absent* would be flaky.
+TEST_F(LuaTest, PooledThreadsAreCapped) {
+  const std::string SCRIPT{R"EOF(
+    function callMe()
+    end
+  )EOF"};
+
+  setup(SCRIPT);
+  const int call_me_ref = state_->getGlobalRef(state_->registerGlobal("callMe", initializers_));
+
+  const size_t burst = Coroutine::Pool::MaxSize + 8;
+  absl::flat_hash_set<lua_State*> first_round;
+  {
+    std::vector<CoroutinePtr> live;
+    for (size_t i = 0; i < burst; i++) {
+      live.push_back(state_->createCoroutine());
+      EXPECT_TRUE(live.back()->start(call_me_ref, 0, yield_callback_).ok());
+      first_round.insert(live.back()->luaState());
+    }
+    // All of them are alive at once, so all of them are distinct.
+    EXPECT_EQ(burst, first_round.size());
+  }
+
+  size_t reused = 0;
+  std::vector<CoroutinePtr> live;
+  for (size_t i = 0; i < burst; i++) {
+    live.push_back(state_->createCoroutine());
+    if (first_round.contains(live.back()->luaState())) {
+      reused++;
+    }
+  }
+  EXPECT_GE(reused, Coroutine::Pool::MaxSize);
 }
 
 // Basic yield/resume functionality.
@@ -174,7 +331,7 @@ TEST_F(LuaTest, MarkDead) {
   EXPECT_THAT(
       cr2->start(state_->getGlobalRef(1), 0, yield_callback_),
       StatusHelpers::HasStatusMessage("[string \"...\"]:10: object used outside of proper scope"));
-  EXPECT_EQ(cr2->state(), Coroutine::State::Finished);
+  EXPECT_EQ(cr2->state(), Coroutine::State::Errored);
 
   ref.markLive();
   EXPECT_CALL(*ref.get(), doTestCall(_));


### PR DESCRIPTION
Commit Message: `ThreadLocalState::createCoroutine()` calls `lua_newthread` and `luaL_ref` once per direction per request, and `~Coroutine` unrefs the thread and leaves it for the collector. A two-handler script therefore creates two threads, resumes each once, and throws both away. This keeps the finished ones on a per-worker free list, bounded at 256.

Resuming a thread that already ran is legal: `lua_resume` requires only `cframe == NULL && status <= LUA_YIELD`, and the "cannot resume dead coroutine" rule lives in the coroutine *library*, not the C API. A thread is pooled only if it never started or finished without raising; an errored coroutine and one abandoned mid-yield are unrefed as before, since neither leaves state the next request should inherit.

Additional Description:

Ownership does not move, deliberately: #3855 put it at the filter level to break a circular reference whose mechanism its own comment says was not fully understood. The pool holds only the thread; a `Coroutine` still owns one for its whole life and hands it back in its destructor.

Medians of five alternating A/B rounds, `-c opt` binaries from `HEAD~1` and `HEAD`, `--benchmark_repetitions=5 --benchmark_enable_random_interleaving=true`, benchmark from #46960 applied to both:

| Arm                                       |  Baseline |    Pooled |     Delta | Change | Rounds pooled won |
| ----------------------------------------- | --------: | --------: | --------: | -----: | ----------------: |
| `CreateCoroutine`, the call on its own    |  175.7 ns |   46.0 ns | -129.7 ns | -73.8% |               5/5 |
| `NoopBoth`, two empty handlers            |  3,343 ns |  2,950 ns | -393.7 ns | -11.8% |               5/5 |
| `NoopRequestOnly`, one empty handler      |  2,727 ns |  2,527 ns | -200.3 ns |  -7.4% |               5/5 |
| `HeaderMetadata`, read/write plus a carry |  6,945 ns |  6,652 ns | -293.1 ns |  -4.2% |               5/5 |
| `CookieMetadata`                          |  8,446 ns |  7,847 ns | -598.6 ns |  -7.1% |               5/5 |
| `HeadersMetadata`, eight headers each way | 13,556 ns | 12,653 ns | -903.8 ns |  -6.7% |               5/5 |
| `Fixture`, no filter at all (control)     |  1,478 ns |  1,505 ns |  +26.6 ns |  +1.8% |               0/5 |

`Fixture` runs no filter and no Lua, so pooling cannot reach it: it moved 1.8% the wrong way and won 0 of 5. Every script arm won all five.

The saving exceeds two coroutines at -129.7 ns, and the residual grows with how much garbage the arm makes — a `sample` profile puts LuaJIT's collector at ~13% of top-of-stack frames whatever the script does, and much of that garbage is the thread itself.

Retained heap after a forced collection does not get worse, so this is not memory-for-speed: -1.75 KB on `NoopBoth` and -4.11 KB on `HeadersMetadata`. `CreateCoroutine` is the only arm that rises, +0.48 KB for the one thread its pool holds at steady state; extrapolated to the 256 bound that is roughly 120 KB per worker as a ceiling — an extrapolation, not a measurement.

Caveat on the absolutes: macOS/arm64 leaves `MAP_JIT` off in Envoy's LuaJIT build, so every trace fails to allocate mcode and the bytecode ran interpreted. Traces do compile in `envoyproxy/envoy:distroless-v1.39.0`, checked with `jit.attach`. What this saves is C-side either way, so the direction holds, but Linux absolutes will differ.

Risk Level: Medium — no config or API change, but threads are reused across requests, so the risk is per-request state surviving into the next one. Hence pooling only a thread that never started or finished cleanly. Happy to add a runtime guard if reviewers prefer.

Testing:
```
bazel test //test/extensions/filters/common/lua:lua_test
bazel test //test/extensions/filters/http/lua:all
```
Five new cases in `lua_test.cc`: a finished thread is reused (asserted on pointer identity), concurrent coroutines get distinct threads, one created after an error starts clean, so does one after an abandoned yield, and the pool honours its bound. Mutation-tested the accept condition rather than trusting a green run: inverting it fails exactly those first two plus `PooledThreadsAreCapped`, nothing else.

Docs Changes: N/A

Release Notes: N/A — no user-visible or extension-developer-visible behavior change.

Platform Specific Features: N/A
