### PR TITLE
reverse_tunnel: deferred-delete handshake wrappers on listener stop

### DIFF
--- a/changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-handshake-wrappers-on-listener-stop.rst
+++ b/changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-handshake-wrappers-on-listener-stop.rst
@@ -1,0 +1,3 @@
+Fixed a use-after-free where reverse-tunnel listener stop left in-flight handshake
+``RCConnectionWrapper`` objects alive until main-thread destruction. Worker
+``resetFileEvents()`` now shuts down those wrappers and deferred-deletes them.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -408,6 +408,30 @@ void ReverseConnectionIOHandle::resetFileEvents() {
   if (worker_dispatcher_ == nullptr || worker_dispatcher_->isThreadSafe()) {
     rev_conn_retry_timer_.reset();
   }
+
+  // Handshake connections have their own file events. Tear them down on this worker so main
+  // close()/destructor does not destroy in-flight codecs. Skip when worker_dispatcher_ is null
+  // (cleanup() after workers are gone).
+  if (worker_dispatcher_ != nullptr && worker_dispatcher_->isThreadSafe()) {
+    conn_wrapper_to_host_map_.clear();
+    std::vector<std::unique_ptr<RCConnectionWrapper>> wrappers = std::move(connection_wrappers_);
+    connection_wrappers_.clear();
+    for (auto& wrapper : wrappers) {
+      if (wrapper == nullptr) {
+        continue;
+      }
+      auto* connection = wrapper->getConnection();
+      if (connection && connection->state() == Network::Connection::State::Open) {
+        if (connection->getSocket()) {
+          connection->getSocket()->ioHandle().resetFileEvents();
+        }
+        connection->close(Network::ConnectionCloseType::NoFlush);
+      }
+      wrapper->shutdown();
+      worker_dispatcher_->deferredDelete(std::move(wrapper));
+    }
+  }
+
   IoSocketHandleImpl::resetFileEvents();
 }
 

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -3503,6 +3503,42 @@ TEST_F(ReverseConnectionIOHandleTest, ResetFileEventsStopsReplacementDialOnListe
   EXPECT_EQ(getHostConnectionInfo(host).connection_keys.count(connection_key), 0);
 }
 
+// Listener stop must shut down in-flight handshake wrappers on the worker.
+TEST_F(ReverseConnectionIOHandleTest, ResetFileEventsShutsDownHandshakeWrappers) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(*mock_timer, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  auto mock_connection = setupMockConnection();
+  EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(42));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  auto wrapper = std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection),
+                                                       mock_host, "test-cluster");
+  addWrapperToHostMap(wrapper.get(), "192.168.1.1");
+  pushConnectionWrapper(std::move(wrapper));
+  ASSERT_EQ(getConnectionWrappers().size(), 1);
+
+  io_handle_->resetFileEvents();
+
+  EXPECT_TRUE(getConnectionWrappers().empty());
+  EXPECT_TRUE(getConnWrapperToHostMap().empty());
+
+  dispatcher_.clearDeferredDeleteList();
+}
+
 } // namespace ReverseConnection
 } // namespace Bootstrap
 } // namespace Extensions


### PR DESCRIPTION
Commit Message: reverse_tunnel: deferred-delete handshake wrappers on listener stop
Additional Description:
After #46726, worker `resetFileEvents()` stops the retry timer on listener stop (LDS drain). In-flight handshake `RCConnectionWrapper` objects were still left until main-thread `close()` / destructor, which can destroy HTTP/1 codecs off the worker.

This change, on the owning worker only (`worker_dispatcher_ != nullptr && isThreadSafe()`):
- closes open handshake connections
- calls `shutdown()`
- deferred-deletes the wrappers

`cleanup()` still nulls `worker_dispatcher_` first, so process shutdown after workers have joined does not tear wrappers down off-thread.

Independent of handshake 403 close-during-dispatch (#46984) and of host-map wrapper deferred-delete (#46732). Listener-stop is not nested under `Http1::dispatch()`, so this path may `close()`.

AI assistance: used Cursor; I reviewed and understand the change.
Risk Level: Low
Testing: Added ReverseConnectionIOHandleTest.ResetFileEventsShutsDownHandshakeWrappers; please rely on CI for full format/tests.
Docs Changes: N/A
Release Notes: changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-handshake-wrappers-on-listener-stop.rst
