### PR TITLE
draining: ensure the connections get notified at all cases

### DIFF
--- a/envoy/network/BUILD
+++ b/envoy/network/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     hdrs = ["connection.h"],
     deps = [
         ":address_interface",
+        ":drain_decision_interface",
         ":filter_interface",
         ":listen_socket_interface",
         "//envoy/buffer:buffer_interface",
@@ -120,6 +121,8 @@ envoy_cc_library(
     hdrs = ["drain_decision.h"],
     deps = [
         "//envoy/common:callback",
+        "//envoy/common:time_interface",
+        "//envoy/server:drain_strategy_interface",
         "@abseil-cpp//absl/base",
         "@abseil-cpp//absl/status",
     ],

--- a/envoy/network/connection.h
+++ b/envoy/network/connection.h
@@ -10,6 +10,7 @@
 #include "envoy/common/scope_tracker.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/network/address.h"
+#include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listen_socket.h"
 #include "envoy/network/socket.h"
@@ -70,8 +71,10 @@ public:
    *
    * The connection remains usable after this call; it is not closed by onDrain() itself.
    * The default implementation is a no-op.
+   * @param drain_event describes the drain sequence (its start time and strategy) as decided on
+   *        the main thread.
    */
-  virtual void onDrain() {}
+  virtual void onDrain(ConnectionDrainEvent drain_event) { (void)drain_event; }
 };
 
 /**
@@ -182,8 +185,15 @@ public:
    * registered ConnectionCallbacks. Drain is a notification only: the connection is
    * not closed and remains usable. Callbacks may react by initiating a graceful
    * shutdown of any higher-level state (e.g. HTTP/2 GOAWAY).
+   *
+   * A connection may be notified more than once (a server drain escalating from InboundOnly to
+   * All re-notifies inbound listeners, and a filter chain drain can follow a server drain). The
+   * first event wins: subsequent notifications are dropped, so a connection that is already
+   * draining stays on its original timeline and its callbacks see onDrain() exactly once.
+   *
+   * @param drain_event describes the drain sequence (start time and strategy).
    */
-  virtual void onDrain() PURE;
+  virtual void onDrain(ConnectionDrainEvent drain_event) PURE;
 
   /**
    * Close the connection.

--- a/envoy/network/connection_handler.h
+++ b/envoy/network/connection_handler.h
@@ -104,16 +104,19 @@ public:
    * timer expires and connections are forcibly closed). It does not close connections.
    * @param listener_tag supplies the tag passed to addListener().
    * @param filter_chains supplies the filter chains whose connections should be notified.
+   * @param drain_event describes the drain sequence (start time and strategy).
    */
   virtual void onFilterChainDrain(uint64_t listener_tag,
-                                  const std::list<const FilterChain*>& filter_chains) PURE;
+                                  const std::list<const FilterChain*>& filter_chains,
+                                  ConnectionDrainEvent drain_event) PURE;
 
   /**
    * Notify all connections belonging to the listener with the given tag that they are being
    * drained. Does not close any connections.
    * @param listener_tag supplies the tag passed to addListener().
+   * @param drain_event describes the drain sequence (start time and strategy).
    */
-  virtual void onListenerDrain(uint64_t listener_tag) PURE;
+  virtual void onListenerDrain(uint64_t listener_tag, ConnectionDrainEvent drain_event) PURE;
 
   /**
    * Stop all listeners. This will not close any connections and is used for draining.
@@ -199,16 +202,19 @@ public:
      * should notify all owned connections that they are being drained (by invoking
      * Network::Connection::onDrain()) so that callbacks registered on those connections can
      * react to the drain (e.g. send GOAWAY). Connections are not closed by this call.
+     * @param drain_event describes the drain sequence (start time and strategy).
      */
-    virtual void onFilterChainDrainStart(
-        const std::list<const Network::FilterChain*>& draining_filter_chains) PURE;
+    virtual void
+    onFilterChainDrainStart(const std::list<const Network::FilterChain*>& draining_filter_chains,
+                            ConnectionDrainEvent drain_event) PURE;
 
     /**
      * Called at the start of the drain sequence for the listener as a whole. Implementations
      * should notify all owned connections that they are being drained. Connections are not
      * closed by this call.
+     * @param drain_event describes the drain sequence (start time and strategy).
      */
-    virtual void onListenerDrainStart() PURE;
+    virtual void onListenerDrainStart(ConnectionDrainEvent drain_event) PURE;
 
     // New method for handling idle connection closing
     virtual void onCloseIdleHttpConnections(bool /*is_saturated*/) {

--- a/envoy/network/drain_decision.h
+++ b/envoy/network/drain_decision.h
@@ -5,6 +5,8 @@
 
 #include "envoy/common/callback.h"
 #include "envoy/common/pure.h"
+#include "envoy/common/time.h"
+#include "envoy/server/drain_strategy.h"
 
 #include "absl/base/attributes.h"
 #include "absl/status/status.h"
@@ -27,6 +29,21 @@ enum class DrainDirection {
    * Drain both inbound and outbound connections.
    */
   All,
+};
+
+/**
+ * Describes a drain sequence that a connection has been notified of via
+ * Network::Connection::onDrain(). The values are captured once on the main thread at the moment
+ * the drain sequence is initiated and are propagated unchanged to every affected connection so
+ * that all connections share a single, consistent view of the drain timeline regardless of when
+ * each connection is notified.
+ */
+struct ConnectionDrainEvent {
+  // The monotonic time at which the drain sequence was initiated on the main thread.
+  MonotonicTime start_time;
+  // The drain strategy to apply to this drain sequence. Usually a copy of
+  // Server::Options::drainStrategy(), but a drain sequence may override it.
+  Server::DrainStrategy strategy{Server::DrainStrategy::Gradual};
 };
 
 class DrainDecision {

--- a/envoy/network/listener.h
+++ b/envoy/network/listener.h
@@ -9,6 +9,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/common/resource.h"
 #include "envoy/config/core/v3/base.pb.h"
+#include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/config/listener/v3/udp_listener_config.pb.h"
 #include "envoy/config/typed_metadata.h"
 #include "envoy/init/manager.h"
@@ -183,6 +184,13 @@ public:
    * @return whether the listener is a Quic listener.
    */
   virtual bool isQuic() const PURE;
+
+  /**
+   * @return envoy::config::listener::v3::Listener::DrainType the drain type configured on this
+   * listener. DEFAULT listeners drain in response to /healthcheck/fail in addition to listener
+   * removal/modification and hot restart; MODIFY_ONLY listeners do not.
+   */
+  virtual envoy::config::listener::v3::Listener::DrainType drainType() const PURE;
 
   /**
    * @return bool whether the listener should bypass overload manager actions

--- a/envoy/server/BUILD
+++ b/envoy/server/BUILD
@@ -164,9 +164,15 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "drain_strategy_interface",
+    hdrs = ["drain_strategy.h"],
+)
+
+envoy_cc_library(
     name = "options_interface",
     hdrs = ["options.h"],
     deps = [
+        ":drain_strategy_interface",
         "//envoy/network:address_interface",
         "//envoy/stats:stats_interface",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
@@ -284,6 +290,7 @@ envoy_cc_library(
         "//envoy/filter:config_provider_manager_interface",
         "//envoy/network:address_interface",
         "//envoy/network:connection_handler_interface",
+        "//envoy/network:drain_decision_interface",
         "//envoy/network:filter_interface",
         "//envoy/network:socket_interface",
         "//envoy/network:socket_interface_interface",

--- a/envoy/server/drain_strategy.h
+++ b/envoy/server/drain_strategy.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace Envoy {
+namespace Server {
+
+/**
+ * During the drain sequence, different components ask the DrainManager
+ * whether to drain via drainClose(). This enum dictates the behaviour of
+ * drainClose() calls.
+ */
+enum class DrainStrategy {
+  /**
+   * The probability of drainClose() returning true increases from 0 to 100%
+   * over the duration of the drain period.
+   */
+  Gradual,
+
+  /**
+   * drainClose() will return true as soon as the drain sequence is initiated.
+   */
+  Immediate,
+};
+
+} // namespace Server
+} // namespace Envoy

--- a/envoy/server/listener_manager.h
+++ b/envoy/server/listener_manager.h
@@ -14,6 +14,7 @@
 #include "envoy/filter/config_provider_manager.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection_handler.h"
+#include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listener.h"
 #include "envoy/network/socket.h"
@@ -284,6 +285,20 @@ public:
    */
   virtual void stopListeners(StopListenersType stop_listeners_type,
                              const Network::ExtraShutdownListenerOptions& options) PURE;
+
+  /**
+   * Notify the connections of active listeners that a server-wide drain sequence has begun, so that
+   * connection-level drain logic (Network::Connection::onDrain()) can react. Only listeners whose
+   * traffic direction is covered by the drain direction are notified: an InboundOnly drain notifies
+   * only inbound listeners, while an All drain notifies every listener. Does not stop listeners or
+   * close connections.
+   * @param direction the direction of the server drain.
+   * @param drain_event the drain sequence to notify the connections of. The caller supplies it so
+   *        that every connection covered by one drain shares a single, consistent timeline, and so
+   *        that a caller which drains on terms of its own.
+   */
+  virtual void onServerDrainStart(Network::DrainDirection direction,
+                                  Network::ConnectionDrainEvent drain_event) PURE;
 
   /**
    * Stop all threaded workers from running. When this routine returns all worker threads will

--- a/envoy/server/options.h
+++ b/envoy/server/options.h
@@ -9,6 +9,7 @@
 #include "envoy/common/pure.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/network/address.h"
+#include "envoy/server/drain_strategy.h"
 #include "envoy/stats/tag.h"
 
 #include "spdlog/spdlog.h"
@@ -41,24 +42,6 @@ enum class Mode {
   // Perform no validation of files referenced in the config, such as runtime configs, SSL certs,
   // etc. Validation will pass even if those files are malformed or don't exist, allowing the config
   // to be validated in a non-prod environment.
-};
-
-/**
- * During the drain sequence, different components ask the DrainManager
- * whether to drain via drainClose(). This enum dictates the behaviour of
- * drainClose() calls.
- */
-enum class DrainStrategy {
-  /**
-   * The probability of drainClose() returning true increases from 0 to 100%
-   * over the duration of the drain period.
-   */
-  Gradual,
-
-  /**
-   * drainClose() will return true as soon as the drain sequence is initiated.
-   */
-  Immediate,
 };
 
 using CommandLineOptionsPtr = std::unique_ptr<envoy::admin::v3::CommandLineOptions>;

--- a/envoy/server/worker.h
+++ b/envoy/server/worker.h
@@ -114,17 +114,24 @@ public:
    * that is posted to the worker's dispatcher.
    * @param listener_tag supplies the tag passed to addListener().
    * @param filter_chains supplies the filter chains whose connections should be notified.
+   * @param drain_event describes the drain sequence (start time and strategy), captured
+   *        once on the main thread so all connections share a consistent drain timeline.
    */
   virtual void onFilterChainDrain(uint64_t listener_tag,
-                                  const std::list<const Network::FilterChain*>& filter_chains) PURE;
+                                  const std::list<const Network::FilterChain*>& filter_chains,
+                                  Network::ConnectionDrainEvent drain_event) PURE;
 
   /**
    * Notify all connections of the given listener that they are being drained. Connections
    * are not closed. This is a fire-and-forget operation that is posted to the worker's
    * dispatcher.
-   * @param listener supplies the listener whose connections should be notified.
+   * @param listener_tag supplies the tag passed to addListener() of the listener whose connections
+   *        should be notified.
+   * @param drain_event describes the drain sequence (start time and strategy), captured
+   *        once on the main thread so all connections share a consistent drain timeline.
    */
-  virtual void onListenerDrain(Network::ListenerConfig& listener) PURE;
+  virtual void onListenerDrain(uint64_t listener_tag,
+                               Network::ConnectionDrainEvent drain_event) PURE;
 };
 
 using WorkerPtr = std::unique_ptr<Worker>;

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.h
@@ -81,6 +81,9 @@ public:
   bool removeListener(const std::string&) override { return true; }
   absl::Status startWorkers(OptRef<GuardDog> guard_dog, std::function<void()> callback) override;
   void stopListeners(StopListenersType, const Network::ExtraShutdownListenerOptions&) override;
+  // API listeners own no downstream network connections, so there is nothing to notify when a
+  // server-wide drain sequence begins.
+  void onServerDrainStart(Network::DrainDirection, Network::ConnectionDrainEvent) override {}
   void stopWorkers() override;
   void beginListenerUpdate() override {}
   void endListenerUpdate(FailureStates&&) override {}

--- a/source/common/listener_manager/BUILD
+++ b/source/common/listener_manager/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "//envoy/access_log:access_log_interface",
         "//envoy/config:typed_metadata_interface",
         "//envoy/network:connection_interface",
+        "//envoy/network:drain_decision_interface",
         "//envoy/network:listener_interface",
         "//envoy/network:udp_packet_writer_factory_factory_interface",
         "//envoy/server:api_listener_interface",

