### PR TITLE
docs: clarify BYTES_SENT/BYTES_RECEIVED directionality

### DIFF
--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -92,9 +92,14 @@ Current supported substitution commands include:
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
 
+.. _config_access_log_format_bytes_received:
+
 ``%BYTES_RECEIVED%``
   HTTP/THRIFT
-    Body bytes received.
+    Body bytes received from the downstream, i.e. the size of the request body. This value is
+    independent of :ref:`%BYTES_SENT% <config_access_log_format_bytes_sent>`, which reflects the
+    response body sent to the downstream, so the two may differ significantly (e.g. a large file
+    upload with a small response, or vice versa).
 
   TCP
     Downstream bytes received on connection.
@@ -200,9 +205,15 @@ Current supported substitution commands include:
   TCP/UDP
     Not implemented. It will appear as ``0`` in the access logs.
 
+.. _config_access_log_format_bytes_sent:
+
 ``%BYTES_SENT%``
   HTTP/THRIFT
-    Body bytes sent. For WebSocket connection it will also include response header bytes.
+    Body bytes sent to the downstream, i.e. the size of the response body (which is typically
+    produced by the upstream). For WebSocket connection it will also include response header
+    bytes. This value is independent of :ref:`%BYTES_RECEIVED% <config_access_log_format_bytes_received>`,
+    which reflects the request body received from the downstream, so the two may differ
+    significantly (e.g. a large file upload with a small response, or vice versa).
 
   TCP
     Downstream bytes sent on connection.


### PR DESCRIPTION
BYTES_RECEIVED reflects the request body received from downstream, while BYTES_SENT reflects the response body sent to downstream (which is typically produced by the upstream). These are independent values and can differ significantly depending on request/response characteristics (e.g. large uploads with small responses).
