### PR TITLE
dfp: fix DNS cache serving stale address forever when refresh fails with disable_dns_refresh_on_failure

### DIFF
--- a/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
+++ b/source/extensions/common/dynamic_forward_proxy/dns_cache_impl.cc
@@ -641,6 +641,22 @@ void DnsCacheImpl::finishResolve(const std::string& host,
       primary_host_info->refresh_timer_->enableTimer(refresh_interval);
       ENVOY_LOG(debug, "DNS refresh rate reset for host '{}', (failure) raw={} ms armed={} ms",
                 host, raw_backoff_ms.count(), refresh_interval.count());
+    } else if (current_address != nullptr) {
+      // This is a failed refresh for a host that had already resolved successfully in the
+      // past. resolutionStatus_ is intentionally left untouched above so that the last known
+      // good address keeps being served (see the comment above address_changed). However,
+      // since disable_dns_refresh_on_failure is set the refresh timer is *not* re-armed, so
+      // nothing will ever revisit this entry again: it would be served forever, well past its
+      // TTL, even after the authoritative DNS record changes to a different address (see
+      // https://github.com/envoyproxy/envoy/issues/46402). Mark the entry as failed so that
+      // the disable_dns_refresh_on_failure check in loadDnsCacheEntryWithForceRefresh() treats
+      // the next active lookup as a cache miss and forces a fresh resolution attempt.
+      primary_host_info->host_info_->setDetails(details_with_maybe_trace);
+      primary_host_info->host_info_->setResolutionStatus(status);
+      ENVOY_LOG(debug,
+                "host '{}' refresh failed with disable_dns_refresh_on_failure set; marking the "
+                "stale cache entry as failed so the next lookup forces re-resolution",
+                host);
     }
   }
 }