--- a/source/common/listener_manager/active_stream_listener_base.cc
+++ b/source/common/listener_manager/active_stream_listener_base.cc
@@ -62,6 +62,11 @@ void ActiveStreamListenerBase::newConnection(Network::ConnectionSocketPtr&& sock
     ENVOY_CONN_LOG(debug, "closing connection from {}: no filters", *server_conn_ptr,
                    server_conn_ptr->connectionInfoProvider().remoteAddress()->asString());
     server_conn_ptr->close(Network::ConnectionCloseType::NoFlush, "no_filters");
+  } else if (drain_event_.has_value()) {
+    // The listener began draining before this connection was accepted. Notify it now (the network
+    // filter chain, and thus any drain-aware callbacks, has just been created) so connection-level
+    // drain logic applies to connections accepted during the drain window.
+    server_conn_ptr->onDrain(*drain_event_);
   }
   newActiveConnection(*filter_chain, std::move(server_conn_ptr), std::move(stream_info));
 }
@@ -153,7 +158,8 @@ ActiveConnections& OwnedActiveStreamListenerBase::getOrCreateActiveConnections(
 }
 
 void OwnedActiveStreamListenerBase::onFilterChainDrainStart(
-    const std::list<const Network::FilterChain*>& draining_filter_chains) {
+    const std::list<const Network::FilterChain*>& draining_filter_chains,
+    Network::ConnectionDrainEvent drain_event) {
   // A drain callback may synchronously close the current connection, which removes it from
   // `connections_` via removeConnection(). Capture `next` before invoking onDrain() so the
   // std::list iteration survives erasure of the current node. Pin `is_deleting_` while
@@ -169,14 +175,24 @@ void OwnedActiveStreamListenerBase::onFilterChainDrainStart(
     auto& connections = map_iter->second->connections_;
     for (auto it = connections.begin(); it != connections.end();) {
       auto next = std::next(it);
-      (*it)->connection_->onDrain();
+      (*it)->connection_->onDrain(drain_event);
       it = next;
     }
   }
   is_deleting_ = was_deleting;
 }
 
-void OwnedActiveStreamListenerBase::onListenerDrainStart() {
+void OwnedActiveStreamListenerBase::onListenerDrainStart(
+    Network::ConnectionDrainEvent drain_event) {
+  // Remember the drain so connections accepted after this point are also notified (see
+  // ActiveStreamListenerBase::newConnection). A listener can be notified more than once (a server
+  // drain escalating from InboundOnly to All re-notifies inbound listeners); the first event wins,
+  // and a later notification neither pushes the drain back nor re-notifies connections, all of
+  // which have already been notified of the first event.
+  if (drain_event_.has_value()) {
+    return;
+  }
+  drain_event_ = drain_event;
   // See onFilterChainDrainStart for why `next` is captured and `is_deleting_` is pinned.
   const bool was_deleting = is_deleting_;
   is_deleting_ = true;
@@ -184,7 +200,7 @@ void OwnedActiveStreamListenerBase::onListenerDrainStart() {
     auto& connections = entry.second->connections_;
     for (auto it = connections.begin(); it != connections.end();) {
       auto next = std::next(it);
-      (*it)->connection_->onDrain();
+      (*it)->connection_->onDrain(drain_event);
       it = next;
     }
   }

--- a/source/common/listener_manager/active_stream_listener_base.h
+++ b/source/common/listener_manager/active_stream_listener_base.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <list>
 #include <memory>
+#include <optional>
 
 #include "envoy/common/time.h"
 #include "envoy/event/dispatcher.h"
@@ -138,6 +139,11 @@ protected:
   // collection is removed. This state is maintained in base class because this state is independent
   // from concrete connection type.
   bool is_deleting_{false};
+  // Set once the listener as a whole begins draining (onListenerDrainStart). Persisted so that
+  // connections accepted after drain has started are also notified via onDrain(): unlike the pull
+  // model of DrainDecision::drainClose(), the onDrain() notification is one-shot, so newly accepted
+  // connections would otherwise miss it.
+  std::optional<Network::ConnectionDrainEvent> drain_event_;
 
 private:
   Event::Dispatcher& dispatcher_;
@@ -204,9 +210,9 @@ public:
   void removeConnection(ActiveTcpConnection& connection);
 
   // Network::ConnectionHandler::ActiveListener
-  void onFilterChainDrainStart(
-      const std::list<const Network::FilterChain*>& draining_filter_chains) override;
-  void onListenerDrainStart() override;
+  void onFilterChainDrainStart(const std::list<const Network::FilterChain*>& draining_filter_chains,
+                               Network::ConnectionDrainEvent drain_event) override;
+  void onListenerDrainStart(Network::ConnectionDrainEvent drain_event) override;
 
 protected:
   /**

--- a/source/common/listener_manager/connection_handler_impl.cc
+++ b/source/common/listener_manager/connection_handler_impl.cc
@@ -266,22 +266,24 @@ void ConnectionHandlerImpl::stopListeners(uint64_t listener_tag,
 }
 
 void ConnectionHandlerImpl::onFilterChainDrain(
-    uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains) {
+    uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
+    Network::ConnectionDrainEvent drain_event) {
   if (auto listener_it = listener_map_by_tag_.find(listener_tag);
       listener_it != listener_map_by_tag_.end()) {
     listener_it->second->invokeListenerMethod(
-        [&filter_chains](Network::ConnectionHandler::ActiveListener& listener) {
-          listener.onFilterChainDrainStart(filter_chains);
+        [&filter_chains, drain_event](Network::ConnectionHandler::ActiveListener& listener) {
+          listener.onFilterChainDrainStart(filter_chains, drain_event);
         });
   }
 }
 
-void ConnectionHandlerImpl::onListenerDrain(uint64_t listener_tag) {
+void ConnectionHandlerImpl::onListenerDrain(uint64_t listener_tag,
+                                            Network::ConnectionDrainEvent drain_event) {
   if (auto listener_it = listener_map_by_tag_.find(listener_tag);
       listener_it != listener_map_by_tag_.end()) {
     listener_it->second->invokeListenerMethod(
-        [](Network::ConnectionHandler::ActiveListener& listener) {
-          listener.onListenerDrainStart();
+        [drain_event](Network::ConnectionHandler::ActiveListener& listener) {
+          listener.onListenerDrainStart(drain_event);
         });
   }
 }

--- a/source/common/listener_manager/connection_handler_impl.h
+++ b/source/common/listener_manager/connection_handler_impl.h
@@ -54,8 +54,9 @@ public:
                      const Network::ExtraShutdownListenerOptions& options) override;
   void stopListeners() override;
   void onFilterChainDrain(uint64_t listener_tag,
-                          const std::list<const Network::FilterChain*>& filter_chains) override;
-  void onListenerDrain(uint64_t listener_tag) override;
+                          const std::list<const Network::FilterChain*>& filter_chains,
+                          Network::ConnectionDrainEvent drain_event) override;
+  void onListenerDrain(uint64_t listener_tag, Network::ConnectionDrainEvent drain_event) override;
   void disableListeners() override;
   void enableListeners() override;
   void setListenerRejectFraction(UnitFloat reject_fraction) override;

--- a/source/common/listener_manager/listener_info_impl.h
+++ b/source/common/listener_manager/listener_info_impl.h
@@ -16,7 +16,8 @@ public:
   explicit ListenerInfoImpl(const envoy::config::listener::v3::Listener& config)
       : name_(config.name()), metadata_(config.metadata()), direction_(config.traffic_direction()),
         is_quic_(config.udp_listener_config().has_quic_options()),
-        bypass_overload_manager_(config.bypass_overload_manager()) {}
+        bypass_overload_manager_(config.bypass_overload_manager()),
+        drain_type_(config.drain_type()) {}
   ListenerInfoImpl() = default;
 
   // Network::ListenerInfo
@@ -26,6 +27,9 @@ public:
   envoy::config::core::v3::TrafficDirection direction() const override { return direction_; }
   bool shouldBypassOverloadManager() const override { return bypass_overload_manager_; };
   bool isQuic() const override { return is_quic_; }
+  envoy::config::listener::v3::Listener::DrainType drainType() const override {
+    return drain_type_;
+  }
 
 private:
   const std::string name_;
@@ -33,6 +37,8 @@ private:
   const envoy::config::core::v3::TrafficDirection direction_{};
   const bool is_quic_{};
   const bool bypass_overload_manager_{};
+  // Defaults to Listener::DEFAULT, which is the proto default (0).
+  const envoy::config::listener::v3::Listener::DrainType drain_type_{};
 };
 
 } // namespace Server

--- a/source/common/listener_manager/listener_manager_impl.cc
+++ b/source/common/listener_manager/listener_manager_impl.cc
@@ -8,6 +8,7 @@
 #include "envoy/config/listener/v3/listener.pb.h"
 #include "envoy/config/listener/v3/listener_components.pb.h"
 #include "envoy/extensions/transport_sockets/raw_buffer/v3/raw_buffer.pb.h"
+#include "envoy/network/drain_decision.h"
 #include "envoy/network/filter.h"
 #include "envoy/network/listener.h"
 #include "envoy/registry/registry.h"
@@ -761,9 +762,13 @@ void ListenerManagerImpl::drainListener(ListenerImplPtr&& listener) {
 
   // Notify existing connections on this listener that draining has begun so that callbacks
   // (e.g. HTTP/2 codecs) can react before the drain timer expires and connections are
-  // forcibly closed.
+  // forcibly closed. The drain start time, duration and strategy are captured once here so that
+  // every connection shares a single, consistent drain timeline regardless of which worker it
+  // lives on or when it is notified.
+  const Network::ConnectionDrainEvent listener_drain_event{
+      server_.api().timeSource().monotonicTime(), server_.options().drainStrategy()};
   for (const auto& worker : workers_) {
-    worker->onListenerDrain(*draining_it->listener_);
+    worker->onListenerDrain(listener_tag, listener_drain_event);
   }
 
   // Start the drain sequence which completes when the listener's drain manager has completed
@@ -966,10 +971,22 @@ void ListenerManagerImpl::drainGroup(
 
   // Notify existing connections in the draining filter chains that draining has begun so
   // callbacks (e.g. HTTP/2 codecs) can react before the drain timer expires and the
-  // connections are forcibly closed.
+  // connections are forcibly closed. The drain start time is captured once here so that every
+  // connection shares a single, consistent drain timeline.
+  //
+  // The strategy is forced to Immediate rather than using the configured
+  // Server::Options::drainStrategy(). This preserves the pre-existing behavior of
+  // PerFilterChainFactoryContextImpl::drainClose(), which returns true unconditionally once the
+  // filter chain is draining, and it is the correct behavior here: unlike a server drain, the
+  // configuration backing these connections is already gone, and at the end of the drain window
+  // removeFilterChains() hard-closes whatever is left. Ramping up gradually would mean a large
+  // share of connections are still running on deleted configuration when that deadline arrives,
+  // and are then closed abruptly instead of being given the whole window to finish gracefully.
+  const Network::ConnectionDrainEvent filter_chain_drain_event{
+      server_.api().timeSource().monotonicTime(), Server::DrainStrategy::Immediate};
   for (const auto& worker : workers_) {
     worker->onFilterChainDrain(draining_group->getDrainingListenerTag(),
-                               draining_group->getDrainingFilterChains());
+                               draining_group->getDrainingFilterChains(), filter_chain_drain_event);
   }
 
   // Start the drain sequence which completes when the listener's drain manager has completed
@@ -1218,6 +1235,34 @@ void ListenerManagerImpl::stopListeners(StopListenersType stop_listeners_type,
           }
         }
       });
+    }
+  }
+}
+
+void ListenerManagerImpl::onServerDrainStart(Network::DrainDirection direction,
+                                             Network::ConnectionDrainEvent drain_event) {
+  // Direction is honored by only notifying listeners whose traffic direction is covered by the
+  // drain, so the connection-level drain logic itself does not need to re-check direction. The
+  // event is supplied by the caller and passed through unchanged, so every connection covered by
+  // one drain shares a single, consistent timeline.
+  //
+  // Only active listeners are notified. Listeners that are themselves already draining are
+  // deliberately skipped: drainListener() has already notified all of their connections, and under
+  // the first-event-wins rule (see Network::Connection::onDrain()) those connections would drop
+  // this later event anyway, staying on the earlier timeline they are already draining on. The
+  // pre-existing pull model OR'd the listener's own drain decision with the server-wide one, which
+  // made drain-close marginally more likely for those connections; dropping the server-wide term
+  // loses a small amount of drain acceleration in that window and nothing else. Their hard
+  // deadline is unchanged, since the listener's own drain sequence still force-closes whatever
+  // remains, and under DrainStrategy::Immediate there is no difference at all.
+  for (Network::ListenerConfig& listener : listeners()) {
+    if (direction == Network::DrainDirection::InboundOnly &&
+        listener.listenerInfo()->direction() != envoy::config::core::v3::INBOUND) {
+      continue;
+    }
+    const uint64_t listener_tag = listener.listenerTag();
+    for (const auto& worker : workers_) {
+      worker->onListenerDrain(listener_tag, drain_event);
     }
   }
 }

--- a/source/common/listener_manager/listener_manager_impl.h
+++ b/source/common/listener_manager/listener_manager_impl.h
@@ -248,6 +248,8 @@ public:
   absl::Status startWorkers(OptRef<GuardDog> guard_dog, std::function<void()> callback) override;
   void stopListeners(StopListenersType stop_listeners_type,
                      const Network::ExtraShutdownListenerOptions& options) override;
+  void onServerDrainStart(Network::DrainDirection direction,
+                          Network::ConnectionDrainEvent drain_event) override;
   void stopWorkers() override;
   void beginListenerUpdate() override { lds_error_state_tracker_.clear(); }
   void endListenerUpdate(FailureStates&& failure_state) override;

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -191,6 +191,18 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "drain_close_util_lib",
+    srcs = ["drain_close_util.cc"],
+    hdrs = ["drain_close_util.h"],
+    deps = [
+        "//envoy/network:drain_decision_interface",
+        "//envoy/server:factory_context_interface",
+        "//source/common/common:assert_lib",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_library(
     name = "hash_policy_lib",
     srcs = ["hash_policy.cc"],
     hdrs = ["hash_policy.h"],

--- a/source/common/network/connection_impl_base.cc
+++ b/source/common/network/connection_impl_base.cc
@@ -16,6 +16,15 @@ ConnectionImplBase::ConnectionImplBase(Event::Dispatcher& dispatcher, uint64_t i
 
 void ConnectionImplBase::addConnectionCallbacks(ConnectionCallbacks& cb) {
   callbacks_.push_back(&cb);
+  // The drain notification is one-shot, so a callback registered after the connection was notified
+  // would otherwise never learn that the connection is draining. This is not a corner case: the
+  // HTTP codec (and any wrapper around it) is created lazily on the first byte of data, so any
+  // connection that is idle when its listener starts draining registers callbacks afterwards.
+  // Implementations of onDrain() must therefore only record the event and must not assume that
+  // construction of their owner has completed.
+  if (drain_event_.has_value()) {
+    cb.onDrain(*drain_event_);
+  }
 }
 
 void ConnectionImplBase::removeConnectionCallbacks(ConnectionCallbacks& callbacks) {
@@ -28,10 +37,19 @@ void ConnectionImplBase::removeConnectionCallbacks(ConnectionCallbacks& callback
   }
 }
 
-void ConnectionImplBase::onDrain() {
+void ConnectionImplBase::onDrain(ConnectionDrainEvent drain_event) {
+  // The first event wins. A connection can be notified more than once (a server drain escalating
+  // from InboundOnly to All re-notifies inbound listeners, and a filter chain drain can follow a
+  // server drain), but a connection that is already draining stays on its original timeline rather
+  // than having the drain pushed back or restarted.
+  if (drain_event_.has_value()) {
+    return;
+  }
+  // Remember the event so that callbacks registered later are also notified.
+  drain_event_ = drain_event;
   for (ConnectionCallbacks* callback : callbacks_) {
     if (callback != nullptr) {
-      callback->onDrain();
+      callback->onDrain(drain_event);
     }
   }
 }

--- a/source/common/network/connection_impl_base.h
+++ b/source/common/network/connection_impl_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "envoy/event/dispatcher.h"
 
 #include "source/common/common/logger.h"
@@ -23,7 +25,7 @@ public:
   // Network::Connection
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   void removeConnectionCallbacks(ConnectionCallbacks& cb) override;
-  void onDrain() override;
+  void onDrain(ConnectionDrainEvent drain_event) override;
 
   // Network::FilterManagerConnection
   void onFilterAboveHighWatermark() override;
@@ -79,6 +81,9 @@ protected:
   Event::Dispatcher& dispatcher_;
   const uint64_t id_;
   std::list<ConnectionCallbacks*> callbacks_;
+  // Set once the connection has been notified of a drain sequence via onDrain(). Retained so that
+  // callbacks registered after the notification are replayed it (see addConnectionCallbacks()).
+  std::optional<ConnectionDrainEvent> drain_event_;
   std::unique_ptr<ConnectionStats> connection_stats_;
   // Number of sources above their high watermark. ConnectionCallbacks are notified on
   // transitions (0→1, 1→0).

--- a/source/common/network/drain_close_util.cc
+++ b/source/common/network/drain_close_util.cc
@@ -1,0 +1,54 @@
+#include "source/common/network/drain_close_util.h"
+
+#include <chrono>
+#include <cstdint>
+
+#include "source/common/common/assert.h"
+
+namespace Envoy {
+namespace Network {
+
+bool shouldDrainClose(Server::Configuration::ServerFactoryContext& context,
+                      envoy::config::listener::v3::Listener::DrainType drain_type,
+                      std::optional<ConnectionDrainEvent> drain_event) {
+  // If we are actively health check failed and the drain type is default, always drain close. This
+  // is polled rather than driven by a drain notification because /healthcheck/ok reverses it.
+  //
+  // TODO(mattklein123): In relation to x-envoy-immediate-health-check-fail, it would be better
+  // if even in the case of server health check failure we had some period of drain ramp up.
+  if (drain_type == envoy::config::listener::v3::Listener::DEFAULT && context.healthCheckFailed()) {
+    return true;
+  }
+
+  // The connection has not been notified of a drain sequence, so there is nothing to ramp against.
+  if (!drain_event.has_value()) {
+    return false;
+  }
+
+  // An immediate strategy drains as soon as the connection has been notified.
+  if (drain_event->strategy == Server::DrainStrategy::Immediate) {
+    return true;
+  }
+  ASSERT(drain_event->strategy == Server::DrainStrategy::Gradual);
+
+  // Gradual strategy: P(return true) = elapsed time / drain time, matching
+  // Server::DrainManagerImpl::drainClose(). The drain start time was captured once on the main
+  // thread so every connection shares the same drain deadline.
+  const std::chrono::seconds drain_time = context.options().drainTime();
+  const MonotonicTime now = context.timeSource().monotonicTime();
+  // Guard against a clock reading earlier than the recorded start time (should not happen with a
+  // monotonic clock, but be defensive).
+  const auto elapsed =
+      now <= drain_event->start_time
+          ? std::chrono::seconds{0}
+          : std::chrono::duration_cast<std::chrono::seconds>(now - drain_event->start_time);
+  // Also covers a zero drain time, in which case we drain as soon as we are notified.
+  if (elapsed >= drain_time) {
+    return true;
+  }
+  return static_cast<uint64_t>(elapsed.count()) >
+         (context.api().randomGenerator().random() % static_cast<uint64_t>(drain_time.count()));
+}
+
+} // namespace Network
+} // namespace Envoy

--- a/source/common/network/drain_close_util.h
+++ b/source/common/network/drain_close_util.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <optional>
+
+#include "envoy/config/listener/v3/listener.pb.h"
+#include "envoy/network/drain_decision.h"
+#include "envoy/server/factory_context.h"
+
+namespace Envoy {
+namespace Network {
+
+/**
+ * Computes whether a connection should now be drain-closed.
+ *
+ * Two independent conditions can trigger a drain close:
+ *
+ * 1. The server is failing health checks (/healthcheck/fail) and the listener's drain type is
+ *    DEFAULT. This is deliberately evaluated as a poll rather than from @param drain_event,
+ *    because /healthcheck/ok reverses it, and a one-shot drain notification cannot be revoked.
+ *
+ * 2. The connection has been notified of a drain sequence via Network::Connection::onDrain(). For
+ *    DrainStrategy::Immediate this returns true as soon as the notification has been received. For
+ *    DrainStrategy::Gradual the probability of returning true ramps linearly from 0 to 1 over the
+ *    drain window: P(true) = elapsed / Server::Options::drainTime().
+ *
+ * @param context supplies the server context, used for the health check state, the configured
+ *        drain time, the time source and the random generator.
+ * @param drain_type supplies the drain type of the listener owning the connection, from
+ *        Network::ListenerInfo::drainType(). For a downstream connection this is reached via
+ *        Connection::connectionInfoProvider().listenerInfo().
+ * @param drain_event supplies the drain sequence the connection has been notified of, or
+ *        std::nullopt if it has not been notified of one.
+ */
+bool shouldDrainClose(Server::Configuration::ServerFactoryContext& context,
+                      envoy::config::listener::v3::Listener::DrainType drain_type,
+                      std::optional<ConnectionDrainEvent> drain_event);
+
+} // namespace Network
+} // namespace Envoy

