### PR TITLE
thread_local: replay active slots on newly registered worker threads

### DIFF
--- a/envoy/thread_local/thread_local.h
+++ b/envoy/thread_local/thread_local.h
@@ -50,7 +50,7 @@ public:
 
   /**
    * Set thread local data on all threads registered via registerThread(). If new threads are
-   * registered in the future, the callback will also be invoked on the newly registered thread
+   * registered in the future, the callback will also be posted to the newly registered thread
    * so long as the slot is still active.
    * @param initializeCb supplies the functor that will be called *on each thread*. The functor
    *                     returns the thread local object which is then stored. The storage is via
@@ -137,7 +137,7 @@ public:
 
   /**
    * Set thread local data on all threads registered via registerThread(). If new threads are
-   * registered in the future, the callback will also be invoked on the newly registered thread
+   * registered in the future, the callback will also be posted to the newly registered thread
    * so long as the slot is still active.
    * @param initializeCb supplies the functor that will be called *on each thread*. The functor
    *                     returns the thread local object which is then stored. The storage is via
@@ -220,8 +220,8 @@ class Instance : public SlotAllocator {
 public:
   /**
    * Register a thread (via its dispatcher) to receive thread local data updates.
-   * Any active slots that had set() called will have their initialize callback invoked
-   * on this dispatcher.
+   * Any active slots that had set() called will have their initialize callback posted
+   * to this dispatcher.
    * @param dispatcher supplies the thread's dispatcher.
    * @param main_thread supplies whether this is the main program thread or not. (The only
    *                    difference is that callbacks fire immediately on the main thread when posted

--- a/envoy/thread_local/thread_local.h
+++ b/envoy/thread_local/thread_local.h
@@ -49,7 +49,9 @@ public:
   }
 
   /**
-   * Set thread local data on all threads previously registered via registerThread().
+   * Set thread local data on all threads registered via registerThread(). If new threads are
+   * registered in the future, the callback will also be invoked on the newly registered thread
+   * so long as the slot is still active.
    * @param initializeCb supplies the functor that will be called *on each thread*. The functor
    *                     returns the thread local object which is then stored. The storage is via
    *                     a shared_ptr. Thus, this is a flexible mechanism that can be used to share
@@ -134,7 +136,9 @@ public:
   bool currentThreadRegistered() { return slot_->currentThreadRegistered(); }
 
   /**
-   * Set thread local data on all threads previously registered via registerThread().
+   * Set thread local data on all threads registered via registerThread(). If new threads are
+   * registered in the future, the callback will also be invoked on the newly registered thread
+   * so long as the slot is still active.
    * @param initializeCb supplies the functor that will be called *on each thread*. The functor
    *                     returns the thread local object which is then stored. The storage is via
    *                     a shared_ptr. Thus, this is a flexible mechanism that can be used to share
@@ -215,8 +219,9 @@ template <class T = ThreadLocalObject> using TypedSlotPtr = std::unique_ptr<Type
 class Instance : public SlotAllocator {
 public:
   /**
-   * A thread (via its dispatcher) must be registered before set() is called on any allocated slots
-   * to receive thread local data updates.
+   * Register a thread (via its dispatcher) to receive thread local data updates.
+   * Any active slots that had set() called will have their initialize callback invoked
+   * on this dispatcher.
    * @param dispatcher supplies the thread's dispatcher.
    * @param main_thread supplies whether this is the main program thread or not. (The only
    *                    difference is that callbacks fire immediately on the main thread when posted

--- a/envoy/thread_local/thread_local.h
+++ b/envoy/thread_local/thread_local.h
@@ -88,6 +88,7 @@ protected:
 };
 
 using SlotSharedPtr = std::shared_ptr<Slot>;
+using SlotPtr = SlotSharedPtr;
 
 /**
  * Interface used to allocate thread local slots.

--- a/envoy/thread_local/thread_local.h
+++ b/envoy/thread_local/thread_local.h
@@ -88,7 +88,6 @@ protected:
 };
 
 using SlotSharedPtr = std::shared_ptr<Slot>;
-using SlotPtr = SlotSharedPtr;
 
 /**
  * Interface used to allocate thread local slots.

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -118,7 +118,7 @@ void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   initialize_cb_ = cb;
 
   for (Event::Dispatcher& dispatcher : parent_.registered_threads_) {
-    // See the header file comments for still_alive_guard_ for why we capture index_.
+    // Capture index_ by value so we don't access this->index_ if the slot is destroyed.
     dispatcher.post(wrapCallback(
         [index = index_, cb, &dispatcher]() -> void { setThreadLocal(index, cb(dispatcher)); }));
   }
@@ -143,12 +143,10 @@ void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_threa
     for (auto& weak_slot : slots_) {
       if (auto slot = weak_slot.lock()) {
         if (slot->initialize_cb_ != nullptr) {
-          dispatcher.post(
-              [weak_slot, cb = slot->initialize_cb_, index = slot->index_, &dispatcher]() -> void {
-                if (auto slot = weak_slot.lock()) {
-                  setThreadLocal(index, cb(dispatcher));
-                }
-              });
+          dispatcher.post(slot->wrapCallback(
+              [index = slot->index_, cb = slot->initialize_cb_, &dispatcher]() -> void {
+                setThreadLocal(index, cb(dispatcher));
+              }));
         }
       }
     }

--- a/source/common/thread_local/thread_local_impl.cc
+++ b/source/common/thread_local/thread_local_impl.cc
@@ -115,7 +115,10 @@ void InstanceImpl::SlotImpl::set(InitializeCb cb) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
   ASSERT(!parent_.shutdown_);
 
+  initialize_cb_ = cb;
+
   for (Event::Dispatcher& dispatcher : parent_.registered_threads_) {
+    // See the header file comments for still_alive_guard_ for why we capture index_.
     dispatcher.post(wrapCallback(
         [index = index_, cb, &dispatcher]() -> void { setThreadLocal(index, cb(dispatcher)); }));
   }
@@ -137,6 +140,18 @@ void InstanceImpl::registerThread(Event::Dispatcher& dispatcher, bool main_threa
     ASSERT(!containsReference(registered_threads_, dispatcher));
     registered_threads_.push_back(dispatcher);
     dispatcher.post([&dispatcher] { thread_local_data_.dispatcher_ = &dispatcher; });
+    for (auto& weak_slot : slots_) {
+      if (auto slot = weak_slot.lock()) {
+        if (slot->initialize_cb_ != nullptr) {
+          dispatcher.post(
+              [weak_slot, cb = slot->initialize_cb_, index = slot->index_, &dispatcher]() -> void {
+                if (auto slot = weak_slot.lock()) {
+                  setThreadLocal(index, cb(dispatcher));
+                }
+              });
+        }
+      }
+    }
   }
 }
 

--- a/source/common/thread_local/thread_local_impl.h
+++ b/source/common/thread_local/thread_local_impl.h
@@ -54,6 +54,7 @@ private:
 
     InstanceImpl& parent_;
     const uint32_t index_;
+    InitializeCb initialize_cb_;
   };
 
   struct ThreadLocalData {

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -396,5 +396,215 @@ TEST(ThreadLocalInstanceImplDispatcherTest, DestroySlotOnWorker) {
   tls.shutdownThread();
 }
 
+TEST_F(ThreadLocalInstanceImplTest, RegisterThreadReplaysActiveSlot) {
+  TypedSlotPtr<> slot = TypedSlot<>::makeUnique(tls_);
+  uint32_t init_calls = 0;
+
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  slot->set([&init_calls](Event::Dispatcher&) {
+    init_calls++;
+    return std::make_shared<ThreadLocalObject>();
+  });
+  EXPECT_EQ(2, init_calls); // Main thread + fixture worker thread
+
+  NiceMock<Event::MockDispatcher> new_worker_dispatcher{"new_worker_thread"};
+  std::list<Event::PostCb> holder;
+
+  // registerThread should post the dispatcher setter and the active slot callback.
+  EXPECT_CALL(new_worker_dispatcher, post(_))
+      .Times(2)
+      .WillRepeatedly(Invoke([&holder](Event::PostCb cb) { holder.push_back(std::move(cb)); }));
+
+  tls_.registerThread(new_worker_dispatcher, false);
+  EXPECT_EQ(2, holder.size());
+
+  while (!holder.empty()) {
+    holder.front()();
+    holder.pop_front();
+  }
+
+  EXPECT_EQ(3, init_calls); // 2 existing threads + 1 new worker
+
+  tls_.shutdownGlobalThreading();
+  tls_.shutdownThread();
+}
+
+TEST_F(ThreadLocalInstanceImplTest, RegisterThreadReplaySlotDeletedBeforeRunning) {
+  TypedSlotPtr<> slot = TypedSlot<>::makeUnique(tls_);
+  uint32_t init_calls = 0;
+
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  slot->set([&init_calls](Event::Dispatcher&) {
+    init_calls++;
+    return std::make_shared<ThreadLocalObject>();
+  });
+  EXPECT_EQ(2, init_calls); // Main thread + fixture worker thread
+
+  NiceMock<Event::MockDispatcher> new_worker_dispatcher{"new_worker_thread"};
+  std::list<Event::PostCb> holder;
+
+  EXPECT_CALL(new_worker_dispatcher, post(_))
+      .Times(2)
+      .WillRepeatedly(Invoke([&holder](Event::PostCb cb) { holder.push_back(std::move(cb)); }));
+
+  tls_.registerThread(new_worker_dispatcher, false);
+  EXPECT_EQ(2, holder.size());
+
+  // Reset slot before running the callbacks on worker.
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  EXPECT_CALL(new_worker_dispatcher, post(_));
+  slot.reset();
+
+  // Run the queued callbacks. The slot initialize callback should not run because
+  // still_alive_guard_ is expired.
+  while (!holder.empty()) {
+    holder.front()();
+    holder.pop_front();
+  }
+
+  EXPECT_EQ(2, init_calls); // Worker callback was skipped.
+
+  tls_.shutdownGlobalThreading();
+  tls_.shutdownThread();
+}
+
+TEST_F(ThreadLocalInstanceImplTest, RegisterThreadReplaySlotReallocated) {
+  TypedSlotPtr<> slot1 = TypedSlot<>::makeUnique(tls_);
+  uint32_t slot1_init_calls = 0;
+
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  slot1->set([&slot1_init_calls](Event::Dispatcher&) {
+    slot1_init_calls++;
+    return std::make_shared<ThreadLocalObject>();
+  });
+  EXPECT_EQ(2, slot1_init_calls); // Main thread + fixture worker thread
+
+  // Free slot1
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  slot1.reset();
+
+  // Allocate new slot which reuses slot1's index, and set a new callback.
+  TypedSlotPtr<> slot2 = TypedSlot<>::makeUnique(tls_);
+  uint32_t slot2_init_calls = 0;
+  EXPECT_CALL(thread_dispatcher_, post(_));
+  slot2->set([&slot2_init_calls](Event::Dispatcher&) {
+    slot2_init_calls++;
+    return std::make_shared<ThreadLocalObject>();
+  });
+  EXPECT_EQ(2, slot2_init_calls); // Main thread + fixture worker thread
+
+  NiceMock<Event::MockDispatcher> new_worker_dispatcher{"new_worker_thread"};
+  std::list<Event::PostCb> holder;
+
+  // registerThread should post dispatcher setter and slot2 callback only (not slot1).
+  EXPECT_CALL(new_worker_dispatcher, post(_))
+      .Times(2)
+      .WillRepeatedly(Invoke([&holder](Event::PostCb cb) { holder.push_back(std::move(cb)); }));
+
+  tls_.registerThread(new_worker_dispatcher, false);
+  EXPECT_EQ(2, holder.size());
+
+  while (!holder.empty()) {
+    holder.front()();
+    holder.pop_front();
+  }
+
+  EXPECT_EQ(2, slot1_init_calls); // Untouched
+  EXPECT_EQ(3, slot2_init_calls); // 2 existing + 1 new worker
+
+  tls_.shutdownGlobalThreading();
+  tls_.shutdownThread();
+}
+
+TEST(ThreadLocalInstanceImplDispatcherTest, NewDispatcherReplaysActiveSlotsRealThreads) {
+  InstanceImpl tls;
+
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::DispatcherPtr main_dispatcher(api->allocateDispatcher("test_main_thread"));
+  Event::DispatcherPtr worker_dispatcher(api->allocateDispatcher("test_worker_thread"));
+
+  tls.registerThread(*main_dispatcher, true);
+  main_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+
+  TypedSlotPtr<StringSlotObject> slot = TypedSlot<StringSlotObject>::makeUnique(tls);
+  slot->set([](Event::Dispatcher&) -> std::shared_ptr<StringSlotObject> {
+    auto s = std::make_shared<StringSlotObject>();
+    s->str_ = "hello";
+    return s;
+  });
+  EXPECT_EQ("hello", slot->get()->str_);
+
+  tls.registerThread(*worker_dispatcher, false);
+
+  Thread::ThreadPtr worker_thread =
+      Thread::threadFactoryForTest().createThread([&worker_dispatcher, &slot]() {
+        worker_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+        EXPECT_EQ("hello", slot->get()->str_);
+      });
+
+  worker_thread->join();
+
+  tls.shutdownGlobalThreading();
+  tls.shutdownThread();
+}
+
+TEST(ThreadLocalInstanceImplDispatcherTest, DestroySlotOnWorkerBeforeRegisterThread) {
+  InstanceImpl tls;
+
+  Api::ApiPtr api = Api::createApiForTest();
+  Event::MockDispatcher main_dispatcher{"test_main_thread"};
+  Event::DispatcherPtr thread_dispatcher(api->allocateDispatcher("test_worker_thread"));
+
+  tls.registerThread(main_dispatcher, true);
+  tls.registerThread(*thread_dispatcher, false);
+
+  auto slot = TypedSlot<>::makeUnique(tls);
+  uint32_t init_calls = 0;
+  slot->set([&init_calls](Event::Dispatcher&) {
+    init_calls++;
+    return std::make_shared<ThreadLocalObject>();
+  });
+
+  Event::PostCb remove_slot_cb;
+
+  Thread::ThreadPtr thread = Thread::threadFactoryForTest().createThread(
+      [&main_dispatcher, &thread_dispatcher, &slot, &remove_slot_cb]() {
+        thread_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+
+        Thread::SkipAsserts skip;
+
+        EXPECT_CALL(main_dispatcher, isThreadSafe()).WillOnce(Return(false));
+        // Capture the removeSlot callback posted from worker to main dispatcher.
+        EXPECT_CALL(main_dispatcher, post(_)).WillOnce(Invoke([&remove_slot_cb](Event::PostCb cb) {
+          remove_slot_cb = std::move(cb);
+        }));
+
+        slot.reset();
+
+        // Overwrite the freed memory on the worker thread.
+        std::vector<std::vector<char>> clobber;
+        for (int i = 0; i < 100; ++i) {
+          clobber.emplace_back(256, 0x5a);
+        }
+
+        thread_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+      });
+  thread->join();
+
+  // At this point, slot has been destroyed on the worker thread, but remove_slot_cb has not run
+  // yet. Registering a new thread here should NOT try to replay or access the destroyed slot!
+  Event::DispatcherPtr new_worker_dispatcher(api->allocateDispatcher("new_worker_thread"));
+  tls.registerThread(*new_worker_dispatcher, false);
+  new_worker_dispatcher->run(Event::Dispatcher::RunType::NonBlock);
+
+  // Now run the removeSlot callback.
+  if (remove_slot_cb != nullptr) {
+    remove_slot_cb();
+  }
+
+  tls.shutdownGlobalThreading();
+  tls.shutdownThread();
+}
+
 } // namespace ThreadLocal
 } // namespace Envoy

--- a/test/common/thread_local/thread_local_impl_test.cc
+++ b/test/common/thread_local/thread_local_impl_test.cc
@@ -456,7 +456,7 @@ TEST_F(ThreadLocalInstanceImplTest, RegisterThreadReplaySlotDeletedBeforeRunning
   slot.reset();
 
   // Run the queued callbacks. The slot initialize callback should not run because
-  // still_alive_guard_ is expired.
+  // the slot was destroyed (weak pointer expired).
   while (!holder.empty()) {
     holder.front()();
     holder.pop_front();


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: thread_local: replay active slots on newly registered worker threads
Additional Description:

I want to create a slot from a resource monitor. This resource monitor will read from each thread's thread local object to determine load. 

Resource monitors are created from bootstrap BEFORE worker threads are created. Additionally, slots' callbacks only get called by dispatchers that exist before their creation. This means the slot I create from my resource monitor does not propagate to the worker threads, so my resource monitor can only monitor the main thread.

This PR improves the thread local system to replay active slots on newly created / registered dispatchers.

Risk Level: low
Testing: tests updated
Docs Changes: none
Release Notes: none (should affect no existing users / features)