### PR TITLE
admin: to enable actual drain when graceful is not set for /drain_listeners

### DIFF
--- a/changelogs/current/minor_behavior_changes/admin__non-graceful-drain-notifies-connections.rst
+++ b/changelogs/current/minor_behavior_changes/admin__non-graceful-drain-notifies-connections.rst
@@ -1,0 +1,10 @@
+A non-graceful drain (``/drain_listeners`` without ``graceful``) now starts a drain sequence and
+notifies the connections of the covered listeners that a drain has begun, in addition to stopping
+the listeners. Previously nothing was drained: the listeners simply stopped accepting, and the
+connections they already owned were never told, so no connection-level drain logic ran for them. The
+drain honors the configured :option:`--drain-strategy`, as a graceful drain does; ``graceful`` only
+controls whether the listeners keep accepting for a drain period before they are stopped. As a
+result, ``skip_exit`` is now accepted without ``graceful`` (it was rejected with a 400 before) and
+means "drain the connections, but never stop the listeners", which is what ``graceful&skip_exit``
+already did. This change can be temporarily reverted by setting the runtime guard
+``envoy.reloadable_features.non_graceful_drain_notifies_connections`` to ``false``.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -380,7 +380,11 @@ modify different aspects of the server:
 
 .. http:post:: /drain_listeners
 
-   :ref:`Drains <arch_overview_draining>` all listeners.
+   :ref:`Drains <arch_overview_draining>` all listeners. The listeners are stopped immediately and
+   a drain sequence is started, so that connection-level drain logic (configurable via
+   :option:`--drain-strategy`) applies to the connections the listeners own. Draining the
+   connections can be temporarily reverted by setting the runtime guard
+   ``envoy.reloadable_features.non_graceful_drain_notifies_connections`` to ``false``.
 
    .. http:post:: /drain_listeners?inboundonly
 
@@ -395,9 +399,11 @@ modify different aspects of the server:
    This behaviour and duration is configurable via server options or CLI
    (:option:`--drain-time-s` and :option:`--drain-strategy`).
 
-   .. http:post:: /drain_listeners?graceful&skip_exit
+   .. http:post:: /drain_listeners?skip_exit
 
-   When draining listeners, do not exit after the drain period. This must be used with `graceful`.
+   When draining listeners, do not stop them: the existing connections are drained while the
+   listeners keep accepting new ones. Since the drain period only delays stopping the listeners,
+   adding ``graceful`` makes no difference when ``skip_exit`` is set.
 
 .. attention::
 

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -103,6 +103,10 @@ RUNTIME_GUARD(envoy_reloadable_features_map_http_stream_reset_to_tcp_rst);
 RUNTIME_GUARD(envoy_reloadable_features_match_headers_individually);
 RUNTIME_GUARD(envoy_reloadable_features_mcp_filter_use_new_metadata_namespace);
 RUNTIME_GUARD(envoy_reloadable_features_mobile_use_network_observer_registry);
+// When enabled, a non-graceful admin drain (/drain_listeners without `graceful`) also starts a
+// drain sequence and notifies the connections of the covered listeners that a drain has begun,
+// instead of only stopping the listeners, and accepts `skip_exit` to drain without stopping them.
+RUNTIME_GUARD(envoy_reloadable_features_non_graceful_drain_notifies_connections);
 // OAuth2 filter cookie decryption: when true (the default), decrypt() accepts legacy CBC
 // ciphertexts via the legacy AES-256-CBC fallback. When false, only "gcm."-prefixed ciphertexts
 // decrypt; legacy CBC cookies are rejected and the affected users are redirected to the OAuth

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -243,6 +243,7 @@ envoy_cc_library(
         "//source/common/buffer:buffer_lib",
         "//source/common/http:codes_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/runtime:runtime_features_lib",
         "@envoy_api//envoy/admin/v3:pkg_cc_proto",
     ],
 )

