### PR TITLE
bazel: fix cel descriptor generation on windows

### DIFF
--- a/bazel/foreign_cc/cel-cpp.patch
+++ b/bazel/foreign_cc/cel-cpp.patch
@@ -1,3 +1,15 @@
+diff --git a/bazel/cel_proto_transitive_descriptor_set.bzl b/bazel/cel_proto_transitive_descriptor_set.bzl
+index e65e0b4a..18837236 100644
+--- a/bazel/cel_proto_transitive_descriptor_set.bzl
++++ b/bazel/cel_proto_transitive_descriptor_set.bzl
+@@ -30,6 +30,7 @@ def _cel_proto_transitive_descriptor_set(ctx):
+         progress_message = "Joining descriptors.",
+         command = ("< \"$1\" xargs cat >{output}".format(output = output.path)),
+         arguments = [args],
++        use_default_shell_env = True,
+     )
+     return DefaultInfo(
+         files = depset([output]),
 diff --git a/bazel/deps.bzl b/bazel/deps.bzl
 index 1f8801df..64ad71b5 100644
 --- a/bazel/deps.bzl


### PR DESCRIPTION
Commit Message: bazel: fix cel descriptor generation on windows
Additional Description: Fix CEL protobuf descriptor generation on Windows by allowing the descriptor-joining shell action to use Bazel's default shell environment. This makes the MSYS2 tools supplied through the Windows action PATH available to `xargs`.

Previously, the Windows Envoy build failed with `xargs: cat: No such file or directory`.

Referenced the patch from: https://github.com/curioswitch/py-envoy-server/blob/main/.github/actions/build-windows/main.patch#L155-L166 for https://github.com/envoyproxy/envoy/issues/46812

Risk Level: Low

Testing:
Manually ran the Windows Envoy build on a Windows EC2 instance:

`bazel --bazelrc=bazelrc.windows build -c fastbuild --config=windows //:envoy`

Before this change, the build failed while joining CEL descriptor sets with `xargs: cat: No such file or directory`. After this change, that action succeeded and the build progressed to the separate known LuaJIT Windows build failure.

Docs Changes: No
Release Notes: No
Platform Specific Features: This fixes CEL descriptor generation for Windows builds using the MSYS2 environment configured by `bazelrc.windows`.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
