### PR TITLE
dynamic_modules: fix input matcher config lifetime

### DIFF
--- a/source/extensions/matching/input_matchers/dynamic_modules/config.cc
+++ b/source/extensions/matching/input_matchers/dynamic_modules/config.cc
@@ -22,8 +22,8 @@ DynamicModuleInputMatcherFactory::createInputMatcherFactoryCb(
 
   const auto& matcher_name = proto_config.matcher_name();
   const auto& module_config = proto_config.dynamic_module_config();
-  // Input matchers do not support remote module sources, so no init manager or async callback is
-  // passed; only the synchronous local-file and by-name paths can succeed here.
+  // Input matchers pass no async callback, so a remote source that is not already cached is
+  // rejected rather than fetched.
   auto load_result = Extensions::DynamicModules::newDynamicModuleByConfig(
       module_config, proto_config.matcher_name(), context);
   if (!load_result.ok()) {
@@ -90,10 +90,15 @@ DynamicModuleInputMatcherFactory::createInputMatcherFactoryCb(
   auto shared_module =
       std::shared_ptr<Extensions::DynamicModules::DynamicModule>(std::move(dynamic_module));
 
-  return [shared_module, on_config_destroy = on_config_destroy.value(), on_match = on_match.value(),
-          in_module_config] {
-    return std::make_unique<DynamicModuleInputMatcher>(shared_module, on_config_destroy, on_match,
-                                                       in_module_config);
+  // Own the in-module configuration in a shared holder so it is destroyed exactly once through
+  // on_matcher_config_destroy, whether the factory callback runs zero, one, or many times. The
+  // deleter also holds the module so the destroy hook is never called into an unloaded module.
+  std::shared_ptr<const void> shared_config(
+      in_module_config, [shared_module, on_config_destroy = on_config_destroy.value()](
+                            const void* config) { on_config_destroy(config); });
+
+  return [shared_module, on_match = on_match.value(), shared_config] {
+    return std::make_unique<DynamicModuleInputMatcher>(shared_module, on_match, shared_config);
   };
 }
 

--- a/source/extensions/matching/input_matchers/dynamic_modules/matcher.cc
+++ b/source/extensions/matching/input_matchers/dynamic_modules/matcher.cc
@@ -9,18 +9,11 @@ namespace DynamicModules {
 using ::Envoy::Extensions::Matching::Http::DynamicModules::DynamicModuleMatchData;
 using ::Envoy::Matcher::MatchResult;
 
-DynamicModuleInputMatcher::DynamicModuleInputMatcher(
-    DynamicModuleSharedPtr module, OnMatcherConfigDestroyType on_config_destroy,
-    OnMatcherMatchType on_match,
-    envoy_dynamic_module_type_matcher_config_module_ptr in_module_config)
-    : module_(std::move(module)), on_config_destroy_(on_config_destroy), on_match_(on_match),
-      in_module_config_(in_module_config) {}
-
-DynamicModuleInputMatcher::~DynamicModuleInputMatcher() {
-  if (in_module_config_ != nullptr && on_config_destroy_ != nullptr) {
-    on_config_destroy_(in_module_config_);
-  }
-}
+DynamicModuleInputMatcher::DynamicModuleInputMatcher(DynamicModuleSharedPtr module,
+                                                     OnMatcherMatchType on_match,
+                                                     std::shared_ptr<const void> in_module_config)
+    : module_(std::move(module)), on_match_(on_match),
+      in_module_config_(std::move(in_module_config)) {}
 
 MatchResult DynamicModuleInputMatcher::match(const ::Envoy::Matcher::DataInputGetResult& input) {
   if (auto dynamic_module_data = input.customData<DynamicModuleMatchData>(); dynamic_module_data) {
@@ -30,7 +23,7 @@ MatchResult DynamicModuleInputMatcher::match(const ::Envoy::Matcher::DataInputGe
     context.response_headers = dynamic_module_data->response_headers_;
     context.response_trailers = dynamic_module_data->response_trailers_;
 
-    if (on_match_(in_module_config_, static_cast<void*>(&context))) {
+    if (on_match_(in_module_config_.get(), static_cast<void*>(&context))) {
       return MatchResult::Matched;
     }
   }

--- a/source/extensions/matching/input_matchers/dynamic_modules/matcher.h
+++ b/source/extensions/matching/input_matchers/dynamic_modules/matcher.h
@@ -43,12 +43,8 @@ struct MatchContext {
 class DynamicModuleInputMatcher : public ::Envoy::Matcher::InputMatcher,
                                   public Logger::Loggable<Logger::Id::matcher> {
 public:
-  DynamicModuleInputMatcher(DynamicModuleSharedPtr module,
-                            OnMatcherConfigDestroyType on_config_destroy,
-                            OnMatcherMatchType on_match,
-                            envoy_dynamic_module_type_matcher_config_module_ptr in_module_config);
-
-  ~DynamicModuleInputMatcher() override;
+  DynamicModuleInputMatcher(DynamicModuleSharedPtr module, OnMatcherMatchType on_match,
+                            std::shared_ptr<const void> in_module_config);
 
   ::Envoy::Matcher::MatchResult match(const ::Envoy::Matcher::DataInputGetResult& input) override;
 
@@ -62,9 +58,10 @@ private:
   DynamicModuleInputMatcher& operator=(const DynamicModuleInputMatcher&) = delete;
 
   DynamicModuleSharedPtr module_;
-  OnMatcherConfigDestroyType on_config_destroy_;
   OnMatcherMatchType on_match_;
-  envoy_dynamic_module_type_matcher_config_module_ptr in_module_config_;
+  // Shared owner of the in-module configuration. The configuration is destroyed exactly once, after
+  // the last matcher instance and the factory callback that built it are released.
+  std::shared_ptr<const void> in_module_config_;
 };
 
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/test_data/c/BUILD
+++ b/test/extensions/dynamic_modules/test_data/c/BUILD
@@ -210,6 +210,8 @@ test_program(name = "matcher_missing_config_destroy")
 
 test_program(name = "matcher_check_headers")
 
+test_program(name = "matcher_lifecycle_counter")
+
 test_program(name = "cert_validator_no_op")
 
 test_program(name = "cert_validator_fail")

--- a/test/extensions/dynamic_modules/test_data/c/matcher_lifecycle_counter.c
+++ b/test/extensions/dynamic_modules/test_data/c/matcher_lifecycle_counter.c
@@ -1,0 +1,32 @@
+#include <stdbool.h>
+
+#include "source/extensions/dynamic_modules/abi/abi.h"
+
+// Matcher module that counts how many times its configuration is destroyed. The count is exposed
+// through getMatcherConfigDestroyCount so a test can assert the destroy runs exactly once.
+static int matcher_config_destroy_count = 0;
+
+int getMatcherConfigDestroyCount(void) { return matcher_config_destroy_count; }
+
+envoy_dynamic_module_type_abi_version_module_ptr envoy_dynamic_module_on_program_init(void) {
+  return envoy_dynamic_modules_abi_version;
+}
+
+envoy_dynamic_module_type_matcher_config_module_ptr envoy_dynamic_module_on_matcher_config_new(
+    envoy_dynamic_module_type_matcher_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer matcher_name,
+    envoy_dynamic_module_type_envoy_buffer matcher_config) {
+  static int config_dummy = 0;
+  return &config_dummy;
+}
+
+void envoy_dynamic_module_on_matcher_config_destroy(
+    envoy_dynamic_module_type_matcher_config_module_ptr config_module_ptr) {
+  matcher_config_destroy_count++;
+}
+
+bool envoy_dynamic_module_on_matcher_match(
+    envoy_dynamic_module_type_matcher_config_module_ptr config_module_ptr,
+    envoy_dynamic_module_type_matcher_input_envoy_ptr matcher_input_envoy_ptr) {
+  return true;
+}

--- a/test/extensions/matching/input_matchers/dynamic_modules/BUILD
+++ b/test/extensions/matching/input_matchers/dynamic_modules/BUILD
@@ -14,6 +14,7 @@ envoy_cc_test(
     data = [
         "//test/extensions/dynamic_modules/test_data/c:matcher_check_headers",
         "//test/extensions/dynamic_modules/test_data/c:matcher_config_new_fail",
+        "//test/extensions/dynamic_modules/test_data/c:matcher_lifecycle_counter",
         "//test/extensions/dynamic_modules/test_data/c:matcher_missing_config_destroy",
         "//test/extensions/dynamic_modules/test_data/c:matcher_missing_config_new",
         "//test/extensions/dynamic_modules/test_data/c:matcher_missing_match",
@@ -21,6 +22,7 @@ envoy_cc_test(
     ],
     deps = [
         "//envoy/registry",
+        "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/matching/input_matchers/dynamic_modules:config",
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/server:server_factory_context_mocks",

--- a/test/extensions/matching/input_matchers/dynamic_modules/config_test.cc
+++ b/test/extensions/matching/input_matchers/dynamic_modules/config_test.cc
@@ -1,5 +1,6 @@
 #include "envoy/registry/registry.h"
 
+#include "source/extensions/dynamic_modules/dynamic_modules.h"
 #include "source/extensions/matching/input_matchers/dynamic_modules/config.h"
 
 #include "test/extensions/dynamic_modules/util.h"
@@ -23,6 +24,22 @@ public:
     std::string shared_object_dir =
         std::filesystem::path(shared_object_path).parent_path().string();
     TestEnvironment::setEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH", shared_object_dir, 1);
+  }
+
+  // Returns the number of times matcher_lifecycle_counter has destroyed its configuration. The
+  // module handle is held so the shared counter stays alive across the factory's own load.
+  std::function<int()> configDestroyCounter() {
+    using GetConfigDestroyCountFuncType = int (*)();
+    auto module = Extensions::DynamicModules::newDynamicModule(
+        Extensions::DynamicModules::testSharedObjectPath("matcher_lifecycle_counter", "c"),
+        /*do_not_close=*/true);
+    EXPECT_TRUE(module.ok());
+    auto destroy_count = module.value()->getFunctionPointer<GetConfigDestroyCountFuncType>(
+        "getMatcherConfigDestroyCount");
+    EXPECT_TRUE(destroy_count.ok());
+    return [module = std::shared_ptr(std::move(module.value())), count = destroy_count.value()]() {
+      return count();
+    };
   }
 
   DynamicModuleInputMatcherFactory factory_;
@@ -231,6 +248,58 @@ TEST_F(DynamicModuleInputMatcherFactoryTest, FactoryRegistration) {
   auto* factory = Registry::FactoryRegistry<::Envoy::Matcher::InputMatcherFactory>::getFactory(
       "envoy.matching.matchers.dynamic_modules");
   EXPECT_NE(nullptr, factory);
+}
+
+// The factory callback may run more than once, and every matcher instance shares one in-module
+// configuration. Releasing all of them must destroy the configuration exactly once.
+TEST_F(DynamicModuleInputMatcherFactoryTest, SharedConfigDestroyedOnceForMultipleMatchers) {
+  const auto destroy_count = configDestroyCounter();
+  const int before = destroy_count();
+
+  const std::string yaml = R"EOF(
+dynamic_module_config:
+  name: matcher_lifecycle_counter
+  do_not_close: true
+matcher_name: test_matcher
+)EOF";
+  envoy::extensions::matching::input_matchers::dynamic_modules::v3::DynamicModuleMatcher
+      proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+
+  {
+    auto factory_cb = factory_.createInputMatcherFactoryCb(proto_config, context_);
+    auto matcher1 = factory_cb();
+    auto matcher2 = factory_cb();
+    EXPECT_NE(nullptr, matcher1);
+    EXPECT_NE(nullptr, matcher2);
+    // The configuration is still referenced, so it has not been destroyed yet.
+    EXPECT_EQ(before, destroy_count());
+  }
+
+  EXPECT_EQ(before + 1, destroy_count());
+}
+
+// A factory callback that is never invoked still owns the in-module configuration and must destroy
+// it once when released, so a rejected match tree does not leak the configuration.
+TEST_F(DynamicModuleInputMatcherFactoryTest, ConfigDestroyedWhenFactoryCallbackNeverInvoked) {
+  const auto destroy_count = configDestroyCounter();
+  const int before = destroy_count();
+
+  const std::string yaml = R"EOF(
+dynamic_module_config:
+  name: matcher_lifecycle_counter
+  do_not_close: true
+matcher_name: test_matcher
+)EOF";
+  envoy::extensions::matching::input_matchers::dynamic_modules::v3::DynamicModuleMatcher
+      proto_config;
+  TestUtility::loadFromYaml(yaml, proto_config);
+
+  {
+    auto factory_cb = factory_.createInputMatcherFactoryCb(proto_config, context_);
+  }
+
+  EXPECT_EQ(before + 1, destroy_count());
 }
 
 } // namespace

--- a/test/extensions/matching/input_matchers/dynamic_modules/matcher_test.cc
+++ b/test/extensions/matching/input_matchers/dynamic_modules/matcher_test.cc
@@ -16,6 +16,15 @@ namespace {
 using ::Envoy::Matcher::DataInputGetResult;
 using ::Envoy::Matcher::MatchResult;
 
+// Wraps the in-module configuration so it is destroyed exactly once when the matcher is released,
+// matching the ownership the production factory sets up.
+std::shared_ptr<const void>
+makeConfigHolder(envoy_dynamic_module_type_matcher_config_module_ptr in_module_config,
+                 OnMatcherConfigDestroyType on_config_destroy) {
+  return std::shared_ptr<const void>(
+      in_module_config, [on_config_destroy](const void* config) { on_config_destroy(config); });
+}
+
 class DynamicModuleMatcherTest : public testing::Test {
 public:
   DynamicModuleMatcherTest() {
@@ -52,8 +61,8 @@ TEST_F(DynamicModuleMatcherTest, AlwaysMatchModule) {
   auto in_module_config = (*on_config_new.value())(nullptr, name_buf, config_buf);
   ASSERT_NE(nullptr, in_module_config);
 
-  auto matcher = std::make_unique<DynamicModuleInputMatcher>(module, on_config_destroy.value(),
-                                                             on_match.value(), in_module_config);
+  auto matcher = std::make_unique<DynamicModuleInputMatcher>(
+      module, on_match.value(), makeConfigHolder(in_module_config, on_config_destroy.value()));
 
   // Create matching data with DynamicModuleMatchData.
   auto match_data = std::make_shared<Http::DynamicModules::DynamicModuleMatchData>();
@@ -92,8 +101,8 @@ TEST_F(DynamicModuleMatcherTest, HeaderCheckModule) {
   auto in_module_config = (*on_config_new.value())(nullptr, name_buf, config_buf);
   ASSERT_NE(nullptr, in_module_config);
 
-  auto matcher = std::make_unique<DynamicModuleInputMatcher>(module, on_config_destroy.value(),
-                                                             on_match.value(), in_module_config);
+  auto matcher = std::make_unique<DynamicModuleInputMatcher>(
+      module, on_match.value(), makeConfigHolder(in_module_config, on_config_destroy.value()));
 
   // Test with matching header.
   {
@@ -148,8 +157,8 @@ TEST_F(DynamicModuleMatcherTest, SupportedDataInputTypes) {
   envoy_dynamic_module_type_envoy_buffer config_buf = {"", 0};
   auto in_module_config = (*on_config_new.value())(nullptr, name_buf, config_buf);
 
-  auto matcher = std::make_unique<DynamicModuleInputMatcher>(module, on_config_destroy.value(),
-                                                             on_match.value(), in_module_config);
+  auto matcher = std::make_unique<DynamicModuleInputMatcher>(
+      module, on_match.value(), makeConfigHolder(in_module_config, on_config_destroy.value()));
 
   EXPECT_TRUE(matcher->supportsDataInputType("dynamic_module_data_input"));
   EXPECT_FALSE(matcher->supportsDataInputType("string"));
@@ -177,8 +186,8 @@ TEST_F(DynamicModuleMatcherTest, NonDynamicModuleCustomMatchDataReturnsFalse) {
   envoy_dynamic_module_type_envoy_buffer config_buf = {"", 0};
   auto in_module_config = (*on_config_new.value())(nullptr, name_buf, config_buf);
 
-  auto matcher = std::make_unique<DynamicModuleInputMatcher>(module, on_config_destroy.value(),
-                                                             on_match.value(), in_module_config);
+  auto matcher = std::make_unique<DynamicModuleInputMatcher>(
+      module, on_match.value(), makeConfigHolder(in_module_config, on_config_destroy.value()));
 
   // Pass a CustomMatchData that is not DynamicModuleMatchData.
   auto other_data = std::make_shared<OtherCustomMatchData>();
@@ -206,8 +215,8 @@ TEST_F(DynamicModuleMatcherTest, NonCustomMatchDataReturnsFalse) {
   envoy_dynamic_module_type_envoy_buffer config_buf = {"", 0};
   auto in_module_config = (*on_config_new.value())(nullptr, name_buf, config_buf);
 
-  auto matcher = std::make_unique<DynamicModuleInputMatcher>(module, on_config_destroy.value(),
-                                                             on_match.value(), in_module_config);
+  auto matcher = std::make_unique<DynamicModuleInputMatcher>(
+      module, on_match.value(), makeConfigHolder(in_module_config, on_config_destroy.value()));
 
   // Pass a string variant instead of CustomMatchData.
   auto input = DataInputGetResult::CreateString("not_custom_data");
@@ -233,8 +242,8 @@ TEST_F(DynamicModuleMatcherTest, NullRequestHeaders) {
   envoy_dynamic_module_type_envoy_buffer config_buf = {"x-test", 6};
   auto in_module_config = (*on_config_new.value())(nullptr, name_buf, config_buf);
 
-  auto matcher = std::make_unique<DynamicModuleInputMatcher>(module, on_config_destroy.value(),
-                                                             on_match.value(), in_module_config);
+  auto matcher = std::make_unique<DynamicModuleInputMatcher>(
+      module, on_match.value(), makeConfigHolder(in_module_config, on_config_destroy.value()));
 
   // Create match data with no headers set.
   auto match_data = std::make_shared<Http::DynamicModules::DynamicModuleMatchData>();


### PR DESCRIPTION
## Description

Today, the dynamic module input matcher create its in-module configuration once in the factory callback but destroy it per matcher instance, so the configuration leaks when the callback ran zero times and was freed more than once when it ran repeatedly. 

This PR makes it own the configuration in a single shared holder that destroys it exactly once through `on_matcher_config_destroy` and keeps the module loaded across that call.

---

**Commit Message:** dynamic_modules: fix input matcher config lifetime
**Risk Level:** Low
**Testing**: Added Tests
**Docs Changes:** Added
**Release Notes:** Added