### PR TITLE
thread_local: require main thread dispatcher in InstanceImpl ctor

### DIFF
--- a/contrib/hyperscan/matching/input_matchers/source/matcher.cc
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.cc
@@ -8,14 +8,15 @@ namespace Hyperscan {
 
 using ::Envoy::Matcher::MatchResult;
 
-ScratchThreadLocal::ScratchThreadLocal(const hs_database_t* database,
-                                       const hs_database_t* start_of_match_database) {
-  hs_error_t err = hs_alloc_scratch(database, &scratch_);
+ScratchThreadLocal::ScratchThreadLocal(DatabaseSharedPtr database,
+                                       DatabaseSharedPtr start_of_match_database)
+    : database_(std::move(database)), start_of_match_database_(std::move(start_of_match_database)) {
+  hs_error_t err = hs_alloc_scratch(database_.get(), &scratch_);
   if (err != HS_SUCCESS) {
     IS_ENVOY_BUG(fmt::format("unable to allocate scratch space, error code {}.", err));
   }
-  if (start_of_match_database) {
-    err = hs_alloc_scratch(start_of_match_database, &scratch_);
+  if (start_of_match_database_) {
+    err = hs_alloc_scratch(start_of_match_database_.get(), &scratch_);
     if (err != HS_SUCCESS) {
       IS_ENVOY_BUG(
           fmt::format("unable to allocate start of match scratch space, error code {}.", err));
@@ -44,7 +45,7 @@ Matcher::Matcher(const std::vector<const char*>& expressions,
   ASSERT(expressions.size() == ids.size());
 
   // Compile database.
-  compile(expressions, flags, ids, &database_);
+  compile(expressions, flags, ids, database_);
 
   // Compile start of match database which will report start of matching, works for replaceAll.
   if (report_start_of_matching) {
@@ -52,25 +53,23 @@ Matcher::Matcher(const std::vector<const char*>& expressions,
     for (unsigned int& start_of_match_flag : start_of_match_flags) {
       start_of_match_flag = start_of_match_flag | HS_FLAG_SOM_LEFTMOST;
     }
-    compile(expressions, start_of_match_flags, ids, &start_of_match_database_);
+    compile(expressions, start_of_match_flags, ids, start_of_match_database_);
   }
 
-  tls_->set([this](Event::Dispatcher&) {
-    return std::make_shared<ScratchThreadLocal>(database_, start_of_match_database_);
+  tls_->set([database = database_,
+             start_of_match_database = start_of_match_database_](Event::Dispatcher&) {
+    return std::make_shared<ScratchThreadLocal>(database, start_of_match_database);
   });
 }
 
-Matcher::~Matcher() {
-  hs_free_database(database_);
-  hs_free_database(start_of_match_database_);
-}
+Matcher::~Matcher() = default;
 
 bool Matcher::match(absl::string_view value) const {
   bool matched = false;
   ScratchThreadLocalPtr local_scratch;
   hs_scratch_t* scratch = getScratch(local_scratch);
   hs_error_t err = hs_scan(
-      database_, value.data(), value.size(), 0, scratch,
+      database_.get(), value.data(), value.size(), 0, scratch,
       [](unsigned int, unsigned long long, unsigned long long, unsigned int, void* context) -> int {
         bool* matched = static_cast<bool*>(context);
         *matched = true;
@@ -92,7 +91,7 @@ std::string Matcher::replaceAll(absl::string_view value, absl::string_view subst
   ScratchThreadLocalPtr local_scratch;
   hs_scratch_t* scratch = getScratch(local_scratch);
   hs_error_t err = hs_scan(
-      start_of_match_database_, value.data(), value.size(), 0, scratch,
+      start_of_match_database_.get(), value.data(), value.size(), 0, scratch,
       [](unsigned int, unsigned long long from, unsigned long long to, unsigned int,
          void* context) -> int {
         std::vector<Bound>* bounds = static_cast<std::vector<Bound>*>(context);
@@ -140,11 +139,11 @@ MatchResult Matcher::match(const ::Envoy::Matcher::DataInputGetResult& input) {
 
 void Matcher::compile(const std::vector<const char*>& expressions,
                       const std::vector<unsigned int>& flags, const std::vector<unsigned int>& ids,
-                      hs_database_t** database) {
+                      DatabaseSharedPtr& database) {
+  hs_database_t* db = nullptr;
   hs_compile_error_t* compile_err;
-  hs_error_t err =
-      hs_compile_multi(expressions.data(), flags.data(), ids.data(), expressions.size(),
-                       HS_MODE_BLOCK, nullptr, database, &compile_err);
+  hs_error_t err = hs_compile_multi(expressions.data(), flags.data(), ids.data(),
+                                    expressions.size(), HS_MODE_BLOCK, nullptr, &db, &compile_err);
   if (err != HS_SUCCESS) {
     std::string compile_err_message(compile_err->message);
     int compile_err_expression = compile_err->expression;
@@ -159,6 +158,7 @@ void Matcher::compile(const std::vector<const char*>& expressions,
     }
   }
   hs_free_compile_error(compile_err);
+  database = DatabaseSharedPtr(db, [](hs_database_t* p) { hs_free_database(p); });
 }
 
 hs_scratch_t* Matcher::getScratch(ScratchThreadLocalPtr& local_scratch) const {
@@ -168,11 +168,12 @@ hs_scratch_t* Matcher::getScratch(ScratchThreadLocalPtr& local_scratch) const {
   // before workers while there is chance to use these matchers in working threads. As a result,
   // we have to ask main thread to allocate thread local object again.
   if (!tls_->get().has_value()) {
-    main_thread_dispatcher_.post([this]() {
-      tls_->set([this](Event::Dispatcher&) {
-        return std::make_shared<ScratchThreadLocal>(database_, start_of_match_database_);
-      });
-    });
+    main_thread_dispatcher_.post(
+        [this, database = database_, start_of_match_database = start_of_match_database_]() {
+          tls_->set([database, start_of_match_database](Event::Dispatcher&) {
+            return std::make_shared<ScratchThreadLocal>(database, start_of_match_database);
+          });
+        });
 
     local_scratch = std::make_unique<ScratchThreadLocal>(database_, start_of_match_database_);
     return local_scratch->scratch_;

--- a/contrib/hyperscan/matching/input_matchers/source/matcher.h
+++ b/contrib/hyperscan/matching/input_matchers/source/matcher.h
@@ -12,10 +12,14 @@ namespace Matching {
 namespace InputMatchers {
 namespace Hyperscan {
 
+using DatabaseSharedPtr = std::shared_ptr<hs_database_t>;
+
 struct ScratchThreadLocal : public ThreadLocal::ThreadLocalObject {
-  ScratchThreadLocal(const hs_database_t* database, const hs_database_t* start_of_match_database);
+  ScratchThreadLocal(DatabaseSharedPtr database, DatabaseSharedPtr start_of_match_database);
   ~ScratchThreadLocal() override;
 
+  DatabaseSharedPtr database_;
+  DatabaseSharedPtr start_of_match_database_;
   hs_scratch_t* scratch_{};
 };
 
@@ -48,15 +52,15 @@ public:
   const std::string& pattern() const override { return EMPTY_STRING; }
 
 private:
-  hs_database_t* database_{};
-  hs_database_t* start_of_match_database_{};
+  DatabaseSharedPtr database_;
+  DatabaseSharedPtr start_of_match_database_;
   Event::Dispatcher& main_thread_dispatcher_;
   ThreadLocal::TypedSlotPtr<ScratchThreadLocal> tls_;
 
   // Compiles the Hyperscan database. It will throw on failure of insufficient memory or malformed
   // regex patterns and flags. Vector parameters should have the same size.
   void compile(const std::vector<const char*>& expressions, const std::vector<unsigned int>& flags,
-               const std::vector<unsigned int>& ids, hs_database_t** database);
+               const std::vector<unsigned int>& ids, DatabaseSharedPtr& database);
 
   hs_scratch_t* getScratch(ScratchThreadLocalPtr& local_scratch) const;
 };

--- a/contrib/hyperscan/matching/input_matchers/test/matcher_speed_test.cc
+++ b/contrib/hyperscan/matching/input_matchers/test/matcher_speed_test.cc
@@ -48,7 +48,7 @@ BENCHMARK(BM_CompiledGoogleReMatcher);
 // NOLINTNEXTLINE(readability-identifier-naming)
 static void BM_HyperscanMatcher(benchmark::State& state) {
   Event::MockDispatcher dispatcher;
-  ThreadLocal::InstanceImpl instance;
+  ThreadLocal::InstanceImpl instance(dispatcher);
   auto matcher = Extensions::Matching::InputMatchers::Hyperscan::Matcher(
       {std::string(ClusterRePattern).c_str()}, {0}, {0}, dispatcher, instance, false);
   uint32_t passes = 0;

--- a/contrib/hyperscan/matching/input_matchers/test/matcher_test.cc
+++ b/contrib/hyperscan/matching/input_matchers/test/matcher_test.cc
@@ -24,10 +24,12 @@ using ::Envoy::Matcher::DataInputGetResult;
 TEST(ThreadLocalTest, RaceScratchCreation) {
   Thread::ThreadFactory& thread_factory = Thread::threadFactoryForTest();
 
-  hs_database_t* database;
+  DatabaseSharedPtr database;
+  hs_database_t* db = nullptr;
   hs_compile_error_t* compile_err;
-  hs_error_t err = hs_compile("hello", 0, HS_MODE_BLOCK, nullptr, &database, &compile_err);
+  hs_error_t err = hs_compile("hello", 0, HS_MODE_BLOCK, nullptr, &db, &compile_err);
   ASSERT(err == HS_SUCCESS);
+  database = DatabaseSharedPtr(db, [](hs_database_t* p) { hs_free_database(p); });
 
   constexpr int num_threads = 100;
   std::vector<Thread::ThreadPtr> threads;
@@ -83,8 +85,6 @@ TEST(BoundTest, Compare) {
 
 class MatcherTest : public ::testing::Test {
 protected:
-  MatcherTest() { instance_.registerThread(dispatcher_, true); }
-
   void setup(const char* expression, unsigned int flag, bool report_start_of_matching) {
     std::vector<const char*> expressions{expression};
     std::vector<unsigned int> flags{flag};
@@ -99,7 +99,7 @@ protected:
   }
 
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
-  ThreadLocal::InstanceImpl instance_;
+  ThreadLocal::InstanceImpl instance_{dispatcher_};
   std::unique_ptr<Matcher> matcher_;
 };
 

--- a/contrib/hyperscan/regex_engines/test/regex_test.cc
+++ b/contrib/hyperscan/regex_engines/test/regex_test.cc
@@ -14,8 +14,6 @@ namespace Hyperscan {
 
 class EngineTest : public ::testing::Test {
 protected:
-  EngineTest() { instance_.registerThread(dispatcher_, true); }
-
   void setup() { engine_ = std::make_shared<HyperscanEngine>(dispatcher_, instance_); }
 
   void TearDown() override {
@@ -24,7 +22,7 @@ protected:
   }
 
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
-  ThreadLocal::InstanceImpl instance_;
+  ThreadLocal::InstanceImpl instance_{dispatcher_};
   std::shared_ptr<HyperscanEngine> engine_;
 };
 

--- a/envoy/thread_local/thread_local.h
+++ b/envoy/thread_local/thread_local.h
@@ -215,14 +215,12 @@ template <class T = ThreadLocalObject> using TypedSlotPtr = std::unique_ptr<Type
 class Instance : public SlotAllocator {
 public:
   /**
-   * A thread (via its dispatcher) must be registered before set() is called on any allocated slots
-   * to receive thread local data updates.
+   * A worker thread (via its dispatcher) must be registered before set() is called on any allocated
+   * slots to receive thread local data updates. The main thread dispatcher is registered
+   * automatically during Instance construction.
    * @param dispatcher supplies the thread's dispatcher.
-   * @param main_thread supplies whether this is the main program thread or not. (The only
-   *                    difference is that callbacks fire immediately on the main thread when posted
-   *                    from the main thread).
    */
-  virtual void registerThread(Event::Dispatcher& dispatcher, bool main_thread) PURE;
+  virtual void registerThread(Event::Dispatcher& dispatcher) PURE;
 
   /**
    * This should be called by the main thread before any worker threads start to exit. This will

--- a/mobile/library/common/engine_common.cc
+++ b/mobile/library/common/engine_common.cc
@@ -94,13 +94,13 @@ EngineCommon::EngineCommon(std::shared_ptr<Envoy::OptionsImplBase> options,
          Event::TimeSystem& time_system, ListenerHooks& hooks, Server::HotRestart& restarter,
          Stats::StoreRoot& store, Thread::BasicLockable& access_log_lock,
          Server::ComponentFactory& component_factory, Random::RandomGeneratorPtr&& random_generator,
-         ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory,
-         Filesystem::Instance& file_system, std::unique_ptr<ProcessContext> process_context,
+         Thread::ThreadFactory& thread_factory, Filesystem::Instance& file_system,
+         std::unique_ptr<ProcessContext> process_context,
          Buffer::WatermarkFactorySharedPtr watermark_factory) {
         auto local_address = Network::Utility::getLocalAddress(options.localAddressIpVersion());
         auto server = std::make_unique<ServerLite>(
             init_manager, options, time_system, hooks, restarter, store, access_log_lock,
-            std::move(random_generator), tls, thread_factory, file_system,
+            std::move(random_generator), thread_factory, file_system,
             std::move(process_context), watermark_factory);
         server->initialize(local_address, component_factory);
         return server;

--- a/mobile/library/common/engine_common.cc
+++ b/mobile/library/common/engine_common.cc
@@ -100,8 +100,8 @@ EngineCommon::EngineCommon(std::shared_ptr<Envoy::OptionsImplBase> options,
         auto local_address = Network::Utility::getLocalAddress(options.localAddressIpVersion());
         auto server = std::make_unique<ServerLite>(
             init_manager, options, time_system, hooks, restarter, store, access_log_lock,
-            std::move(random_generator), thread_factory, file_system,
-            std::move(process_context), watermark_factory);
+            std::move(random_generator), thread_factory, file_system, std::move(process_context),
+            watermark_factory);
         server->initialize(local_address, component_factory);
         return server;
       };

--- a/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.cc
+++ b/mobile/library/common/extensions/listener_managers/api_listener_manager/api_listener_manager.cc
@@ -26,7 +26,7 @@ namespace Server {
 ApiListenerWorker::ApiListenerWorker(Instance& server)
     : server_(server), dispatcher_(server.api().allocateDispatcher("api_listener_worker")),
       provisional_dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
-  server_.threadLocal().registerThread(*dispatcher_, false);
+  server_.threadLocal().registerThread(*dispatcher_);
   provisional_dispatcher_->drain(*dispatcher_);
 }
 

--- a/source/common/stats/thread_local_store.cc
+++ b/source/common/stats/thread_local_store.cc
@@ -287,6 +287,9 @@ void ThreadLocalStoreImpl::shutdownThreading() {
   shutting_down_ = true;
   ASSERT(!tls_.has_value() || tls_->isShutdown());
 
+  tls_cache_.reset();
+  tls_.reset();
+
   // We can't call runOnAllThreads here as global threading has already been shutdown. It is okay
   // to simply clear the scopes and central cache entries here as they will be cleaned up during
   // thread local data cleanup in InstanceImpl::shutdownThread().

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -121,9 +121,15 @@ void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   }
 
   // Handle main thread.
+<<<<<<< HEAD
   ASSERT(parent_.main_thread_dispatcher_ != nullptr,
          "main thread dispatcher must be registered before initializing thread local slots");
   setThreadLocal(index_, cb(*parent_.main_thread_dispatcher_));
+=======
+  if (parent_.main_thread_dispatcher_ != nullptr) {
+    setThreadLocal(index_, cb(*parent_.main_thread_dispatcher_));
+  }
+>>>>>>> 0a683fb684 (thread_local: refactor SlotImpl to use SlotSharedPtr and std::enable_shared_from_this)
 }
 
 void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_thread) {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -25,6 +25,7 @@ InstanceImpl::~InstanceImpl() {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
   ASSERT(shutdown_);
   thread_local_data_.data_.clear();
+  thread_local_data_.dispatcher_ = nullptr;
 }
 
 SlotSharedPtr InstanceImpl::allocateSlot() {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -121,15 +121,9 @@ void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   }
 
   // Handle main thread.
-<<<<<<< HEAD
   ASSERT(parent_.main_thread_dispatcher_ != nullptr,
          "main thread dispatcher must be registered before initializing thread local slots");
   setThreadLocal(index_, cb(*parent_.main_thread_dispatcher_));
-=======
-  if (parent_.main_thread_dispatcher_ != nullptr) {
-    setThreadLocal(index_, cb(*parent_.main_thread_dispatcher_));
-  }
->>>>>>> 0a683fb684 (thread_local: refactor SlotImpl to use SlotSharedPtr and std::enable_shared_from_this)
 }
 
 void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_thread) {

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -16,7 +16,10 @@ namespace ThreadLocal {
 
 thread_local InstanceImpl::ThreadLocalData InstanceImpl::thread_local_data_;
 
-InstanceImpl::InstanceImpl() = default;
+InstanceImpl::InstanceImpl(Event::Dispatcher& main_dispatcher)
+    : main_thread_dispatcher_(main_dispatcher) {
+  thread_local_data_.dispatcher_ = &main_dispatcher;
+}
 
 InstanceImpl::~InstanceImpl() {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
@@ -52,10 +55,7 @@ InstanceImpl::SlotImpl::~SlotImpl() {
     return;
   }
 
-  auto* main_thread_dispatcher = parent_.main_thread_dispatcher_;
-  // Main thread dispatcher may be nullptr if the slot is being created and destroyed during
-  // server initialization.
-  if (main_thread_dispatcher == nullptr || main_thread_dispatcher->isThreadSafe()) {
+  if (parent_.main_thread_dispatcher_.isThreadSafe()) {
     // If the slot is being destroyed on the main thread, we can remove it immediately.
     parent_.removeSlot(index_);
   } else {
@@ -67,7 +67,7 @@ InstanceImpl::SlotImpl::~SlotImpl() {
     // 2. The removal is not executed if the main dispatcher has already exited. This is fine
     //    because the removal has no side effect and will be ignored. The shutdown process will
     //    clean up all the slots anyway.
-    main_thread_dispatcher->post([i = index_, &tls = parent_] { tls.removeSlot(i); });
+    parent_.main_thread_dispatcher_.post([i = index_, &tls = parent_] { tls.removeSlot(i); });
   }
 }
 
@@ -121,23 +121,16 @@ void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   }
 
   // Handle main thread.
-  ASSERT(parent_.main_thread_dispatcher_ != nullptr,
-         "main thread dispatcher must be registered before initializing thread local slots");
-  setThreadLocal(index_, cb(*parent_.main_thread_dispatcher_));
+  setThreadLocal(index_, cb(parent_.main_thread_dispatcher_));
 }
 
-void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_thread) {
+void InstanceImpl::registerThread(Event::Dispatcher& dispatcher) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
   ASSERT(!shutdown_);
 
-  if (main_thread) {
-    main_thread_dispatcher_ = &dispatcher;
-    thread_local_data_.dispatcher_ = &dispatcher;
-  } else {
-    ASSERT(!containsReference(registered_threads_, dispatcher));
-    registered_threads_.push_back(dispatcher);
-    dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
-  }
+  ASSERT(!containsReference(registered_threads_, dispatcher));
+  registered_threads_.push_back(dispatcher);
+  dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
 }
 
 void InstanceImpl::removeSlot(uint32_t slot) {
@@ -190,7 +183,7 @@ void InstanceImpl::runOnAllThreads(std::function<void()> cb,
 
   std::shared_ptr<std::function<void()>> cb_guard(
       new std::function<void()>(cb), [this, all_threads_complete_cb](std::function<void()>* cb) {
-        main_thread_dispatcher_->post(all_threads_complete_cb);
+        main_thread_dispatcher_.post(all_threads_complete_cb);
         delete cb;
       });
 

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -19,12 +19,12 @@ namespace ThreadLocal {
  */
 class InstanceImpl : Logger::Loggable<Logger::Id::main>, public NonCopyable, public Instance {
 public:
-  InstanceImpl();
+  explicit InstanceImpl(Event::Dispatcher& main_dispatcher);
   ~InstanceImpl() override;
 
   // ThreadLocal::Instance
   SlotSharedPtr allocateSlot() override;
-  void registerThread(Event::Dispatcher& dispatcher, bool main_thread) override;
+  void registerThread(Event::Dispatcher& dispatcher) override;
   void shutdownGlobalThreading() override;
   void shutdownThread() override;
   Event::Dispatcher& dispatcher() override;
@@ -73,7 +73,7 @@ private:
   // A collection of indices of freed slots.
   std::vector<uint32_t> free_slot_indexes_;
   std::list<std::reference_wrapper<Event::Dispatcher>> registered_threads_;
-  Event::Dispatcher* main_thread_dispatcher_{};
+  Event::Dispatcher& main_thread_dispatcher_;
   std::atomic<bool> shutdown_{false};
 
   // Test only.

--- a/source/exe/main_common.cc
+++ b/source/exe/main_common.cc
@@ -32,22 +32,21 @@
 namespace Envoy {
 
 StrippedMainBase::CreateInstanceFunction createFunction() {
-  return
-      [](Init::Manager& init_manager, const Server::Options& options,
-         Event::TimeSystem& time_system, ListenerHooks& hooks, Server::HotRestart& restarter,
-         Stats::StoreRoot& store, Thread::BasicLockable& access_log_lock,
-         Server::ComponentFactory& component_factory, Random::RandomGeneratorPtr&& random_generator,
-         ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory,
-         Filesystem::Instance& file_system, std::unique_ptr<ProcessContext> process_context,
-         Buffer::WatermarkFactorySharedPtr watermark_factory) {
-        auto local_address = Network::Utility::getLocalAddress(options.localAddressIpVersion());
-        auto server = std::make_unique<Server::InstanceImpl>(
-            init_manager, options, time_system, hooks, restarter, store, access_log_lock,
-            std::move(random_generator), tls, thread_factory, file_system,
-            std::move(process_context), watermark_factory);
-        server->initialize(local_address, component_factory);
-        return server;
-      };
+  return [](Init::Manager& init_manager, const Server::Options& options,
+            Event::TimeSystem& time_system, ListenerHooks& hooks, Server::HotRestart& restarter,
+            Stats::StoreRoot& store, Thread::BasicLockable& access_log_lock,
+            Server::ComponentFactory& component_factory,
+            Random::RandomGeneratorPtr&& random_generator, Thread::ThreadFactory& thread_factory,
+            Filesystem::Instance& file_system, std::unique_ptr<ProcessContext> process_context,
+            Buffer::WatermarkFactorySharedPtr watermark_factory) {
+    auto local_address = Network::Utility::getLocalAddress(options.localAddressIpVersion());
+    auto server = std::make_unique<Server::InstanceImpl>(
+        init_manager, options, time_system, hooks, restarter, store, access_log_lock,
+        std::move(random_generator), thread_factory, file_system, std::move(process_context),
+        watermark_factory);
+    server->initialize(local_address, component_factory);
+    return server;
+  };
 }
 
 MainCommonBase::MainCommonBase(const Server::Options& options, Event::TimeSystem& time_system,

--- a/source/exe/stripped_main_base.cc
+++ b/source/exe/stripped_main_base.cc
@@ -65,7 +65,6 @@ StrippedMainBase::StrippedMainBase(const Server::Options& options,
   case Server::Mode::InitOnly:
   case Server::Mode::Serve:
     configureHotRestarter(random_generator);
-    tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
     stats_store_ = std::make_unique<Stats::ThreadLocalStoreImpl>(stats_allocator_);
     break;
   case Server::Mode::Validate:
@@ -85,7 +84,7 @@ void StrippedMainBase::init(Event::TimeSystem& time_system, ListenerHooks& liste
 
     server_ = create_instance(*init_manager_, options_, time_system, listener_hooks, *restarter_,
                               *stats_store_, restarter_->accessLogLock(), component_factory_,
-                              std::move(random_generator), *tls_, platform_impl_->threadFactory(),
+                              std::move(random_generator), platform_impl_->threadFactory(),
                               platform_impl_->fileSystem(), std::move(process_context), nullptr);
     break;
   }

--- a/source/exe/stripped_main_base.h
+++ b/source/exe/stripped_main_base.h
@@ -39,9 +39,8 @@ public:
       Init::Manager& init_manager, const Server::Options& options, Event::TimeSystem& time_system,
       ListenerHooks& hooks, Server::HotRestart& restarter, Stats::StoreRoot& store,
       Thread::BasicLockable& access_log_lock, Server::ComponentFactory& component_factory,
-      Random::RandomGeneratorPtr&& random_generator, ThreadLocal::Instance& tls,
-      Thread::ThreadFactory& thread_factory, Filesystem::Instance& file_system,
-      std::unique_ptr<ProcessContext> process_context,
+      Random::RandomGeneratorPtr&& random_generator, Thread::ThreadFactory& thread_factory,
+      Filesystem::Instance& file_system, std::unique_ptr<ProcessContext> process_context,
       Buffer::WatermarkFactorySharedPtr watermark_factory)>;
 
   static std::string hotRestartVersion(bool hot_restart_enabled);
@@ -80,7 +79,6 @@ protected:
   Stats::SymbolTableImpl symbol_table_;
   Stats::Allocator stats_allocator_;
 
-  ThreadLocal::InstanceImplPtr tls_;
   std::unique_ptr<Server::HotRestart> restarter_;
   Stats::ThreadLocalStoreImplPtr stats_store_;
   // logging_context_ is only used in (some) subclasses, but it must be declared here so that it's

--- a/source/server/BUILD
+++ b/source/server/BUILD
@@ -443,6 +443,7 @@ envoy_cc_library(
         "//source/common/singleton:manager_impl_lib",
         "//source/common/stats:tag_producer_lib",
         "//source/common/stats:thread_local_store_lib",
+        "//source/common/thread_local:thread_local_lib",
         "//source/common/tls:context_lib",
         "//source/common/upstream:cluster_manager_lib",
         "//source/common/version:version_lib",

--- a/source/server/config_validation/server.cc
+++ b/source/server/config_validation/server.cc
@@ -59,7 +59,7 @@ ValidationInstance::ValidationInstance(
       stats_store_(store),
       api_(new Api::ValidationImpl(thread_factory, store, time_system, file_system,
                                    random_generator_, bootstrap_, process_context)),
-      dispatcher_(api_->allocateDispatcher("main_thread")),
+      dispatcher_(api_->allocateDispatcher("main_thread")), thread_local_(*dispatcher_),
       access_log_manager_(options.fileFlushIntervalMsec(), options.fileFlushMinSizeKB(), *api_,
                           *dispatcher_, access_log_lock, store),
       grpc_context_(stats_store_.symbolTable()), http_context_(stats_store_.symbolTable()),
@@ -130,7 +130,6 @@ void ValidationInstance::initialize(const Options& options,
   AdminFactoryContext factory_context(*this, std::make_shared<ListenerInfoImpl>());
   initial_config.initAdminAccessLog(bootstrap_, factory_context);
   admin_ = std::make_unique<Server::ValidationAdmin>(initial_config.admin().address());
-  thread_local_.registerThread(*dispatcher_, true);
 
   // Create bootstrap extensions to validate their configs and register any providers
   // or singletons needed by downstream config elements.

--- a/source/server/config_validation/server.h
+++ b/source/server/config_validation/server.h
@@ -175,13 +175,11 @@ private:
   const Options& options_;
   ProtobufMessage::ProdValidationContextImpl validation_context_;
   Stats::IsolatedStoreImpl& stats_store_;
-  ThreadLocal::InstanceImpl thread_local_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   Api::ApiPtr api_;
-  // ssl_context_manager_ must come before dispatcher_, since ClusterInfo
-  // references SslSocketFactory and is deleted on the main thread via the dispatcher.
   std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   Event::DispatcherPtr dispatcher_;
+  ThreadLocal::InstanceImpl thread_local_;
   std::unique_ptr<Server::ValidationAdmin> admin_;
   Singleton::ManagerImpl singleton_manager_;
   std::unique_ptr<Runtime::Loader> runtime_;

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -81,8 +81,7 @@ InstanceBase::InstanceBase(Init::Manager& init_manager, const Options& options,
                            HotRestart& restarter, Stats::StoreRoot& store,
                            Thread::BasicLockable& access_log_lock,
                            Random::RandomGeneratorPtr&& random_generator,
-                           ThreadLocal::Instance& tls, Thread::ThreadFactory& thread_factory,
-                           Filesystem::Instance& file_system,
+                           Thread::ThreadFactory& thread_factory, Filesystem::Instance& file_system,
                            std::unique_ptr<ProcessContext> process_context,
                            Buffer::WatermarkFactorySharedPtr watermark_factory)
     : init_manager_(init_manager), live_(false), options_(options),
@@ -90,13 +89,13 @@ InstanceBase::InstanceBase(Init::Manager& init_manager, const Options& options,
                           !options.rejectUnknownDynamicFields(),
                           options.ignoreUnknownDynamicFields(), options.skipDeprecatedLogs()),
       time_source_(time_system), restarter_(restarter), start_time_(time(nullptr)),
-      original_start_time_(start_time_), stats_store_(store), thread_local_(tls),
+      original_start_time_(start_time_), stats_store_(store),
       random_generator_(std::move(random_generator)),
       api_(new Api::Impl(
           thread_factory, store, time_system, file_system, *random_generator_, bootstrap_,
           process_context ? ProcessContextOptRef(std::ref(*process_context)) : std::nullopt,
           watermark_factory)),
-      dispatcher_(api_->allocateDispatcher("main_thread")),
+      dispatcher_(api_->allocateDispatcher("main_thread")), thread_local_(*dispatcher_),
       access_log_manager_(options.fileFlushIntervalMsec(), options.fileFlushMinSizeKB(), *api_,
                           *dispatcher_, access_log_lock, store),
       handler_(getHandler(*dispatcher_)), worker_factory_(thread_local_, *api_, hooks),
@@ -469,12 +468,6 @@ absl::Status InstanceBase::initializeOrThrow(Network::Address::InstanceConstShar
   for (const auto& ext : Envoy::Registry::FactoryCategoryRegistry::registeredFactories()) {
     ENVOY_LOG(info, "  {}: {}", ext.first, absl::StrJoin(ext.second->registeredNames(), ", "));
   }
-
-  // The main thread is registered for thread local updates so that code that does not care
-  // whether it runs on the main thread or on workers can still use TLS.
-  // We do this as early as possible because this has no side effect and could ensure that the
-  // TLS always contains a valid main thread dispatcher when TLS is used.
-  thread_local_.registerThread(*dispatcher_, true);
 
   // Handle configuration that needs to take place prior to the main configuration load.
   RETURN_IF_NOT_OK(InstanceUtil::loadBootstrapConfig(

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -40,6 +40,7 @@
 #include "source/common/runtime/runtime_impl.h"
 #include "source/common/secret/secret_manager_impl.h"
 #include "source/common/singleton/manager_impl.h"
+#include "source/common/thread_local/thread_local_impl.h"
 
 #ifdef ENVOY_ADMIN_FUNCTIONALITY
 #include "source/server/admin/admin.h"
@@ -247,9 +248,8 @@ public:
   InstanceBase(Init::Manager& init_manager, const Options& options, Event::TimeSystem& time_system,
                ListenerHooks& hooks, HotRestart& restarter, Stats::StoreRoot& store,
                Thread::BasicLockable& access_log_lock,
-               Random::RandomGeneratorPtr&& random_generator, ThreadLocal::Instance& tls,
-               Thread::ThreadFactory& thread_factory, Filesystem::Instance& file_system,
-               std::unique_ptr<ProcessContext> process_context,
+               Random::RandomGeneratorPtr&& random_generator, Thread::ThreadFactory& thread_factory,
+               Filesystem::Instance& file_system, std::unique_ptr<ProcessContext> process_context,
                Buffer::WatermarkFactorySharedPtr watermark_factory = nullptr);
 
   // initialize the server. This must be called before run().
@@ -392,10 +392,10 @@ private:
   std::unique_ptr<ServerStats> server_stats_;
   std::unique_ptr<CompilationSettings::ServerCompilationSettingsStats>
       server_compilation_settings_stats_;
+  Thread::MainThread main_thread_;
   Assert::ActionRegistrationPtr assert_action_registration_;
   Assert::ActionRegistrationPtr envoy_bug_action_registration_;
   Assert::ActionRegistrationPtr envoy_notification_registration_;
-  ThreadLocal::Instance& thread_local_;
   Random::RandomGeneratorPtr random_generator_;
   envoy::config::bootstrap::v3::Bootstrap bootstrap_;
   Api::ApiPtr api_;
@@ -403,6 +403,7 @@ private:
   // references SslSocketFactory and is deleted on the main thread via the dispatcher.
   std::unique_ptr<Ssl::ContextManager> ssl_context_manager_;
   Event::DispatcherPtr dispatcher_;
+  ThreadLocal::InstanceImpl thread_local_;
   AccessLog::AccessLogManagerImpl access_log_manager_;
   std::shared_ptr<Admin> admin_;
   Singleton::ManagerImpl singleton_manager_;

--- a/source/server/worker_impl.cc
+++ b/source/server/worker_impl.cc
@@ -54,7 +54,7 @@ WorkerImpl::WorkerImpl(ThreadLocal::Instance& tls, ListenerHooks& hooks,
     : tls_(tls), hooks_(hooks), dispatcher_(std::move(dispatcher)), handler_(std::move(handler)),
       api_(api), reset_streams_counter_(
                      api_.rootScope().counterFromStatName(stat_names.reset_high_memory_stream_)) {
-  tls_.registerThread(*dispatcher_, false);
+  tls_.registerThread(*dispatcher_);
   overload_manager.registerForAction(
       OverloadActionNames::get().StopAcceptingConnections, *dispatcher_,
       [this](OverloadActionState state) { stopAcceptingConnectionsCb(state); });

--- a/test/common/network/io_uring_socket_handle_impl_integration_test.cc
+++ b/test/common/network/io_uring_socket_handle_impl_integration_test.cc
@@ -28,24 +28,24 @@ public:
   }
 
   void TearDown() override {
-    if (!thread_is_shutdown_) {
-      instance_.shutdownGlobalThreading();
-      instance_.shutdownThread();
+    if (!thread_is_shutdown_ && instance_ != nullptr) {
+      instance_->shutdownGlobalThreading();
+      instance_->shutdownThread();
     }
   }
 
   void initialize(bool create_second_thread = false) {
     api_ = Api::createApiForTest(time_system_);
     dispatcher_ = api_->allocateDispatcher("test_thread");
-    instance_.registerThread(*dispatcher_, true);
+    instance_ = std::make_unique<ThreadLocal::InstanceImpl>(*dispatcher_);
 
     if (create_second_thread) {
       second_dispatcher_ = api_->allocateDispatcher("test_second_thread");
-      instance_.registerThread(*second_dispatcher_, false);
+      instance_->registerThread(*second_dispatcher_);
     }
 
     io_uring_worker_factory_ = std::make_unique<Io::IoUringWorkerFactoryImpl>(
-        10, false, false, 8192, 1000, 131072, 16384, instance_);
+        10, false, false, 8192, 1000, 131072, 16384, *instance_);
     io_uring_worker_factory_->onWorkerThreadInitialized();
 
     // Create the thread after the io_uring worker has been initialized, otherwise the dispatcher
@@ -136,7 +136,7 @@ public:
   Api::ApiPtr api_;
   Event::DispatcherPtr dispatcher_;
   Event::GlobalTimeSystem time_system_;
-  ThreadLocal::InstanceImpl instance_;
+  ThreadLocal::InstanceImplPtr instance_;
   std::unique_ptr<Io::IoUringWorkerFactory> io_uring_worker_factory_;
   os_fd_t fd_;
   IoHandlePtr io_uring_socket_handle_;
@@ -916,8 +916,8 @@ TEST_F(IoUringSocketHandleImplIntegrationTest, IoUringWorkerEarlyRelease) {
   createClientConnection();
 
   thread_is_shutdown_ = true;
-  instance_.shutdownGlobalThreading();
-  instance_.shutdownThread();
+  instance_->shutdownGlobalThreading();
+  instance_->shutdownThread();
 }
 
 TEST_F(IoUringSocketHandleImplIntegrationTest, MigrateServerSocketBetweenThreads) {

--- a/test/common/stats/thread_local_store_speed_test.cc
+++ b/test/common/stats/thread_local_store_speed_test.cc
@@ -60,8 +60,7 @@ public:
       Envoy::Event::Libevent::Global::initialize();
     }
     dispatcher_ = api_->allocateDispatcher("test_thread");
-    tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
-    tls_->registerThread(*dispatcher_, true);
+    tls_ = std::make_unique<ThreadLocal::InstanceImpl>(*dispatcher_);
     store_.initializeThreading(*dispatcher_, *tls_);
   }
 

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -27,7 +27,8 @@ TEST(MainThreadVerificationTest, All) {
   EXPECT_TRUE(Thread::MainThread::isMainOrTestThread());
 #endif
   {
-    InstanceImpl tls;
+    Event::MockDispatcher main_dispatcher;
+    InstanceImpl tls(main_dispatcher);
     // Tls instance has been initialized.
     // Call to main thread verification should succeed in main thread.
     EXPECT_TRUE(Thread::MainThread::isMainThread());
@@ -55,14 +56,11 @@ public:
 
 class ThreadLocalInstanceImplTest : public testing::Test {
 public:
-  ThreadLocalInstanceImplTest() {
+  ThreadLocalInstanceImplTest() : tls_(main_dispatcher_) {
     EXPECT_CALL(main_dispatcher_, isThreadSafe()).WillRepeatedly(Return(true));
 
-    EXPECT_CALL(thread_dispatcher_, post(_));
-    tls_.registerThread(thread_dispatcher_, false);
-    // Register the main thread after the worker thread to ensure that the
-    // thread_local_data_.dispatcher_ of current test thread is set to the main thread dispatcher.
-    tls_.registerThread(main_dispatcher_, true);
+    EXPECT_CALL(thread_dispatcher_, post(_)).WillOnce(Return());
+    tls_.registerThread(thread_dispatcher_);
     EXPECT_EQ(&main_dispatcher_, &tls_.dispatcher());
   }
 
@@ -81,10 +79,9 @@ public:
     return object_ref;
   }
   int freeSlotIndexesListSize() { return tls_.free_slot_indexes_.size(); }
-  InstanceImpl tls_;
-
   NiceMock<Event::MockDispatcher> main_dispatcher_{"test_main_thread"};
   NiceMock<Event::MockDispatcher> thread_dispatcher_{"test_worker_thread"};
+  InstanceImpl tls_;
 };
 
 TEST_F(ThreadLocalInstanceImplTest, All) {
@@ -300,14 +297,12 @@ TEST_F(ThreadLocalInstanceImplTest, RunOnAllThreads) {
 
 // Validate ThreadLocal::InstanceImpl's dispatcher() behavior.
 TEST(ThreadLocalInstanceImplDispatcherTest, Dispatcher) {
-  InstanceImpl tls;
-
   Api::ApiPtr api = Api::createApiForTest();
   Event::DispatcherPtr main_dispatcher(api->allocateDispatcher("test_main_thread"));
   Event::DispatcherPtr thread_dispatcher(api->allocateDispatcher("test_worker_thread"));
 
-  tls.registerThread(*main_dispatcher, true);
-  tls.registerThread(*thread_dispatcher, false);
+  InstanceImpl tls(*main_dispatcher);
+  tls.registerThread(*thread_dispatcher);
 
   // Ensure that the dispatcher update in tls posted during the above registerThread happens.
   main_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
@@ -352,14 +347,12 @@ TEST(ThreadLocalInstanceImplDispatcherTest, Dispatcher) {
 }
 
 TEST(ThreadLocalInstanceImplDispatcherTest, DestroySlotOnWorker) {
-  InstanceImpl tls;
-
   Api::ApiPtr api = Api::createApiForTest();
   Event::MockDispatcher main_dispatcher{"test_main_thread"};
   Event::DispatcherPtr thread_dispatcher(api->allocateDispatcher("test_worker_thread"));
 
-  tls.registerThread(main_dispatcher, true);
-  tls.registerThread(*thread_dispatcher, false);
+  InstanceImpl tls(main_dispatcher);
+  tls.registerThread(*thread_dispatcher);
 
   // Verify we have the expected dispatcher for the main thread.
   EXPECT_EQ(&main_dispatcher, &tls.dispatcher());

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_tunnel_initiator_extension_test.cc
@@ -975,10 +975,10 @@ TEST_F(ReverseTunnelInitiatorExtensionTest, EmitAccessLogErrorFieldAlwaysPresent
 // ThreadLocal::InstanceImpl and a real worker OS thread because ThreadLocal storage is
 // per-OS-thread, so the value must be read on the worker itself.
 TEST(ReverseTunnelInitiatorExtensionFileContentTest, FileContentResolvesOnWorkerThread) {
-  ThreadLocal::InstanceImpl tls;
   Api::ApiPtr api = Api::createApiForTest();
   Event::DispatcherPtr main_dispatcher = api->allocateDispatcher("test_main_thread");
   Event::DispatcherPtr worker_dispatcher = api->allocateDispatcher("test_worker_thread");
+  ThreadLocal::InstanceImpl tls(*main_dispatcher);
 
   Stats::IsolatedStoreImpl stats_store;
   Stats::ScopeSharedPtr scope = stats_store.createScope("test.");
@@ -995,8 +995,6 @@ TEST(ReverseTunnelInitiatorExtensionFileContentTest, FileContentResolvesOnWorker
   const std::string token_path =
       TestEnvironment::writeStringToFileForTest("reverse_tunnel_token.jwt", token);
 
-  // Register the main thread first (as the server does before creating bootstrap extensions).
-  tls.registerThread(*main_dispatcher, true);
   main_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
 
   envoy::extensions::bootstrap::reverse_tunnel::downstream_socket_interface::v3::
@@ -1016,7 +1014,7 @@ TEST(ReverseTunnelInitiatorExtensionFileContentTest, FileContentResolvesOnWorker
 
   // Register the worker thread after construction, as the ListenerManager does (workers register
   // after the bootstrap extensions are created).
-  tls.registerThread(*worker_dispatcher, false);
+  tls.registerThread(*worker_dispatcher);
 
   // Build the handshake formatters now that the worker is registered. This creates the
   // file_content provider's ThreadLocal slot and propagates its content to the worker thread.

--- a/test/extensions/filters/common/lua/lua_test.cc
+++ b/test/extensions/filters/common/lua/lua_test.cc
@@ -191,7 +191,7 @@ class ThreadSafeTest : public testing::Test {
 public:
   ThreadSafeTest()
       : api_(Api::createApiForTest()), main_dispatcher_(api_->allocateDispatcher("main")),
-        worker_dispatcher_(api_->allocateDispatcher("worker")) {}
+        worker_dispatcher_(api_->allocateDispatcher("worker")), tls_(*main_dispatcher_) {}
 
   // Use real dispatchers to verify that callback functions can be executed correctly.
   Api::ApiPtr api_;
@@ -210,9 +210,8 @@ TEST_F(ThreadSafeTest, StateDestructedBeforeWorkerRun) {
     end
   )EOF"};
 
-  tls_.registerThread(*main_dispatcher_, true);
   EXPECT_EQ(main_dispatcher_.get(), &tls_.dispatcher());
-  tls_.registerThread(*worker_dispatcher_, false);
+  tls_.registerThread(*worker_dispatcher_);
 
   // Some callback functions waiting to be executed will be added to the dispatcher of the Worker
   // thread. The callback functions in the main thread will be executed directly.

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -253,16 +253,16 @@ void IntegrationTestServerImpl::createAndRunEnvoyServer(
     Random::RandomGeneratorPtr&& random_generator, ProcessObjectOptRef process_object,
     Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_admin_server) {
   {
+    Thread::MainThread main_thread;
     Init::ManagerImpl init_manager{"Server"};
     Server::HotRestartNopImpl restarter;
-    ThreadLocal::InstanceImpl tls;
     Stats::ThreadLocalStoreImpl stat_store(*stats_allocator_);
     std::unique_ptr<ProcessContext> process_context;
     if (process_object.has_value()) {
       process_context = std::make_unique<ProcessContextImpl>(process_object->get());
     }
     Server::InstanceImpl server(init_manager, options, time_system, hooks, restarter, stat_store,
-                                access_log_lock, std::move(random_generator), tls,
+                                access_log_lock, std::move(random_generator),
                                 Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(),
                                 std::move(process_context), watermark_factory);
     server.initialize(local_address, component_factory);

--- a/test/mocks/thread_local/mocks.h
+++ b/test/mocks/thread_local/mocks.h
@@ -22,7 +22,7 @@ public:
 
   // Server::ThreadLocal
   MOCK_METHOD(SlotSharedPtr, allocateSlot, ());
-  MOCK_METHOD(void, registerThread, (Event::Dispatcher & dispatcher, bool main_thread));
+  MOCK_METHOD(void, registerThread, (Event::Dispatcher & dispatcher));
   void shutdownGlobalThreading() override { shutdown_ = true; }
   MOCK_METHOD(void, shutdownThread, ());
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());

--- a/test/server/server_fuzz_test.cc
+++ b/test/server/server_fuzz_test.cc
@@ -137,7 +137,6 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v3::Bootstrap& input) {
   Stats::TestIsolatedStoreImpl stats_store;
   Thread::MutexBasicLockable fakelock;
   TestComponentFactory component_factory;
-  ThreadLocal::InstanceImpl thread_local_instance;
   DangerousDeprecatedTestTime test_time;
   Fuzz::PerTestEnvironment test_env;
   Init::ManagerImpl init_manager{"Server"};
@@ -154,8 +153,8 @@ DEFINE_PROTO_FUZZER(const envoy::config::bootstrap::v3::Bootstrap& input) {
   try {
     server = std::make_unique<InstanceImpl>(
         init_manager, options, test_time.timeSystem(), hooks, restart, stats_store, fakelock,
-        std::make_unique<Random::RandomGeneratorImpl>(), thread_local_instance,
-        Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr);
+        std::make_unique<Random::RandomGeneratorImpl>(), Thread::threadFactoryForTest(),
+        Filesystem::fileSystemForTest(), nullptr);
     server->initialize(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"),
                        component_factory);
   } catch (const EnvoyException& ex) {

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -292,7 +292,6 @@ protected:
       options_.config_path_ = TestEnvironment::temporaryFileSubstitute(
           bootstrap_path, {{"upstream_0", 0}, {"upstream_1", 0}}, version_);
     }
-    thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
     if (process_object_ != nullptr) {
       process_context_ = std::make_unique<ProcessContextImpl>(*process_object_);
     }
@@ -301,9 +300,8 @@ protected:
 
     server_ = std::make_unique<InstanceImpl>(
         *init_manager_, options_, time_system_, hooks, restart_, stats_store_, fakelock_,
-        std::make_unique<NiceMock<Random::MockRandomGenerator>>(), *thread_local_,
-        Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(),
-        std::move(process_context_));
+        std::make_unique<NiceMock<Random::MockRandomGenerator>>(), Thread::threadFactoryForTest(),
+        Filesystem::fileSystemForTest(), std::move(process_context_));
     server_->initialize(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"),
                         component_factory_);
     EXPECT_TRUE(server_->api().fileSystem().fileExists(std::string(Platform::null_device_path)));
@@ -316,12 +314,11 @@ protected:
         {{"health_check_timeout", fmt::format("{}", timeout).c_str()},
          {"health_check_interval", fmt::format("{}", interval).c_str()}},
         TestEnvironment::PortMap{}, version_);
-    thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
     init_manager_ = std::make_unique<Init::ManagerImpl>("Server");
     server_ = std::make_unique<InstanceImpl>(
         *init_manager_, options_, time_system_, hooks_, restart_, stats_store_, fakelock_,
-        std::make_unique<NiceMock<Random::MockRandomGenerator>>(), *thread_local_,
-        Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr);
+        std::make_unique<NiceMock<Random::MockRandomGenerator>>(), Thread::threadFactoryForTest(),
+        Filesystem::fileSystemForTest(), nullptr);
     server_->initialize(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"),
                         component_factory_);
 
@@ -346,7 +343,6 @@ protected:
       startup_handle = nullptr;
       post_init_handle = nullptr;
       server_ = nullptr;
-      thread_local_ = nullptr;
     });
 
     started.WaitForNotification();
@@ -370,7 +366,6 @@ protected:
   testing::NiceMock<MockOptions> options_;
   DefaultListenerHooks hooks_;
   testing::NiceMock<MockHotRestart> restart_;
-  ThreadLocal::InstanceImplPtr thread_local_;
   Stats::TestIsolatedStoreImpl stats_store_;
   Thread::MutexBasicLockable fakelock_;
   TestComponentFactory component_factory_;
@@ -547,12 +542,11 @@ TEST_P(ServerInstanceImplTest, ExplicitTagsEnabledByRuntimeGuard) {
 
   options_.config_path_ = TestEnvironment::temporaryFileSubstitute(
       "test/server/test_data/server/empty_bootstrap.yaml", {}, version_);
-  thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
   init_manager_ = std::make_unique<Init::ManagerImpl>("Server");
   server_ = std::make_unique<InstanceImpl>(
       *init_manager_, options_, time_system_, hooks_, restart_, *real_store, fakelock_,
-      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), *thread_local_,
-      Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr);
+      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), Thread::threadFactoryForTest(),
+      Filesystem::fileSystemForTest(), nullptr);
   server_->initialize(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"),
                       component_factory_);
   EXPECT_TRUE(real_store->useExplicitTags());
@@ -561,7 +555,6 @@ TEST_P(ServerInstanceImplTest, ExplicitTagsEnabledByRuntimeGuard) {
   // and restore the process-global runtime flag so it does not leak into other tests.
   server_.reset();
   real_store.reset();
-  thread_local_.reset();
   Runtime::maybeSetRuntimeGuard("envoy.reloadable_features.enable_stats_explicit_tags", false);
 }
 
@@ -574,19 +567,17 @@ TEST_P(ServerInstanceImplTest, ExplicitTagsDisabledByDefault) {
 
   options_.config_path_ = TestEnvironment::temporaryFileSubstitute(
       "test/server/test_data/server/empty_bootstrap.yaml", {}, version_);
-  thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
   init_manager_ = std::make_unique<Init::ManagerImpl>("Server");
   server_ = std::make_unique<InstanceImpl>(
       *init_manager_, options_, time_system_, hooks_, restart_, *real_store, fakelock_,
-      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), *thread_local_,
-      Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr);
+      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), Thread::threadFactoryForTest(),
+      Filesystem::fileSystemForTest(), nullptr);
   server_->initialize(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"),
                       component_factory_);
   EXPECT_FALSE(real_store->useExplicitTags());
 
   server_.reset();
   real_store.reset();
-  thread_local_.reset();
 }
 
 // Validates that server stats are flushed even when server is stuck with initialization.
@@ -713,7 +704,6 @@ TEST_P(ServerInstanceImplTest, LifecycleNotifications) {
     // handle3 is nulled out in the callback itself, to test that works as well
     handle4 = nullptr;
     server_ = nullptr;
-    thread_local_ = nullptr;
   });
 
   started.WaitForNotification();
@@ -758,7 +748,6 @@ protected:
       initialize("test/server/test_data/server/node_bootstrap.yaml", false, hooks);
       server_->run();
       server_ = nullptr;
-      thread_local_ = nullptr;
     });
 
     workers_started_fired_.WaitForNotification();
@@ -845,7 +834,6 @@ TEST_P(ServerInstanceImplTest, NoLifecycleNotificationOnEarlyShutdown) {
 
     shutdown_handle = nullptr;
     server_ = nullptr;
-    thread_local_ = nullptr;
   });
 
   // Wait until the init manager starts initializing targets...
@@ -875,7 +863,6 @@ TEST_P(ServerInstanceImplTest, ShutdownBeforeWorkersStarted) {
     post_init_handle = nullptr;
     shutdown_handle = nullptr;
     server_ = nullptr;
-    thread_local_ = nullptr;
   });
 
   server_thread->join();
@@ -1054,7 +1041,6 @@ TEST_P(ServerInstanceImplTest, ConcurrentFlushes) {
     initialize("test/server/test_data/server/stats_sink_manual_flush_bootstrap.yaml", false, hooks);
     server_->run();
     server_ = nullptr;
-    thread_local_ = nullptr;
   });
 
   workers_started_fired.WaitForNotification();
@@ -1484,12 +1470,11 @@ TEST_P(ServerInstanceImplTest, LogToFileError) {
 // When there are no bootstrap CLI options, either for content or path, we can load the server with
 // an empty config.
 TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
-  thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
   init_manager_ = std::make_unique<Init::ManagerImpl>("Server");
   server_ = std::make_unique<InstanceImpl>(
       *init_manager_, options_, time_system_, hooks_, restart_, stats_store_, fakelock_,
-      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), *thread_local_,
-      Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr);
+      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), Thread::threadFactoryForTest(),
+      Filesystem::fileSystemForTest(), nullptr);
   EXPECT_THROW_WITH_MESSAGE(
       server_->initialize(std::make_shared<Network::Address::Ipv4Instance>("127.0.0.1"),
                           component_factory_),
@@ -1499,12 +1484,11 @@ TEST_P(ServerInstanceImplTest, NoOptionsPassed) {
 }
 
 TEST_P(ServerInstanceImplTest, ServerContextSingleton) {
-  thread_local_ = std::make_unique<ThreadLocal::InstanceImpl>();
   init_manager_ = std::make_unique<Init::ManagerImpl>("Server");
   server_ = std::make_unique<InstanceImpl>(
       *init_manager_, options_, time_system_, hooks_, restart_, stats_store_, fakelock_,
-      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), *thread_local_,
-      Thread::threadFactoryForTest(), Filesystem::fileSystemForTest(), nullptr);
+      std::make_unique<NiceMock<Random::MockRandomGenerator>>(), Thread::threadFactoryForTest(),
+      Filesystem::fileSystemForTest(), nullptr);
 
   EXPECT_EQ(&server_->serverFactoryContext(),
             Configuration::ServerFactoryContextInstance::getExisting());

--- a/test/test_common/real_threads_test_helper.cc
+++ b/test/test_common/real_threads_test_helper.cc
@@ -21,11 +21,10 @@ RealThreadsTestHelper::RealThreadsTestHelper(uint32_t num_threads)
     }
   }
   runOnMainBlocking([this]() {
-    tls_ = std::make_unique<ThreadLocal::InstanceImpl>();
-    tls_->registerThread(*main_dispatcher_, true);
+    tls_ = std::make_unique<ThreadLocal::InstanceImpl>(*main_dispatcher_);
     for (Event::DispatcherPtr& dispatcher : thread_dispatchers_) {
       // Worker threads must be registered from the main thread, per assert in registerThread().
-      tls_->registerThread(*dispatcher, false);
+      tls_->registerThread(*dispatcher);
     }
   });
 }


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: thread_local: require main thread dispatcher in InstanceImpl ctor
Additional Description:

Two changes:

- ThreadLocal::Instance::registerThread is now only used to register worker thread dispatchers (removed "main_thread" boolean parameter)
- ThreadLocal:: InstanceImpl now forces you to provide the main thread dispatcher at construction

With these changes we simplify the lifecycle / initialization of `InstanceImpl`, which previously was in an invalid state until `registerThread(_, true)` was called. This allows us to replace `InstanceImpl`'s raw nullable pointer to the main thread dispatcher and replace it with Dispatcher&. Now from the moment of its construction `InstanceImpl` is in a valid useable state.

This is purely an interface cleanup & should be functionally identical to before. Though it does cause a rather large diff since all main functions & test fixtures must now create main thread dispatchers before their thread local instances.

Risk Level: low / none
Testing: tests updated
Docs Changes: none
Release Notes: none

I used generative AI to help with this change.