### PR TITLE
deps: bump icalendar to 7.1.3 (GHSA-cv84-9p8j-fj68)

### DIFF
--- a/tools/base/requirements.txt
+++ b/tools/base/requirements.txt
@@ -718,9 +718,9 @@ humanfriendly==10.0 \
     --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
     --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
     # via coloredlogs
-icalendar==7.1.1 \
-    --hash=sha256:5e581b8376df7c66972edcf1597c99efc07011829f73df420c2648784c424b42 \
-    --hash=sha256:df80df31f57d345b68b2d07be579a24e8103f7b6555c548e8ef8246cb2353186
+icalendar==7.1.3 \
+    --hash=sha256:690f30aa50a76cbf854db5ad52654705db9c5cd0e1b152222f5d4b7854b60667 \
+    --hash=sha256:eb03a0e215f30db689a72c49f18f998aabf17522eb0858a293c393510850727c
     # via -r tools/base/requirements.in
 idna==3.15 \
     --hash=sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8 \


### PR DESCRIPTION
Updates icalendar to address GHSA-cv84-9p8j-fj68 (algorithmic complexity in Component equality, fix released in 7.1.3).

Evidence:
- tools/base/requirements.txt pinned icalendar==7.1.1
- osv-scanner reported GHSA-cv84-9p8j-fj68 for icalendar@7.1.1 before the update
- updated version: 7.1.3 (hashes refreshed from PyPI)

Validation:
- osv-scanner no longer reports GHSA-cv84-9p8j-fj68 for icalendar after the update
- wheel install check passes (pip download icalendar==7.1.3)

Note: osv-scanner still reports separate advisories for pyasn1@0.6.3 (PYSEC-2026-3455, PYSEC-2026-3456, PYSEC-2026-3457 and aliases). Those are pre-existing on main and out of scope here.

Scope: tools/base/requirements.txt only.
