### PR TITLE
Reduce unnecessary integration test repetitions

### DIFF
--- a/test/extensions/filters/http/cache_v2/BUILD
+++ b/test/extensions/filters/http/cache_v2/BUILD
@@ -162,7 +162,6 @@ envoy_extension_cc_test(
     ],
     extension_names = ["envoy.filters.http.cache_v2"],
     rbe_pool = "linux_x64_small",
-    shard_count = 4,
     deps = [
         "//source/extensions/filters/http/cache_v2:config",
         "//source/extensions/filters/http/cache_v2:http_cache_lib",

--- a/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
@@ -135,7 +135,7 @@ public:
 
 INSTANTIATE_TEST_SUITE_P(
     Protocols, CacheIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getJustOneProtocolTestParams()),
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CacheIntegrationTest, MissInsertHit) {

--- a/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
@@ -133,10 +133,9 @@ public:
   OptRef<const Http::TestResponseTrailerMapImpl> no_trailers_;
 };
 
-// TODO(#26236): Fix test suite for HTTP/3.
 INSTANTIATE_TEST_SUITE_P(
     Protocols, CacheIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    testing::ValuesIn(HttpProtocolIntegrationTest::getJustOneProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CacheIntegrationTest, MissInsertHit) {

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -65,7 +65,7 @@ public:
   // This is the recommended choice for HTTP filter integration tests that do not interact
   // directly with HTTP protocols or IP versions. It tests HTTP/1 over IPv4 when available,
   // falling back to IPv6 when IPv4 is unavailable.
-  static std::vector<HttpProtocolTestParams> getJustOneProtocolTestParams() {
+  static std::vector<HttpProtocolTestParams> getHttp1OnlyProtocolTestParams() {
     const auto params = getProtocolTestParams({Http::CodecType::HTTP1}, {Http::CodecType::HTTP1});
     return {params.front()};
   }

--- a/test/integration/http_protocol_integration.h
+++ b/test/integration/http_protocol_integration.h
@@ -62,6 +62,14 @@ public:
         /*upstream_protocols = */ {Http::CodecType::HTTP1, Http::CodecType::HTTP2});
   }
 
+  // This is the recommended choice for HTTP filter integration tests that do not interact
+  // directly with HTTP protocols or IP versions. It tests HTTP/1 over IPv4 when available,
+  // falling back to IPv6 when IPv4 is unavailable.
+  static std::vector<HttpProtocolTestParams> getJustOneProtocolTestParams() {
+    const auto params = getProtocolTestParams({Http::CodecType::HTTP1}, {Http::CodecType::HTTP1});
+    return {params.front()};
+  }
+
   // Allows pretty printed test names of the form
   // FooTestCase.BarInstance/IPv4_Http2Downstream_HttpUpstream
   static std::string


### PR DESCRIPTION
Commit Message: Reduce unnecessary integration test repetitions
Additional Description: HTTP filter integration tests are typically configured using either `getProtocolTestParams` or `getProtocolTestParamsWithoutHTTP3` - these options make many repetitions of each test, often to no purpose as most HTTP filters implementations don't interact in any way with the codecs or IP format. One common difference is a test-only config change to support trailers in HTTP/1, but that doesn't exercise any different paths in the implementation.

This PR adds a helper function to make the "don't do that" option convenient, along with applying it to one filter as a proof of concept. Before this change, there are 150 test cases in the modified target, and it was 4x sharded. After the change, there are only 15 test cases, so the sharding can be removed and the test execution will still take less time to complete.

If it's agreed that this is a good change, I will do similar to other http filters after confirming they don't have anything in their implementations that behaves differently by codec / ipv.

This was AI assisted with GPT Luna. There were manual corrections and I have reviewed it before sending for review.

Risk Level: None, test-only.
Testing: It is.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