--- a/source/server/admin/admin.cc
+++ b/source/server/admin/admin.cc
@@ -225,8 +225,9 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server,
                 "listeners. This behaviour and duration is configurable via server options "
                 "or CLI"},
                {ParamDescriptor::Type::Boolean, "skip_exit",
-                "When draining listeners, do not exit after the drain period. "
-                "This must be used with graceful"},
+                "When draining listeners, drain the connections but never stop the listeners. The "
+                "graceful parameter has no effect when this is set, since the drain period only "
+                "delays stopping the listeners"},
                {ParamDescriptor::Type::Boolean, "inboundonly",
                 "Drains all inbound listeners. traffic_direction field in "
                 "envoy_v3_api_msg_config.listener.v3.Listener is used to determine whether a "

--- a/source/server/admin/listeners_handler.cc
+++ b/source/server/admin/listeners_handler.cc
@@ -5,6 +5,7 @@
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
 #include "source/common/network/utility.h"
+#include "source/common/runtime/runtime_features.h"
 #include "source/server/admin/utils.h"
 
 namespace Envoy {
@@ -24,15 +25,29 @@ Http::Code ListenersHandler::handlerDrainListeners(Http::ResponseHeaderMap&,
 
   const bool graceful = params.getFirstValue("graceful").has_value();
   const bool skip_exit = params.getFirstValue("skip_exit").has_value();
-  if (skip_exit && !graceful) {
+  // A non-graceful drain used to do nothing but stop the listeners: no drain sequence was started
+  // and the connections those listeners already owned were never notified that a drain had begun,
+  // so nothing was actually drained, and skip_exit -- which left nothing at all to do once stopping
+  // the listeners was skipped -- was rejected. With this guard enabled a non-graceful drain drains
+  // those connections just as a graceful one does; it simply does not wait out a drain period
+  // before stopping the listeners, and skip_exit becomes meaningful for it.
+  //
+  // TODO(wbpcode): once this guard is removed, the two branches below can be collapsed: every drain
+  // then drains the connections the same way and `graceful`/`skip_exit` only decide when, or
+  // whether, the listeners are stopped.
+  const bool non_graceful_drain_notifies_connections = Runtime::runtimeFeatureEnabled(
+      "envoy.reloadable_features.non_graceful_drain_notifies_connections");
+  if (skip_exit && !graceful && !non_graceful_drain_notifies_connections) {
     response.add("skip_exit requires graceful\n");
     return Http::Code::BadRequest;
   }
+
+  auto direction = Network::DrainDirection::All;
+  if (stop_listeners_type == ListenerManager::StopListenersType::InboundOnly) {
+    direction = Network::DrainDirection::InboundOnly;
+  }
+
   if (graceful) {
-    auto direction = Network::DrainDirection::All;
-    if (stop_listeners_type == ListenerManager::StopListenersType::InboundOnly) {
-      direction = Network::DrainDirection::InboundOnly;
-    }
     // If draining(direction) returns true, it means:
     // 1. we are already draining
     // 2. That drain includes the direction we're being asked to drain
@@ -59,7 +74,26 @@ Http::Code ListenersHandler::handlerDrainListeners(Http::ResponseHeaderMap&,
       }
     });
   } else {
-    server_.listenerManager().stopListeners(stop_listeners_type, {});
+    if (non_graceful_drain_notifies_connections) {
+      // Notify before stopping the listeners so that a connection accepted in the window between
+      // the two is notified as well: the active listener replays the event to connections accepted
+      // after the drain started.
+      //
+      // The strategy is the server-wide default, as for a graceful drain: `graceful` only decides
+      // whether the listeners keep accepting for a drain period before they are stopped, which is
+      // independent of how the existing connections are drained.
+      server_.listenerManager().onServerDrainStart(
+          direction, Network::ConnectionDrainEvent{server_.api().timeSource().monotonicTime(),
+                                                   server_.options().drainStrategy()});
+      // Also put the drain manager into the draining state, so that consumers that poll
+      // DrainDecision::drainClose() (rather than reacting to the push notification above) see the
+      // drain too. No completion callback is needed: the listeners are stopped right below, or
+      // deliberately left running when skip_exit is set.
+      server_.drainManager().startDrainSequence(direction, []() {});
+    }
+    if (!skip_exit) {
+      server_.listenerManager().stopListeners(stop_listeners_type, {});
+    }
   }
 
   response.add("OK\n");

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -222,6 +222,64 @@ TEST_P(DrainCloseIntegrationTest, AdminGracefulDrainSkipExit) {
   ASSERT_TRUE(waitForPortAvailable(http_port));
 }
 
+// A non-graceful drain with skip_exit drains the existing connections without stopping the
+// listeners, so the listeners keep accepting new connections.
+TEST_P(DrainCloseIntegrationTest, AdminNonGracefulDrainSkipExit) {
+  drain_strategy_ = Server::DrainStrategy::Immediate;
+  // Long enough that nothing here depends on the drain period elapsing.
+  drain_time_ = std::chrono::seconds(999);
+  initialize();
+  uint32_t http_port = lookupPort("http");
+  codec_client_ = makeHttpConnection(http_port);
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest(0);
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
+  // The request is completed but the connection remains open.
+  EXPECT_TRUE(codec_client_->connected());
+
+  // Invoke /drain_listeners without graceful: the connections drain immediately, but skip_exit
+  // leaves the listeners running.
+  BufferingStreamDecoderPtr admin_response =
+      IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/drain_listeners?skip_exit",
+                                         "", downstreamProtocol(), version_);
+  EXPECT_EQ(admin_response->headers().Status()->value().getStringView(), "200");
+
+  // Listeners should remain open.
+  EXPECT_EQ(test_server_->counter("listener_manager.listener_stopped")->value(), 0);
+
+  // The already-established connection is drained: it terminates once the request completes.
+  response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest(0);
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_THAT(response->headers(), Http::HttpStatusIs("200"));
+
+  ASSERT_TRUE(codec_client_->waitForDisconnect());
+  if (downstream_protocol_ == Http::CodecType::HTTP2) {
+    EXPECT_TRUE(codec_client_->sawGoAway());
+  } else {
+    EXPECT_EQ("close", response->headers().getConnectionValue());
+  }
+
+  // New connections can still be made.
+  auto second_codec_client_ = makeRawHttpConnection(makeClientConnection(http_port), std::nullopt);
+  EXPECT_TRUE(second_codec_client_->connected());
+
+  // Invoke /drain_listeners and shut down listeners.
+  second_codec_client_->rawConnection().close(Network::ConnectionCloseType::NoFlush);
+  admin_response = IntegrationUtil::makeSingleRequest(
+      lookupPort("admin"), "POST", "/drain_listeners", "", downstreamProtocol(), version_);
+  EXPECT_EQ(admin_response->headers().Status()->value().getStringView(), "200");
+
+  test_server_->waitForCounter("listener_manager.listener_stopped", Eq(1));
+  ASSERT_TRUE(waitForPortAvailable(http_port));
+}
+
 INSTANTIATE_TEST_SUITE_P(Protocols, DrainCloseIntegrationTest,
                          testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
                              {Http::CodecType::HTTP1, Http::CodecType::HTTP2},

--- a/test/integration/drain_close_integration_test.cc
+++ b/test/integration/drain_close_integration_test.cc
@@ -246,7 +246,7 @@ TEST_P(DrainCloseIntegrationTest, AdminNonGracefulDrainSkipExit) {
   BufferingStreamDecoderPtr admin_response =
       IntegrationUtil::makeSingleRequest(lookupPort("admin"), "POST", "/drain_listeners?skip_exit",
                                          "", downstreamProtocol(), version_);
-  EXPECT_EQ(admin_response->headers().Status()->value().getStringView(), "200");
+  EXPECT_THAT(admin_response->headers(), Http::HttpStatusIs("200"));
 
   // Listeners should remain open.
   EXPECT_EQ(test_server_->counter("listener_manager.listener_stopped")->value(), 0);
@@ -274,7 +274,7 @@ TEST_P(DrainCloseIntegrationTest, AdminNonGracefulDrainSkipExit) {
   second_codec_client_->rawConnection().close(Network::ConnectionCloseType::NoFlush);
   admin_response = IntegrationUtil::makeSingleRequest(
       lookupPort("admin"), "POST", "/drain_listeners", "", downstreamProtocol(), version_);
-  EXPECT_EQ(admin_response->headers().Status()->value().getStringView(), "200");
+  EXPECT_THAT(admin_response->headers(), Http::HttpStatusIs("200"));
 
   test_server_->waitForCounter("listener_manager.listener_stopped", Eq(1));
   ASSERT_TRUE(waitForPortAvailable(http_port));

--- a/test/server/admin/BUILD
+++ b/test/server/admin/BUILD
@@ -70,6 +70,7 @@ envoy_cc_test(
         "//test/test_common:logging_lib",
         "//test/test_common:network_utility_lib",
         "//test/test_common:status_utility_lib",
+        "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -35,6 +35,10 @@ using testing::StartsWith;
 namespace Envoy {
 namespace Server {
 
+MATCHER_P(HasEventStrategy, m, "") {
+  return testing::ExplainMatchResult(m, arg.strategy, result_listener);
+}
+
 INSTANTIATE_TEST_SUITE_P(IpVersions, AdminInstanceTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
@@ -87,17 +91,17 @@ TEST_P(AdminInstanceTest, NonGracefulDrainNotifiesListeners) {
   // so the notification carries the server-wide strategy just as a graceful drain's does.
   ON_CALL(server_.options_, drainStrategy())
       .WillByDefault(testing::Return(Server::DrainStrategy::Gradual));
-  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(Network::DrainDirection::All, _))
-      .WillOnce([](Network::DrainDirection, Network::ConnectionDrainEvent event) {
-        EXPECT_EQ(Server::DrainStrategy::Gradual, event.strategy);
-      });
+  EXPECT_CALL(server_.listener_manager_,
+              onServerDrainStart(Network::DrainDirection::All,
+                                 HasEventStrategy(Server::DrainStrategy::Gradual)));
 
   EXPECT_CALL(server_.listener_manager_, stopListeners(ListenerManager::StopListenersType::All, _));
   EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners", header_map, data));
 
   // Inbound-only drains pass the narrower direction through, as for a graceful drain.
   EXPECT_CALL(server_.listener_manager_,
-              onServerDrainStart(Network::DrainDirection::InboundOnly, _));
+              onServerDrainStart(Network::DrainDirection::InboundOnly,
+                                 HasEventStrategy(Server::DrainStrategy::Gradual)));
   EXPECT_CALL(server_.listener_manager_,
               stopListeners(ListenerManager::StopListenersType::InboundOnly, _));
   EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners?inboundonly", header_map, data));

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -23,6 +23,7 @@
 #include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/status_utility.h"
+#include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "absl/strings/match.h"
@@ -74,10 +75,67 @@ TEST_P(AdminInstanceTest, GracefulDrainNotifiesListeners) {
               onServerDrainStart(Network::DrainDirection::InboundOnly, _));
   EXPECT_EQ(Http::Code::OK,
             postCallback("/drain_listeners?graceful&inboundonly", header_map, data));
+}
 
-  // A non-graceful drain stops the listeners outright; there is no drain window to notify about.
-  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(_, _)).Times(0);
+// A non-graceful drain stops the listeners immediately, but the connections they own still have to
+// be told that a drain has begun -- otherwise nothing about them drains at all.
+TEST_P(AdminInstanceTest, NonGracefulDrainNotifiesListeners) {
+  Buffer::OwnedImpl data;
+  Http::TestResponseHeaderMapImpl header_map;
+
+  // The `graceful` parameter only decides whether the listeners keep accepting for a drain period,
+  // so the notification carries the server-wide strategy just as a graceful drain's does.
+  ON_CALL(server_.options_, drainStrategy())
+      .WillByDefault(testing::Return(Server::DrainStrategy::Gradual));
+  Network::ConnectionDrainEvent captured;
+  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(Network::DrainDirection::All, _))
+      .WillOnce(
+          testing::Invoke([&captured](Network::DrainDirection,
+                                      Network::ConnectionDrainEvent event) { captured = event; }));
+  EXPECT_CALL(server_.listener_manager_, stopListeners(ListenerManager::StopListenersType::All, _));
   EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners", header_map, data));
+  EXPECT_EQ(Server::DrainStrategy::Gradual, captured.strategy);
+
+  // Inbound-only drains pass the narrower direction through, as for a graceful drain.
+  EXPECT_CALL(server_.listener_manager_,
+              onServerDrainStart(Network::DrainDirection::InboundOnly, _));
+  EXPECT_CALL(server_.listener_manager_,
+              stopListeners(ListenerManager::StopListenersType::InboundOnly, _));
+  EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners?inboundonly", header_map, data));
+}
+
+// skip_exit applies to a non-graceful drain too: the connections are drained, but the listeners are
+// left running rather than being stopped -- the same thing graceful&skip_exit does, since the drain
+// period only delays stopping the listeners.
+TEST_P(AdminInstanceTest, NonGracefulDrainSkipExitDoesNotStopListeners) {
+  Buffer::OwnedImpl data;
+  Http::TestResponseHeaderMapImpl header_map;
+
+  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(Network::DrainDirection::All, _));
+  EXPECT_CALL(server_.drain_manager_, startDrainSequence(Network::DrainDirection::All, _));
+  EXPECT_CALL(server_.listener_manager_, stopListeners(_, _)).Times(0);
+  EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners?skip_exit", header_map, data));
+}
+
+// With the guard disabled, a non-graceful drain only stops the listeners and skip_exit is rejected.
+TEST_P(AdminInstanceTest, NonGracefulDrainNotifyRuntimeGuardDisabled) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues(
+      {{"envoy.reloadable_features.non_graceful_drain_notifies_connections", "false"}});
+
+  Buffer::OwnedImpl data;
+  Http::TestResponseHeaderMapImpl header_map;
+
+  EXPECT_CALL(server_.listener_manager_, onServerDrainStart(_, _)).Times(0);
+  EXPECT_CALL(server_.drain_manager_, startDrainSequence(_, _)).Times(0);
+  EXPECT_CALL(server_.listener_manager_, stopListeners(ListenerManager::StopListenersType::All, _));
+  EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners", header_map, data));
+
+  Buffer::OwnedImpl skip_exit_data;
+  EXPECT_CALL(server_.listener_manager_, stopListeners(_, _)).Times(0);
+  EXPECT_EQ(Http::Code::BadRequest,
+            postCallback("/drain_listeners?skip_exit", header_map, skip_exit_data));
+  EXPECT_EQ("skip_exit requires graceful\n", skip_exit_data.toString());
 }
 
 TEST_P(AdminInstanceTest, Getters) {
@@ -189,7 +247,7 @@ TEST_P(AdminInstanceTest, Help) {
       enable: enables the CPU profiler; One of (y, n)
   /drain_listeners (POST): drain listeners
       graceful: When draining listeners, enter a graceful drain period prior to closing listeners. This behaviour and duration is configurable via server options or CLI
-      skip_exit: When draining listeners, do not exit after the drain period. This must be used with graceful
+      skip_exit: When draining listeners, drain the connections but never stop the listeners. The graceful parameter has no effect when this is set, since the drain period only delays stopping the listeners
       inboundonly: Drains all inbound listeners. traffic_direction field in envoy_v3_api_msg_config.listener.v3.Listener is used to determine whether a listener is inbound or outbound.
   /healthcheck/fail (POST): cause the server to fail health checks
   /healthcheck/ok (POST): cause the server to pass health checks

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -87,14 +87,13 @@ TEST_P(AdminInstanceTest, NonGracefulDrainNotifiesListeners) {
   // so the notification carries the server-wide strategy just as a graceful drain's does.
   ON_CALL(server_.options_, drainStrategy())
       .WillByDefault(testing::Return(Server::DrainStrategy::Gradual));
-  Network::ConnectionDrainEvent captured;
   EXPECT_CALL(server_.listener_manager_, onServerDrainStart(Network::DrainDirection::All, _))
-      .WillOnce(
-          testing::Invoke([&captured](Network::DrainDirection,
-                                      Network::ConnectionDrainEvent event) { captured = event; }));
+      .WillOnce([](Network::DrainDirection, Network::ConnectionDrainEvent event) {
+        EXPECT_EQ(Server::DrainStrategy::Gradual, event.strategy);
+      });
+
   EXPECT_CALL(server_.listener_manager_, stopListeners(ListenerManager::StopListenersType::All, _));
   EXPECT_EQ(Http::Code::OK, postCallback("/drain_listeners", header_map, data));
-  EXPECT_EQ(Server::DrainStrategy::Gradual, captured.strategy);
 
   // Inbound-only drains pass the narrower direction through, as for a graceful drain.
   EXPECT_CALL(server_.listener_manager_,


### PR DESCRIPTION
Commit Message: admin: to enable actual drain when graceful is not set for /drain_listeners
Additional Description:

Before this PR, the `/drain_listeners` will never actually start the drain logic but only stop to accept new connections, that's say no existing connection know the server enter drain mode, then no one will send go away or append the `Connection: close` to response.
But the `/drain_listeners?graceful` will notify the drain close decision correctly by the `startDrainSequence` call.

After this PR, the `/drain_listeners` will also handle it correctly. And this PR unbounded the `skip_exit` and `graceful`. Now, we will have clearly three options:

1. `/drain_listeners`: start draining and stop accepting new connections immediately 
2. `/drain_listeners?graceful`: start draining and stop accepting new connection after drain duration.
3. `/drain_listeners?skip_exit`: start draining and never stop accepting new connections.

Risk Level: low.
Testing: unit/integration.
Docs Changes: added
Release Notes: added.
Platform Specific Features: n/a.