### PR TITLE
docs: fix typo mutliple -> multiple

### DIFF
--- a/contrib/kafka/filters/network/source/mesh/command_handlers.md
+++ b/contrib/kafka/filters/network/source/mesh/command_handlers.md
@@ -76,7 +76,7 @@ graph TD;
     KC["RichKafkaConsumer"]
     FRH -.-> |registers itself with| SCM
     SCM -.-> |provides records| FRH
-    SCM --> |stores mutliple| KC
+    SCM --> |stores multiple| KC
 
     LibrdKafkaConsumer["<< librdkafka >> \n KafkaConsumer"]
     ConsumerPoller["<< thread >> \n consumer poller"]


### PR DESCRIPTION
One-word typo fix in `contrib/kafka/filters/network/source/mesh/command_handlers.md:79` — a Mermaid edge label reading `stores mutliple` → `multiple`.
