### PR TITLE
Add early load shedding on downstream data during memory pressure

### DIFF
--- a/changelogs/current/new_features/tcp_proxy__load-shed-point.rst
+++ b/changelogs/current/new_features/tcp_proxy__load-shed-point.rst
@@ -1,0 +1,3 @@
+Added load shed point ``envoy.load_shed_points.tcp_proxy_on_data`` to close downstream TCP connections
+when receiving data under resource pressure, and added the ``downstream_cx_overload_close`` counter stat
+to the TCP proxy filter to track connections closed by load shedding.

--- a/docs/root/configuration/listeners/network_filters/tcp_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/tcp_proxy_filter.rst
@@ -228,6 +228,7 @@ The downstream statistics are rooted at *tcp.<stat_prefix>.* with the following 
   downstream_cx_total, Counter, Total number of connections handled by the filter
   downstream_cx_no_route, Counter, Number of connections for which no matching route was found or the cluster for the route was not found
   downstream_cx_drain_close, Counter, Total number of connections closed due to drain close
+  downstream_cx_overload_close, Counter, Total number of connections closed due to overload manager load shedding
   downstream_cx_tx_bytes_total, Counter, Total bytes written to the downstream connection
   downstream_cx_tx_bytes_buffered, Gauge, Total bytes currently buffered to the downstream connection
   downstream_cx_rx_bytes_total, Counter, Total bytes read from the downstream connection

--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -269,6 +269,11 @@ The following core load shed points are supported:
       (causes downstream connections to ungracefully close) that should only be
       used with a very high threshold (if at all).
 
+  * - envoy.load_shed_points.tcp_proxy_on_data
+    - Envoy will close the downstream TCP connection in the TCP proxy filter when receiving data
+      (e.g., during early data buffering or active proxying) if Envoy is under resource pressure,
+      typically memory.
+
 .. _config_overload_manager_reducing_timeouts:
 
 Reducing timeouts

--- a/envoy/server/overload/load_shed_point.h
+++ b/envoy/server/overload/load_shed_point.h
@@ -55,6 +55,10 @@ public:
   // which will eventually drain the HTTP/3 connection.
   const std::string H3ServerGoAwayOnDispatch =
       "envoy.load_shed_points.http3_server_go_away_on_dispatch";
+
+  // Envoy will close the TCP proxy downstream connection upon receiving
+  // data if under memory pressure.
+  const std::string TcpProxyOnData = "envoy.load_shed_points.tcp_proxy_on_data";
 };
 
 using LoadShedPointName = ConstSingleton<LoadShedPointNameValues>;

--- a/envoy/stream_info/stream_info.h
+++ b/envoy/stream_info/stream_info.h
@@ -297,6 +297,7 @@ struct LocalCloseReasonValues {
   const std::string NonPooledTcpConnectionHostHealthFailure =
       "non_pooled_tcp_connection_host_health_failure";
   const std::string BufferHighWatermarkTimeout = "buffer_high_watermark_timeout_reached";
+  const std::string OverloadManagerClose = "overload_manager_close";
 };
 
 using LocalCloseReasons = ConstSingleton<LocalCloseReasonValues>;

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -217,6 +217,15 @@ Config::SharedConfig::SharedConfig(
     proxy_protocol_tlvs_ =
         parseTLVs(config.proxy_protocol_tlvs(), context, dynamic_tlv_formatters_);
   }
+
+  Server::OverloadManager& overload_manager =
+      context.shouldBypassOverloadManager() ? context.serverFactoryContext().nullOverloadManager()
+                                            : context.serverFactoryContext().overloadManager();
+  tcp_proxy_on_data_loadshed_point_ =
+      overload_manager.getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData);
+  ENVOY_LOG_ONCE_MISC_IF(
+      trace, tcp_proxy_on_data_loadshed_point_ == nullptr,
+      "LoadShedPoint envoy.load_shed_points.tcp_proxy_on_data is not found. Is it configured?");
 }
 
 Config::Config(const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy& config,
@@ -1092,6 +1101,16 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
                  read_callbacks_->connection(), data.length(), end_stream, upstream_ != nullptr,
                  receive_before_connect_, static_cast<int>(connect_mode_));
   getStreamInfo().getDownstreamBytesMeter()->addWireBytesReceived(data.length());
