### PR TITLE
cache_filter: Fix revalidations for cache entries without a Date header

### DIFF
--- a/changelogs/current/bug_fixes/cache_filter__missing-date-header.rst
+++ b/changelogs/current/bug_fixes/cache_filter__missing-date-header.rst
@@ -1,0 +1,4 @@
+Fixed a bug in the ``cache`` and ``cache_v2`` filters where a cacheable response without a ``Date``
+header was treated as stale on every lookup. The cache now appends a ``Date`` on insert and on
+``304`` as required by https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1 and ages entries stored
+without one from their response time as specified in https://www.rfc-editor.org/rfc/rfc9111#section-4.2.1.

--- a/source/extensions/filters/http/cache/BUILD
+++ b/source/extensions/filters/http/cache/BUILD
@@ -139,6 +139,7 @@ envoy_cc_library(
         "//envoy/common:time_interface",
         "//envoy/http:header_map_interface",
         "//source/common/common:matchers_lib",
+        "//source/common/common:utility_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -7,6 +7,7 @@
 
 #include "envoy/http/header_map.h"
 
+#include "source/common/common/utility.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
 #include "source/extensions/filters/http/cache/cache_custom_headers.h"
@@ -219,7 +220,13 @@ void CacheHeadersUtils::ensureDateHeader(Http::ResponseHeaderMap& headers,
 Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_headers,
                                         const SystemTime response_time, const SystemTime now) {
   // Age headers calculations follow: https://httpwg.org/specs/rfc7234.html#age.calculations
-  const SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  // New entries always carry a Date due to ensureDateHeader, but old entries persisted by the
+  // filesystem cache may not until their next validation. Fall back to the response time for
+  // them, see https://www.rfc-editor.org/rfc/rfc9111#section-4.2.1.
+  if (!DateUtil::timePointValid(date_value)) {
+    date_value = response_time;
+  }
 
   long age_value;
   const absl::string_view age_header = response_headers.getInlineValue(CacheCustomHeaders::age());

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -207,6 +207,15 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
   return {};
 }
 
+void CacheHeadersUtils::ensureDateHeader(Http::ResponseHeaderMap& headers,
+                                         const SystemTime response_time) {
+  if (!DateUtil::timePointValid(httpTime(headers.Date()))) {
+    // Sender must use IMF-fixdate, see https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7
+    static const DateFormatter formatter("%a, %d %b %Y %H:%M:%S GMT");
+    headers.setDate(formatter.fromTime(response_time));
+  }
+}
+
 Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_headers,
                                         const SystemTime response_time, const SystemTime now) {
   // Age headers calculations follow: https://httpwg.org/specs/rfc7234.html#age.calculations

--- a/source/extensions/filters/http/cache/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache/cache_headers_utils.h
@@ -103,6 +103,11 @@ namespace CacheHeadersUtils {
 // header_entry is null or malformed.
 SystemTime httpTime(const Http::HeaderEntry* header_entry);
 
+// Sets Date to response_time in IMF-fixdate format if it is absent or does not parse.
+// A cache must append a Date with the response time when it is absent, and may replace an invalid
+// one with it, see https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1.
+void ensureDateHeader(Http::ResponseHeaderMap& headers, SystemTime response_time);
+
 // Calculates the age of a cached response
 Seconds calculateAge(const Http::ResponseHeaderMap& response_headers, SystemTime response_time,
                      SystemTime now);

--- a/source/extensions/filters/http/cache/upstream_request.cc
+++ b/source/extensions/filters/http/cache/upstream_request.cc
@@ -4,6 +4,7 @@
 #include "source/common/http/utility.h"
 #include "source/extensions/filters/http/cache/cache_custom_headers.h"
 #include "source/extensions/filters/http/cache/cache_filter.h"
+#include "source/extensions/filters/http/cache/cache_headers_utils.h"
 #include "source/extensions/filters/http/cache/cacheability_utils.h"
 
 namespace Envoy {
@@ -56,6 +57,12 @@ void UpstreamRequest::processSuccessfulValidation(Http::ResponseHeaderMapPtr res
   // Remove any existing Age header in the cached response.
   lookup_result_->headers_->removeInline(CacheCustomHeaders::age());
 
+  const ResponseMetadata response_metadata = {config_->timeSource().systemTime()};
+  // A 304 without a Date would inherit the stored one in the update below, and the validated entry
+  // would still read as aged since its insertion rather than since its validation, see
+  // https://www.rfc-editor.org/rfc/rfc9111#section-4.2.3.
+  CacheHeadersUtils::ensureDateHeader(*response_headers, response_metadata.response_time_);
+
   // Add any missing headers from the cached response to the 304 response.
   lookup_result_->headers_->iterate([&response_headers](const Http::HeaderEntry& cached_header) {
     // TODO(yosrym93): Try to avoid copying the header key twice.
@@ -70,8 +77,7 @@ void UpstreamRequest::processSuccessfulValidation(Http::ResponseHeaderMapPtr res
   if (should_update_cached_entry) {
     // TODO(yosrym93): else the cached entry should be deleted.
     // Update metadata associated with the cached response. Right now this is only response_time;
-    const ResponseMetadata metadata = {config_->timeSource().systemTime()};
-    cache_->updateHeaders(*lookup_, *response_headers, metadata,
+    cache_->updateHeaders(*lookup_, *response_headers, response_metadata,
                           [](bool updated ABSL_ATTRIBUTE_UNUSED) {});
     setInsertStatus(InsertStatus::HeaderUpdate);
   }
@@ -216,6 +222,9 @@ void UpstreamRequest::onHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_s
                                                            std::move(insert_context), *this);
         // Add metadata associated with the cached response. Right now this is only response_time;
         const ResponseMetadata metadata = {config_->timeSource().systemTime()};
+        // Must stay after isCacheableResponse, which rejects a response that has Expires but no
+        // Date. Adding the Date first would make such responses cacheable.
+        CacheHeadersUtils::ensureDateHeader(*headers, metadata.response_time_);
         insert_queue_->insertHeaders(*headers, metadata, end_stream);
         // insert_status_ remains std::nullopt if end_stream == false, as we have not completed the
         // insertion yet.

--- a/source/extensions/filters/http/cache_v2/BUILD
+++ b/source/extensions/filters/http/cache_v2/BUILD
@@ -202,6 +202,7 @@ envoy_cc_library(
         "//envoy/common:time_interface",
         "//envoy/http:header_map_interface",
         "//source/common/common:matchers_lib",
+        "//source/common/common:utility_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
@@ -8,6 +8,7 @@
 #include "envoy/http/header_map.h"
 
 #include "source/common/common/enum_to_int.h"
+#include "source/common/common/utility.h"
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/header_utility.h"
 #include "source/common/http/utility.h"
@@ -221,7 +222,13 @@ void CacheHeadersUtils::ensureDateHeader(Http::ResponseHeaderMap& headers,
 Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_headers,
                                         const SystemTime response_time, const SystemTime now) {
   // Age headers calculations follow: https://httpwg.org/specs/rfc7234.html#age.calculations
-  const SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  SystemTime date_value = CacheHeadersUtils::httpTime(response_headers.Date());
+  // New entries always carry a Date due to ensureDateHeader, but old entries persisted by the
+  // filesystem cache may not until their next validation. Fall back to the response time for
+  // them, see https://www.rfc-editor.org/rfc/rfc9111#section-4.2.1.
+  if (!DateUtil::timePointValid(date_value)) {
+    date_value = response_time;
+  }
 
   long age_value;
   const absl::string_view age_header = response_headers.getInlineValue(CacheCustomHeaders::age());

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
@@ -209,6 +209,15 @@ SystemTime CacheHeadersUtils::httpTime(const Http::HeaderEntry* header_entry) {
   return {};
 }
 
+void CacheHeadersUtils::ensureDateHeader(Http::ResponseHeaderMap& headers,
+                                         const SystemTime response_time) {
+  if (!DateUtil::timePointValid(httpTime(headers.Date()))) {
+    // Sender must use IMF-fixdate, see https://www.rfc-editor.org/rfc/rfc9110#section-5.6.7
+    static const DateFormatter formatter("%a, %d %b %Y %H:%M:%S GMT");
+    headers.setDate(formatter.fromTime(response_time));
+  }
+}
+
 Seconds CacheHeadersUtils::calculateAge(const Http::ResponseHeaderMap& response_headers,
                                         const SystemTime response_time, const SystemTime now) {
   // Age headers calculations follow: https://httpwg.org/specs/rfc7234.html#age.calculations

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.h
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.h
@@ -104,6 +104,11 @@ namespace CacheHeadersUtils {
 // header_entry is null or malformed.
 SystemTime httpTime(const Http::HeaderEntry* header_entry);
 
+// Sets Date to response_time in IMF-fixdate format if it is absent or does not parse.
+// A cache must append a Date with the response time when it is absent, and may replace an invalid
+// one with it, see https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1.
+void ensureDateHeader(Http::ResponseHeaderMap& headers, SystemTime response_time);
+
 // Calculates the age of a cached response
 Seconds calculateAge(const Http::ResponseHeaderMap& response_headers, SystemTime response_time,
                      SystemTime now);

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -202,7 +202,6 @@ void CacheSession::onHeadersInserted(CacheReaderPtr cache_reader,
   }
   entry_.cache_reader_ = std::move(cache_reader);
   entry_.response_headers_ = std::move(headers);
-  entry_.response_metadata_ = cache_sessions->makeMetadata();
   if (end_stream) {
     insertComplete();
   } else {
@@ -695,6 +694,15 @@ void CacheSession::processSuccessfulValidation(Http::ResponseHeaderMapPtr header
   // Remove any existing Age header in the cached response.
   entry_.response_headers_->removeInline(CacheCustomHeaders::age());
 
+  const auto cache_sessions = cache_sessions_.lock();
+  // Without a live cache nothing is persisted, so the entry keeps its existing metadata.
+  const ResponseMetadata response_metadata =
+      cache_sessions ? cache_sessions->makeMetadata() : entry_.response_metadata_;
+  // A 304 without a Date would inherit the stored one in the update below, and the validated entry
+  // would still read as aged since its insertion rather than since its validation, see
+  // https://www.rfc-editor.org/rfc/rfc9111#section-4.2.3.
+  CacheHeadersUtils::ensureDateHeader(*headers, response_metadata.response_time_);
+
   // Add any missing headers from the cached response to the 304 response.
   entry_.response_headers_->iterate([&headers](const Http::HeaderEntry& cached_header) {
     // TODO(yosrym93): see if we do this without copying the header key twice.
@@ -707,13 +715,13 @@ void CacheSession::processSuccessfulValidation(Http::ResponseHeaderMapPtr header
 
   entry_.response_headers_ = std::move(headers);
   state_ = State::Exists;
-  if (auto cache_sessions = cache_sessions_.lock()) {
+  if (cache_sessions) {
     if (should_update_cached_entry) {
       // TODO(yosrym93): else evict, set state to Pending, and treat as insert.
       LookupSubscriber& sub = lookup_subscribers_.front();
       // Update metadata associated with the cached response. Right now this is only
       // response_time.
-      entry_.response_metadata_.response_time_ = cache_sessions->time_source_.systemTime();
+      entry_.response_metadata_ = response_metadata;
       cache_sessions->cache().updateHeaders(sub.dispatcher(), key_, *entry_.response_headers_,
                                             entry_.response_metadata_);
     }
@@ -726,7 +734,7 @@ void CacheSession::processSuccessfulValidation(Http::ResponseHeaderMapPtr header
     // so it's detectable that we didn't need to do multiple validations.
     status = CacheEntryStatus::ValidatedFree;
   }
-  if (auto cache_sessions = cache_sessions_.lock()) {
+  if (cache_sessions) {
     cache_sessions->stats().subCacheSessionsSubscribers(lookup_subscribers_.size());
   }
   lookup_subscribers_.clear();
@@ -832,15 +840,19 @@ void CacheSession::onUpstreamHeaders(Http::ResponseHeaderMapPtr headers, EndStre
   if (end_stream == EndStream::End) {
     upstream_request_ = nullptr;
   }
+  // Must stay after isCacheableResponse, which rejects a response that has Expires but no
+  // Date. Adding the Date first would make such responses cacheable.
+  const ResponseMetadata metadata = cache_sessions->makeMetadata();
+  CacheHeadersUtils::ensureDateHeader(*headers, metadata.response_time_);
+  entry_.response_metadata_ = metadata;
   // We're already on this subscriber's thread; this is posted to ensure no
   // deadlock on the mutex if the insert operation calls back directly.
   lookup_subscribers_.front().dispatcher().post(
       [p = shared_from_this(), &dispatcher = lookup_subscribers_.front().dispatcher(), key = key_,
-       cache_sessions, headers = std::move(headers),
+       cache_sessions, headers = std::move(headers), metadata,
        upstream_request = std::move(upstream_request_)]() mutable {
-        cache_sessions->cache().insert(dispatcher, key, std::move(headers),
-                                       cache_sessions->makeMetadata(), std::move(upstream_request),
-                                       p);
+        cache_sessions->cache().insert(dispatcher, key, std::move(headers), metadata,
+                                       std::move(upstream_request), p);
         // When the cache entry insertion completes it will call back to onHeadersInserted,
         // or on error onInsertFailed.
       });

--- a/test/extensions/filters/http/cache/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache/cache_filter_integration_test.cc
@@ -158,6 +158,43 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
   }
 }
 
+TEST_P(CacheIntegrationTest, MissInsertHitWithoutDateHeader) {
+  initializeFilter(default_config);
+
+  const Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", /*authority=*/"MissInsertHitWithoutDateHeader");
+  const std::string response_body(42, 'a');
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(response_body);
+  response_headers.removeDate();
+  const std::string insert_date = formatter_.now(simTime());
+
+  {
+    IntegrationStreamDecoderPtr response_decoder = sendHeaderOnlyRequestAwaitResponse(
+        request_headers,
+        simulateUpstreamResponse(response_headers, makeOptRef(response_body), empty_trailers_));
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->headers().get(Http::CustomHeaders::get().Age).size(), 0);
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr("- via_upstream"));
+  }
+
+  simTime().advanceTimeWait(Seconds(10));
+
+  {
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "10"));
+    // The connection manager only sets Date when absent, so the cache-appended value is served.
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader("date", insert_date));
+    // Advance time to force a log flush.
+    simTime().advanceTimeWait(Seconds(1));
+    EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
+                testing::HasSubstr("RFCF cache.response_from_cache_filter"));
+  }
+}
+
 TEST_P(CacheIntegrationTest, ExpiredValidated) {
   initializeFilter(default_config);
 
@@ -223,6 +260,60 @@ TEST_P(CacheIntegrationTest, ExpiredValidated) {
         sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
     EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "1"));
 
+    // Advance time to force a log flush.
+    simTime().advanceTimeWait(Seconds(1));
+    EXPECT_THAT(waitForAccessLog(access_log_name_, 2),
+                testing::HasSubstr("RFCF cache.response_from_cache_filter"));
+  }
+}
+
+// Neither the origin response nor its 304 carries a Date
+TEST_P(CacheIntegrationTest, ExpiredValidatedWithoutDateHeader) {
+  initializeFilter(default_config);
+
+  const Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", /*authority=*/"ExpiredValidatedWithoutDateHeader");
+  const std::string response_body(42, 'a');
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(
+      response_body, /*cache_control=*/"max-age=10", /*extra_headers=*/{{"etag", "abc123"}});
+  response_headers.removeDate();
+
+  {
+    IntegrationStreamDecoderPtr response_decoder = sendHeaderOnlyRequestAwaitResponse(
+        request_headers,
+        simulateUpstreamResponse(response_headers, makeOptRef(response_body), empty_trailers_));
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(waitForAccessLog(access_log_name_), testing::HasSubstr("- via_upstream"));
+  }
+
+  simTime().advanceTimeWait(Seconds(11));
+
+  {
+    const std::string validation_date = formatter_.now(simTime());
+    const Http::TestResponseHeaderMapImpl not_modified_response_headers = {{":status", "304"}};
+
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, [&]() {
+          waitForNextUpstreamRequest();
+          Http::TestRequestHeaderMapImpl injected_headers = {{"if-none-match", "abc123"}};
+          EXPECT_THAT(upstream_request_->headers(), IsSupersetOfHeaders(injected_headers));
+          upstream_request_->encodeHeaders(not_modified_response_headers, /*end_stream=*/true);
+        });
+
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader("date", validation_date));
+    EXPECT_EQ(response_decoder->headers().get(Http::CustomHeaders::get().Age).size(), 0);
+  }
+
+  simTime().advanceTimeWait(Seconds(1));
+
+  // Response was validated and should have fresh age
+  {
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "1"));
     // Advance time to force a log flush.
     simTime().advanceTimeWait(Seconds(1));
     EXPECT_THAT(waitForAccessLog(access_log_name_, 2),

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -325,12 +325,16 @@ TEST_P(ResponseCacheControlTest, ResponseCacheControlTest) {
   EXPECT_EQ(expected_response_cache_control, ResponseCacheControl(cache_control_header));
 }
 
+// Manually confirmed that 784111777 is 11/6/94, 8:49:37.
+constexpr SystemTime kDateSystemTime{Seconds(784111777)};
+constexpr absl::string_view kDateImfFixdate = "Sun, 06 Nov 1994 08:49:37 GMT";
+
 class HttpTimeTest : public testing::TestWithParam<std::string> {
 public:
   static const std::vector<std::string>& getOkTestCases() {
     // clang-format off
     CONSTRUCT_ON_FIRST_USE(std::vector<std::string>,
-        "Sun, 06 Nov 1994 08:49:37 GMT",  // IMF-fixdate.
+        std::string(kDateImfFixdate),     // IMF-fixdate.
         "Sunday, 06-Nov-94 08:49:37 GMT", // obsolete RFC 850 format.
         "Sun Nov  6 08:49:37 1994"        // ANSI C's asctime() format.
     );
@@ -342,9 +346,13 @@ INSTANTIATE_TEST_SUITE_P(Ok, HttpTimeTest, testing::ValuesIn(HttpTimeTest::getOk
 
 TEST_P(HttpTimeTest, OkFormats) {
   const Http::TestResponseHeaderMapImpl response_headers{{"date", GetParam()}};
-  // Manually confirmed that 784111777 is 11/6/94, 8:46:37.
-  EXPECT_EQ(784111777,
-            SystemTime::clock::to_time_t(CacheHeadersUtils::httpTime(response_headers.Date())));
+  EXPECT_EQ(CacheHeadersUtils::httpTime(response_headers.Date()), kDateSystemTime);
+}
+
+TEST_P(HttpTimeTest, EnsureDateHeaderPreservesParseableDate) {
+  Http::TestResponseHeaderMapImpl response_headers{{"date", GetParam()}};
+  CacheHeadersUtils::ensureDateHeader(response_headers, kDateSystemTime + Seconds(30));
+  EXPECT_EQ(response_headers.getDateValue(), GetParam());
 }
 
 TEST(HttpTime, InvalidFormat) {
@@ -354,6 +362,18 @@ TEST(HttpTime, InvalidFormat) {
 }
 
 TEST(HttpTime, Null) { EXPECT_EQ(CacheHeadersUtils::httpTime(nullptr), SystemTime()); }
+
+TEST(EnsureDateHeader, StampsAbsentDate) {
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  CacheHeadersUtils::ensureDateHeader(response_headers, kDateSystemTime);
+  EXPECT_EQ(response_headers.getDateValue(), kDateImfFixdate);
+}
+
+TEST(EnsureDateHeader, ReplacesUnparseableDate) {
+  Http::TestResponseHeaderMapImpl response_headers{{"date", "Sun, 06 Nov 1994 08:49:37 +0000"}};
+  CacheHeadersUtils::ensureDateHeader(response_headers, kDateSystemTime);
+  EXPECT_EQ(response_headers.getDateValue(), kDateImfFixdate);
+}
 
 struct CalculateAgeTestCase {
   std::string test_name;

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -453,6 +453,13 @@ public:
           /*now=*/currentTime() + Seconds(5),
           /*expected_age=*/Seconds(5)
         },
+        {
+          "no_date_header",
+          /*response_headers=*/{{"age", "1"}},
+          /*response_time=*/currentTime(),
+          /*now=*/currentTime() + Seconds(5),
+          /*expected_age=*/Seconds(6)
+        },
     );
     // clang-format on
   }

--- a/test/extensions/filters/http/cache/http_cache_test.cc
+++ b/test/extensions/filters/http/cache/http_cache_test.cc
@@ -260,6 +260,19 @@ TEST_F(LookupRequestTest, NotExpiredViaFallbackheader) {
   EXPECT_EQ(CacheEntryStatus::Ok, lookup_response.cache_entry_status_);
 }
 
+TEST_F(LookupRequestTest, HitWithoutDateHeader) {
+  const LookupRequest lookup_request(request_headers_, currentTime() + Seconds(40),
+                                     vary_allow_list_);
+  const Http::TestResponseHeaderMapImpl response_headers(
+      {{"cache-control", "public, max-age=3600"}});
+  const LookupResult lookup_response = lookup_request.makeLookupResult(
+      std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers),
+      ResponseMetadata{currentTime()}, std::nullopt);
+  // An entry stored without a Date is aged from its response_time, not from the epoch.
+  EXPECT_EQ(CacheEntryStatus::Ok, lookup_response.cache_entry_status_);
+  EXPECT_THAT(*lookup_response.headers_, ContainsHeader(Http::CustomHeaders::get().Age, "40"));
+}
+
 // If request Cache-Control header is missing,
 // "Pragma:no-cache" is equivalent to "Cache-Control:no-cache".
 // https://httpwg.org/specs/rfc7234.html#header.pragma

--- a/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
@@ -178,6 +178,44 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
   }
 }
 
+TEST_P(CacheIntegrationTest, MissInsertHitWithoutDateHeader) {
+  initializeFilter(default_config);
+
+  const Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", /*authority=*/"MissInsertHitWithoutDateHeader");
+  const std::string response_body(42, 'a');
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(response_body);
+  response_headers.removeDate();
+  const std::string insert_date = formatter_.now(simTime());
+
+  {
+    IntegrationStreamDecoderPtr response_decoder = sendHeaderOnlyRequestAwaitResponse(
+        request_headers,
+        simulateUpstreamResponse(response_headers, makeOptRef(response_body), no_trailers_));
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_THAT(response_decoder->headers(),
+                Not(ContainsHeader(Http::CustomHeaders::get().Age, _)));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("via_upstream"));
+  }
+
+  simTime().advanceTimeWait(Seconds(10));
+
+  {
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "10"));
+    // The connection manager only sets Date when absent, so the cache-appended value is served.
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader("date", insert_date));
+    // Advance time to force a log flush.
+    simTime().advanceTimeWait(Seconds(1));
+    EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
+                HasSubstr("RFCF cache.response_from_cache_filter"));
+  }
+}
+
 TEST_P(CacheIntegrationTest, ParallelRequestsShareInsert) {
   initializeFilter(default_config);
 
@@ -440,6 +478,60 @@ TEST_P(CacheIntegrationTest, ExpiredValidated) {
         sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
     EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "1"));
 
+    // Advance time to force a log flush.
+    simTime().advanceTimeWait(Seconds(1));
+    EXPECT_THAT(waitForAccessLog(access_log_name_, 2),
+                HasSubstr("RFCF cache.response_from_cache_filter"));
+  }
+}
+
+// Neither the origin response nor its 304 carries a Date
+TEST_P(CacheIntegrationTest, ExpiredValidatedWithoutDateHeader) {
+  initializeFilter(default_config);
+
+  const Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", /*authority=*/"ExpiredValidatedWithoutDateHeader");
+  const std::string response_body(42, 'a');
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(
+      response_body, /*cache_control=*/"max-age=10", /*extra_headers=*/{{"etag", "abc123"}});
+  response_headers.removeDate();
+
+  {
+    IntegrationStreamDecoderPtr response_decoder = sendHeaderOnlyRequestAwaitResponse(
+        request_headers,
+        simulateUpstreamResponse(response_headers, makeOptRef(response_body), no_trailers_));
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("via_upstream"));
+  }
+
+  simTime().advanceTimeWait(Seconds(11));
+
+  {
+    const std::string validation_date = formatter_.now(simTime());
+    const Http::TestResponseHeaderMapImpl not_modified_response_headers = {{":status", "304"}};
+
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, [&]() {
+          waitForNextUpstreamRequest();
+          EXPECT_THAT(upstream_request_->headers(), ContainsHeader("if-none-match", "abc123"));
+          upstream_request_->encodeHeaders(not_modified_response_headers, /*end_stream=*/true);
+        });
+
+    EXPECT_THAT(response_decoder->headers(), IsSupersetOfHeaders(response_headers));
+    EXPECT_EQ(response_decoder->body(), response_body);
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader("date", validation_date));
+    EXPECT_THAT(response_decoder->headers(),
+                Not(ContainsHeader(Http::CustomHeaders::get().Age, _)));
+  }
+
+  simTime().advanceTimeWait(Seconds(1));
+
+  // Response was validated and should have fresh age
+  {
+    IntegrationStreamDecoderPtr response_decoder =
+        sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+    EXPECT_THAT(response_decoder->headers(), ContainsHeader(Http::CustomHeaders::get().Age, "1"));
     // Advance time to force a log flush.
     simTime().advanceTimeWait(Seconds(1));
     EXPECT_THAT(waitForAccessLog(access_log_name_, 2),

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -454,6 +454,13 @@ public:
           /*now=*/currentTime() + Seconds(5),
           /*expected_age=*/Seconds(5)
         },
+        {
+          "no_date_header",
+          /*response_headers=*/{{"age", "1"}},
+          /*response_time=*/currentTime(),
+          /*now=*/currentTime() + Seconds(5),
+          /*expected_age=*/Seconds(6)
+        },
     );
     // clang-format on
   }

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -326,12 +326,16 @@ TEST_P(ResponseCacheControlTest, ResponseCacheControlTest) {
   EXPECT_EQ(expected_response_cache_control, ResponseCacheControl(cache_control_header));
 }
 