--- a/source/common/network/multi_connection_base_impl.cc
+++ b/source/common/network/multi_connection_base_impl.cc
@@ -360,18 +360,18 @@ void MultiConnectionBaseImpl::removeConnectionCallbacks(ConnectionCallbacks& cb)
   IS_ENVOY_BUG("Failed to remove connection callbacks");
 }
 
-void MultiConnectionBaseImpl::onDrain() {
+void MultiConnectionBaseImpl::onDrain(ConnectionDrainEvent drain_event) {
   if (connect_finished_) {
-    connections_[0]->onDrain();
+    connections_[0]->onDrain(drain_event);
     return;
   }
-  // Notify all deferred callbacks directly since no underlying connection has been
-  // chosen yet.
-  for (auto* cb : post_connect_state_.connection_callbacks_) {
-    if (cb != nullptr) {
-      cb->onDrain();
-    }
+  // No underlying connection has been chosen yet, so there is nothing to drain and no connection
+  // to notify on behalf of. Retain the event and hand it to the chosen connection once the connect
+  // finishes.
+  if (drain_event_.has_value()) {
+    return;
   }
+  drain_event_ = drain_event;
 }
 
 void MultiConnectionBaseImpl::close(ConnectionCloseType type, absl::string_view details) {
@@ -621,6 +621,12 @@ void MultiConnectionBaseImpl::setUpFinalConnection(ConnectionEvent event,
     if (cb) {
       connections_[0]->addConnectionCallbacks(*cb);
     }
+  }
+
+  // Hand the retained drain event to the chosen connection last, once every deferred callback has
+  // been added to it and the rest of the post-connect state has been applied.
+  if (drain_event_.has_value()) {
+    connections_[0]->onDrain(*drain_event_);
   }
 }
 

--- a/source/common/network/multi_connection_base_impl.h
+++ b/source/common/network/multi_connection_base_impl.h
@@ -85,7 +85,7 @@ public:
   void write(Buffer::Instance& data, bool end_stream) override;
   void addConnectionCallbacks(ConnectionCallbacks& cb) override;
   void removeConnectionCallbacks(ConnectionCallbacks& cb) override;
-  void onDrain() override;
+  void onDrain(ConnectionDrainEvent drain_event) override;
 
   // Methods which are applied to each connection attempt.
   void enableHalfClose(bool enabled) override;
@@ -248,6 +248,10 @@ private:
 
   // True when connect() has finished, either success or failure.
   bool connect_finished_ = false;
+  // Set if the wrapper is notified of a drain sequence before the final connection has been
+  // chosen. Retained so that deferred callbacks registered after the notification are replayed it,
+  // and so that the event can be handed to the chosen connection once the connect completes.
+  std::optional<ConnectionDrainEvent> drain_event_;
   Event::TimerPtr next_attempt_timer_;
 };
 

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -477,6 +477,7 @@ envoy_cc_library(
         ":envoy_quic_server_crypto_stream_factory_lib",
         ":envoy_quic_server_session_lib",
         ":quic_stat_names_lib",
+        "//envoy/network:drain_decision_interface",
         "//envoy/network:listener_interface",
         "//source/common/http:session_idle_list_lib",
         "@quiche//:quic_core_server_lib",

--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -291,14 +291,13 @@ void ActiveQuicListener::onFilterChainDraining(
 }
 
 void ActiveQuicListener::onFilterChainDrainStart(
-    const std::list<const Network::FilterChain*>& /*draining_filter_chains*/) {
-  // TODO: notify QUIC connections in the given filter chains that draining has begun
-  // (e.g. via HTTP/3 GOAWAY) without closing them.
+    const std::list<const Network::FilterChain*>& draining_filter_chains,
+    Network::ConnectionDrainEvent drain_event) {
+  quic_dispatcher_->drainConnectionsWithFilterChains(draining_filter_chains, drain_event);
 }
 
-void ActiveQuicListener::onListenerDrainStart() {
-  // TODO: notify all QUIC connections on this listener that draining has begun without
-  // closing them.
+void ActiveQuicListener::onListenerDrainStart(Network::ConnectionDrainEvent drain_event) {
+  quic_dispatcher_->drainAllConnections(drain_event);
 }
 
 void ActiveQuicListener::closeConnectionsWithFilterChain(const Network::FilterChain* filter_chain) {

--- a/source/common/quic/active_quic_listener.h
+++ b/source/common/quic/active_quic_listener.h
@@ -74,9 +74,9 @@ public:
   void updateListenerConfig(Network::ListenerConfig& config) override;
   void onFilterChainDraining(
       const std::list<const Network::FilterChain*>& draining_filter_chains) override;
-  void onFilterChainDrainStart(
-      const std::list<const Network::FilterChain*>& draining_filter_chains) override;
-  void onListenerDrainStart() override;
+  void onFilterChainDrainStart(const std::list<const Network::FilterChain*>& draining_filter_chains,
+                               Network::ConnectionDrainEvent drain_event) override;
+  void onListenerDrainStart(Network::ConnectionDrainEvent drain_event) override;
 
   void onCloseIdleHttpConnections(bool is_saturated) override;
 

--- a/source/common/quic/envoy_quic_dispatcher.cc
+++ b/source/common/quic/envoy_quic_dispatcher.cc
@@ -157,6 +157,11 @@ std::unique_ptr<quic::QuicSession> EnvoyQuicDispatcher::CreateQuicSession(
     quic_session->close(Network::ConnectionCloseType::FlushWrite, "no filter chain found");
   }
   quic_session->Initialize();
+  if (filter_chain != nullptr && drain_event_.has_value()) {
+    // The listener began draining before this session was created. Notify it now that its network
+    // filter chain.
+    quic_session->onDrain(*drain_event_);
+  }
   connection_handler_.incNumConnections();
   listener_stats_.downstream_cx_active_.inc();
   listener_stats_.downstream_cx_total_.inc();
@@ -204,6 +209,59 @@ void EnvoyQuicDispatcher::closeConnectionsWithFilterChain(
       // If any filters access those configs during destruction, it'll be use-after-free
       DeleteSessions();
     }
+  }
+}
+
+void EnvoyQuicDispatcher::drainSessionsOfFilterChain(const Network::FilterChain* filter_chain,
+                                                     Network::ConnectionDrainEvent drain_event) {
+  auto iter = connections_by_filter_chain_.find(filter_chain);
+  if (iter == connections_by_filter_chain_.end()) {
+    return;
+  }
+  // Snapshot the sessions before notifying any of them. A drain callback may synchronously close a
+  // session, which removes it from this list, and the last such removal erases the whole map entry
+  // (see EnvoyQuicServerSession::OnConnectionClosed()), destroying the list this would otherwise be
+  // iterating. A closed session is not destroyed until quic::QuicDispatcher deletes it on a later
+  // event loop iteration, so the snapshot stays valid; skip any session a previous callback closed.
+  const std::vector<std::reference_wrapper<Network::Connection>> sessions(iter->second.begin(),
+                                                                          iter->second.end());
+  for (Network::Connection& session : sessions) {
+    if (session.state() != Network::Connection::State::Open) {
+      continue;
+    }
+    session.onDrain(drain_event);
+  }
+}
+
+void EnvoyQuicDispatcher::drainConnectionsWithFilterChains(
+    const std::list<const Network::FilterChain*>& filter_chains,
+    Network::ConnectionDrainEvent drain_event) {
+  for (const Network::FilterChain* filter_chain : filter_chains) {
+    drainSessionsOfFilterChain(filter_chain, drain_event);
+  }
+}
+
+void EnvoyQuicDispatcher::drainAllConnections(Network::ConnectionDrainEvent drain_event) {
+  // Remember the drain so sessions created after this point are also notified (see
+  // CreateQuicSession). As on the TCP path (OwnedActiveStreamListenerBase::onListenerDrainStart),
+  // the first event wins: a listener can be notified more than once (a server drain escalating
+  // from InboundOnly to All), and a later notification neither pushes the drain back nor
+  // re-notifies sessions, all of which have already been notified of the first event.
+  if (drain_event_.has_value()) {
+    return;
+  }
+  drain_event_ = drain_event;
+  // Snapshot the keys before notifying: a drain callback may synchronously close a session, and the
+  // last close for a filter chain erases its entry from connections_by_filter_chain_, which would
+  // invalidate an iterator held across the loop. Entries erased in the meantime are simply not
+  // found on lookup.
+  std::vector<const Network::FilterChain*> filter_chains;
+  filter_chains.reserve(connections_by_filter_chain_.size());
+  for (const auto& entry : connections_by_filter_chain_) {
+    filter_chains.push_back(entry.first);
+  }
+  for (const Network::FilterChain* filter_chain : filter_chains) {
+    drainSessionsOfFilterChain(filter_chain, drain_event);
   }
 }
 

--- a/source/common/quic/envoy_quic_dispatcher.h
+++ b/source/common/quic/envoy_quic_dispatcher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "envoy/network/listener.h"
@@ -78,6 +79,20 @@ public:
 
   void closeConnectionsWithFilterChain(const Network::FilterChain* filter_chain);
 
+  /**
+   * Notify the sessions belonging to the given filter chains that they are being drained, without
+   * closing them. Filter chains with no sessions are skipped.
+   */
+  void drainConnectionsWithFilterChains(const std::list<const Network::FilterChain*>& filter_chains,
+                                        Network::ConnectionDrainEvent drain_event);
+
+  /**
+   * Notify every session on this listener that it is being drained, without closing any. The event
+   * is also retained so that sessions created later, while the drain is still in progress, are
+   * notified as they are created.
+   */
+  void drainAllConnections(Network::ConnectionDrainEvent drain_event);
+
   void updateListenerConfig(Network::ListenerConfig& new_listener_config);
 
   // Similar to quic::QuicDispatcher's ProcessPacket, but returns a bool.
@@ -106,6 +121,11 @@ private:
   // NOLINTNEXTLINE(readability-identifier-naming)
   Http::SessionIdleListInterface* idle_session_list() { return session_idle_list_.get(); }
 
+  // Notify every session belonging to `filter_chain` of the drain, without closing any. A no-op if
+  // the filter chain has no sessions.
+  void drainSessionsOfFilterChain(const Network::FilterChain* filter_chain,
+                                  Network::ConnectionDrainEvent drain_event);
+
   Network::ConnectionHandler& connection_handler_;
   Network::ListenerConfig* listener_config_{nullptr};
   Server::ListenerStats& listener_stats_;
@@ -115,6 +135,11 @@ private:
   QuicStatNames& quic_stat_names_;
   EnvoyQuicCryptoServerStreamFactoryInterface& crypto_server_stream_factory_;
   FilterChainToConnectionMap connections_by_filter_chain_;
+  // Set once the listener as a whole begins draining. Retained so that sessions created after the
+  // drain has started are also notified: the onDrain() notification is one-shot, so newly created
+  // sessions would otherwise miss it. Mirrors
+  // Server::ActiveStreamListenerBase::drain_event_ for the TCP path.
+  std::optional<Network::ConnectionDrainEvent> drain_event_;
   QuicDispatcherStats quic_stats_;
   QuicConnectionStats connection_stats_;
   bool current_packet_dispatch_success_;

--- a/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
+++ b/source/extensions/api_listeners/default_api_listener/api_listener_impl.h
@@ -134,7 +134,7 @@ protected:
         IS_ENVOY_BUG("Unexpected function call");
         return false;
       }
-      void onDrain() override {}
+      void onDrain(Network::ConnectionDrainEvent) override {}
       void close(Network::ConnectionCloseType) override {}
       void close(Network::ConnectionCloseType, absl::string_view) override {}
       StreamInfo::DetectedCloseType detectedCloseType() const override {

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -493,6 +493,7 @@ envoy_cc_library(
         "//envoy/api:api_interface",
         "//envoy/event:dispatcher_interface",
         "//envoy/event:timer_interface",
+        "//envoy/network:drain_decision_interface",
         "//envoy/network:exception_interface",
         "//envoy/server:configuration_interface",
         "//envoy/server:guarddog_interface",

--- a/source/server/active_udp_listener.h
+++ b/source/server/active_udp_listener.h
@@ -114,10 +114,14 @@ public:
   void onFilterChainDraining(const std::list<const Network::FilterChain*>&) override {
     IS_ENVOY_BUG("unexpected call to onFilterChainDraining");
   }
-  void onFilterChainDrainStart(const std::list<const Network::FilterChain*>&) override {
-    IS_ENVOY_BUG("unexpected call to onFilterChainDrainStart");
-  }
-  void onListenerDrainStart() override { IS_ENVOY_BUG("unexpected call to onListenerDrainStart"); }
+  // Drain notifications are broadcast to every listener owned by the connection handler, UDP
+  // listeners included, so these are reachable and must not be flagged as bugs. There is no
+  // connection-level state to notify for a raw UDP listener, so they are no-ops. Note that this
+  // differs from onFilterChainDraining() above, which is only invoked for listener types that
+  // support filter chain removal.
+  void onFilterChainDrainStart(const std::list<const Network::FilterChain*>&,
+                               Network::ConnectionDrainEvent) override {}
+  void onListenerDrainStart(Network::ConnectionDrainEvent) override {}
 
   // Network::UdpListenerFilterManager
   void addReadFilter(Network::UdpListenerReadFilterPtr&& filter) override;

--- a/source/server/admin/listeners_handler.cc
+++ b/source/server/admin/listeners_handler.cc
@@ -41,10 +41,20 @@ Http::Code ListenersHandler::handlerDrainListeners(Http::ResponseHeaderMap&,
       response.add("OK\n");
       return Http::Code::OK;
     }
+
+    // The start time and strategy are captured once here so every notified connection shares a
+    // single, consistent drain timeline. A future query parameter can override the strategy for
+    // this drain without touching the server-wide default.
+    server_.listenerManager().onServerDrainStart(
+        direction, Network::ConnectionDrainEvent{server_.api().timeSource().monotonicTime(),
+                                                 server_.options().drainStrategy()});
     // This means either we aren't draining or we still have to do some work
     // (e.g. we were draining inbound only but now we're being asked to drain all)
     server_.drainManager().startDrainSequence(direction, [this, stop_listeners_type, skip_exit]() {
       if (!skip_exit) {
+        // Stop the listeners after the drain duration because for admin initiated drain, there is
+        // no another versions of the listeners to take care of the new connections. So Envoy still
+        // accepts new connections during the drain duration to reduce the errors.
         server_.listenerManager().stopListeners(stop_listeners_type, {});
       }
     });

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -160,6 +160,16 @@ void InstanceBase::drainListeners(OptRef<const Network::ExtraShutdownListenerOpt
   listener_manager_->stopListeners(ListenerManager::StopListenersType::All,
                                    options.has_value() ? *options
                                                        : Network::ExtraShutdownListenerOptions{});
+  // Notify the connections of every listener that draining has begun, so connection-level drain
+  // logic can react. Server-wide drains notify from their entry
+  // point rather than from DrainManagerImpl, whose per-listener children must not fan out. The
+  // start time and strategy are captured once here so every notified connection shares a single,
+  // consistent drain timeline.
+  listener_manager_->onServerDrainStart(
+      Network::DrainDirection::All,
+      Network::ConnectionDrainEvent{api().timeSource().monotonicTime(),
+                                    InstanceBase::options().drainStrategy()});
+
   drain_manager_->startDrainSequence(Network::DrainDirection::All, [] {});
 }
 

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -6,6 +6,7 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/event/timer.h"
+#include "envoy/network/drain_decision.h"
 #include "envoy/network/exception.h"
 #include "envoy/server/configuration.h"
 #include "envoy/thread_local/thread_local.h"
@@ -154,15 +155,17 @@ void WorkerImpl::stopListener(Network::ListenerConfig& listener,
 }
 
 void WorkerImpl::onFilterChainDrain(uint64_t listener_tag,
-                                    const std::list<const Network::FilterChain*>& filter_chains) {
-  dispatcher_->post([this, listener_tag, &filter_chains]() -> void {
-    handler_->onFilterChainDrain(listener_tag, filter_chains);
+                                    const std::list<const Network::FilterChain*>& filter_chains,
+                                    Network::ConnectionDrainEvent drain_event) {
+  dispatcher_->post([this, listener_tag, &filter_chains, drain_event]() -> void {
+    handler_->onFilterChainDrain(listener_tag, filter_chains, drain_event);
   });
 }
 
-void WorkerImpl::onListenerDrain(Network::ListenerConfig& listener) {
-  const uint64_t listener_tag = listener.listenerTag();
-  dispatcher_->post([this, listener_tag]() -> void { handler_->onListenerDrain(listener_tag); });
+void WorkerImpl::onListenerDrain(uint64_t listener_tag, Network::ConnectionDrainEvent drain_event) {
+  dispatcher_->post([this, listener_tag, drain_event]() -> void {
+    handler_->onListenerDrain(listener_tag, drain_event);
+  });
 }
 
 void WorkerImpl::threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb) {

--- a/source/server/worker_impl.h
+++ b/source/server/worker_impl.h
@@ -70,8 +70,9 @@ public:
                     const Network::ExtraShutdownListenerOptions& options,
                     std::function<void()> completion) override;
   void onFilterChainDrain(uint64_t listener_tag,
-                          const std::list<const Network::FilterChain*>& filter_chains) override;
-  void onListenerDrain(Network::ListenerConfig& listener) override;
+                          const std::list<const Network::FilterChain*>& filter_chains,
+                          Network::ConnectionDrainEvent drain_event) override;
+  void onListenerDrain(uint64_t listener_tag, Network::ConnectionDrainEvent drain_event) override;
 
 private:
   void threadRoutine(OptRef<GuardDog> guard_dog, const std::function<void()>& cb);

--- a/test/common/listener_manager/listener_manager_impl_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_test.cc
@@ -3193,6 +3193,47 @@ filter_chains:
   checkStats(__LINE__, 1, 0, 1, 0, 0, 0, 0);
 }
 
+// A listener drain propagates the configured drain strategy, so its connections ramp up over the
+// drain window like a server drain does.
+TEST_P(ListenerManagerImplTest, DrainListenerUsesConfiguredDrainStrategy) {
+  InSequence s;
+
+  EXPECT_CALL(*worker_, start(_, _, _));
+  ASSERT_OK(manager_->startWorkers(guard_dog_, callback_.AsStdFunction()));
+
+  const std::string listener_foo_yaml = R"EOF(
+name: foo
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+filter_chains:
+- filters: []
+  )EOF";
+
+  ListenerHandle* listener_foo = expectListenerCreate(false, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
+  worker_->callAddCompletion();
+
+  ON_CALL(server_.options_, drainStrategy()).WillByDefault(Return(Server::DrainStrategy::Gradual));
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
+  Network::ConnectionDrainEvent captured;
+  EXPECT_CALL(*worker_, onListenerDrain(_, _))
+      .WillOnce(
+          Invoke([&captured](uint64_t, Network::ConnectionDrainEvent event) { captured = event; }));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
+  EXPECT_TRUE(manager_->removeListener("foo"));
+  EXPECT_EQ(Server::DrainStrategy::Gradual, captured.strategy);
+
+  EXPECT_CALL(*worker_, removeListener(_, _));
+  listener_foo->drain_manager_->drain_sequence_completion_();
+
+  EXPECT_CALL(*listener_foo, onDestroy());
+  worker_->callRemovalCompletion();
+}
+
 // Verify ListenerManagerImpl::drainListener fans out worker_->onListenerDrain at the start
 // of the drain sequence, before connections are closed.
 TEST_P(ListenerManagerImplTest, DrainListenerFansOutToWorker) {
@@ -3221,13 +3262,111 @@ filter_chains:
   // drain_manager->startDrainSequence. Override the AnyNumber() default from SetUp() so we
   // assert worker->onListenerDrain is invoked exactly once.
   EXPECT_CALL(*worker_, stopListener(_, _, _));
-  EXPECT_CALL(*worker_, onListenerDrain(_));
+  EXPECT_CALL(*worker_, onListenerDrain(_, _));
   EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
   EXPECT_TRUE(manager_->removeListener("foo"));
 
   EXPECT_CALL(*worker_, removeListener(_, _));
   listener_foo->drain_manager_->drain_sequence_completion_();
 
+  EXPECT_CALL(*listener_foo, onDestroy());
+  worker_->callRemovalCompletion();
+}
+
+// Verify that onServerDrainStart (server-wide/admin drain) notifies connections via the worker's
+// onListenerDrain, and honors direction: an InboundOnly drain only notifies inbound listeners.
+TEST_P(ListenerManagerImplTest, OnServerDrainStartHonorsDirection) {
+  InSequence s;
+
+  EXPECT_CALL(*worker_, start(_, _, _));
+  ASSERT_OK(manager_->startWorkers(guard_dog_, callback_.AsStdFunction()));
+
+  const std::string inbound_yaml = R"EOF(
+name: inbound
+traffic_direction: INBOUND
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+filter_chains:
+- filters: []
+  )EOF";
+  ListenerHandle* inbound = expectListenerCreate(false, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(inbound_yaml)));
+  worker_->callAddCompletion();
+
+  const std::string outbound_yaml = R"EOF(
+name: outbound
+traffic_direction: OUTBOUND
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1235
+filter_chains:
+- filters: []
+  )EOF";
+  ListenerHandle* outbound = expectListenerCreate(false, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(outbound_yaml)));
+  worker_->callAddCompletion();
+
+  // An All drain notifies both listeners (override the AnyNumber() default from SetUp()).
+  EXPECT_CALL(*worker_, onListenerDrain(_, _)).Times(2);
+  manager_->onServerDrainStart(Network::DrainDirection::All, Network::ConnectionDrainEvent{});
+
+  // An InboundOnly drain notifies only the single inbound listener.
+  EXPECT_CALL(*worker_, onListenerDrain(_, _));
+  manager_->onServerDrainStart(Network::DrainDirection::InboundOnly,
+                               Network::ConnectionDrainEvent{});
+
+  EXPECT_CALL(*inbound, onDestroy());
+  EXPECT_CALL(*outbound, onDestroy());
+}
+
+// A server-wide drain notifies only active listeners. Listeners that are already draining are
+// deliberately skipped, because drainListener() has already notified all of their connections with
+// an earlier (and therefore further advanced) drain event. See
+// ListenerManagerImpl::onServerDrainStart().
+TEST_P(ListenerManagerImplTest, OnServerDrainStartSkipsDrainingListeners) {
+  EXPECT_CALL(*worker_, start(_, _, _));
+  ASSERT_OK(manager_->startWorkers(guard_dog_, callback_.AsStdFunction()));
+
+  const std::string listener_foo_yaml = R"EOF(
+name: foo
+traffic_direction: INBOUND
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+filter_chains:
+- filters: []
+  )EOF";
+
+  ListenerHandle* listener_foo = expectListenerCreate(false, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
+  worker_->callAddCompletion();
+
+  // Remove the listener so it moves into the draining state. It stays owned by the worker until
+  // its drain sequence completes.
+  EXPECT_CALL(*worker_, stopListener(_, _, _));
+  EXPECT_CALL(*listener_foo->drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
+  EXPECT_TRUE(manager_->removeListener("foo"));
+  EXPECT_EQ(0UL, manager_->listeners().size());
+  EXPECT_EQ(1UL, manager_->listeners(ListenerManager::ListenerState::DRAINING).size());
+
+  // A server drain does not re-notify the draining listener: it is not in the active set, and its
+  // connections were already notified by removeListener() above. Overrides the AnyNumber() default
+  // from SetUp().
+  EXPECT_CALL(*worker_, onListenerDrain(_, _)).Times(0);
+  manager_->onServerDrainStart(Network::DrainDirection::All, Network::ConnectionDrainEvent{});
+
+  EXPECT_CALL(*worker_, removeListener(_, _));
+  listener_foo->drain_manager_->drain_sequence_completion_();
   EXPECT_CALL(*listener_foo, onDestroy());
   worker_->callRemovalCompletion();
 }
@@ -8070,6 +8209,81 @@ filter_chains:
   EXPECT_CALL(*listener_foo_update1, onDestroy());
 }
 
