### PR TITLE
Restrict use of C++ exceptions in formatters

### DIFF
--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -112,8 +112,6 @@ paths:
     - source/common/network/listen_socket_impl.cc
     - source/common/network/io_socket_handle_base_impl.cc
     - source/common/network/address_impl.cc
-    - source/common/formatter/http_specific_formatter.cc
-    - source/common/formatter/substitution_formatter.cc
     - source/common/stats/tag_extractor_impl.cc
     - source/common/protobuf/yaml_utility.cc
     - source/common/protobuf/utility.cc


### PR DESCRIPTION
Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
