### PR TITLE
[bp/1.37] fix: skip null pointer in EDS endpoints validation (#45207)

### DIFF
--- a/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
+++ b/source/extensions/load_balancing_policies/common/thread_aware_lb_impl.cc
@@ -362,15 +362,19 @@ TypedHashLbConfigBase::TypedHashLbConfigBase(absl::Span<const HashPolicyProto* c
 absl::Status TypedHashLbConfigBase::validateEndpoints(const PriorityState& priorities) const {
 
   for (const auto& [hosts, locality_weights_map] : priorities) {
-    // Sum should be at most uint32_t max value, so we can validate it by accumulating into uint64_t
-    // and making sure there was no overflow.
-    uint64_t host_sum = 0;
-    for (const auto& host : *hosts) {
-      host_sum += host->weight();
-      if (host_sum > std::numeric_limits<uint32_t>::max()) {
-        return absl::InvalidArgumentError(
-            fmt::format("The sum of weights of all upstream hosts in a locality exceeds {}",
-                        std::numeric_limits<uint32_t>::max()));
+    // Non-contiguous priorities can leave null entries in the priority vector.
+    // Only skip the host-weight check; locality weights are still validated.
+    if (hosts != nullptr) {
+      // Sum should be at most uint32_t max value, so we can validate it by accumulating into
+      // uint64_t and making sure there was no overflow.
+      uint64_t host_sum = 0;
+      for (const auto& host : *hosts) {
+        host_sum += host->weight();
+        if (host_sum > std::numeric_limits<uint32_t>::max()) {
+          return absl::InvalidArgumentError(
+              fmt::format("The sum of weights of all upstream hosts in a locality exceeds {}",
+                          std::numeric_limits<uint32_t>::max()));
+        }
       }
     }
 

--- a/test/extensions/load_balancing_policies/ring_hash/BUILD
+++ b/test/extensions/load_balancing_policies/ring_hash/BUILD
@@ -26,7 +26,6 @@ envoy_extension_cc_test(
         "//source/extensions/load_balancing_policies/ring_hash:ring_hash_lb_lib",
         "//test/common/upstream:utility_lib",
         "//test/mocks:common_lib",
-        "//test/mocks/runtime:runtime_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:cluster_info_mocks",
         "//test/mocks/upstream:host_mocks",
@@ -34,6 +33,7 @@ envoy_extension_cc_test(
         "//test/mocks/upstream:load_balancer_context_mock",
         "//test/mocks/upstream:priority_set_mocks",
         "//test/test_common:simulated_time_system_lib",
+        "//test/test_common:test_runtime_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
+++ b/test/extensions/load_balancing_policies/ring_hash/ring_hash_lb_test.cc
@@ -12,7 +12,6 @@
 
 #include "test/common/upstream/utility.h"
 #include "test/mocks/common.h"
-#include "test/mocks/runtime/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/upstream/cluster_info.h"
 #include "test/mocks/upstream/host.h"
@@ -20,6 +19,7 @@
 #include "test/mocks/upstream/load_balancer_context.h"
 #include "test/mocks/upstream/priority_set.h"
 #include "test/test_common/simulated_time_system.h"
+#include "test/test_common/test_runtime.h"
 
 #include "absl/container/node_hash_map.h"
 #include "absl/types/optional.h"
@@ -1149,6 +1149,131 @@ TEST(TypedRingHashLbConfigTest, TypedRingHashLbConfigTest) {
     EXPECT_EQ(envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash::MURMUR_HASH_2,
               typed_config.lb_config_.hash_function());
   }
+}
+
+TEST(RingHashCoalesceDisabledTest, FallbackPathExercised) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update", "false"}});
+
+  Stats::IsolatedStoreImpl stats_store;
+  ClusterLbStatNames stat_names(stats_store.symbolTable());
+  ClusterLbStats stats(stat_names, *stats_store.rootScope());
+  NiceMock<MockPrioritySet> priority_set;
+  NiceMock<MockPrioritySet> worker_priority_set;
+  auto info = std::make_shared<NiceMock<MockClusterInfo>>();
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash config;
+  absl::Status creation_status;
+  TypedRingHashLbConfig typed_config(config, context.regex_engine_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  auto lb = std::make_unique<RingHashLoadBalancer>(
+      priority_set, stats, *stats_store.rootScope(), context.runtime_loader_, context.api_.random_,
+      50, typed_config.lb_config_, typed_config.hash_policy_);
+  EXPECT_TRUE(lb->initialize().ok());
+
+  MockHostSet& host_set = *priority_set.getMockHostSet(0);
+  host_set.hosts_ = {makeTestHost(info, "tcp://127.0.0.1:80")};
+  host_set.healthy_hosts_ = host_set.hosts_;
+  host_set.runCallbacks({}, {});
+
+  LoadBalancerParams lb_params{worker_priority_set, {}};
+  auto worker_lb = lb->factory()->create(lb_params);
+  EXPECT_NE(nullptr, worker_lb);
+}
+
+// Calls lb->initialize() from inside a PrioritySet batch update. This reproduces:
+// EDS batchUpdate -> updateHosts(P0) -> updateHosts(P1) -> onPreInitComplete -> initialize().
+class InitializeDuringBatchUpdateCb : public PrioritySet::BatchUpdateCb {
+public:
+  InitializeDuringBatchUpdateCb(std::shared_ptr<MockClusterInfo> info, RingHashLoadBalancer& lb)
+      : info_(info), lb_(lb) {}
+
+  void batchUpdate(PrioritySet::HostUpdateCb& host_update_cb) override {
+    HostVectorSharedPtr hosts_p0 = std::make_shared<HostVector>();
+    hosts_p0->push_back(makeTestHost(info_, "tcp://127.0.0.1:80"));
+    HostsPerLocalitySharedPtr hosts_per_locality_p0 = std::make_shared<HostsPerLocalityImpl>();
+    host_update_cb.updateHosts(
+        0,
+        updateHostsParams(hosts_p0, hosts_per_locality_p0,
+                          std::make_shared<const HealthyHostVector>(*hosts_p0),
+                          hosts_per_locality_p0),
+        {}, *hosts_p0, {}, absl::nullopt, absl::nullopt);
+
+    // Grow hostSetsPerPriority() to include P1 before initialize() is called.
+    HostVectorSharedPtr hosts_p1 = std::make_shared<HostVector>();
+    hosts_p1->push_back(makeTestHost(info_, "tcp://127.0.0.2:80"));
+    HostsPerLocalitySharedPtr hosts_per_locality_p1 = std::make_shared<HostsPerLocalityImpl>();
+    host_update_cb.updateHosts(
+        1,
+        updateHostsParams(hosts_p1, hosts_per_locality_p1,
+                          std::make_shared<const HealthyHostVector>(*hosts_p1),
+                          hosts_per_locality_p1),
+        {}, *hosts_p1, {}, absl::nullopt, absl::nullopt);
+
+    EXPECT_TRUE(lb_.initialize().ok());
+  }
+
+  std::shared_ptr<MockClusterInfo> info_;
+  RingHashLoadBalancer& lb_;
+};
+
+TEST(RingHashMidBatchInitializeCrashTest, NoOobOnNewPriority) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.coalesce_lb_rebuilds_on_batch_update", "true"}});
+
+  Stats::IsolatedStoreImpl stats_store;
+  ClusterLbStatNames stat_names(stats_store.symbolTable());
+  ClusterLbStats stats(stat_names, *stats_store.rootScope());
+  PrioritySetImpl priority_set;
+  priority_set.getOrCreateHostSet(0);
+  NiceMock<MockPrioritySet> worker_priority_set;
+  auto info = std::make_shared<NiceMock<MockClusterInfo>>();
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+
+  envoy::extensions::load_balancing_policies::ring_hash::v3::RingHash config;
+  absl::Status creation_status;
+  TypedRingHashLbConfig typed_config(config, context.regex_engine_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  RingHashLoadBalancer lb(priority_set, stats, *stats_store.rootScope(), context.runtime_loader_,
+                          context.api_.random_, 50, typed_config.lb_config_,
+                          typed_config.hash_policy_);
+
+  InitializeDuringBatchUpdateCb batch_update(info, lb);
+  priority_set.batchHostUpdate(batch_update);
+
+  LoadBalancerParams lb_params{worker_priority_set, {}};
+  auto worker_lb = lb.factory()->create(lb_params);
+  EXPECT_NE(nullptr, worker_lb);
+}
+
+// Regression test for https://github.com/envoyproxy/envoy/issues/44349.
+// Null entries in PriorityState (from non-contiguous priority levels) must not segfault.
+TEST_P(RingHashLoadBalancerTest, ValidateEndpointsSkipsNullPriorityEntries) {
+  PriorityState priorities;
+
+  auto hosts_p0 = std::make_unique<HostVector>();
+  hosts_p0->push_back(makeTestHost(info_, "tcp://127.0.0.1:80"));
+  priorities.emplace_back(std::move(hosts_p0), LocalityWeightsMap{});
+
+  // Gaps at priorities 1-4 (null host lists, as produced by non-contiguous EDS assignments).
+  for (int i = 0; i < 4; ++i) {
+    priorities.emplace_back(nullptr, LocalityWeightsMap{});
+  }
+
+  auto hosts_p5 = std::make_unique<HostVector>();
+  hosts_p5->push_back(makeTestHost(info_, "tcp://127.0.0.1:81"));
+  priorities.emplace_back(std::move(hosts_p5), LocalityWeightsMap{});
+
+  absl::Status creation_status;
+  TypedRingHashLbConfig typed_config(config_, context_.regex_engine_, creation_status);
+  ASSERT_TRUE(creation_status.ok());
+
+  EXPECT_TRUE(typed_config.validateEndpoints(priorities).ok());
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: fix: skip null pointer in EDS validation Additional Description: Skips gap in LocalityLbEndpoints priorities that caused nullprt dereference and Envoy crashed with SEGFAULT. Affected when RING_HASH or MAGLEV loadbalancer policy is used. Risk Level: Low
Testing: https://github.com/dajas22/envoy-playground Docs Changes:
Release Notes:

Affects releases since 1.36.0.

cc @botengyao