+// Manually confirmed that 784111777 is 11/6/94, 8:49:37.
+constexpr SystemTime kDateSystemTime{Seconds(784111777)};
+constexpr absl::string_view kDateImfFixdate = "Sun, 06 Nov 1994 08:49:37 GMT";
+
 class HttpTimeTest : public testing::TestWithParam<std::string> {
 public:
   static const std::vector<std::string>& getOkTestCases() {
     // clang-format off
     CONSTRUCT_ON_FIRST_USE(std::vector<std::string>,
-        "Sun, 06 Nov 1994 08:49:37 GMT",  // IMF-fixdate.
+        std::string(kDateImfFixdate),     // IMF-fixdate.
         "Sunday, 06-Nov-94 08:49:37 GMT", // obsolete RFC 850 format.
         "Sun Nov  6 08:49:37 1994"        // ANSI C's asctime() format.
     );
@@ -343,9 +347,13 @@ INSTANTIATE_TEST_SUITE_P(Ok, HttpTimeTest, testing::ValuesIn(HttpTimeTest::getOk
 
 TEST_P(HttpTimeTest, OkFormats) {
   const Http::TestResponseHeaderMapImpl response_headers{{"date", GetParam()}};
-  // Manually confirmed that 784111777 is 11/6/94, 8:46:37.
-  EXPECT_EQ(784111777,
-            SystemTime::clock::to_time_t(CacheHeadersUtils::httpTime(response_headers.Date())));
+  EXPECT_EQ(CacheHeadersUtils::httpTime(response_headers.Date()), kDateSystemTime);
+}
+
+TEST_P(HttpTimeTest, EnsureDateHeaderPreservesParseableDate) {
+  Http::TestResponseHeaderMapImpl response_headers{{"date", GetParam()}};
+  CacheHeadersUtils::ensureDateHeader(response_headers, kDateSystemTime + Seconds(30));
+  EXPECT_EQ(response_headers.getDateValue(), GetParam());
 }
 
 TEST(HttpTime, InvalidFormat) {
@@ -355,6 +363,18 @@ TEST(HttpTime, InvalidFormat) {
 }
 
 TEST(HttpTime, Null) { EXPECT_EQ(CacheHeadersUtils::httpTime(nullptr), SystemTime()); }
+
+TEST(EnsureDateHeader, StampsAbsentDate) {
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  CacheHeadersUtils::ensureDateHeader(response_headers, kDateSystemTime);
+  EXPECT_EQ(response_headers.getDateValue(), kDateImfFixdate);
+}
+
+TEST(EnsureDateHeader, ReplacesUnparseableDate) {
+  Http::TestResponseHeaderMapImpl response_headers{{"date", "Sun, 06 Nov 1994 08:49:37 +0000"}};
+  CacheHeadersUtils::ensureDateHeader(response_headers, kDateSystemTime);
+  EXPECT_EQ(response_headers.getDateValue(), kDateImfFixdate);
+}
 
 struct CalculateAgeTestCase {
   std::string test_name;

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -531,6 +531,32 @@ TEST_F(CacheSessionsTest,
   pumpDispatcher();
 }
 
+TEST_F(CacheSessionsTest, HitWithoutDateHeader) {
+  auto response_headers = cacheableResponseHeaders();
+  response_headers->removeDate();
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRequest("/a"),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime() - std::chrono::seconds(40);
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{
+      std::make_unique<MockCacheReader>(),
+      Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers),
+      nullptr,
+      std::move(metadata),
+      5,
+  });
+  pumpDispatcher();
+  // An entry stored without a Date is aged from its response_time, not from the epoch.
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::Hit));
+  MockFunction<void(Http::ResponseHeaderMapPtr, EndStream)> header_callback;
+  EXPECT_CALL(header_callback, Call(Pointee(HasHeader("age", "40")), EndStream::More));
+  result->http_source_->getHeaders(header_callback.AsStdFunction());
+}
+
 TEST_F(CacheSessionsTest, CacheHitGoesDirectlyToCachedResponses) {
   auto response_headers = cacheableResponseHeaders();
   EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));

--- a/test/extensions/filters/http/cache_v2/mocks.cc
+++ b/test/extensions/filters/http/cache_v2/mocks.cc
@@ -48,7 +48,7 @@ void FakeStreamHttpSource::getBody(AdjustedByteRange range, GetBodyCallback&& cb
     if (range.begin() == body_.size()) {
       cb(nullptr, trailers_ ? EndStream::More : EndStream::End);
     } else {
-      range = AdjustedByteRange(range.begin(), std::min(range.end(), body_.size()));
+      range = AdjustedByteRange(range.begin(), std::min<uint64_t>(range.end(), body_.size()));
       EndStream end_stream =
           (trailers_ || range.end() < body_.size()) ? EndStream::More : EndStream::End;
       Buffer::InstancePtr fragment = std::make_unique<Buffer::OwnedImpl>(


### PR DESCRIPTION
Commit Message: cache_filter: Fix revalidations for cache entries without a Date header
Additional Description:

Fixed a bug in the ``cache`` and ``cache_v2`` filters where a cacheable response without a ``Date`` header was treated as stale on every lookup. The cache now appends a ``Date`` on insert and on ``304`` as required by https://www.rfc-editor.org/rfc/rfc9110#section-6.6.1 and ages entries stored without one from their response time as specified in https://www.rfc-editor.org/rfc/rfc9111#section-4.2.1.

Risk Level: Low
Testing: Unit and integration tests for both caches, manual
Docs Changes: N/A
Release Notes: Added bug_fixes/cache_filter__missing-date-header.rst
Platform Specific Features: N/A
[Optional Runtime guard:]
Fixes #46947
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
Co-authored-by: Sona Molnarova <molnsona@gmail.com>