### PR TITLE
credential_injector: fix OAuth2 form-urlencoding to handle '+' correctly

### DIFF
--- a/changelogs/current/bug_fixes/credential_injector__oauth2-form-urlencoding.rst
+++ b/changelogs/current/bug_fixes/credential_injector__oauth2-form-urlencoding.rst
@@ -1,0 +1,6 @@
+Fixed a bug in the ``credential_injector`` OAuth2 ``client_credentials`` provider where the token
+request body was percent-encoded with a generic URI-component character set instead of the
+``application/x-www-form-urlencoded`` algorithm. A literal ``+`` in ``client_id``, ``client_secret``,
+``scope``, or a custom ``token_endpoint`` parameter was left unescaped and silently decoded by the
+token endpoint as a space, corrupting the credential. This most commonly affected base64-encoded
+IdP-issued client secrets, which contain ``+`` roughly half the time.

--- a/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
+++ b/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
@@ -36,15 +36,6 @@ OAuth2ClientImpl::asyncGetAccessToken(const std::string& client_id, const std::s
   if (in_flight_request_ != nullptr) {
     return GetTokenResult::NotDispatchedAlreadyInFlight;
   }
-  // Use urlEncode(), not encode(value, ":/=&?"): the request body below is
-  // application/x-www-form-urlencoded, not a URI component, and the two encoding rulesets
-  // differ. encode() with this reserved-char set leaves '+' (and '%', and space) unescaped;
-  // per the x-www-form-urlencoded serialization spec a literal '+' is decoded by
-  // the receiving end as a space, silently corrupting any client_id/secret/scope that contains
-  // one -- which happens routinely, since identity providers commonly issue base64 client
-  // secrets. urlEncode()
-  // implements the x-www-form-urlencoded algorithm directly (percent-encodes everything except
-  // ALPHA | DIGIT | * | - | . | _, with space as %20) and is the correct encoder for this body.
   const auto encoded_client_id = Envoy::Http::Utility::PercentEncoding::urlEncode(client_id);
   const auto encoded_secret = Envoy::Http::Utility::PercentEncoding::urlEncode(secret);
 

--- a/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
+++ b/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
@@ -36,22 +36,31 @@ OAuth2ClientImpl::asyncGetAccessToken(const std::string& client_id, const std::s
   if (in_flight_request_ != nullptr) {
     return GetTokenResult::NotDispatchedAlreadyInFlight;
   }
-  const auto encoded_client_id = Envoy::Http::Utility::PercentEncoding::encode(client_id, ":/=&?");
-  const auto encoded_secret = Envoy::Http::Utility::PercentEncoding::encode(secret, ":/=&?");
+  // Use urlEncode(), not encode(value, ":/=&?"): the request body below is
+  // application/x-www-form-urlencoded, not a URI component, and the two encoding rulesets
+  // differ. encode() with this reserved-char set leaves '+' (and '%', and space) unescaped;
+  // per the x-www-form-urlencoded serialization spec a literal '+' is decoded by
+  // the receiving end as a space, silently corrupting any client_id/secret/scope that contains
+  // one -- which happens routinely, since identity providers commonly issue base64 client
+  // secrets. urlEncode()
+  // implements the x-www-form-urlencoded algorithm directly (percent-encodes everything except
+  // ALPHA | DIGIT | * | - | . | _, with space as %20) and is the correct encoder for this body.
+  const auto encoded_client_id = Envoy::Http::Utility::PercentEncoding::urlEncode(client_id);
+  const auto encoded_secret = Envoy::Http::Utility::PercentEncoding::urlEncode(secret);
 
   Envoy::Http::RequestMessagePtr request = createPostRequest();
   std::string body;
   if (scopes.empty()) {
     body = fmt::format(GetAccessTokenBodyFormatString, encoded_client_id, encoded_secret);
   } else {
-    const auto encoded_scopes = Envoy::Http::Utility::PercentEncoding::encode(scopes, ":/=&?");
+    const auto encoded_scopes = Envoy::Http::Utility::PercentEncoding::urlEncode(scopes);
     body = fmt::format(GetAccessTokenBodyFormatStringWithScopes, encoded_client_id, encoded_secret,
                        encoded_scopes);
   }
 
   for (const auto& [param_name, param_value] : endpoint_params) {
-    const auto encoded_name = Envoy::Http::Utility::PercentEncoding::encode(param_name, ":/=&?");
-    const auto encoded_value = Envoy::Http::Utility::PercentEncoding::encode(param_value, ":/=&?");
+    const auto encoded_name = Envoy::Http::Utility::PercentEncoding::urlEncode(param_name);
+    const auto encoded_value = Envoy::Http::Utility::PercentEncoding::urlEncode(param_value);
     body += fmt::format("&{}={}", encoded_name, encoded_value);
   }
 

--- a/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
@@ -181,6 +181,75 @@ typed_config:
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Regression test: a client_secret containing '+', '/' and '=' (a realistic base64-encoded
+// IdP-issued secret, e.g. Keycloak) must be fully percent-encoded on the wire.
+//
+// This asserts on the raw bytes of request_body_ directly, NOT via the HasClientSecret matcher
+// used elsewhere in this file: that matcher decodes via QueryParamsMulti::parseParameters ->
+// PercentEncoding::decode(), which only handles %XX sequences and does NOT implement the
+// x-www-form-urlencoded '+' -> space substitution -- so it cannot
+// distinguish a raw, unescaped '+' from a correctly-encoded one and would pass either way. The
+// real token endpoint on the other end of this request *does* implement that substitution (this
+// was independently confirmed against a live Keycloak instance), so the wire bytes are what
+// actually matters here, not what this test suite's own simplified decoder reports.
+//
+// '/' and '=' are included alongside '+' as a control: PercentEncoding::encode(value, ":/=&?")
+// (the pre-fix code) already encodes those two correctly, so their presence in the assertion
+// confirms this test isn't trivially passing on unrelated grounds.
+TEST_P(CredentialInjectorIntegrationTest, InjectCredentialSecretWithSpecialCharacters) {
+  const std::string filter_config =
+      R"EOF(
+name: envoy.filters.http.credential_injector
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.credential_injector.v3.CredentialInjector
+  overwrite: false
+  credential:
+    name: envoy.http.injected_credentials.oauth2
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.http.injected_credentials.oauth2.v3.OAuth2
+      token_endpoint:
+        cluster: oauth
+        timeout: 3s
+        uri: "oauth.com/token"
+      client_credentials:
+        client_id: test_client_id
+        client_secret:
+          name: test-client-secret
+)EOF";
+  const std::string secret_with_special_chars = "sec+ret/with=chars";
+  const std::string expected_wire_encoded_secret = "sec%2Bret%2Fwith%3Dchars";
+  config_helper_.addConfigModifier(
+      [&secret_with_special_chars](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        auto* secret = bootstrap.mutable_static_resources()->add_secrets();
+        secret->set_name("test-client-secret");
+        auto* generic = secret->mutable_generic_secret();
+        generic->mutable_secret()->set_inline_string(secret_with_special_chars);
+      });
+  initializeFilter(filter_config);
+  getFakeOauth2Connection();
+  acceptNewStream();
+  EXPECT_THAT(request_body_, testing::HasSubstr("client_secret=" + expected_wire_encoded_secret));
+  oauth2_request_->encodeHeaders(jsonResponseHeaders(), false);
+  encodeGoodJsonResponseBody();
+  test_server_->waitForCounter("http.config_test.credential_injector.oauth2.token_fetched", Eq(1),
+                               std::chrono::milliseconds(2500));
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  waitForNextUpstreamRequest();
+
+  EXPECT_EQ("Bearer test-access-token", upstream_request_->headers()
+                                            .get(Http::LowerCaseString("Authorization"))[0]
+                                            ->value()
+                                            .getStringView());
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Inject credential to a request without credential
 TEST_P(CredentialInjectorIntegrationTest, InjectCredential) {
   const std::string filter_config =


### PR DESCRIPTION
## Commit Message
credential_injector: fix OAuth2 form-urlencoding to handle '+' correctly

## Additional Description

Found and root-caused while debugging a real Grafana MCP integration failing token acquisition through a `credential_injector` OAuth2 sidecar against a live Keycloak 26.x instance — a client secret containing `+` was silently corrupted on the wire (Keycloak's form-decoder reads an un-escaped `+` as a space), while a secret without `+` (but with `/` and `=`) worked fine through the identical filter config. Traced this to `oauth_client.cc` using a generic URI-component percent-encoder (reserved-char set `":/=&?"`) for an `application/x-www-form-urlencoded` body, rather than the x-www-form-urlencoded-specific `PercentEncoding::urlEncode()` already present in the same codebase.

**The sibling `extensions/filters/http/oauth2` implementation already hit this and fixed it differently** — its `oauth_client.cc` defines `constexpr absl::string_view WwwFormUrlEncodedReservedCharacters = ":/=&?+";`, i.e. the same reserved set plus `+`. I went with `urlEncode()` instead of just adding `+` to the reserved set here, because that set still leaves `%` and space unescaped by the same predicate — `urlEncode()` implements the actual x-www-form-urlencoded algorithm and closes the gap completely rather than patching the one character that happened to get reported. (Separately, that sibling file has its own missed call site — `encode(refresh_token)` with the default `"%"` reserved set, leaving `+`/`/`/`=`/`&` unescaped — a real latent bug, but deliberately out of scope for this PR.)

Confirmed against a real Keycloak instance (not just reasoning about the spec) that this is a genuine, currently-live bug, not something already fixed on `main` — the file is byte-identical across the `v1.38.3` release tag and current `main`.

**AI disclosure, per CONTRIBUTING.md**: this PR — the diagnosis, the source fix, the regression test, and this description — was produced with AI assistance (Claude, via Claude Code), with me directing, reviewing, and verifying every step, including running the full existing test suite for this component locally to confirm no regressions before opening this PR. I take full ownership of this change and will respond to review.

## Risk Level
Low. `envoy.http.injected_credentials.oauth2` is `status: alpha` in `extensions_metadata.yaml`, and per CONTRIBUTING.md runtime-guarding applies to user-visible protocol-processing changes on non-alpha features — this doesn't qualify, and I haven't added one. Behavior-only change to how three string fields are percent-encoded before being placed in a form body; no new dependencies, no API/proto changes. `urlEncode()` is existing, already-used code in the same file's own namespace. The change is strictly-more-encoding: any spec-compliant `application/x-www-form-urlencoded` decoder on the receiving end treats the newly-escaped output identically to the old one for every character except `+`, `%`, and space, which were the ones silently wrong before.

## Testing
- New integration test (`InjectCredentialSecretWithSpecialCharacters`) verifying a client_secret containing `+`, `/`, and `=` is correctly percent-encoded (`%2B`, `%2F`, `%3D`) in the request body sent to the token endpoint.
- Verified by hand against both the pre-fix and post-fix source: pre-fix produces `...client_secret=sec+ret%2Fwith%3Dchars` (only `+` left unescaped — confirms `/`/`=` were already correct and this isn't a trivially-passing assertion); post-fix produces `...client_secret=sec%2Bret%2Fwith%3Dchars`.
- Full existing suite for this component passes with the fix applied: `bazel test //test/extensions/http/credential_injector/oauth2/...` → 3 targets, 3 tests, no regressions. (Worth noting precisely: `config_test`/`token_provider_test` don't exercise the request-body encoding path at all, so the real coverage for this fix is the integration test above, not the "3/3" count by itself.)
- Not yet covered: the fix also changes `scope` and `endpoint_params` encoding, and only `client_secret` has a dedicated special-character test. Happy to add coverage for those too if reviewers want it.

## Docs Changes
None — this is an internal request-body encoding correctness fix, no observable config or API surface change.

## Release Notes
Included in this PR: `changelogs/current/bug_fixes/credential_injector__oauth2-form-urlencoding.rst`.

## Platform Specific Features
None.