+
+  if (config_->tcpProxyOnDataLoadShedPoint() != nullptr &&
+      config_->tcpProxyOnDataLoadShedPoint()->shouldShedLoad()) {
+    ENVOY_CONN_LOG(trace, "load shedding in onData", read_callbacks_->connection());
+    config_->stats().downstream_cx_overload_close_.inc();
+    getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::OverloadManager);
+    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush,
+                                        StreamInfo::LocalCloseReasons::get().OverloadManagerClose);
+    return Network::FilterStatus::StopIteration;
+  }
 
   if (upstream_) {
     getStreamInfo().getUpstreamBytesMeter()->addWireBytesSent(data.length());

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -63,6 +63,7 @@ constexpr absl::string_view ReceiveBeforeConnectKey = "envoy.tcp_proxy.receive_b
 #define ALL_TCP_PROXY_STATS(COUNTER, GAUGE)                                                        \
   COUNTER(downstream_cx_drain_close)                                                               \
   COUNTER(downstream_cx_no_route)                                                                  \
+  COUNTER(downstream_cx_overload_close)                                                            \
   COUNTER(downstream_cx_rx_bytes_total)                                                            \
   COUNTER(downstream_cx_total)                                                                     \
   COUNTER(downstream_cx_tx_bytes_total)                                                            \
@@ -272,6 +273,9 @@ public:
     proxyProtocolTlvMergePolicy() const {
       return proxy_protocol_tlv_merge_policy_;
     }
+    Server::LoadShedPoint* tcpProxyOnDataLoadShedPoint() const {
+      return tcp_proxy_on_data_loadshed_point_;
+    }
 
     // Evaluate dynamic TLV formatters and combine with static TLVs.
     Network::ProxyProtocolTLVVector
@@ -310,6 +314,7 @@ public:
     envoy::extensions::filters::network::tcp_proxy::v3::ProxyProtocolTlvMergePolicy
         proxy_protocol_tlv_merge_policy_{
             envoy::extensions::filters::network::tcp_proxy::v3::ADD_IF_ABSENT};
+    Server::LoadShedPoint* tcp_proxy_on_data_loadshed_point_{nullptr};
   };
 
   using SharedConfigSharedPtr = std::shared_ptr<SharedConfig>;
@@ -386,6 +391,9 @@ public:
   Network::DrainDirection drainCloseScope() const { return drain_close_scope_; }
   Server::Configuration::ServerFactoryContext& serverFactoryContext() const {
     return server_factory_context_;
+  }
+  Server::LoadShedPoint* tcpProxyOnDataLoadShedPoint() const {
+    return shared_config_->tcpProxyOnDataLoadShedPoint();
   }
 
 private:

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -2909,6 +2909,137 @@ TEST_P(TcpProxyTest, EmptyDataWithEndStreamDoesNotTriggerConnection) {
   EXPECT_TRUE(conn_pool_callbacks_.empty());
 }
 
