### PR TITLE
Drop dynamic module warning

### DIFF
--- a/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
+++ b/docs/root/intro/arch_overview/advanced/dynamic_modules.rst
@@ -3,12 +3,6 @@
 Dynamic modules
 ===============
 
-.. attention::
-
-   The dynamic modules feature is currently under active development.
-   Capabilities will be expanded over time and it still lacks some features that are available in other extension mechanisms.
-   We are looking for feedback from the community to improve the feature.
-
 Envoy has support for loading shared libraries at runtime to extend its functionality. In Envoy, these are known as "dynamic modules." More specifically, dynamic modules are shared libraries that implement the
 :repo:`ABI <source/extensions/dynamic_modules/abi/abi.h>` written in a pure C header file. The ABI defines a set of functions
 that the dynamic module must implement to be loaded by Envoy. Also, it specifies the functions implemented by Envoy


### PR DESCRIPTION
This is from the very early stage and no longer appropriate to keep it.