### PR TITLE
dynamic_modules: add more tests for cluster specifier extension

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-a-cluster-specifier-extension.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-a-cluster-specifier-extension.rst
@@ -7,9 +7,8 @@ The selection context exposes the request headers, stream info attributes, dynam
 route name, the random value Envoy generated for cluster selection, and a routability query that
 reports host counts for a named cluster from the current worker, and the module is invoked
 again whenever a filter refreshes the route cluster. Custom counters, gauges and histograms can be
-defined during configuration through the ``metrics_namespace`` field on ``DynamicModuleConfig``.
-The Rust SDK exposes this through the
-again whenever a filter refreshes the route cluster. The Rust SDK exposes this through the
+defined during configuration and recorded during selection, and are emitted under the
+``metrics_namespace`` prefix of ``DynamicModuleConfig``. The Rust SDK exposes this through the
 ``cluster_specifier`` module and the ``cluster_specifier:`` arm of ``declare_all_init_functions!``.
 See
 :ref:`DynamicModuleClusterSpecifier <envoy_v3_api_msg_extensions.router.cluster_specifiers.dynamic_modules.v3.DynamicModuleClusterSpecifier>`

--- a/docs/root/configuration/http/cluster_specifier/dynamic_modules.rst
+++ b/docs/root/configuration/http/cluster_specifier/dynamic_modules.rst
@@ -46,11 +46,10 @@ a different point:
 * The cluster not found response code is read only when the selected cluster does not exist, which
   ends the request, so the selection that named the missing cluster is the one that applies.
 * ``get_cluster_host_count`` reports whether a cluster is routable from the current worker and
-  returns host counts for the named cluster.
-* Custom counters, gauges and histograms can be defined during configuration through the
-  ``metrics_namespace`` field on ``dynamicModuleConfig``.
   returns host counts at a priority level. It uses ``getThreadLocalCluster()``, so it can return
   false even when the cluster is configured but not yet warmed on the worker.
+* Custom counters, gauges and histograms can be defined during configuration and recorded during
+  selection, and are emitted under the ``metrics_namespace`` prefix of ``DynamicModuleConfig``.
 
 Configuration
 -------------

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster_specifier.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster_specifier.rs
@@ -10,6 +10,7 @@ use crate::{
   abi, ClusterHostCount, EnvoyBuffer, EnvoyCounterId, EnvoyCounterVecId, EnvoyGaugeId,
   EnvoyGaugeVecId, EnvoyHistogramId, EnvoyHistogramVecId,
 };
+use mockall::*;
 use std::ffi::c_void;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
@@ -457,48 +458,71 @@ pub trait ClusterSpecifierConfig: Send + Sync {
   fn on_select(&self, ctx: &mut ClusterSpecifierContext) -> bool;
 }
 