+// A draining filter chain is notified with DrainStrategy::Immediate regardless of the configured
+// strategy to keep backwards compatibility with existing filter chain drain behavior.
+TEST_P(ListenerManagerImplForInPlaceFilterChainUpdateTest, FilterChainDrainUsesImmediateStrategy) {
+  // Deliberately no InSequence: this test asserts the content of the drain notification, not the
+  // ordering of the surrounding calls.
+  EXPECT_CALL(*worker_, start(_, _, _));
+  ASSERT_OK(manager_->startWorkers(guard_dog_, callback_.AsStdFunction()));
+
+  const std::string listener_foo_yaml = R"EOF(
+name: foo
+traffic_direction: INBOUND
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+filter_chains:
+- filters: []
+  )EOF";
+
+  ListenerHandle* listener_foo = expectListenerCreate(true, true);
+  EXPECT_CALL(listener_factory_, createListenSocket(_, _, _, default_bind_type, _, 0));
+  EXPECT_CALL(listener_foo->target_, initialize());
+  EXPECT_TRUE(addOrUpdateListener(parseListenerFromV3Yaml(listener_foo_yaml)));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  listener_foo->target_.ready();
+  worker_->callAddCompletion();
+
+  // Update foo in place so its original filter chain begins draining.
+  const auto listener_foo_update1_proto = parseListenerFromV3Yaml(R"EOF(
+name: foo
+traffic_direction: INBOUND
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: 1234
+filter_chains:
+- filters:
+  filter_chain_match:
+    destination_port: 1234
+  )EOF");
+
+  ListenerHandle* listener_foo_update1 = expectListenerOverridden(true, listener_foo);
+  auto duplicated_socket = new NiceMock<Network::MockListenSocket>();
+  EXPECT_CALL(*listener_factory_.socket_, duplicate())
+      .WillOnce(Return(ByMove(std::unique_ptr<Network::Socket>(duplicated_socket))));
+  EXPECT_CALL(listener_foo_update1->target_, initialize());
+  EXPECT_TRUE(addOrUpdateListener(listener_foo_update1_proto));
+
+  // Configure a gradual server drain strategy; the filter chain drain must override it.
+  ON_CALL(server_.options_, drainStrategy()).WillByDefault(Return(Server::DrainStrategy::Gradual));
+  ON_CALL(server_.options_, drainTime()).WillByDefault(Return(std::chrono::seconds(600)));
+
+  Network::ConnectionDrainEvent captured;
+  // Overrides the AnyNumber() default installed by SetUp().
+  EXPECT_CALL(*worker_, onFilterChainDrain(_, _, _))
+      .WillOnce(Invoke([&captured](uint64_t, const std::list<const Network::FilterChain*>&,
+                                   Network::ConnectionDrainEvent event) { captured = event; }));
+  EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
+  Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
+  EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
+  listener_foo_update1->target_.ready();
+  worker_->callAddCompletion();
+
+  EXPECT_EQ(Server::DrainStrategy::Immediate, captured.strategy);
+
+  // Timer expires, the worker removes the draining filter chains, and once that completes the
+  // main thread can destroy the original listener.
+  EXPECT_CALL(*worker_, removeFilterChains(_, _, _));
+  filter_chain_drain_timer->invokeCallback();
+  EXPECT_CALL(*listener_foo, onDestroy());
+  worker_->callDrainFilterChainsComplete();
+
+  EXPECT_CALL(*listener_foo_update1, onDestroy());
+}
+
 TEST_P(ListenerManagerImplForInPlaceFilterChainUpdateTest, RemoveTheInplaceUpdatingListener) {
   InSequence s;
 
@@ -8124,7 +8338,7 @@ filter_chains:
 
   // The warmed up starts the drain timer.
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
-  EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
+  ON_CALL(server_.options_, drainTime()).WillByDefault(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
   listener_foo_update1->target_.ready();
@@ -8208,7 +8422,7 @@ filter_chains:
 
   // The warmed up starts the drain timer.
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
-  EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
+  ON_CALL(server_.options_, drainTime()).WillByDefault(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
   listener_foo_update1->target_.ready();
@@ -8340,7 +8554,7 @@ filter_chains:
 
   // The warmed up starts the drain timer.
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
-  EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
+  ON_CALL(server_.options_, drainTime()).WillByDefault(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
   listener_foo_update1->target_.ready();
@@ -8446,7 +8660,7 @@ filter_chains:
 
   // The warmed up starts the drain timer.
   EXPECT_CALL(*worker_, addListener(_, _, _, _, _));
-  EXPECT_CALL(server_.options_, drainTime()).WillOnce(Return(std::chrono::seconds(600)));
+  ON_CALL(server_.options_, drainTime()).WillByDefault(Return(std::chrono::seconds(600)));
   Event::MockTimer* filter_chain_drain_timer = new Event::MockTimer(&server_.dispatcher_);
   EXPECT_CALL(*filter_chain_drain_timer, enableTimer(std::chrono::milliseconds(600000), _));
   listener_foo_update1->target_.ready();

--- a/test/common/listener_manager/listener_manager_impl_test.h
+++ b/test/common/listener_manager/listener_manager_impl_test.h
@@ -80,8 +80,8 @@ protected:
     EXPECT_CALL(worker_factory_, createWorker_()).WillOnce(Return(worker_));
     // Drain notifications are scheduled whenever a listener or its filter chains begin draining.
     // They are not the focus of these tests, so allow them in any number.
-    EXPECT_CALL(*worker_, onListenerDrain(_)).Times(::testing::AnyNumber());
-    EXPECT_CALL(*worker_, onFilterChainDrain(_, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(*worker_, onListenerDrain(_, _)).Times(::testing::AnyNumber());
+    EXPECT_CALL(*worker_, onFilterChainDrain(_, _, _)).Times(::testing::AnyNumber());
     ON_CALL(server_.validation_context_, staticValidationVisitor())
         .WillByDefault(ReturnRef(validation_visitor));
     ON_CALL(server_.validation_context_, dynamicValidationVisitor())

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -95,6 +95,18 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "drain_close_util_test",
+    srcs = ["drain_close_util_test.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/network:drain_close_util_lib",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/test_common:simulated_time_system_lib",
+        "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
     name = "connection_impl_test",
     srcs = ["connection_impl_test.cc"],
     rbe_pool = "6gig",

--- a/test/common/network/connection_impl_test.cc
+++ b/test/common/network/connection_impl_test.cc
@@ -377,10 +377,10 @@ TEST_P(ConnectionImplTest, DrainFiresOnDrainOnAllCallbacks) {
   client_connection_->addConnectionCallbacks(cb_b);
 
   // client_callbacks_ was registered by setUpBasicConnection(); it also receives onDrain().
-  EXPECT_CALL(client_callbacks_, onDrain());
-  EXPECT_CALL(cb_a, onDrain());
-  EXPECT_CALL(cb_b, onDrain());
-  client_connection_->onDrain();
+  EXPECT_CALL(client_callbacks_, onDrain(_));
+  EXPECT_CALL(cb_a, onDrain(_));
+  EXPECT_CALL(cb_b, onDrain(_));
+  client_connection_->onDrain(Network::ConnectionDrainEvent{});
 
   client_connection_->removeConnectionCallbacks(cb_a);
   client_connection_->removeConnectionCallbacks(cb_b);
@@ -398,12 +398,78 @@ TEST_P(ConnectionImplTest, DrainSkipsRemovedCallbacks) {
   // removeConnectionCallbacks nulls out the slot without resizing; onDrain() must skip it.
   client_connection_->removeConnectionCallbacks(removed_cb);
 
-  EXPECT_CALL(client_callbacks_, onDrain());
-  EXPECT_CALL(kept_cb, onDrain());
+  EXPECT_CALL(client_callbacks_, onDrain(_));
+  EXPECT_CALL(kept_cb, onDrain(_));
   // removed_cb.onDrain must NOT be invoked (StrictMock catches it).
-  client_connection_->onDrain();
+  client_connection_->onDrain(Network::ConnectionDrainEvent{});
 
   client_connection_->removeConnectionCallbacks(kept_cb);
+  disconnect(true);
+}
+
+// A callback registered after the connection has been notified of a drain must be replayed the
+// event. The HTTP codec (and wrappers around it) are created lazily on the first byte of data, so
+// an idle connection whose listener starts draining registers its drain-aware callbacks after the
+// notification and would otherwise never learn of the drain.
+TEST_P(ConnectionImplTest, DrainIsReplayedToLateRegisteredCallbacks) {
+  setUpBasicConnection();
+  connect();
+
+  const MonotonicTime start_time = dispatcher_->timeSource().monotonicTime();
+  EXPECT_CALL(client_callbacks_, onDrain(_));
+  client_connection_->onDrain(
+      Network::ConnectionDrainEvent{start_time, Server::DrainStrategy::Immediate});
+
+  StrictMock<MockConnectionCallbacks> late_cb;
+  Network::ConnectionDrainEvent replayed;
+  EXPECT_CALL(late_cb, onDrain(_))
+      .WillOnce(Invoke([&replayed](Network::ConnectionDrainEvent event) { replayed = event; }));
+  client_connection_->addConnectionCallbacks(late_cb);
+  EXPECT_EQ(start_time, replayed.start_time);
+  EXPECT_EQ(Server::DrainStrategy::Immediate, replayed.strategy);
+
+  client_connection_->removeConnectionCallbacks(late_cb);
+  disconnect(true);
+}
+
+// A callback registered before any drain notification is not replayed anything.
+TEST_P(ConnectionImplTest, NoDrainReplayWithoutNotification) {
+  setUpBasicConnection();
+  connect();
+
+  StrictMock<MockConnectionCallbacks> cb;
+  // cb.onDrain must NOT be invoked (StrictMock catches it).
+  client_connection_->addConnectionCallbacks(cb);
+
+  client_connection_->removeConnectionCallbacks(cb);
+  disconnect(true);
+}
+
+// The first drain event wins: a connection that is already draining stays on its original
+// timeline, and a later notification is ignored rather than re-notifying callbacks or pushing the
+// drain back.
+TEST_P(ConnectionImplTest, DrainKeepsFirstEvent) {
+  setUpBasicConnection();
+  connect();
+
+  const MonotonicTime start_time = dispatcher_->timeSource().monotonicTime();
+  EXPECT_CALL(client_callbacks_, onDrain(_));
+  client_connection_->onDrain(
+      Network::ConnectionDrainEvent{start_time, Server::DrainStrategy::Gradual});
+  // A second notification (an InboundOnly -> All drain escalation, or a filter chain drain
+  // following a server drain) is dropped, even though it is more aggressive.
+  client_connection_->onDrain(Network::ConnectionDrainEvent{start_time + std::chrono::seconds(30),
+                                                            Server::DrainStrategy::Immediate});
+
+  StrictMock<MockConnectionCallbacks> late_cb;
+  Network::ConnectionDrainEvent replayed;
+  EXPECT_CALL(late_cb, onDrain(_))
+      .WillOnce(Invoke([&replayed](Network::ConnectionDrainEvent event) { replayed = event; }));
+  client_connection_->addConnectionCallbacks(late_cb);
+  EXPECT_EQ(start_time, replayed.start_time);
+  EXPECT_EQ(Server::DrainStrategy::Gradual, replayed.strategy);
+
+  client_connection_->removeConnectionCallbacks(late_cb);
   disconnect(true);
 }
 

--- a/test/common/network/drain_close_util_test.cc
+++ b/test/common/network/drain_close_util_test.cc
@@ -1,0 +1,132 @@
+#include <chrono>
+
+#include "envoy/config/listener/v3/listener.pb.h"
+
+#include "source/common/network/drain_close_util.h"
+
+#include "test/mocks/server/server_factory_context.h"
+#include "test/test_common/simulated_time_system.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::NiceMock;
+using testing::Return;
+
+namespace Envoy {
+namespace Network {
+namespace {
+
+constexpr auto Default = envoy::config::listener::v3::Listener::DEFAULT;
+constexpr auto ModifyOnly = envoy::config::listener::v3::Listener::MODIFY_ONLY;
+
+class DrainCloseUtilTest : public testing::Test {
+public:
+  DrainCloseUtilTest() {
+    // MockServerFactoryContext defaults timeSource() to its own time_system_, which
+    // SimulatedTimeSystemHelper redirects to the simulated clock installed by this fixture.
+    setDrainTime(std::chrono::seconds(100));
+    setHealthCheckFailed(false);
+  }
+
+  void setDrainTime(std::chrono::seconds drain_time) {
+    ON_CALL(context_.options_, drainTime()).WillByDefault(Return(drain_time));
+  }
+  void setHealthCheckFailed(bool failed) {
+    ON_CALL(context_, healthCheckFailed()).WillByDefault(Return(failed));
+  }
+  // Forces the random generator to return `value`, which the gradual ramp compares against.
+  void setRandom(uint64_t value) {
+    ON_CALL(context_.api_.random_, random()).WillByDefault(Return(value));
+  }
+
+  ConnectionDrainEvent gradualEventStartingNow() {
+    return ConnectionDrainEvent{time_system_.monotonicTime(), Server::DrainStrategy::Gradual};
+  }
+
+  Event::SimulatedTimeSystem time_system_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+};
+
+// With no drain notification and a healthy server, nothing drains.
+TEST_F(DrainCloseUtilTest, NoEventNoDrain) {
+  EXPECT_FALSE(shouldDrainClose(context_, Default, std::nullopt));
+  EXPECT_FALSE(shouldDrainClose(context_, ModifyOnly, std::nullopt));
+}
+
+// A failing health check drains a DEFAULT listener with no drain notification at all, and is
+// reversible because it is polled rather than pushed.
+TEST_F(DrainCloseUtilTest, HealthCheckFailedDrainsDefaultListener) {
+  setHealthCheckFailed(true);
+  EXPECT_TRUE(shouldDrainClose(context_, Default, std::nullopt));
+
+  setHealthCheckFailed(false);
+  EXPECT_FALSE(shouldDrainClose(context_, Default, std::nullopt));
+}
+
+// A MODIFY_ONLY listener ignores the health check state.
+TEST_F(DrainCloseUtilTest, HealthCheckFailedIgnoredForModifyOnlyListener) {
+  setHealthCheckFailed(true);
+  EXPECT_FALSE(shouldDrainClose(context_, ModifyOnly, std::nullopt));
+}
+
+// An immediate strategy drains as soon as the notification is received, without consulting the
+// clock, the drain time or the random generator.
+TEST_F(DrainCloseUtilTest, ImmediateStrategyDrainsAtOnce) {
+  const ConnectionDrainEvent event{time_system_.monotonicTime(), Server::DrainStrategy::Immediate};
+  EXPECT_CALL(context_.api_.random_, random()).Times(0);
+  EXPECT_TRUE(shouldDrainClose(context_, Default, event));
+  EXPECT_TRUE(shouldDrainClose(context_, ModifyOnly, event));
+}
+
+// A gradual strategy never drains at the instant it is notified: elapsed is 0, and the ramp
+// requires elapsed > random % drain_time.
+TEST_F(DrainCloseUtilTest, GradualStrategyDoesNotDrainImmediately) {
+  const ConnectionDrainEvent event = gradualEventStartingNow();
+  setRandom(0);
+  EXPECT_FALSE(shouldDrainClose(context_, Default, event));
+}
+
+// Once the drain window has fully elapsed, a gradual strategy always drains.
+TEST_F(DrainCloseUtilTest, GradualStrategyDrainsAfterDeadline) {
+  const ConnectionDrainEvent event = gradualEventStartingNow();
+  time_system_.advanceTimeWait(std::chrono::seconds(100));
+  // Even the largest random value cannot prevent the drain past the deadline.
+  setRandom(std::numeric_limits<uint64_t>::max());
+  EXPECT_TRUE(shouldDrainClose(context_, Default, event));
+}
+
+// Mid-window the decision is the ramp: drain iff elapsed > random % drain_time.
+TEST_F(DrainCloseUtilTest, GradualStrategyRampsWithElapsedTime) {
+  const ConnectionDrainEvent event = gradualEventStartingNow();
+  time_system_.advanceTimeWait(std::chrono::seconds(30));
+
+  // random % 100 == 29 < 30 elapsed -> drain.
+  setRandom(29);
+  EXPECT_TRUE(shouldDrainClose(context_, Default, event));
+  // random % 100 == 30, not strictly less than 30 elapsed -> no drain.
+  setRandom(30);
+  EXPECT_FALSE(shouldDrainClose(context_, Default, event));
+  // random % 100 == 70 > 30 elapsed -> no drain.
+  setRandom(70);
+  EXPECT_FALSE(shouldDrainClose(context_, Default, event));
+}
+
+// A zero drain time means drain as soon as the connection is notified.
+TEST_F(DrainCloseUtilTest, ZeroDrainTimeDrainsAtOnce) {
+  setDrainTime(std::chrono::seconds(0));
+  EXPECT_TRUE(shouldDrainClose(context_, Default, gradualEventStartingNow()));
+}
+
+// A start time in the future (a non-monotonic clock reading) is clamped to zero elapsed rather
+// than underflowing into a huge elapsed value.
+TEST_F(DrainCloseUtilTest, StartTimeInTheFutureDoesNotUnderflow) {
+  const ConnectionDrainEvent event{time_system_.monotonicTime() + std::chrono::seconds(10),
+                                   Server::DrainStrategy::Gradual};
+  setRandom(0);
+  EXPECT_FALSE(shouldDrainClose(context_, Default, event));
+}
+
+} // namespace
+} // namespace Network
+} // namespace Envoy

--- a/test/common/network/multi_connection_base_impl_test.cc
+++ b/test/common/network/multi_connection_base_impl_test.cc
@@ -13,6 +13,7 @@
 #include "test/mocks/network/transport_socket.h"
 #include "test/mocks/stream_info/mocks.h"
 
+using testing::Invoke;
 using testing::Return;
 using testing::ReturnRef;
 using testing::StrictMock;
@@ -204,7 +205,10 @@ TEST_F(MultiConnectionBaseImplTest, ConnectTimeoutThenFirstSuccess) {
   EXPECT_FALSE(impl_->connecting());
 }
 
-TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedFiresOnDeferredCallbacks) {
+// Deferred callbacks are not notified while the connect is in flight: they are only notified of
+// events on the final connection, and notifying them here would deliver onDrain() a second time
+// when they are added to that connection.
+TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedDoesNotNotifyDeferredCallbacks) {
   setupMultiConnectionImpl(2);
   startConnect();
 
@@ -213,11 +217,60 @@ TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedFiresOnDeferredCal
   impl_->addConnectionCallbacks(cb_a);
   impl_->addConnectionCallbacks(cb_b);
 
-  EXPECT_CALL(cb_a, onDrain());
-  EXPECT_CALL(cb_b, onDrain());
-  impl_->onDrain();
+  // Neither callback may be notified (StrictMock catches it).
+  impl_->onDrain(Network::ConnectionDrainEvent{});
 }
 
+// Once the connect completes, the deferred callbacks are added to the chosen connection first and
+// the retained event is handed to it last, so it fans the event out to all of them in one pass,
+// exactly once.
+TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectIsForwardedToFinalConnection) {
+  setupMultiConnectionImpl(2);
+  startConnect();
+
+  StrictMock<MockConnectionCallbacks> cb;
+  impl_->addConnectionCallbacks(cb);
+
+  const MonotonicTime start_time = dispatcher_.timeSource().monotonicTime();
+  impl_->onDrain(Network::ConnectionDrainEvent{start_time, Server::DrainStrategy::Gradual});
+
+  testing::InSequence s;
+  Network::ConnectionDrainEvent forwarded;
+  EXPECT_CALL(*failover_timer_, disableTimer());
+  EXPECT_CALL(*createdConnections()[0], removeConnectionCallbacks(_));
+  EXPECT_CALL(*createdConnections()[0], addConnectionCallbacks(_));
+  EXPECT_CALL(*createdConnections()[0], onDrain(_))
+      .WillOnce(Invoke([&forwarded](Network::ConnectionDrainEvent event) { forwarded = event; }));
+  connectionCallbacks()[0]->onEvent(ConnectionEvent::Connected);
+
+  EXPECT_EQ(start_time, forwarded.start_time);
+  EXPECT_EQ(Server::DrainStrategy::Gradual, forwarded.strategy);
+}
+
+// The first event wins before the connect finishes too: a later notification does not replace the
+// event that is handed to the chosen connection.
+TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedKeepsFirstEvent) {
+  setupMultiConnectionImpl(2);
+  startConnect();
+
+  const MonotonicTime start_time = dispatcher_.timeSource().monotonicTime();
+  impl_->onDrain(Network::ConnectionDrainEvent{start_time, Server::DrainStrategy::Gradual});
+  impl_->onDrain(Network::ConnectionDrainEvent{start_time + std::chrono::seconds(30),
+                                               Server::DrainStrategy::Immediate});
+
+  Network::ConnectionDrainEvent forwarded;
+  EXPECT_CALL(*failover_timer_, disableTimer());
+  EXPECT_CALL(*createdConnections()[0], removeConnectionCallbacks(_));
+  EXPECT_CALL(*createdConnections()[0], onDrain(_))
+      .WillOnce(Invoke([&forwarded](Network::ConnectionDrainEvent event) { forwarded = event; }));
+  connectionCallbacks()[0]->onEvent(ConnectionEvent::Connected);
+
+  EXPECT_EQ(start_time, forwarded.start_time);
+  EXPECT_EQ(Server::DrainStrategy::Gradual, forwarded.strategy);
+}
+
+// A callback removed before the connect finished is neither added to the chosen connection nor
+// replayed the drain event: the null slot left by removeConnectionCallbacks() is skipped.
 TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedSkipsRemovedCallbacks) {
   setupMultiConnectionImpl(2);
   startConnect();
@@ -226,13 +279,16 @@ TEST_F(MultiConnectionBaseImplTest, DrainBeforeConnectFinishedSkipsRemovedCallba
   StrictMock<MockConnectionCallbacks> kept_cb;
   impl_->addConnectionCallbacks(removed_cb);
   impl_->addConnectionCallbacks(kept_cb);
-  // Pre-connect removeConnectionCallbacks nulls the slot rather than erasing it; onDrain()
-  // must skip the null entry.
   impl_->removeConnectionCallbacks(removed_cb);
 
-  EXPECT_CALL(kept_cb, onDrain());
-  // StrictMock catches any call on removed_cb.
-  impl_->onDrain();
+  impl_->onDrain(Network::ConnectionDrainEvent{});
+
+  // Only kept_cb is handed to the chosen connection.
+  EXPECT_CALL(*failover_timer_, disableTimer());
+  EXPECT_CALL(*createdConnections()[0], removeConnectionCallbacks(_));
+  EXPECT_CALL(*createdConnections()[0], addConnectionCallbacks(_));
+  EXPECT_CALL(*createdConnections()[0], onDrain(_));
+  connectionCallbacks()[0]->onEvent(ConnectionEvent::Connected);
 }
 
 TEST_F(MultiConnectionBaseImplTest, DrainAfterConnectFinishedDelegatesToFinalConnection) {
@@ -245,8 +301,8 @@ TEST_F(MultiConnectionBaseImplTest, DrainAfterConnectFinishedDelegatesToFinalCon
   connectionCallbacks()[0]->onEvent(ConnectionEvent::Connected);
 
   // onDrain() now delegates to the surviving connection.
-  EXPECT_CALL(*createdConnections()[0], onDrain());
-  impl_->onDrain();
+  EXPECT_CALL(*createdConnections()[0], onDrain(_));
+  impl_->onDrain(Network::ConnectionDrainEvent{});
 }
 
 TEST_F(MultiConnectionBaseImplTest, DisallowedFunctions) {

--- a/test/common/quic/envoy_quic_dispatcher_test.cc
+++ b/test/common/quic/envoy_quic_dispatcher_test.cc
@@ -119,6 +119,42 @@ public:
     dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
   }
 
+  // Creates a single QUIC session whose network filter chain registers `callbacks` as connection
+  // callbacks, so that drain notifications delivered to the session can be observed.
+  void setUpSessionWithConnectionCallbacks(Network::ConnectionCallbacks& callbacks,
+                                           std::shared_ptr<Network::MockReadFilter> read_filter) {
+    // Capture the callbacks by address: `callbacks` is a reference parameter that does not outlive
+    // this call, while the lambda does.
+    drain_filter_factory_.push_back(
+        std::make_unique<Config::TestExtensionConfigProvider<Network::FilterFactoryCb>>(
+            [cb = &callbacks, read_filter](Network::FilterManager& filter_manager) {
+              filter_manager.addReadFilter(read_filter);
+              read_filter->callbacks_->connection().addConnectionCallbacks(*cb);
+            }));
+    EXPECT_CALL(filter_chain_manager_, findFilterChain(_, _))
+        .WillRepeatedly(Return(&proof_source_->filterChain()));
+    EXPECT_CALL(proof_source_->filterChain(), networkFilterFactories())
+        .WillRepeatedly(ReturnRef(drain_filter_factory_));
+    EXPECT_CALL(listener_config_.filter_chain_factory_, createQuicListenerFilterChain(_))
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(listener_config_.filter_chain_factory_, createNetworkFilterChain(_, _))
+        .WillOnce(Invoke([](Network::Connection& connection,
+                            const Filter::NetworkFilterFactoriesList& filter_factories) {
+          Server::Configuration::FilterChainUtility::buildFilterChain(connection, filter_factories);
+          return true;
+        }));
+    EXPECT_CALL(*read_filter, onNewConnection())
+        // Stop iteration to avoid calling getRead/WriteBuffer().
+        .WillOnce(Return(Network::FilterStatus::StopIteration));
+
+    const quic::QuicSocketAddress peer_addr(version_ == Network::Address::IpVersion::v4
+                                                ? quic::QuicIpAddress::Loopback4()
+                                                : quic::QuicIpAddress::Loopback6(),
+                                            54321);
+    envoy_quic_dispatcher_.ProcessBufferedChlos(kNumSessionsToCreatePerLoopForTests);
+    processValidChloPacket(peer_addr);
+  }
+
   void processValidChloPacket(const quic::QuicSocketAddress& peer_addr) {
     // Create a Quic Crypto or TLS1.3 CHLO packet.
     EnvoyQuicClock clock(*dispatcher_);
@@ -287,6 +323,9 @@ protected:
   std::unique_ptr<QuicServerTransportSocketFactory> transport_socket_factory_;
   testing::NiceMock<Network::MockFilterChainManager> filter_chain_manager_;
   Filter::NetworkFilterFactoriesList empty_filter_factory_;
+  // Used by setUpSessionWithConnectionCallbacks(); a fixture member so the factories outlive the
+  // session they build.
+  Filter::NetworkFilterFactoriesList drain_filter_factory_;
 };
 
 INSTANTIATE_TEST_SUITE_P(EnvoyQuicDispatcherTests, EnvoyQuicDispatcherTest,
@@ -517,6 +556,75 @@ TEST_P(EnvoyQuicDispatcherTest, CloseWithGivenFilterChain) {
 
   EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
   envoy_quic_dispatcher_.closeConnectionsWithFilterChain(&proof_source_->filterChain());
+}
+
+TEST_P(EnvoyQuicDispatcherTest, DrainConnectionsWithGivenFilterChains) {
+  std::shared_ptr<Network::MockReadFilter> read_filter(new Network::MockReadFilter());
+  Network::MockConnectionCallbacks network_connection_callbacks;
+  setUpSessionWithConnectionCallbacks(network_connection_callbacks, read_filter);
+
+  // The session belonging to the drained filter chain is notified, and is NOT closed.
+  const MonotonicTime start_time = dispatcher_->timeSource().monotonicTime();
+  Network::ConnectionDrainEvent observed;
+  EXPECT_CALL(network_connection_callbacks, onDrain(_))
+      .WillOnce(Invoke([&observed](Network::ConnectionDrainEvent event) { observed = event; }));
+  EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose)).Times(0);
+  const std::list<const Network::FilterChain*> filter_chains{&proof_source_->filterChain()};
+  envoy_quic_dispatcher_.drainConnectionsWithFilterChains(
+      filter_chains, Network::ConnectionDrainEvent{start_time, Server::DrainStrategy::Immediate});
+  EXPECT_EQ(start_time, observed.start_time);
+  EXPECT_EQ(Server::DrainStrategy::Immediate, observed.strategy);
+
+  // A filter chain with no sessions is skipped rather than treated as an error.
+  Network::MockFilterChain unrelated_filter_chain;
+  const std::list<const Network::FilterChain*> unrelated{&unrelated_filter_chain};
+  EXPECT_CALL(network_connection_callbacks, onDrain(_)).Times(0);
+  envoy_quic_dispatcher_.drainConnectionsWithFilterChains(unrelated,
+                                                          Network::ConnectionDrainEvent{});
+
+  EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
+  envoy_quic_dispatcher_.closeConnectionsWithFilterChain(&proof_source_->filterChain());
+}
+
+TEST_P(EnvoyQuicDispatcherTest, DrainAllConnectionsNotifiesEverySession) {
+  std::shared_ptr<Network::MockReadFilter> read_filter(new Network::MockReadFilter());
+  Network::MockConnectionCallbacks network_connection_callbacks;
+  setUpSessionWithConnectionCallbacks(network_connection_callbacks, read_filter);
+
+  const MonotonicTime start_time = dispatcher_->timeSource().monotonicTime();
+  Network::ConnectionDrainEvent observed;
+  EXPECT_CALL(network_connection_callbacks, onDrain(_))
+      .WillOnce(Invoke([&observed](Network::ConnectionDrainEvent event) { observed = event; }));
+  EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose)).Times(0);
+  envoy_quic_dispatcher_.drainAllConnections(
+      Network::ConnectionDrainEvent{start_time, Server::DrainStrategy::Gradual});
+  EXPECT_EQ(start_time, observed.start_time);
+  EXPECT_EQ(Server::DrainStrategy::Gradual, observed.strategy);
+
+  // The first event wins: a second notification (a server drain escalating from InboundOnly to
+  // All) is dropped rather than re-notifying sessions. The WillOnce() above fails the test if
+  // onDrain() fires again.
+  envoy_quic_dispatcher_.drainAllConnections(Network::ConnectionDrainEvent{
+      start_time + std::chrono::seconds(30), Server::DrainStrategy::Immediate});
+
+  EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
+  envoy_quic_dispatcher_.closeConnectionsWithFilterChain(&proof_source_->filterChain());
+}
+
+// A drain callback is allowed to synchronously close its session. Closing the last session of a
+// filter chain erases the whole entry from connections_by_filter_chain_ (see
+// EnvoyQuicServerSession::OnConnectionClosed()), so the drain must not be iterating that list.
+TEST_P(EnvoyQuicDispatcherTest, DrainCallbackClosingSessionIsSafe) {
+  std::shared_ptr<Network::MockReadFilter> read_filter(new Network::MockReadFilter());
+  Network::MockConnectionCallbacks network_connection_callbacks;
+  setUpSessionWithConnectionCallbacks(network_connection_callbacks, read_filter);
+
+  EXPECT_CALL(network_connection_callbacks, onDrain(_))
+      .WillOnce(Invoke([read_filter](Network::ConnectionDrainEvent) {
+        read_filter->callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+      }));
+  EXPECT_CALL(network_connection_callbacks, onEvent(Network::ConnectionEvent::LocalClose));
+  envoy_quic_dispatcher_.drainAllConnections(Network::ConnectionDrainEvent{});
 }
 
 TEST_P(EnvoyQuicDispatcherTest, EnvoyQuicCryptoServerStreamHelper) {

--- a/test/extensions/bootstrap/internal_listener/client_connection_factory_test.cc
+++ b/test/extensions/bootstrap/internal_listener/client_connection_factory_test.cc
@@ -87,8 +87,9 @@ public:
   MOCK_METHOD(void, shutdownListener, (const Network::ExtraShutdownListenerOptions&));
   MOCK_METHOD(void, updateListenerConfig, (Network::ListenerConfig&));
   MOCK_METHOD(void, onFilterChainDraining, (const std::list<const Network::FilterChain*>&));
-  MOCK_METHOD(void, onFilterChainDrainStart, (const std::list<const Network::FilterChain*>&));
-  MOCK_METHOD(void, onListenerDrainStart, ());
+  MOCK_METHOD(void, onFilterChainDrainStart,
+              (const std::list<const Network::FilterChain*>&, Network::ConnectionDrainEvent));
+  MOCK_METHOD(void, onListenerDrainStart, (Network::ConnectionDrainEvent));
   MOCK_METHOD(void, onAccept, (Network::ConnectionSocketPtr&&));
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
 };

--- a/test/extensions/filters/network/common/fuzz/utils/fakes.h
+++ b/test/extensions/filters/network/common/fuzz/utils/fakes.h
@@ -25,6 +25,9 @@ public:
   envoy::config::core::v3::TrafficDirection direction() const override { return direction_; }
   bool isQuic() const override { return is_quic_; }
   bool shouldBypassOverloadManager() const override { return bypass_overload_manager_; }
+  envoy::config::listener::v3::Listener::DrainType drainType() const override {
+    return envoy::config::listener::v3::Listener::DEFAULT;
+  }
 
 private:
   const std::string name_;

--- a/test/mocks/network/BUILD
+++ b/test/mocks/network/BUILD
@@ -16,6 +16,7 @@ envoy_cc_mock(
     rbe_pool = "6gig",
     deps = [
         "//envoy/network:connection_interface",
+        "//envoy/network:drain_decision_interface",
         "//source/common/network:filter_manager_lib",
         "//test/mocks/event:event_mocks",
         "//test/mocks/stream_info:stream_info_mocks",

--- a/test/mocks/network/connection.cc
+++ b/test/mocks/network/connection.cc
@@ -31,6 +31,14 @@ void MockConnectionBase::raiseEvent(Network::ConnectionEvent event) {
   }
 }
 
+void MockConnectionBase::raiseConnectionDrain(Network::ConnectionDrainEvent event) {
+  for (Network::ConnectionCallbacks* callbacks : callbacks_) {
+    if (callbacks) {
+      callbacks->onDrain(event);
+    }
+  }
+}
+
 void MockConnectionBase::raiseBytesSentCallbacks(uint64_t num_bytes) {
   for (Network::Connection::BytesSentCb& cb : bytes_sent_callbacks_) {
     cb(num_bytes);

--- a/test/mocks/network/connection.h
+++ b/test/mocks/network/connection.h
@@ -5,6 +5,7 @@
 #include <ostream>
 
 #include "envoy/network/connection.h"
+#include "envoy/network/drain_decision.h"
 
 #include "source/common/network/filter_manager_impl.h"
 
@@ -25,12 +26,15 @@ public:
   MOCK_METHOD(void, onEvent, (Network::ConnectionEvent event));
   MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
-  MOCK_METHOD(void, onDrain, ());
+  MOCK_METHOD(void, onDrain, (Network::ConnectionDrainEvent info));
 };
 
 class MockConnectionBase {
 public:
   void raiseEvent(Network::ConnectionEvent event);
+  // Fan out onDrain(event) to all registered ConnectionCallbacks, mirroring the real connection's
+  // Connection::onDrain(). Used to exercise connection-level drain in tests.
+  void raiseConnectionDrain(Network::ConnectionDrainEvent event);
   void raiseBytesSentCallbacks(uint64_t num_bytes);
   void runHighWatermarkCallbacks();
   void runLowWatermarkCallbacks();
@@ -52,7 +56,7 @@ public:
   /* Network::Connection */                                                                        \
   MOCK_METHOD(void, addConnectionCallbacks, (ConnectionCallbacks & cb));                           \
   MOCK_METHOD(void, removeConnectionCallbacks, (ConnectionCallbacks & cb));                        \
-  MOCK_METHOD(void, onDrain, ());                                                                  \
+  MOCK_METHOD(void, onDrain, (ConnectionDrainEvent info));                                         \
   MOCK_METHOD(void, addBytesSentCallback, (BytesSentCb cb));                                       \
   MOCK_METHOD(void, addWriteFilter, (WriteFilterSharedPtr filter));                                \
   MOCK_METHOD(void, addFilter, (FilterSharedPtr filter));                                          \

--- a/test/mocks/network/mocks.h
+++ b/test/mocks/network/mocks.h
@@ -505,6 +505,7 @@ public:
   MOCK_METHOD(envoy::config::core::v3::TrafficDirection, direction, (), (const));
   MOCK_METHOD(bool, isQuic, (), (const));
   MOCK_METHOD(bool, shouldBypassOverloadManager, (), (const));
+  MOCK_METHOD(envoy::config::listener::v3::Listener::DrainType, drainType, (), (const));
 };
 
 class MockListenerConfig : public ListenerConfig {
@@ -581,8 +582,10 @@ public:
               (uint64_t listener_tag, const Network::ExtraShutdownListenerOptions& options));
   MOCK_METHOD(void, stopListeners, ());
   MOCK_METHOD(void, onFilterChainDrain,
-              (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains));
-  MOCK_METHOD(void, onListenerDrain, (uint64_t listener_tag));
+              (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
+               Network::ConnectionDrainEvent drain_event));
+  MOCK_METHOD(void, onListenerDrain,
+              (uint64_t listener_tag, Network::ConnectionDrainEvent drain_event));
   MOCK_METHOD(void, disableListeners, ());
   MOCK_METHOD(void, enableListeners, ());
   MOCK_METHOD(void, setListenerRejectFraction, (UnitFloat), (override));

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -182,6 +182,7 @@ envoy_cc_mock(
     srcs = ["worker.cc"],
     hdrs = ["worker.h"],
     deps = [
+        "//envoy/network:drain_decision_interface",
         "//envoy/server:worker_interface",
     ],
 )

--- a/test/mocks/server/listener_manager.h
+++ b/test/mocks/server/listener_manager.h
@@ -26,6 +26,8 @@ public:
   MOCK_METHOD(void, stopListeners,
               (StopListenersType listeners_type,
                const Network::ExtraShutdownListenerOptions& options));
+  MOCK_METHOD(void, onServerDrainStart,
+              (Network::DrainDirection direction, Network::ConnectionDrainEvent drain_event));
   MOCK_METHOD(void, stopWorkers, ());
   MOCK_METHOD(void, beginListenerUpdate, ());
   MOCK_METHOD(void, endListenerUpdate, (ListenerManager::FailureStates&&));

--- a/test/mocks/server/worker.h
+++ b/test/mocks/server/worker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "envoy/network/drain_decision.h"
 #include "envoy/server/worker.h"
 
 #include "absl/strings/string_view.h"
@@ -50,8 +51,10 @@ public:
               (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
                std::function<void()> completion));
   MOCK_METHOD(void, onFilterChainDrain,
-              (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains));
-  MOCK_METHOD(void, onListenerDrain, (Network::ListenerConfig & listener));
+              (uint64_t listener_tag, const std::list<const Network::FilterChain*>& filter_chains,
+               Network::ConnectionDrainEvent drain_event));
+  MOCK_METHOD(void, onListenerDrain,
+              (uint64_t listener_tag, Network::ConnectionDrainEvent drain_event));
 
   AddListenerCompletion add_listener_completion_;
   std::function<void()> remove_listener_completion_;

--- a/test/server/active_udp_listener_test.cc
+++ b/test/server/active_udp_listener_test.cc
@@ -195,6 +195,17 @@ TEST_P(ActiveUdpListenerTest, MultipleFiltersOnReceiveErrorStopIteration) {
   active_listener_->onReceiveError(Api::IoError::IoErrorCode::UnknownError);
 }
 
+// Drain notifications are broadcast to every listener the connection handler owns, so a UDP
+// listener receives them on any server drain or hot restart. They must be silent no-ops rather
+// than ENVOY_BUGs. See ListenerManagerImpl::onServerDrainStart().
+TEST_P(ActiveUdpListenerTest, DrainNotificationsAreNoOps) {
+  setup();
+
+  active_listener_->onListenerDrainStart(Network::ConnectionDrainEvent{});
+  const std::list<const Network::FilterChain*> filter_chains;
+  active_listener_->onFilterChainDrainStart(filter_chains, Network::ConnectionDrainEvent{});
+}
+
 } // namespace
 } // namespace Server
 } // namespace Envoy

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -49,6 +49,37 @@ TEST_P(AdminInstanceTest, MutatesErrorWithGet) {
                       EXPECT_EQ(Http::Code::MethodNotAllowed, getCallback(path, header_map, data)));
 }
 
