### PR TITLE
lua: set a dynamic metadata field without copying it first

### DIFF
--- a/source/common/config/metadata.cc
+++ b/source/common/config/metadata.cc
@@ -68,7 +68,9 @@ const Protobuf::Value& Metadata::metadataValue(const envoy::config::core::v3::Me
 }
 
 Protobuf::Value& Metadata::mutableMetadataValue(envoy::config::core::v3::Metadata& metadata,
-                                                const std::string& filter, const std::string& key) {
+                                                absl::string_view filter, absl::string_view key) {
+  // Both maps are keyed by string, which protobuf looks up transparently, so a caller holding a
+  // view does not have to own the key to reach an entry that already exists.
   return (*(*metadata.mutable_filter_metadata())[filter].mutable_fields())[key];
 }
 

--- a/source/common/config/metadata.h
+++ b/source/common/config/metadata.h
@@ -14,6 +14,7 @@
 #include "source/common/shared_pool/shared_pool.h"
 
 #include "absl/container/node_hash_map.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Config {
@@ -83,7 +84,7 @@ public:
    * @return Protobuf::Value&. A Value message is created if not found.
    */
   static Protobuf::Value& mutableMetadataValue(envoy::config::core::v3::Metadata& metadata,
-                                               const std::string& filter, const std::string& key);
+                                               absl::string_view filter, absl::string_view key);
 
   using LabelSet = std::vector<std::pair<std::string, Protobuf::Value>>;
 

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -43,6 +43,7 @@ envoy_cc_library(
         "//envoy/http:header_map_interface",
         "//envoy/registry",
         "//envoy/stream_info:stream_info_interface",
+        "//source/common/config:metadata_lib",
         "//source/common/crypto:utility_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http:utility_lib",

--- a/source/extensions/filters/http/lua/wrappers.cc
+++ b/source/extensions/filters/http/lua/wrappers.cc
@@ -3,6 +3,7 @@
 #include "envoy/registry/registry.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/config/metadata.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
@@ -346,9 +347,13 @@ int DynamicMetadataMapWrapper::luaSet(lua_State* state) {
   // so push a copy of the 3rd arg ("value") to the top.
   lua_pushvalue(state, 4);
 
-  Protobuf::Struct value;
-  (*value.mutable_fields())[key] = Filters::Common::Lua::MetadataMapHelper::loadValue(state);
-  streamInfo().setDynamicMetadata(filter_name, value);
+  // Load the value before touching the metadata map: loadValue() raises on a type it cannot
+  // convert, and a map reached first would keep an empty struct for a set that never happened.
+  // Writing the field in place avoids setDynamicMetadata()'s Struct merge, which copies once per
+  // field of the value.
+  Protobuf::Value value = Filters::Common::Lua::MetadataMapHelper::loadValue(state);
+  Config::Metadata::mutableMetadataValue(streamInfo().dynamicMetadata(), filter_name, key) =
+      std::move(value);
 
   // Pop the copy of the metadata value from the stack.
   lua_pop(state, 1);

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -599,6 +599,10 @@ TEST_F(LuaStreamInfoWrapperTest, BadTypesInTableForDynamicMetadata) {
   EXPECT_THAT(start("callMe"),
               StatusHelpers::HasStatusMessage(
                   "[string \"...\"]:3: unexpected type 'function' in dynamicMetadata"));
+  // A set that raises must not leave the filter's entry behind: the value has to be converted
+  // before anything reaches the metadata map. Nothing in luaSet() states that ordering, and this
+  // script raises partway through converting a table, so it is the case that would notice.
+  EXPECT_EQ(0, stream_info.dynamicMetadata().filter_metadata().count("envoy.lb"));
 }
 
 // Modify during iteration.


### PR DESCRIPTION
Commit Message: `dynamicMetadata():set(name, key, value)` builds a one-field `Protobuf::Struct` and hands it to `StreamInfo::setDynamicMetadata()`, which does `filter_metadata()[name].MergeFrom(that struct)` — so setting one field allocates a `Struct`, allocates a field in it, then copies that field into the real one. This writes the field straight into `dynamicMetadata().mutable_filter_metadata()` instead.

Observably equivalent for a single field: protobuf's map merge is `dest[key] = value` per key, an overwrite rather than a nested merge, and `setDynamicMetadata` does nothing else.

One ordering detail had to be designed around: `loadValue()` raises on a type it cannot convert, and reaching the map first would leave an empty struct behind for a `set` that never happened — the old temporary was also the rollback. The value is loaded into a local first, and `BadTypesInTableForDynamicMetadata` now asserts that after a raise, `filter_metadata()` lacks the entry.

Additional Description:

The first commit widens `Metadata::mutableMetadataValue()` to take filter and key as `absl::string_view`; protobuf looks up both string-keyed maps transparently, so a view reaches an existing entry without owning the key. On blast radius: the new Lua call site is the helper's *only* caller under `source/`. The other 91 are all under `test/`, passing a literal or a `const std::string&` — both convert implicitly.

Medians of five alternating A/B rounds, `-c opt` binaries before and after, `--benchmark_repetitions=5 --benchmark_enable_random_interleaving=true`, benchmark from #46960 on both:

| Arm                              | What the script sets         |    Before |     After |     Delta | Change | Rounds won |
| -------------------------------- | ---------------------------- | --------: | --------: | --------: | -----: | ---------: |
| `RepeatMetadataSet`              | 16 scalars                   |  9,531 ns |  7,000 ns | -2,530 ns | -26.6% |        5/5 |
| `MetadataSet16Get1`              | 16 scalars, one read         | 11,624 ns |  9,087 ns | -2,538 ns | -21.8% |        5/5 |
| `HeadersMetadata`                | one 8-field table            | 12,704 ns | 11,687 ns | -1,018 ns |  -8.0% |        5/5 |
| `HeaderMetadata`                 | one scalar, one read         |  6,604 ns |  6,416 ns |   -188 ns |  -2.9% |        5/5 |
| `HeaderFilterState` (control)    | nothing; filter state        |  6,196 ns |  6,130 ns |    -66 ns |  -1.1% |        3/5 |
| `RepeatFilterStateSet` (control) | nothing; 16 via filter state |  6,943 ns |  6,920 ns |    -23 ns |  -0.3% |        4/5 |
| `Fixture` (control)              | no filter at all             |  1,469 ns |  1,470 ns |     +1 ns |  +0.1% |        3/5 |

Three further single-scalar arms are omitted for brevity; all moved -2% to -3% and won 5/5.

The saving is not a fixed three allocations, it scales with the value's size: `MergeFrom` deep-copies one field at a time. Hence `HeadersMetadata`, a *single* `set` carrying an eight-entry table, saves 1,018 ns — seven times what one scalar `set` saves — while `RepeatMetadataSet`'s sixteen save 158 ns each, about a third of a scalar `set`'s 493 ns.

The two filter-state arms exercise the other carry channel, untouched here, and behave like the controls they are: -1.1% and -0.3%, 3 and 4 rounds of 5.

Caveat on the absolutes: macOS/arm64 leaves `MAP_JIT` off in Envoy's LuaJIT build, so the bytecode ran interpreted. What this removes is C++-side protobuf allocation and copying, so the direction holds, but Linux absolutes will differ.

Risk Level: Low — no config or API change; the only behavior difference is that a `set` raising mid-conversion no longer leaves an empty struct behind.

Testing:
```
bazel test //test/extensions/filters/http/lua:all
bazel test //test/common/config:metadata_test
```
No new case for the fast path; the existing `wrappers_test.cc` coverage exercises it. The one uncovered behavior was the raise-leaves-nothing-behind ordering, now asserted in the test whose script already raises partway through converting a table.

Docs Changes: N/A

Release Notes: N/A — no user-visible or extension-developer-visible behavior change.

Platform Specific Features: N/A

