### PR TITLE
http: prefer to call new unified factory directly

### DIFF
--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -507,6 +507,34 @@ public:
   }
 };
 
+/**
+ * Create an HTTP filter factory from the given filter config factory. Unified filters are created
+ * by the new createHttpFilterFactoryFromProto entry point while legacy filters keep using
+ * createFilterFactoryFromProto. This should be used by all the callers that create HTTP filters
+ * from the registered factories.
+ *
+ * @param factory the HTTP filter config factory. Either NamedHttpFilterConfigFactory or
+ * UpstreamHttpFilterConfigFactory.
+ * @param config supplies the general Protobuf message to be marshaled into a filter-specific
+ * configuration.
+ * @param stat_prefix prefix for stat logging.
+ * @param context supplies the filter's context. Either FactoryContext or UpstreamFactoryContext
+ * based on the factory type.
+ * @return absl::StatusOr<Http::FilterFactoryCb> the factory creation function or an error if
+ * creation fails.
+ */
+template <class FactoryType, class ContextType>
+absl::StatusOr<Http::FilterFactoryCb>
+createHttpFilterFactory(FactoryType& factory, const Protobuf::Message& config,
+                        const std::string& stat_prefix, ContextType& context) {
+  if (factory.isUnifiedFilter()) {
+    auto extra_context = ExtraFactoryContext::create(context, stat_prefix);
+    return factory.createHttpFilterFactoryFromProto(config, context.serverFactoryContext(),
+                                                    extra_context);
+  }
+  return factory.createFilterFactoryFromProto(config, stat_prefix, context);
+}
+
 } // namespace Configuration
 } // namespace Server
 } // namespace Envoy

--- a/source/common/filter/BUILD
+++ b/source/common/filter/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     deps = [
         "//envoy/config:subscription_interface",
         "//envoy/filter:config_provider_manager_interface",
+        "//envoy/server:filter_config_interface",
         "//envoy/singleton:instance_interface",
         "//envoy/stats:stats_macros",
         "//envoy/thread_local:thread_local_interface",

--- a/source/common/filter/config_discovery_impl.h
+++ b/source/common/filter/config_discovery_impl.h
@@ -10,6 +10,7 @@
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/server/admin.h"
 #include "envoy/server/factory_context.h"
+#include "envoy/server/filter_config.h"
 #include "envoy/singleton/instance.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stats/stats_macros.h"
@@ -217,7 +218,8 @@ private:
   instantiateFilterFactory(const Protobuf::Message& message) const override {
     auto* factory = Registry::FactoryRegistry<NeutralHttpFilterConfigFactory>::getFactoryByType(
         message.GetTypeName());
-    return factory->createFilterFactoryFromProto(message, getStatPrefix(), factory_context_);
+    return Server::Configuration::createHttpFilterFactory(*factory, message, getStatPrefix(),
+                                                          factory_context_);
   }
 
   Server::Configuration::ServerFactoryContext& server_context_;

--- a/source/common/http/BUILD
+++ b/source/common/http/BUILD
@@ -198,6 +198,7 @@ envoy_cc_library(
         "//envoy/http:filter_interface",
         "//envoy/registry",
         "//envoy/router:route_config_provider_manager_interface",
+        "//envoy/server:filter_config_interface",
         "//source/common/common:minimal_logger_lib",
         "//source/common/filter:config_discovery_lib",
         "//source/extensions/filters/http/common:pass_through_filter_lib",

--- a/source/common/http/filter_chain_helper.h
+++ b/source/common/http/filter_chain_helper.h
@@ -5,6 +5,7 @@
 #include "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.pb.h"
 #include "envoy/filter/config_provider_manager.h"
 #include "envoy/http/filter.h"
+#include "envoy/server/filter_config.h"
 
 #include "source/common/common/empty_string.h"
 #include "source/common/common/logger.h"
@@ -144,7 +145,8 @@ private:
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         proto_config, server_context_.messageValidationVisitor(), *factory);
     absl::StatusOr<Http::FilterFactoryCb> callback_or_error =
-        factory->createFilterFactoryFromProto(*message, stats_prefix_, factory_context_);
+        Server::Configuration::createHttpFilterFactory(*factory, *message, stats_prefix_,
+                                                       factory_context_);
     if (!callback_or_error.status().ok()) {
       return callback_or_error.status();
     }


### PR DESCRIPTION
Commit Message: http: migrate to use the unified http filter factory
Additional Description:

Now, if the HTTP filter implemented `UnifiedFactoryBase`, the caller will call the `createHttpFilterFactoryFromProto` to create HTTP filter factory directly rather than to call the legacy `createFilterFactoryFromProto`.

By this way, we could gradually deprecate the legacy `createFilterFactoryFromProto` and migrate to new `createHttpFilterFactoryFromProto` smoothly.

This PR self won't change any existing behavior, and won't break out-of-tree extensions.

One step by step.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.