### PR TITLE
ext_proc: Fixes a stream hang on webSocket upgrade

### DIFF
--- a/source/extensions/filters/http/ext_proc/BUILD
+++ b/source/extensions/filters/http/ext_proc/BUILD
@@ -33,6 +33,8 @@ envoy_cc_library(
         "//envoy/stats:stats_macros",
         "//source/common/buffer:buffer_lib",
         "//source/common/http:header_map_lib",
+        "//source/common/http:header_utility_lib",
+        "//source/common/http:utility_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
         "//source/common/runtime:runtime_features_lib",

--- a/source/extensions/filters/http/ext_proc/processor_state.cc
+++ b/source/extensions/filters/http/ext_proc/processor_state.cc
@@ -4,6 +4,8 @@
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/http/header_map_impl.h"
+#include "source/common/http/header_utility.h"
+#include "source/common/http/utility.h"
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/common/processing_effect/processing_effect.h"
 #include "source/extensions/filters/http/ext_proc/ext_proc.h"
@@ -262,6 +264,9 @@ absl::Status ProcessorState::handleHeaderContinue() {
   } else if (body_mode_ == ProcessingMode::STREAMED ||
              body_mode_ == ProcessingMode::FULL_DUPLEX_STREAMED) {
     sendBufferedDataInStreamedMode(false);
+    if (body_mode_ == ProcessingMode::STREAMED) {
+      continueIfNecessary();
+    }
     return absl::OkStatus();
   } else if (body_mode_ == ProcessingMode::BUFFERED_PARTIAL) {
     return handleBufferedPartialMode();

--- a/test/extensions/filters/http/ext_proc/ext_proc_misc_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_misc_test.cc
@@ -296,4 +296,67 @@ TEST_P(ExtProcMiscIntegrationTest, SendEmptyLastBodyChunk) {
 // Test Ext_Proc filter and WebSocket configuration combination.
 TEST_P(ExtProcMiscIntegrationTest, WebSocketExtProcCombo) { websocketExtProcTest(); }
 
+// Regression test: with a STREAMED request body mode, a WebSocket upgrade must not deadlock.
+// handleHeaderContinue() leaves header iteration paused in streamed mode and normally relies on a
+// subsequent body chunk to resume it, but on an upgrade the client will not send any frame until
+// it has seen the 101 response, so iteration must be resumed on the header response itself or the
+// handshake never reaches the upstream.
+TEST_P(ExtProcMiscIntegrationTest, WebSocketExtProcStreamedRequestBody) {
+  if (!isEnvoyGrpc()) {
+    return;
+  }
+
+  http_codec_type_ = Http::CodecType::HTTP1;
+  proto_config_.mutable_processing_mode()->set_request_body_mode(ProcessingMode::STREAMED);
+
+  auto* allowed_headers = proto_config_.mutable_forward_rules()->mutable_allowed_headers();
+  allowed_headers->add_patterns()->set_exact("upgrade");
+  allowed_headers->add_patterns()->set_exact("connection");
+
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) { hcm.add_upgrade_configs()->set_upgrade_type("websocket"); });
+
+  initializeConfig();
+  HttpIntegrationTest::initialize();
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  headers.addCopy(LowerCaseString("upgrade"), "websocket");
+  headers.addCopy(LowerCaseString("connection"), "Upgrade");
+  auto encoder_decoder = codec_client_->startRequest(headers);
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  // ext_proc server processes the upgrade request headers.
+  processRequestHeadersMessage(*grpc_upstreams_[0], true, std::nullopt);
+
+  // The handshake must reach the upstream even though no request body has been sent yet.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "101"},
+                                                                   {"connection", "upgrade"},
+                                                                   {"upgrade", "websocket"}},
+                                   false);
+  processResponseHeadersMessage(*grpc_upstreams_[0], false, std::nullopt);
+
+  response->waitForHeaders();
+  EXPECT_EQ("101", response->headers().getStatusValue());
+
+  // Tunnel data from the client is streamed through ext_proc and reaches the upstream.
+  codec_client_->sendData(*request_encoder_, "client-frame", false);
+  processRequestBodyMessage(*grpc_upstreams_[0], false, std::nullopt);
+  ASSERT_TRUE(upstream_request_->waitForData(*dispatcher_, 12));
+
+  // Tunnel data from the upstream reaches the client.
+  upstream_request_->encodeData("server-frame", false);
+  response->waitForBodyData(12);
+  EXPECT_EQ("server-frame", response->body());
+
+  cleanupUpstreamAndDownstream();
+}
+
 } // namespace Envoy

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -1796,7 +1796,7 @@ TEST_F(HttpFilterTest, StreamingDataSmallChunk) {
   request_headers_.setMethod("POST");
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   const uint32_t chunk_number = 20;
   sendChunkRequestData(chunk_number, true);
@@ -1846,7 +1846,7 @@ TEST_F(HttpFilterTest, StreamingSendRequestDataGrpcFail) {
   request_headers_.setMethod("POST");
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   Buffer::OwnedImpl req_data("foo");
   const uint32_t chunk_number = 20;
@@ -1898,7 +1898,7 @@ TEST_F(HttpFilterTest, StreamingSendResponseDataGrpcFail) {
   request_headers_.setMethod("POST");
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   const uint32_t chunk_number = 20;
   sendChunkRequestData(chunk_number, true);
@@ -2188,7 +2188,7 @@ TEST_F(HttpFilterTest, PostStreamingBodies) {
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
   EXPECT_TRUE(last_request_.has_protocol_config());
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
   EXPECT_EQ(0, config_->stats().streams_closed_.value());
   // Test content-length header is removed in request in streamed mode.
   EXPECT_EQ(request_headers_.ContentLength(), nullptr);
@@ -2296,7 +2296,7 @@ TEST_F(HttpFilterTest, PostStreamingBodiesDifferentOrder) {
 
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   bool decoding_watermarked = false;
   setUpDecodingWatermarking(decoding_watermarked);
@@ -3709,7 +3709,7 @@ TEST_F(HttpFilterTest, StreamedBodyCallbackWithEmptyQueue) {
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
 
   // Handle headers response to establish the gRPC stream and initialize stream_callbacks_.
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   // Manually transition decoding_state_ to StreamedBodyCallback while the chunk_queue_ is empty.
   auto& decoding_state = const_cast<ProcessorState&>(filter_->decodingState());
@@ -5836,7 +5836,7 @@ TEST_F(HttpFilterTest, SaveResponseTrailers) {
   request_headers_.setMethod("POST");
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   const uint32_t chunk_number = 20;
   sendChunkRequestData(chunk_number, true);
@@ -5960,7 +5960,7 @@ TEST_F(HttpFilterTest, DontSaveProcessingResponse) {
   request_headers_.setMethod("POST");
   EXPECT_CALL(decoder_callbacks_, decodingBuffer()).WillRepeatedly(Return(nullptr));
   EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
-  processRequestHeaders(true, std::nullopt);
+  processRequestHeaders(false, std::nullopt);
 
   const uint32_t chunk_number = 20;
   sendChunkRequestData(chunk_number, true);


### PR DESCRIPTION
Caused by https://github.com/envoyproxy/envoy/pull/45355 
Fixes https://github.com/envoyproxy/envoy/issues/47048


<details>

<summary>
envoy config used for issue recreation 
</summary>

```
admin:
  address:
    socket_address:
      protocol: TCP
      address: 127.0.0.1
      port_value: 9902
  allow_paths:
  - exact: /ready
  - prefix: /stats
  - prefix: /

static_resources:
  listeners:

  - name: http2_listener

    address:
      socket_address:
        address: 0.0.0.0
        port_value: 10000
        protocol: TCP

    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager

          codec_type: AUTO
          stat_prefix: ingress_ws_h2

          http2_protocol_options:
            allow_connect: true

          upgrade_configs:
          - upgrade_type: websocket

          route_config:
            name: local_route
            virtual_hosts:
            - name: app
              domains:
              - "*"

              routes:
              - match:
                  prefix: "/"
                route:
                  cluster: service_ws

          http_filters:
          - name: envoy.filters.http.ext_proc
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
              grpc_service:
                envoy_grpc:
                  cluster_name: ext_proc-grpc-service
                timeout: 5s
              failure_mode_allow: false
              message_timeout: 5s
              processing_mode:
                request_header_mode: SEND
                response_header_mode: SEND
                request_body_mode: STREAMED
                response_body_mode: STREAMED
          - name: envoy.filters.http.router
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

  clusters:
  - name: service_ws
    type: STRICT_DNS
    lb_policy: ROUND_ROBIN
    load_assignment:
      cluster_name: service_ws
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: 127.0.0.1
                port_value: 18088
  
  - name: ext_proc-grpc-service
    type: STRICT_DNS
    lb_policy: ROUND_ROBIN
    typed_extension_protocol_options:
      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
        explicit_http_config:
          http2_protocol_options: {}
    load_assignment:
      cluster_name: ext_proc-grpc-service
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: 127.0.0.1
                port_value: 9002
```

</details>