+// A graceful drain notifies the listeners that draining has begun, so that connection-level drain
+// logic (Network::Connection::onDrain()) applies to connections on -- and accepted by -- the
+// listeners covered by the drain. DrainManagerImpl deliberately does not do this itself: its
+// per-listener children must not fan out, so each server-drain entry point notifies instead.
+TEST_P(AdminInstanceTest, GracefulDrainNotifiesListeners) {
+  Buffer::OwnedImpl data;
+  Http::TestResponseHeaderMapImpl header_map;
+
+  // The event carries the server's configured strategy, so connections can reproduce the same
+  // gradual/immediate drain behavior the pull model applied.
+  ON_CALL(server_.options_, drainStrategy())
+      .WillByDefault(testing::Return(Server::DrainStrategy::Gradual));
+  Network::ConnectionDrainEvent captured;
+  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(Network::DrainDirection::All, _))
+      .WillOnce(
+          testing::Invoke([&captured](Network::DrainDirection,
+                                      Network::ConnectionDrainEvent event) { captured = event; }));
+  EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners?graceful", header_map, data));
+  EXPECT_EQ(Server::DrainStrategy::Gradual, captured.strategy);
+
+  // Inbound-only drains pass the narrower direction through.
+  EXPECT_CALL(server_.listener_manager_,
+              onServerDrainStart(Network::DrainDirection::InboundOnly, _));
+  EXPECT_EQ(Http::Code::OK,
+            postCallback("/drain_listeners?graceful&inboundonly", header_map, data));
+
+  // A non-graceful drain stops the listeners outright; there is no drain window to notify about.
+  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(_, _)).Times(0);
+  EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners", header_map, data));
+}
+
 TEST_P(AdminInstanceTest, Getters) {
   EXPECT_EQ(&admin_.mutableSocket(), &admin_.socket());
   EXPECT_EQ(1, admin_.concurrency());

--- a/test/server/api_listener_test.cc
+++ b/test/server/api_listener_test.cc
@@ -483,7 +483,7 @@ api_listener:
 
   // No-op and trivial accessors.
   EXPECT_TRUE(connection.initializeReadFilters());
-  connection.onDrain();
+  connection.onDrain(Network::ConnectionDrainEvent{});
   connection.close(Network::ConnectionCloseType::NoFlush);
   connection.close(Network::ConnectionCloseType::NoFlush, "details");
   EXPECT_EQ(StreamInfo::DetectedCloseType::Normal, connection.detectedCloseType());

--- a/test/server/connection_handler_test.cc
+++ b/test/server/connection_handler_test.cc
@@ -2368,8 +2368,8 @@ TEST_F(ConnectionHandlerTest, TcpListenerDrainFilterChainsNotifiesConnections) {
   const std::list<const Network::FilterChain*> filter_chains{filter_chain_.get()};
   // onFilterChainDrain must call onDrain() on every connection owned by the listed filter chains
   // without closing them.
-  EXPECT_CALL(*server_connection, onDrain());
-  handler_->onFilterChainDrain(listener_tag, filter_chains);
+  EXPECT_CALL(*server_connection, onDrain(_));
+  handler_->onFilterChainDrain(listener_tag, filter_chains, Network::ConnectionDrainEvent{});
   // Connection remains tracked; only when filter chains are actually removed does it close.
   EXPECT_EQ(1UL, handler_->numConnections());
 
@@ -2399,9 +2399,15 @@ TEST_F(ConnectionHandlerTest, TcpListenerDrainListenersNotifiesAllConnections) {
   listener_callbacks->onAccept(Network::ConnectionSocketPtr{connection});
 
   // onListenerDrain should fan out onDrain() to every connection in the listener.
-  EXPECT_CALL(*server_connection, onDrain());
-  handler_->onListenerDrain(listener_tag);
+  EXPECT_CALL(*server_connection, onDrain(_));
+  handler_->onListenerDrain(listener_tag, Network::ConnectionDrainEvent{});
   EXPECT_EQ(1UL, handler_->numConnections());
+
+  // The first event wins: a second notification (a server drain escalating from InboundOnly to
+  // All re-notifies inbound listeners) is dropped rather than fanned out again, since every
+  // connection has already been notified of the first event.
+  EXPECT_CALL(*server_connection, onDrain(_)).Times(0);
+  handler_->onListenerDrain(listener_tag, Network::ConnectionDrainEvent{});
 
   // Cleanup.
   EXPECT_CALL(*access_log_, log(_, _));

--- a/test/server/worker_impl_test.cc
+++ b/test/server/worker_impl_test.cc
@@ -162,23 +162,24 @@ TEST_F(WorkerImplTest, DrainPostsToWorkerThread) {
 
   // onListenerDrain posts to the worker dispatcher and invokes handler->onListenerDrain on
   // the worker thread.
-  EXPECT_CALL(*handler_, onListenerDrain(7UL))
+  EXPECT_CALL(*handler_, onListenerDrain(7UL, _))
       .WillOnce(InvokeWithoutArgs([current_thread_id, &ci]() {
         EXPECT_NE(current_thread_id, std::this_thread::get_id());
         ci.setReady();
       }));
-  worker_.onListenerDrain(listener);
+  worker_.onListenerDrain(7UL, Network::ConnectionDrainEvent{});
   ci.waitReady();
 
   // onFilterChainDrain likewise posts and forwards on the worker thread.
   const std::list<const Network::FilterChain*> filter_chains;
-  EXPECT_CALL(*handler_, onFilterChainDrain(7UL, _))
+  EXPECT_CALL(*handler_, onFilterChainDrain(7UL, _, _))
       .WillOnce(
-          Invoke([current_thread_id, &ci](uint64_t, const std::list<const Network::FilterChain*>&) {
+          Invoke([current_thread_id, &ci](uint64_t, const std::list<const Network::FilterChain*>&,
+                                          Network::ConnectionDrainEvent) {
             EXPECT_NE(current_thread_id, std::this_thread::get_id());
             ci.setReady();
           }));
-  worker_.onFilterChainDrain(7UL, filter_chains);
+  worker_.onFilterChainDrain(7UL, filter_chains, Network::ConnectionDrainEvent{});
   ci.waitReady();
 
   worker_.stop();


### PR DESCRIPTION
Commit Message: draining: ensure the connections get notified at all cases
Additional Description:

Now, at all cases, server draining, listener draining, filter chain draining, admin handler and so on, the connections and related connection callbacks get notified.

This is continuous work of #45254 which introduced the `onDrain()`. At the #45254, we only covered the draining of TCP listener and the draining that triggered by the xDS update. This PR completes the left part.

This PR is a premise of actual event-driven connection draining support (#46985) and have no any actual behavior change.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.