### PR TITLE
dynamic modules: expose downstream StartTLS to network filters

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__added-downstream-starttls.rst
+++ b/changelogs/current/new_features/dynamic_modules__added-downstream-starttls.rst
@@ -1,0 +1,3 @@
+Added the ``envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport`` ABI
+callback so a dynamic-module network filter can promote its downstream connection to TLS. The Rust
+SDK exposes this as ``EnvoyNetworkFilter::start_downstream_secure_transport``.

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -4807,6 +4807,21 @@ uint64_t envoy_dynamic_module_callback_network_filter_get_upstream_connection_id
 // ---------------------- StartTLS Support Callbacks ---------------------------
 
 /**
+ * envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport is called by the
+ * module to convert the downstream connection from non-secure to secure mode (StartTLS).
+ *
+ * This signals the downstream connection to enable secure transport mode. This is done when the
+ * downstream connection's transport socket is of startTLS type. At the moment it is the only
+ * transport socket type which can be programmatically converted from non-secure to secure mode.
+ *
+ * @param filter_envoy_ptr is the pointer to the DynamicModuleNetworkFilter object.
+ * @return true if the downstream transport was successfully converted to secure mode, false
+ * otherwise.
+ */
+bool envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr);
+
+/**
  * envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport is called by the
  * module to convert the upstream connection from non-secure to secure mode (StartTLS).
  *

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -1808,6 +1808,14 @@ envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(
 }
 
 __attribute__((weak)) bool
+envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(
+    envoy_dynamic_module_type_network_filter_envoy_ptr) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport: "
+               "not implemented in this context");
+  return false;
+}
+
+__attribute__((weak)) bool
 envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
     envoy_dynamic_module_type_network_filter_envoy_ptr) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport: "

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -1838,6 +1838,13 @@ pub extern "C" fn envoy_dynamic_module_callback_network_filter_get_upstream_conn
 }
 
 #[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(
+  _filter_envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
+) -> bool {
+  MOCK_START_TLS_RESULT.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+#[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
   _filter_envoy_ptr: abi::envoy_dynamic_module_type_network_filter_envoy_ptr,
 ) -> bool {
@@ -2066,6 +2073,30 @@ fn test_http_get_upstream_connection_id_unavailable() {
 // =============================================================================
 // StartTLS Tests
 // =============================================================================
+
+#[test]
+fn test_start_downstream_secure_transport_success() {
+  reset_upstream_host_mock();
+  set_start_tls_result(true);
+
+  let mut filter = EnvoyNetworkFilterImpl {
+    raw: std::ptr::null_mut(),
+  };
+
+  assert!(filter.start_downstream_secure_transport());
+}
+
+#[test]
+fn test_start_downstream_secure_transport_failure() {
+  reset_upstream_host_mock();
+  set_start_tls_result(false);
+
+  let mut filter = EnvoyNetworkFilterImpl {
+    raw: std::ptr::null_mut(),
+  };
+
+  assert!(!filter.start_downstream_secure_transport());
+}
 
 #[test]
 fn test_start_upstream_secure_transport_success() {

--- a/source/extensions/dynamic_modules/sdk/rust/src/network.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/network.rs
@@ -506,6 +506,11 @@ pub trait EnvoyNetworkFilter {
   /// Get the upstream connection ID, or 0 if not available.
   fn get_upstream_connection_id(&self) -> u64;
 
+  /// Signal the downstream connection to enable secure transport mode.
+  /// This is done when the downstream connection's transport socket is of startTLS type.
+  /// Returns true if the downstream transport was successfully converted to secure mode.
+  fn start_downstream_secure_transport(&mut self) -> bool;
+
   /// Signal to the filter manager to enable secure transport mode in upstream connection.
   /// This is done when upstream connection's transport socket is of startTLS type.
   /// Returns true if the upstream transport was successfully converted to secure mode.
@@ -1803,6 +1808,12 @@ impl EnvoyNetworkFilter for EnvoyNetworkFilterImpl {
   fn get_upstream_connection_id(&self) -> u64 {
     unsafe {
       abi::envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(self.raw)
+    }
+  }
+
+  fn start_downstream_secure_transport(&mut self) -> bool {
+    unsafe {
+      abi::envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(self.raw)
     }
   }
 

--- a/source/extensions/filters/network/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/network/dynamic_modules/abi_impl.cc
@@ -1141,6 +1141,16 @@ uint64_t envoy_dynamic_module_callback_network_filter_get_upstream_connection_id
 // StartTLS Support Callbacks
 // -----------------------------------------------------------------------------
 
+bool envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(
+    envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
+  auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);
+  if (filter->readCallbacks() == nullptr) {
+    return false;
+  }
+
+  return filter->readCallbacks()->connection().startSecureTransport();
+}
+
 bool envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(
     envoy_dynamic_module_type_network_filter_envoy_ptr filter_envoy_ptr) {
   auto* filter = static_cast<DynamicModuleNetworkFilter*>(filter_envoy_ptr);

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -768,6 +768,8 @@ WEAK_STUB(NetworkFilterHasUpstreamHost,
           envoy_dynamic_module_callback_network_filter_has_upstream_host(nullptr))
 WEAK_STUB(NetworkFilterGetUpstreamConnectionId,
           envoy_dynamic_module_callback_network_filter_get_upstream_connection_id(nullptr))
+WEAK_STUB(NetworkFilterStartDownstreamSecureTransport,
+          envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(nullptr))
 WEAK_STUB(NetworkFilterStartUpstreamSecureTransport,
           envoy_dynamic_module_callback_network_filter_start_upstream_secure_transport(nullptr))
 WEAK_STUB(NetworkFilterReadEnabled,

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2347,8 +2347,32 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetUpstreamConnectionIdNullCal
 }
 
 // =============================================================================
-// Tests for startUpstreamSecureTransport (StartTLS).
+// Tests for StartTLS callbacks.
 // =============================================================================
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, StartDownstreamSecureTransportSuccess) {
+  EXPECT_CALL(connection_, startSecureTransport()).WillOnce(testing::Return(true));
+
+  bool result =
+      envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(filterPtr());
+  EXPECT_TRUE(result);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, StartDownstreamSecureTransportFailure) {
+  EXPECT_CALL(connection_, startSecureTransport()).WillOnce(testing::Return(false));
+
+  bool result =
+      envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(filterPtr());
+  EXPECT_FALSE(result);
+}
+
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, StartDownstreamSecureTransportNullCallbacks) {
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+
+  bool result = envoy_dynamic_module_callback_network_filter_start_downstream_secure_transport(
+      static_cast<void*>(filter.get()));
+  EXPECT_FALSE(result);
+}
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, StartUpstreamSecureTransportSuccess) {
   EXPECT_CALL(read_callbacks_, startUpstreamSecureTransport()).WillOnce(testing::Return(true));


### PR DESCRIPTION
Commit Message:
dynamic modules: expose downstream StartTLS to network filters

Additional Description:
Adds the downstream counterpart to the existing upstream StartTLS callback for dynamic network filters. A protocol-aware filter can consume a plaintext upgrade exchange, then ask Envoy to promote the downstream connection by calling Network::Connection::startSecureTransport().

The callback is part of the language-neutral dynamic-modules ABI and is exposed through the Rust SDK as EnvoyNetworkFilter::start_downstream_secure_transport. It contains no protocol-specific behavior.

This change was prepared with assistance from Codex. I reviewed and understand the implementation and tests.

Risk Level:
Low. The API is additive and runs only when a dynamic module explicitly invokes the callback.

Testing:
- cargo test --locked: 284 unit tests and 29 doc tests passed
- Envoy format checker on all changed source and test files
- git diff --check

Docs Changes:
The ABI and Rust SDK method include API documentation.

Release Notes:
Added a new-features changelog fragment for the dynamic-modules callback.

Platform Specific Features:
N/A

[Optional Runtime guard:]
N/A

[Optional Fixes #Issue]
N/A

[Optional Fixes commit #PR or SHA]
N/A

[Optional Deprecated:]
N/A

[Optional API Considerations:]
This adds an opt-in dynamic-modules ABI callback and Rust SDK trait method; existing modules are unaffected.