### PR TITLE
reverse tunnel: use portable socket APIs

### DIFF
--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/BUILD
@@ -15,6 +15,7 @@ envoy_cc_library(
     hdrs = ["reverse_connection_address.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//envoy/common:base_includes",
         "//envoy/network:address_interface",
         "//source/common/network:address_lib",
         "//source/common/network:socket_interface_lib",

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.cc
@@ -1,9 +1,5 @@
 #include "source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.h"
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-
 #include <cstring>
 #include <functional>
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_address.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <netinet/in.h>
-#include <sys/socket.h>
-
 #include <functional>
 
+#include "envoy/common/platform.h"
 #include "envoy/network/address.h"
 
 #include "source/common/common/logger.h"

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/BUILD
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/BUILD
@@ -75,6 +75,7 @@ envoy_cc_extension(
     visibility = ["//visibility:public"],
     deps = [
         "reverse_tunnel_acceptor_includes",
+        "//envoy/common:base_includes",
         "//envoy/event:dispatcher_interface",
         "//envoy/event:timer_interface",
         "//envoy/network:io_handle_interface",

--- a/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface/upstream_socket_manager.cc
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <string>
 
+#include "envoy/common/platform.h"
+
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
 #include "source/common/common/random_generator.h"
@@ -445,7 +447,7 @@ void UpstreamSocketManager::markSocketDead(const int fd) {
     // Found in idle pool — erase from list and clean up timers/events.
     ENVOY_LOG(debug, "reverse_tunnel: marking idle socket dead. node: {} cluster: {} fd: {}.",
               node_id, cluster_id, fd);
-    ::shutdown(fd, SHUT_RDWR);
+    ::shutdown(fd, ENVOY_SHUT_RDWR);
     accepted_reverse_connections_[node_id].erase(socket_it->second);
     fd_to_socket_it_map_.erase(socket_it);
 

--- a/source/extensions/clusters/reverse_connection/BUILD
+++ b/source/extensions/clusters/reverse_connection/BUILD
@@ -14,6 +14,7 @@ envoy_cc_extension(
     hdrs = ["reverse_connection.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//envoy/common:base_includes",
         "//envoy/upstream:admin_endpoint_provider_interface",
         "//envoy/upstream:cluster_factory_interface",
         "//source/common/formatter:builtin_command_parser_factory_helper_lib",

--- a/source/extensions/clusters/reverse_connection/reverse_connection.h
+++ b/source/extensions/clusters/reverse_connection/reverse_connection.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <netinet/in.h>
-#include <sys/socket.h>
-
 #include <cstdint>
 #include <cstring>
 #include <functional>
 #include <string>
 #include <vector>
 
+#include "envoy/common/platform.h"
 #include "envoy/config/cluster/v3/cluster.pb.h"
 #include "envoy/extensions/clusters/reverse_connection/v3/reverse_connection.pb.h"
 #include "envoy/extensions/clusters/reverse_connection/v3/reverse_connection.pb.validate.h"


### PR DESCRIPTION
Commit Message:
Additional Description: Make reverse tunnel socket usage portable by replacing POSIX-only socket headers with Envoy's platform abstraction and using ENVOY_SHUT_RDWR instead of SHUT_RDWR.

Partially addresses: https://github.com/envoyproxy/envoy/issues/46812. This moves a focused portion of the Windows patch maintained at: https://github.com/curioswitch/py-envoy-server/blob/main/.github/actions/build-windows/main.patch

Risk Level: Low
Testing:  Built the following targets successfully on Windows using clang-cl:
  - //source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_address_lib
  - //source/extensions/clusters/reverse_connection:reverse_connection_lib

Docs Changes: No
Release Notes: No
Platform Specific Features:  This removes POSIX-only socket usage from reverse tunnel code so it can compile on Windows. Existing platform abstractions in "envoy/common/platform.h" are used without adding OS-specific preprocessor branches.