+// Test load shedding in onData() when receive_before_connect is enabled.
+TEST_P(TcpProxyTest, OnDataLoadShedPointCanCloseConnection) {
+  // Mock load shed point
+  Server::MockLoadShedPoint on_data_loadshed_point;
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
+      .WillOnce(Return(&on_data_loadshed_point));
+
+  // Configure TCP Proxy
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
+  config.set_upstream_connect_mode(
+      envoy::extensions::filters::network::tcp_proxy::v3::ON_DOWNSTREAM_DATA);
+  config.mutable_max_early_data_bytes()->set_value(1024);
+  setupOnDownstreamDataMode(config, true);
+
+  // Verify if TCP filter ready to receive downstream data
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+
+  // Mock TCP memory overload
+  EXPECT_CALL(on_data_loadshed_point, shouldShedLoad()).WillOnce(Return(true));
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::NoFlush,
+                    StreamInfo::LocalCloseReasons::get().OverloadManagerClose));
+
+  // Mock TCP package data
+  Buffer::OwnedImpl data("hello");
+
+  // Verify TCP connection dropped when memory overloaded
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  EXPECT_EQ(1U, config_->stats().downstream_cx_overload_close_.value());
+  EXPECT_TRUE(filter_callbacks_.connection_.stream_info_.hasResponseFlag(
+      StreamInfo::CoreResponseFlag::OverloadManager));
+}
+
+// Test that early downstream data triggers upstream connection when not overloaded.
+TEST_P(TcpProxyTest, OnDataLoadShedPointNotTriggeredWhenNotOverloaded) {
+  Server::MockLoadShedPoint on_data_loadshed_point;
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
+      .WillOnce(Return(&on_data_loadshed_point));
+
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
+  config.set_upstream_connect_mode(
+      envoy::extensions::filters::network::tcp_proxy::v3::ON_DOWNSTREAM_DATA);
+  config.mutable_max_early_data_bytes()->set_value(1024);
+  setupOnDownstreamDataMode(config, true);
+
+  // Verify if TCP filter ready to receive downstream data
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+
+  EXPECT_CALL(on_data_loadshed_point, shouldShedLoad()).WillOnce(Return(false));
+  EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
+              tcpConnPool(_, _, _))
+      .WillOnce(Return(Upstream::TcpPoolData([]() {}, &conn_pool_)));
+  EXPECT_CALL(conn_pool_, newConnection(_))
+      .WillOnce(
+          Invoke([&](Tcp::ConnectionPool::Callbacks& cb) -> Tcp::ConnectionPool::Cancellable* {
+            conn_pool_callbacks_.push_back(&cb);
+            return conn_pool_handles_
+                .emplace_back(std::make_unique<NiceMock<Envoy::ConnectionPool::MockCancellable>>())
+                .get();
+          }));
+
+  Buffer::OwnedImpl data("hello");
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  // Verify that the load shedding is not triggered and the TCP connection is not dropped
+  EXPECT_EQ(0U, config_->stats().downstream_cx_overload_close_.value());
+  // Verifies that the connection was not flagged with an overload failure
+  EXPECT_FALSE(filter_callbacks_.connection_.stream_info_.hasResponseFlag(
+      StreamInfo::CoreResponseFlag::OverloadManager));
+  EXPECT_EQ(conn_pool_callbacks_.size(), 1);
+}
+
+// Test load shedding in onData() when upstream is already connected.
+TEST_P(TcpProxyTest, OnDataLoadShedPointCanCloseConnectionWhenUpstreamConnected) {
+  Server::MockLoadShedPoint on_data_loadshed_point;
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
+      .WillOnce(Return(&on_data_loadshed_point));
+
+  setup(1);
+  raiseEventUpstreamConnected(0);
+
+  EXPECT_CALL(on_data_loadshed_point, shouldShedLoad()).WillOnce(Return(true));
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::NoFlush,
+                    StreamInfo::LocalCloseReasons::get().OverloadManagerClose));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  EXPECT_EQ(1U, config_->stats().downstream_cx_overload_close_.value());
+  EXPECT_TRUE(filter_callbacks_.connection_.stream_info_.hasResponseFlag(
+      StreamInfo::CoreResponseFlag::OverloadManager));
+}
+
+// Test that overload manager is bypassed when context.shouldBypassOverloadManager() returns true.
+TEST_P(TcpProxyTest, OnDataLoadShedPointBypassedWhenOverloadManagerBypassed) {
+  EXPECT_CALL(factory_context_, shouldBypassOverloadManager()).WillRepeatedly(Return(true));
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_, getLoadShedPoint(_))
+      .Times(0);
+
+  envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
+  config.set_upstream_connect_mode(
+      envoy::extensions::filters::network::tcp_proxy::v3::ON_DOWNSTREAM_DATA);
+  config.mutable_max_early_data_bytes()->set_value(1024);
+  setupOnDownstreamDataMode(config, true);
+
+  EXPECT_EQ(nullptr, config_->tcpProxyOnDataLoadShedPoint());
+  EXPECT_EQ(Network::FilterStatus::Continue, filter_->onNewConnection());
+
+  EXPECT_CALL(factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_,
+              tcpConnPool(_, _, _))
+      .WillOnce(Return(Upstream::TcpPoolData([]() {}, &conn_pool_)));
+  EXPECT_CALL(conn_pool_, newConnection(_))
+      .WillOnce(
+          Invoke([&](Tcp::ConnectionPool::Callbacks& cb) -> Tcp::ConnectionPool::Cancellable* {
+            conn_pool_callbacks_.push_back(&cb);
+            return conn_pool_handles_
+                .emplace_back(std::make_unique<NiceMock<Envoy::ConnectionPool::MockCancellable>>())
+                .get();
+          }));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onData(data, false));
+  EXPECT_EQ(0U, config_->stats().downstream_cx_overload_close_.value());
+  EXPECT_FALSE(filter_callbacks_.connection_.stream_info_.hasResponseFlag(
+      StreamInfo::CoreResponseFlag::OverloadManager));
+  EXPECT_EQ(conn_pool_callbacks_.size(), 1);
+}
+
 // Test that StopIteration in ON_DOWNSTREAM_DATA mode still allows reading.
 TEST_P(TcpProxyTest, StopIterationAllowsReading) {
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();


### PR DESCRIPTION
Commit Message: 
        * Add early load shedding on downstream data during memory pressure

Additional Description: 
        * Drop connections immediately in onData() when receive_before_connect is enabled to avoid wasted payload buffering during memory shortages.

Risk Level: 
        * Low

Testing: 
        * Added unit tests in tcp_proxy_test.cc

Docs Changes: 
        * N/A

Release Notes: 
        * N/A
