### PR TITLE
cache: treat responses without a Date header as fresh

### DIFF
--- a/changelogs/current/bug_fixes/cache__responses-without-date-header-stale.rst
+++ b/changelogs/current/bug_fixes/cache__responses-without-date-header-stale.rst
@@ -1,0 +1,6 @@
+Fixed a bug where HTTP cache and cache_v2 responses with a ``max-age`` (or ``s-maxage``) but no
+``Date`` header were considered stale and revalidated or refetched on every request. Per
+:rfc:`9110#section-6.6.1`, a caching recipient that receives a response without a ``Date`` header
+records the time it was received. The cache now falls back to the response time when no valid
+``Date`` header is present, and no longer emits an empty ``If-Modified-Since`` header during
+validation when neither ``Last-Modified`` nor ``Date`` is present.

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -210,7 +210,13 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
 Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_headers,
                                         const SystemTime response_time, const SystemTime now) {
   // Age headers calculations follow: https://httpwg.org/specs/rfc7234.html#age.calculations
-  const SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  if (date_value == SystemTime()) {
+    // RFC 9110 6.6.1: a recipient that receives a response without a Date
+    // header records the time it was received. Fall back to the response
+    // time so the entry is not immediately considered stale.
+    date_value = response_time;
+  }
 
   long age_value;
   const absl::string_view age_header = response_headers.getInlineValue(CacheCustomHeaders::age());

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
@@ -212,7 +212,13 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
 Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_headers,
                                         const SystemTime response_time, const SystemTime now) {
   // Age headers calculations follow: https://httpwg.org/specs/rfc7234.html#age.calculations
-  const SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  if (!DateUtil::timePointValid(date_value)) {
+    // RFC 9110 6.6.1: a recipient that receives a response without a Date
+    // header records the time it was received. Fall back to the response
+    // time so the entry is not immediately considered stale.
+    date_value = response_time;
+  }
 
   long age_value;
   const absl::string_view age_header = response_headers.getInlineValue(CacheCustomHeaders::age());
@@ -248,12 +254,14 @@ void CacheHeadersUtils::injectValidationHeaders(
     // Valid Last-Modified header exists.
     absl::string_view last_modified = last_modified_header->value().getStringView();
     request_headers.setInline(CacheCustomHeaders::ifModifiedSince(), last_modified);
-  } else {
+  } else if (DateUtil::timePointValid(CacheHeadersUtils::httpTime(old_response_headers.Date()))) {
     // Either Last-Modified is missing or invalid, fallback to Date.
     // A correct behaviour according to:
     // https://httpwg.org/specs/rfc7232.html#header.if-modified-since
-    absl::string_view date = old_response_headers.getDateValue();
-    request_headers.setInline(CacheCustomHeaders::ifModifiedSince(), date);
+    // Don't emit an empty If-Modified-Since when neither Date nor
+    // Last-Modified is present.
+    request_headers.setInline(CacheCustomHeaders::ifModifiedSince(),
+                              old_response_headers.getDateValue());
   }
 }
 

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -145,6 +145,20 @@ public:
           // {must_validate_, no_store_, no_transform_, only_if_cached_, max_age_, min_fresh_, max_stale_}
           {true, true, false, false, Seconds(10), std::nullopt, std::nullopt}
         },
+        {
+          "no_date_header_uses_response_time",
+          /*response_headers=*/{},
+          /*response_time=*/currentTime(),
+          /*now=*/currentTime(),
+          /*expected_age=*/Seconds(0)
+        },
+        {
+          "no_date_header_only_resident_time_counts",
+          /*response_headers=*/{},
+          /*response_time=*/currentTime(),
+          /*now=*/currentTime() + Seconds(7),
+          /*expected_age=*/Seconds(7)
+        },
     );
     // clang-format on
   }

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -146,6 +146,20 @@ public:
           // {must_validate_, no_store_, no_transform_, only_if_cached_, max_age_, min_fresh_, max_stale_}
           {true, true, false, false, Seconds(10), std::nullopt, std::nullopt}
         },
+        {
+          "no_date_header_uses_response_time",
+          /*response_headers=*/{},
+          /*response_time=*/currentTime(),
+          /*now=*/currentTime(),
+          /*expected_age=*/Seconds(0)
+        },
+        {
+          "no_date_header_only_resident_time_counts",
+          /*response_headers=*/{},
+          /*response_time=*/currentTime(),
+          /*now=*/currentTime() + Seconds(7),
+          /*expected_age=*/Seconds(7)
+        },
     );
     // clang-format on
   }
@@ -939,6 +953,13 @@ TEST(InjectValidationHeaders, FallsBackToDateWhenLastModifiedMissing) {
   Http::TestRequestHeaderMapImpl request_headers;
   CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
   EXPECT_THAT(request_headers, ContainsHeader("if-modified-since", date));
+}
+
+TEST(InjectValidationHeaders, NoLastModifiedOrDateSkipsIfModifiedSince) {
+  Http::TestResponseHeaderMapImpl old_response_headers;
+  Http::TestRequestHeaderMapImpl request_headers;
+  CacheHeadersUtils::injectValidationHeaders(request_headers, old_response_headers);
+  EXPECT_EQ(request_headers.getInlineValue(CacheCustomHeaders::ifModifiedSince()), "");
 }
 
 TEST(ShouldUpdateCachedEntry, ComparesEtags) {


### PR DESCRIPTION
Fixes #46947

## Problem

Responses with ``max-age`` (or ``s-maxage``) but no ``Date`` header are revalidated or refetched on every request.

`CacheHeadersUtils::httpTime` returns the epoch for a missing or unparseable `Date` header, so `calculateAge` computes an apparent age equal to the response time's time since epoch. This makes the cached response appear stale on every lookup, even though `max-age` is present.

## Fix

Per RFC 9110 6.6.1, a caching recipient that receives a response without a `Date` header records the time it was received. This PR:

1. **`cache_headers_utils.cc` (cache and cache_v2)**: in `calculateAge`, fall back to `response_time` when no valid `Date` header is present, so the apparent age is zero instead of ~epoch.
2. **`cache_v2/cache_headers_utils.cc`**: in `injectValidationHeaders`, only emit an `If-Modified-Since` header when a valid `Date` header actually exists — previously a missing Date produced an empty (malformed) `If-Modified-Since`.

## Tests

- Added `CalculateAgeTest` cases covering a response with no `Date` header.
- Added `InjectValidationHeaders.NoLastModifiedOrDateSkipsIfModifiedSince`.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>