### PR TITLE
ai_protocol_manager: fold usage adjuncts when the base count is absent

### DIFF
--- a/source/extensions/filters/http/ai_protocol_manager/api_protocol_adapters.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/api_protocol_adapters.cc
@@ -128,11 +128,9 @@ public:
 
   void canonicalizeUsage(TokenUsage& usage, bool& overflow) const override {
     // Native input excludes the two disjoint cache buckets.
-    if (usage.input_tokens.has_value()) {
-      usage.input_tokens =
-          addCounts(addCounts(usage.input_tokens, usage.cached_input_tokens, overflow),
-                    usage.cache_creation_input_tokens, overflow);
-    }
+    usage.input_tokens =
+        addCounts(addCounts(usage.input_tokens, usage.cached_input_tokens, overflow),
+                  usage.cache_creation_input_tokens, overflow);
   }
 
   bool isTerminalEvent(const nlohmann::json& json) const override {
@@ -194,13 +192,12 @@ public:
   const PayloadSchema* schema() const override { return nullptr; }
 
   void canonicalizeUsage(TokenUsage& usage, bool& overflow) const override {
-    // Native prompt/candidates counts exclude tool-use and thoughts.
-    if (usage.input_tokens.has_value()) {
-      usage.input_tokens = addCounts(usage.input_tokens, usage.tool_use_input_tokens, overflow);
-    }
-    if (usage.output_tokens.has_value()) {
-      usage.output_tokens = addCounts(usage.output_tokens, usage.reasoning_tokens, overflow);
-    }
+    // Native prompt/candidates counts exclude tool-use and thoughts, and are
+    // themselves absent when the model produced only the adjunct: a response
+    // truncated at MAX_TOKENS while still thinking reports
+    // `thoughtsTokenCount` with no `candidatesTokenCount` at all.
+    usage.input_tokens = addCounts(usage.input_tokens, usage.tool_use_input_tokens, overflow);
+    usage.output_tokens = addCounts(usage.output_tokens, usage.reasoning_tokens, overflow);
   }
 
   // No in-band terminator; extraction finalizes at end of stream.

--- a/source/extensions/filters/http/ai_protocol_manager/json_readers.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/json_readers.cc
@@ -79,10 +79,12 @@ const nlohmann::json* readObject(const nlohmann::json& json, const std::string& 
 
 std::optional<uint64_t> addCounts(std::optional<uint64_t> base,
                                   const std::optional<uint64_t>& extra, bool& overflow) {
-  if (!base.has_value() || !extra.has_value()) {
+  if (!extra.has_value()) {
     return base;
   }
-  const uint64_t sum = base.value() + extra.value();
+  // Both operands are bounded by MaxSafeCount at read time, so the sum cannot
+  // wrap.
+  const uint64_t sum = base.value_or(0) + extra.value();
   if (sum > MaxSafeCount) {
     overflow = true;
     return std::nullopt;

--- a/source/extensions/filters/http/ai_protocol_manager/json_readers.h
+++ b/source/extensions/filters/http/ai_protocol_manager/json_readers.h
@@ -58,10 +58,13 @@ const nlohmann::json* readObject(const nlohmann::json& json, const std::string& 
                                  bool& malformed,
                                  NullPolicy null_policy = NullPolicy::NullIsMalformed);
 
-// Adds an optional adjunct onto a base count. A sum above the metadata-safe
-// bound is dropped rather than published imprecisely, and reported through
-// `overflow` so the caller flags the record instead of silently omitting a
-// canonical component.
+// Adds an optional adjunct onto a base count. An absent adjunct leaves the
+// base as it is; an absent base with a present adjunct reads as zero, because
+// a dialect omits its native bucket when the model produced none of it and
+// the adjunct still belongs in the canonical count. A sum above the
+// metadata-safe bound is dropped rather than published imprecisely, and
+// reported through `overflow` so the caller flags the record instead of
+// silently omitting a canonical component.
 std::optional<uint64_t> addCounts(std::optional<uint64_t> base,
                                   const std::optional<uint64_t>& extra, bool& overflow);
 

--- a/test/extensions/filters/http/ai_protocol_manager/api_protocol_adapters_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/api_protocol_adapters_test.cc
@@ -331,6 +331,35 @@ TEST(ExtractGeminiTest, ToolUseAndThoughtsAccounting) {
   EXPECT_EQ(usage.reasoning_tokens, 12);
 }
 
+TEST(ExtractGeminiTest, ThoughtsWithoutCandidatesAreCounted) {
+  // A response truncated at MAX_TOKENS while the model was still thinking
+  // carries `thoughtsTokenCount` and no `candidatesTokenCount` at all. Those
+  // tokens were generated and billed, so canonical output is the thoughts
+  // count rather than absent.
+  auto usage = extractUsage(ApiProtocol::GeminiGenerateContent, parse(R"(
+      {"candidates":[{"finishReason":"MAX_TOKENS"}],
+       "usageMetadata":{"promptTokenCount":6,"totalTokenCount":34,
+                        "thoughtsTokenCount":28}})"));
+  EXPECT_FALSE(usage.output_tokens.has_value()); // No native candidates count.
+  finalizeUsage(usage);
+  EXPECT_EQ(usage.input_tokens, 6);
+  EXPECT_EQ(usage.output_tokens, 28);
+  EXPECT_EQ(usage.total_tokens, 34);
+  EXPECT_EQ(usage.provider_total_tokens, 34);
+  EXPECT_EQ(usage.reasoning_tokens, 28);
+}
+
+TEST(ExtractGeminiTest, ToolUseWithoutPromptCountIsCounted) {
+  // Same shape on the input side: the tool-use adjunct still belongs in the
+  // canonical input when the native prompt count is absent.
+  auto usage = extractUsage(ApiProtocol::GeminiGenerateContent, parse(R"(
+      {"usageMetadata":{"toolUsePromptTokenCount":5,"candidatesTokenCount":10}})"));
+  finalizeUsage(usage);
+  EXPECT_EQ(usage.input_tokens, 5);
+  EXPECT_EQ(usage.output_tokens, 10);
+  EXPECT_EQ(usage.total_tokens, 15);
+}
+
 TEST(ExtractAnthropicTest, CanonicalInclusiveAccounting) {
   // Reviewer merge-gate case: input 100 + cache-creation 20 + cache-read 30
   // yields canonical input 150 and (with output 10) total 160.
@@ -342,6 +371,17 @@ TEST(ExtractAnthropicTest, CanonicalInclusiveAccounting) {
   EXPECT_EQ(usage.cached_input_tokens, 30);
   EXPECT_EQ(usage.cache_creation_input_tokens, 20);
   EXPECT_EQ(usage.total_tokens, 160);
+}
+
+TEST(ExtractAnthropicTest, CacheBucketsWithoutInputTokensAreCounted) {
+  // Same shape as the Gemini truncation case: the cache buckets still belong
+  // in the canonical input when the native input count is absent.
+  auto usage = extractUsage(ApiProtocol::AnthropicMessages, parse(R"(
+      {"type":"message","usage":{"cache_read_input_tokens":30,
+       "cache_creation_input_tokens":20,"output_tokens":10}})"));
+  finalizeUsage(usage);
+  EXPECT_EQ(usage.input_tokens, 50);
+  EXPECT_EQ(usage.total_tokens, 60);
 }
 
 TEST(ExtractAnthropicTest, PartialInputUpdatePreservesCacheBuckets) {


### PR DESCRIPTION
canonicalizeUsage() only summed a dialect's adjunct buckets into the canonical count when the native base count was present. Gemini omits `candidatesTokenCount` entirely when a response is truncated at MAX_TOKENS with thoughts and no text, so `thoughtsTokenCount` was dropped: generated, billed output tokens went unreported, and the record still published as complete. Sum the adjunct onto an absent base as zero, in addCounts(), which covers the tool-use input bucket and Anthropic's cache buckets on the same shape.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