-/// Metrics that a cluster specifier module may define during configuration and record at runtime.
+/// Envoy-side metrics interface for the cluster specifier dynamic module.
+///
+/// This trait provides the ability to define and record custom metrics (counters, gauges,
+/// histograms) scoped to the cluster specifier configuration. Metrics should be defined during
+/// config creation and can be recorded at any point during selection.
+///
+/// Implementations must be `Send + Sync` since they may be accessed from multiple threads.
+#[automock]
 #[allow(clippy::needless_lifetimes)]
 pub trait EnvoyClusterSpecifierMetrics: Send + Sync {
+  // -------------------------------------------------------------------------
+  // Define metrics (call during config creation).
+  // -------------------------------------------------------------------------
+
+  /// Define a new counter with the given name and no labels.
   fn define_counter(
     &self,
     name: &str,
   ) -> Result<EnvoyCounterId, abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Define a new counter vec with the given name and label names.
   fn define_counter_vec<'a>(
     &self,
     name: &str,
     labels: &[&'a str],
   ) -> Result<EnvoyCounterVecId, abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Define a new gauge with the given name and no labels.
   fn define_gauge(
     &self,
     name: &str,
   ) -> Result<EnvoyGaugeId, abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Define a new gauge vec with the given name and label names.
   fn define_gauge_vec<'a>(
     &self,
     name: &str,
     labels: &[&'a str],
   ) -> Result<EnvoyGaugeVecId, abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Define a new histogram with the given name and no labels.
   fn define_histogram(
     &self,
     name: &str,
   ) -> Result<EnvoyHistogramId, abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Define a new histogram vec with the given name and label names.
   fn define_histogram_vec<'a>(
     &self,
     name: &str,
     labels: &[&'a str],
   ) -> Result<EnvoyHistogramVecId, abi::envoy_dynamic_module_type_metrics_result>;
 
+  // -------------------------------------------------------------------------
+  // Record metrics (call at runtime, e.g., during selection).
+  // -------------------------------------------------------------------------
+
+  /// Increment a previously defined counter by the given value.
   fn increment_counter(
     &self,
     id: EnvoyCounterId,
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Increment a previously defined counter vec by the given value with label values.
   fn increment_counter_vec<'a>(
     &self,
     id: EnvoyCounterVecId,
@@ -506,12 +530,14 @@ pub trait EnvoyClusterSpecifierMetrics: Send + Sync {
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Set the value of a previously defined gauge.
   fn set_gauge(
     &self,
     id: EnvoyGaugeId,
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Set the value of a previously defined gauge vec with label values.
   fn set_gauge_vec<'a>(
     &self,
     id: EnvoyGaugeVecId,
@@ -519,12 +545,14 @@ pub trait EnvoyClusterSpecifierMetrics: Send + Sync {
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Increase a previously defined gauge by the given value.
   fn increase_gauge(
     &self,
     id: EnvoyGaugeId,
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Increase a previously defined gauge vec by the given value with label values.
   fn increase_gauge_vec<'a>(
     &self,
     id: EnvoyGaugeVecId,
@@ -532,12 +560,14 @@ pub trait EnvoyClusterSpecifierMetrics: Send + Sync {
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Decrease a previously defined gauge by the given value.
   fn decrease_gauge(
     &self,
     id: EnvoyGaugeId,
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Decrease a previously defined gauge vec by the given value with label values.
   fn decrease_gauge_vec<'a>(
     &self,
     id: EnvoyGaugeVecId,
@@ -545,12 +575,14 @@ pub trait EnvoyClusterSpecifierMetrics: Send + Sync {
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Record a value in a previously defined histogram.
   fn record_histogram_value(
     &self,
     id: EnvoyHistogramId,
     value: u64,
   ) -> Result<(), abi::envoy_dynamic_module_type_metrics_result>;
 
+  /// Record a value in a previously defined histogram vec with label values.
   fn record_histogram_value_vec<'a>(
     &self,
     id: EnvoyHistogramVecId,

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -9494,3 +9494,270 @@ fn test_cluster_specifier_context_records_selection() {
   assert_eq!(Some(u64::MAX), selection.timeout_ms);
   assert_eq!(Some(u64::MAX), selection.idle_timeout_ms);
 }
+
+// =============================================================================
+// Cluster Specifier Metrics Tests
+// =============================================================================
+
+// The cluster specifier module is not glob re-exported at the crate root, so bring its metrics
+// trait into scope to call it on the generated mock.
+use crate::cluster_specifier::EnvoyClusterSpecifierMetrics;
+
+#[test]
+fn test_cluster_specifier_metrics_define_counter() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_counter()
+    .with(mockall::predicate::eq("test_counter"))
+    .returning(|_| Ok(EnvoyCounterId(1)));
+  let result = mock.define_counter("test_counter");
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), EnvoyCounterId(1));
+}
+
+#[test]
+fn test_cluster_specifier_metrics_define_gauge() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_gauge()
+    .with(mockall::predicate::eq("test_gauge"))
+    .returning(|_| Ok(EnvoyGaugeId(1)));
+  let result = mock.define_gauge("test_gauge");
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), EnvoyGaugeId(1));
+}
+
+#[test]
+fn test_cluster_specifier_metrics_define_histogram() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_histogram()
+    .with(mockall::predicate::eq("test_histogram"))
+    .returning(|_| Ok(EnvoyHistogramId(1)));
+  let result = mock.define_histogram("test_histogram");
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), EnvoyHistogramId(1));
+}
+
+#[test]
+fn test_cluster_specifier_metrics_increment_counter() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_increment_counter()
+    .with(
+      mockall::predicate::eq(EnvoyCounterId(1)),
+      mockall::predicate::eq(5u64),
+    )
+    .returning(|_, _| Ok(()));
+  assert!(mock.increment_counter(EnvoyCounterId(1), 5).is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_increment_counter_invalid_id() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_increment_counter()
+    .returning(|_, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  assert!(mock.increment_counter(EnvoyCounterId(999), 1).is_err());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_gauge_operations() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_set_gauge()
+    .with(
+      mockall::predicate::eq(EnvoyGaugeId(1)),
+      mockall::predicate::eq(42u64),
+    )
+    .returning(|_, _| Ok(()));
+  mock
+    .expect_increase_gauge()
+    .with(
+      mockall::predicate::eq(EnvoyGaugeId(1)),
+      mockall::predicate::eq(10u64),
+    )
+    .returning(|_, _| Ok(()));
+  mock
+    .expect_decrease_gauge()
+    .with(
+      mockall::predicate::eq(EnvoyGaugeId(1)),
+      mockall::predicate::eq(5u64),
+    )
+    .returning(|_, _| Ok(()));
+  assert!(mock.set_gauge(EnvoyGaugeId(1), 42).is_ok());
+  assert!(mock.increase_gauge(EnvoyGaugeId(1), 10).is_ok());
+  assert!(mock.decrease_gauge(EnvoyGaugeId(1), 5).is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_gauge_invalid_id() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_set_gauge()
+    .returning(|_, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  mock
+    .expect_increase_gauge()
+    .returning(|_, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  mock
+    .expect_decrease_gauge()
+    .returning(|_, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  assert!(mock.set_gauge(EnvoyGaugeId(999), 1).is_err());
+  assert!(mock.increase_gauge(EnvoyGaugeId(999), 1).is_err());
+  assert!(mock.decrease_gauge(EnvoyGaugeId(999), 1).is_err());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_record_histogram_value() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_record_histogram_value()
+    .with(
+      mockall::predicate::eq(EnvoyHistogramId(1)),
+      mockall::predicate::eq(42u64),
+    )
+    .returning(|_, _| Ok(()));
+  assert!(mock.record_histogram_value(EnvoyHistogramId(1), 42).is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_record_histogram_value_invalid_id() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_record_histogram_value()
+    .returning(|_, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  assert!(mock
+    .record_histogram_value(EnvoyHistogramId(999), 1)
+    .is_err());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_define_all_metric_types_and_use() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_counter()
+    .returning(|_| Ok(EnvoyCounterId(1)));
+  mock
+    .expect_define_gauge()
+    .returning(|_| Ok(EnvoyGaugeId(1)));
+  mock
+    .expect_define_histogram()
+    .returning(|_| Ok(EnvoyHistogramId(1)));
+  mock.expect_increment_counter().returning(|_, _| Ok(()));
+  mock.expect_set_gauge().returning(|_, _| Ok(()));
+  mock
+    .expect_record_histogram_value()
+    .returning(|_, _| Ok(()));
+
+  let counter_id = mock.define_counter("c").unwrap();
+  let gauge_id = mock.define_gauge("g").unwrap();
+  let histogram_id = mock.define_histogram("h").unwrap();
+  assert!(mock.increment_counter(counter_id, 1).is_ok());
+  assert!(mock.set_gauge(gauge_id, 100).is_ok());
+  assert!(mock.record_histogram_value(histogram_id, 50).is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_define_counter_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_counter_vec()
+    .returning(|_, _| Ok(EnvoyCounterVecId(1)));
+  let result = mock.define_counter_vec("test_counter", &["region", "zone"]);
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), EnvoyCounterVecId(1));
+}
+
+#[test]
+fn test_cluster_specifier_metrics_define_gauge_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_gauge_vec()
+    .returning(|_, _| Ok(EnvoyGaugeVecId(1)));
+  let result = mock.define_gauge_vec("test_gauge", &["env"]);
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), EnvoyGaugeVecId(1));
+}
+
+#[test]
+fn test_cluster_specifier_metrics_define_histogram_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_define_histogram_vec()
+    .returning(|_, _| Ok(EnvoyHistogramVecId(1)));
+  let result = mock.define_histogram_vec("test_histogram", &["method"]);
+  assert!(result.is_ok());
+  assert_eq!(result.unwrap(), EnvoyHistogramVecId(1));
+}
+
+#[test]
+fn test_cluster_specifier_metrics_increment_counter_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_increment_counter_vec()
+    .returning(|_, _, _| Ok(()));
+  assert!(mock
+    .increment_counter_vec(EnvoyCounterVecId(1), &["us-east-1"], 1)
+    .is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_set_gauge_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock.expect_set_gauge_vec().returning(|_, _, _| Ok(()));
+  assert!(mock
+    .set_gauge_vec(EnvoyGaugeVecId(1), &["prod"], 42)
+    .is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_increase_gauge_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock.expect_increase_gauge_vec().returning(|_, _, _| Ok(()));
+  assert!(mock
+    .increase_gauge_vec(EnvoyGaugeVecId(1), &["prod"], 10)
+    .is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_decrease_gauge_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock.expect_decrease_gauge_vec().returning(|_, _, _| Ok(()));
+  assert!(mock
+    .decrease_gauge_vec(EnvoyGaugeVecId(1), &["prod"], 5)
+    .is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_record_histogram_value_vec() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_record_histogram_value_vec()
+    .returning(|_, _, _| Ok(()));
+  assert!(mock
+    .record_histogram_value_vec(EnvoyHistogramVecId(1), &["GET"], 100)
+    .is_ok());
+}
+
+#[test]
+fn test_cluster_specifier_metrics_vec_metric_invalid_id() {
+  let mut mock = cluster_specifier::MockEnvoyClusterSpecifierMetrics::new();
+  mock
+    .expect_increment_counter_vec()
+    .returning(|_, _, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  mock
+    .expect_set_gauge_vec()
+    .returning(|_, _, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  mock
+    .expect_record_histogram_value_vec()
+    .returning(|_, _, _| Err(abi::envoy_dynamic_module_type_metrics_result::MetricNotFound));
+  assert!(mock
+    .increment_counter_vec(EnvoyCounterVecId(999), &["v1"], 1)
+    .is_err());
+  assert!(mock
+    .set_gauge_vec(EnvoyGaugeVecId(999), &["v1"], 1)
+    .is_err());
+  assert!(mock
+    .record_histogram_value_vec(EnvoyHistogramVecId(999), &["v1"], 1)
+    .is_err());
+}

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
@@ -12,6 +12,7 @@
 #include "source/common/router/config_impl.h"
 #include "source/common/router/metadatamatchcriteria_impl.h"
 #include "source/common/router/retry_policy_impl.h"
+#include "source/common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -145,7 +146,13 @@ newDynamicModuleClusterSpecifierConfig(const DynamicModuleClusterSpecifierProto&
       proto_config.dynamic_module_config().metrics_namespace().empty()
           ? std::string(DefaultMetricsNamespace)
           : proto_config.dynamic_module_config().metrics_namespace();
-  context.api().customStatNamespaces().registerStatNamespace(metrics_namespace);
+  // When the runtime guard is enabled, register the metrics namespace as a custom stat namespace.
+  // This causes the namespace prefix to be stripped from prometheus output and no envoy_ prefix
+  // is added. This is the legacy behavior for backward compatibility.
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.dynamic_modules_strip_custom_stat_prefix")) {
+    context.api().customStatNamespaces().registerStatNamespace(metrics_namespace);
+  }
 
   auto config = std::make_shared<DynamicModuleClusterSpecifierConfig>(
       proto_config.specifier_name(), specifier_config, std::move(dynamic_module),

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
@@ -5,7 +5,8 @@
 //! can control every branch, and it exercises the full cluster specifier context ABI surface:
 //! request headers (single value, indexed value, count, and bulk iteration), stream info attributes
 //! (string, int, and bool), dynamic metadata, the route name, the random value, the scalar route
-//! action setters, and the named route action overrides.
+//! action setters, the named route action overrides, and the configuration metrics recorded on each
+//! selection.
 //!
 //! The headers the module reads are:
 //!   `env`               the cluster to route to, prefixed with the `specifier_config` bytes.
@@ -27,6 +28,7 @@
 
 use envoy_proxy_dynamic_modules_rust_sdk::cluster_specifier::*;
 use envoy_proxy_dynamic_modules_rust_sdk::*;
+use std::sync::Arc;
 use std::time::Duration;
 
 declare_all_init_functions!(init, cluster_specifier: new_cluster_specifier_config_fn);
@@ -41,18 +43,32 @@ fn init() -> bool {
 fn new_cluster_specifier_config_fn(
   name: &str,
   config: &[u8],
-  _metrics: std::sync::Arc<dyn EnvoyClusterSpecifierMetrics>,
+  metrics: Arc<dyn EnvoyClusterSpecifierMetrics>,
 ) -> Option<Box<dyn ClusterSpecifierConfig>> {
   match name {
-    "test_cluster_specifier" => Some(Box::new(TestClusterSpecifierConfig {
-      cluster_prefix: String::from_utf8_lossy(config).into_owned(),
-    })),
+    "test_cluster_specifier" => {
+      // Metrics are defined once here while stat creation is still allowed, and recorded on every
+      // selection so a test can observe both the scalar and the labeled record paths.
+      let selections_total_id = metrics.define_counter("selections_total").ok();
+      let selections_by_env_id = metrics
+        .define_counter_vec("selections_by_env", &["env"])
+        .ok();
+      Some(Box::new(TestClusterSpecifierConfig {
+        cluster_prefix: String::from_utf8_lossy(config).into_owned(),
+        metrics,
+        selections_total_id,
+        selections_by_env_id,
+      }))
+    },
     _ => None,
   }
 }
 
 struct TestClusterSpecifierConfig {
   cluster_prefix: String,
+  metrics: Arc<dyn EnvoyClusterSpecifierMetrics>,
+  selections_total_id: Option<EnvoyCounterId>,
+  selections_by_env_id: Option<EnvoyCounterVecId>,
 }
 
 /// Stands in for a value the module could not read, so that the absent case is observable too.
@@ -185,6 +201,15 @@ impl ClusterSpecifierConfig for TestClusterSpecifierConfig {
       });
     if let Some(priority) = priority {
       ctx.set_priority(priority);
+    }
+
+    // Record the selection so an integration test can observe the values that crossed the ABI
+    // boundary from the worker thread.
+    if let Some(id) = self.selections_total_id {
+      let _ = self.metrics.increment_counter(id, 1);
+    }
+    if let Some(id) = self.selections_by_env_id {
+      let _ = self.metrics.increment_counter_vec(id, &[env.as_str()], 1);
     }
     true
   }

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
@@ -34,6 +34,7 @@ envoy_extension_cc_test(
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:logging_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@abseil-cpp//absl/strings",
         "@envoy_api//envoy/extensions/router/cluster_specifiers/dynamic_modules/v3:pkg_cc_proto",

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
@@ -18,6 +18,7 @@
 #include "test/mocks/upstream/cluster_manager.h"
 #include "test/mocks/upstream/thread_local_cluster.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/str_cat.h"
@@ -980,7 +981,6 @@ public:
 
 TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, CounterDefineAndIncrement) {
   auto config = makeConfig();
-  EXPECT_TRUE(custom_stat_namespaces_.registered(DefaultMetricsNamespace));
   unfreezeStatCreation(*config);
   auto* config_ptr = static_cast<void*>(config.get());
 
@@ -998,11 +998,10 @@ TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, CounterDefineAndIncrement) {
   EXPECT_EQ(5, counter->value());
 }
 
-TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, CustomMetricsNamespaceRegisteredAndUsed) {
+TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, CustomMetricsNamespaceUsed) {
   auto proto_config = protoConfig("cluster_specifier_no_op", "test_cluster_specifier");
   proto_config.mutable_dynamic_module_config()->set_metrics_namespace("cluster_specifier_custom");
   auto config = makeConfig(proto_config);
-  EXPECT_TRUE(custom_stat_namespaces_.registered("cluster_specifier_custom"));
   unfreezeStatCreation(*config);
 
   size_t counter_id = 0;
@@ -1012,6 +1011,19 @@ TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, CustomMetricsNamespaceRegist
           static_cast<void*>(config.get()), metricBuffer("test_counter"), nullptr, 0, &counter_id));
   EXPECT_NE(nullptr,
             TestUtility::findCounter(context_.store_, "cluster_specifier_custom.test_counter"));
+}
+
+// Test that the legacy behavior registers the custom stat namespace when the runtime guard is
+// enabled.
+TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, RegisterStatNamespaceWithRuntimeGuard) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.dynamic_modules_strip_custom_stat_prefix", "true"}});
+
+  auto proto_config = protoConfig("cluster_specifier_no_op", "test_cluster_specifier");
+  proto_config.mutable_dynamic_module_config()->set_metrics_namespace("cluster_specifier_custom");
+  auto config = makeConfig(proto_config);
+  EXPECT_TRUE(custom_stat_namespaces_.registered("cluster_specifier_custom"));
 }
 
 TEST_F(DynamicModuleClusterSpecifierMetricsAbiTest, ScalarGaugeDefineAndOperate) {

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/integration_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/integration_test.cc
@@ -207,6 +207,22 @@ TEST_P(DynamicModuleClusterSpecifierIntegrationTest, SelectsCluster) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// The module defines metrics at configuration time and records them on each selection, so a
+// request that selects a cluster increments both the plain counter and the counter labeled with
+// the selected env.
+TEST_P(DynamicModuleClusterSpecifierIntegrationTest, RecordsSelectionMetrics) {
+  setupTest();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(requestHeaders({{"env", "prod"}}));
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  test_server_->waitForCounter("dynamicmodulescustom.selections_total", testing::Ge(1));
+  test_server_->waitForCounter("dynamicmodulescustom.selections_by_env.env.prod", testing::Ge(1));
+}
+
 // Setting every property the module can select still routes the request.
 TEST_P(DynamicModuleClusterSpecifierIntegrationTest, SelectsClusterWithRouteActionOverride) {
   setupTest();


### PR DESCRIPTION
# Description

This PR add some more tests for Dynamic Modules cluster specifier extension.

---

**Commit Message**: dynamic_modules: add more tests for cluster specifier extension
**Risk Level**: Low
**Testing**: CI
**Docs Changes**: N/A
**Release Notes**: N/A