--- a/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
+++ b/test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc
@@ -1170,6 +1170,104 @@ TEST_F(DnsCacheImplTest, DisableRefreshOnFailureContainsSuccessfulHost) {
              1 /* added */, 0 /* removed */, 1 /* num hosts */);
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/46402: a host that has
+// already resolved successfully must not be served forever out of the cache once a later
+// background refresh fails while disable_dns_refresh_on_failure is set. Because that setting
+// also disables re-arming the refresh timer on failure, nothing would otherwise ever revisit
+// the entry again (unlike the normal TTL-based eviction path exercised by
+// ResolveFailureAfterResolveSuccess above), so a subsequent lookup must be treated as a cache
+// miss and trigger a fresh resolution instead of continuing to hand out the stale address.
+TEST_F(DnsCacheImplTest, DisableRefreshOnFailureRemovesStaleSuccessfulHostOnFailedRefresh) {
+  config_.set_disable_dns_refresh_on_failure(true);
+
+  initialize();
+  InSequence s;
+
+  MockLoadDnsCacheEntryCallbacks callbacks;
+  Network::DnsResolver::ResolveCb resolve_cb;
+  Event::MockTimer* refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  Event::MockTimer* query_timeout_timer =
+      new Event::MockTimer(&context_.server_context_.dispatcher_);
+  EXPECT_CALL(*query_timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
+  EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
+      .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
+  auto result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::Loading, result.status_);
+  EXPECT_NE(result.handle_, nullptr);
+  EXPECT_EQ(std::nullopt, result.host_info_);
+
+  // The first resolution succeeds normally, populating the cache with 10.0.0.1.
+  EXPECT_CALL(*query_timeout_timer, disableTimer());
+  EXPECT_CALL(
+      update_callbacks_,
+      onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
+  EXPECT_CALL(callbacks,
+              onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.1:80", "foo.com", false)));
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("10.0.0.1:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Completed));
+  EXPECT_CALL(*refresh_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
+             TestUtility::makeDnsResponse({"10.0.0.1"}));
+  checkStats(1 /* attempt */, 1 /* success */, 0 /* failure */, 1 /* address changed */,
+             1 /* added */, 0 /* removed */, 1 /* num hosts */);
+
+  // The host is still in continuous use, so the background refresh timer firing does not evict
+  // it for TTL; it instead kicks off a new resolution, which then fails (e.g. the DNS server
+  // becomes unreachable).
+  query_timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  EXPECT_CALL(*query_timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
+  EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
+      .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
+  refresh_timer->invokeCallback();
+
+  EXPECT_CALL(*query_timeout_timer, disableTimer());
+  EXPECT_CALL(update_callbacks_, onDnsHostAddOrUpdate(_, _)).Times(0);
+  EXPECT_CALL(callbacks, onLoadDnsCacheComplete(_)).Times(0);
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("10.0.0.1:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Failure));
+  // No refresh timer is re-armed here: that is exactly what makes
+  // disable_dns_refresh_on_failure dangerous without the fix, since nothing else would ever
+  // revisit this entry again.
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Failure, "", TestUtility::makeDnsResponse({}));
+  checkStats(2 /* attempt */, 1 /* success */, 1 /* failure */, 1 /* address changed */,
+             1 /* added */, 0 /* removed */, 1 /* num hosts */);
+
+  // A subsequent lookup must not keep being served the stale 10.0.0.1 address: it should be
+  // treated as a cache miss, forcing a fresh resolution attempt.
+  refresh_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  query_timeout_timer = new Event::MockTimer(&context_.server_context_.dispatcher_);
+  EXPECT_CALL(*query_timeout_timer, enableTimer(std::chrono::milliseconds(5000), nullptr));
+  EXPECT_CALL(*resolver_, resolve("foo.com", _, _))
+      .WillOnce(DoAll(SaveArg<2>(&resolve_cb), Return(&resolver_->active_query_)));
+  result = dns_cache_->loadDnsCacheEntry("foo.com", 80, false, callbacks);
+  EXPECT_EQ(DnsCache::LoadDnsCacheEntryStatus::Loading, result.status_);
+  EXPECT_NE(result.handle_, nullptr);
+  EXPECT_EQ(std::nullopt, result.host_info_);
+
+  // The name now resolves to a different address (as would happen once the DNS resolver becomes
+  // reachable again and the record has changed), confirming the cache picks up the change
+  // instead of continuing to use the stale one forever.
+  EXPECT_CALL(*query_timeout_timer, disableTimer());
+  EXPECT_CALL(
+      update_callbacks_,
+      onDnsHostAddOrUpdate("foo.com:80", DnsHostInfoEquals("10.0.0.2:80", "foo.com", false)));
+  EXPECT_CALL(callbacks,
+              onLoadDnsCacheComplete(DnsHostInfoEquals("10.0.0.2:80", "foo.com", false)));
+  EXPECT_CALL(update_callbacks_,
+              onDnsResolutionComplete("foo.com:80",
+                                      DnsHostInfoEquals("10.0.0.2:80", "foo.com", false),
+                                      Network::DnsResolver::ResolutionStatus::Completed));
+  EXPECT_CALL(*refresh_timer, enableTimer(std::chrono::milliseconds(dns_ttl_), _));
+  resolve_cb(Network::DnsResolver::ResolutionStatus::Completed, "",
+             TestUtility::makeDnsResponse({"10.0.0.2"}));
+  checkStats(3 /* attempt */, 2 /* success */, 1 /* failure */, 2 /* address changed */,
+             2 /* added */, 1 /* removed */, 1 /* num hosts */);
+}
+
 TEST_F(DnsCacheImplTest, ResolveFailureWithFailureRefreshRate) {
   *config_.mutable_dns_failure_refresh_rate()->mutable_base_interval() =
       Protobuf::util::TimeUtil::SecondsToDuration(7);


### PR DESCRIPTION
## Root cause

#46402 reports that when `disable_dns_refresh_on_failure=true`, a DNS Cache entry that had already resolved successfully keeps being served with its last resolved address forever if a later background refresh fails, even long past its `host_ttl` and even after the record starts pointing elsewhere.

This snapshot has already diverged somewhat from the version linked in the issue: it has its own mechanism for the *first-resolve-fails* case -- `loadDnsCacheEntryWithForceRefresh()` treats a cache hit as a miss (forcing a fresh resolve) whenever `disable_dns_refresh_on_failure()` is set and `DnsHostInfoImpl::resolutionStatus() == Failure`. That machinery is exercised by the existing `DisableRefreshOnFailureContainsFailedHost` test.

The gap is the case the issue actually reports: a host that *had already resolved successfully* and then fails on a subsequent background refresh. In `DnsCacheImpl::finishResolve`, when the resolution fails and the host already has a `current_address`, the code intentionally does **not** call `setResolutionStatus()`/`setDetails()` (the comment explains this is so the last good address keeps sticking). So `resolutionStatus()` stays `Completed`, and the cache-miss check above never fires for this entry. Compounding this, the refresh-timer re-arm logic just below is entirely gated on `!config_.disable_dns_refresh_on_failure()`, so with the flag set, nothing ever re-arms the timer either. The result: the entry is never revisited again by any code path and is served forever with the stale address, exactly matching the repro steps in the issue.

## Why this fix

The issue's own suggested patch (against a different revision) calls `removeHost()` directly from `finishResolve()` on a failed refresh when `disable_dns_refresh_on_failure` is set. I considered mirroring that literally, but on this codebase's current structure it's simpler and lower-risk to reuse the mechanism that's already implemented and tested for the sibling case (first-resolve failure): mark the entry `Failure` via the existing `setResolutionStatus()`/`setDetails()` calls, scoped to `disable_dns_refresh_on_failure() && current_address != nullptr` (i.e. specifically a refresh failure on a previously-resolved host). This:
- Reuses the already-tested `resolutionStatus() == Failure` cache-miss check and the lazy `removeHost()` + re-resolve already implemented in `startCacheLoad()`, instead of adding a second, parallel removal path with its own dangling-pointer/`update_threads` considerations at the tail of `finishResolve()`.
- Keeps the pre-existing, documented "stick with the last good address" behavior intact for any consumer that queries the cache before the next active lookup arrives (i.e. it doesn't yank the address out from under in-flight traffic the instant a background refresh fails), while still guaranteeing the *next* lookup forces re-resolution instead of serving the stale entry forever.
- Is a small, localized change (one new `else if` branch) that doesn't touch the first-resolve-failure path or the non-`disable_dns_refresh_on_failure` path, so none of the existing behavior/tests for those paths change.

## Testing

Added `DisableRefreshOnFailureContainsSuccessfulHost`'s missing counterpart: `DisableRefreshOnFailureRemovesStaleSuccessfulHostOnFailedRefresh` in `test/extensions/common/dynamic_forward_proxy/dns_cache_impl_test.cc`. It follows the existing test file's established idiom (mirroring `ResolveFailureAfterResolveSuccess` and `DisableRefreshOnFailureContainsFailedHost`, whose patterns/stat deltas it directly reuses): resolves a host successfully to `10.0.0.1`, fires the background refresh timer which then fails, asserts (via `checkStats`) that the entry is *not* removed but also that no refresh timer is re-armed (reproducing the "stuck forever" precondition without the fix), then performs a subsequent lookup and asserts it is treated as a cache miss that triggers a brand-new resolution -- which resolves to a different address (`10.0.0.2`) to concretely prove the cache is no longer stuck serving the stale one. Without the fix, the subsequent lookup would incorrectly return `LoadDnsCacheEntryStatus::InCache` with the stale `10.0.0.1` entry instead of `Loading`/triggering a fresh `resolver_->resolve()` call, so the test fails without the change and passes with it. I traced the test's expectations step-by-step against the production code paths (`loadDnsCacheEntryWithForceRefresh`, `startCacheLoad`, `finishResolve`) and cross-checked the stat deltas against the analogous existing tests; I was not able to actually run the Envoy bazel test suite in this environment (no network/toolchain access here), so this is based on careful manual tracing rather than an executed test run.

Fixes #46402