### PR TITLE
ai_protocol_manager: keep best-effort parsing off full-duplex streams

### DIFF
--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -60,6 +60,12 @@ message RequestHandling {
   // When ``true``, such routes are parsed too, but never failed over it — a
   // route that declared no AI wire contract has nothing to hold its payload
   // to, so a body that fails to parse is forwarded unchanged.
+  //
+  // Only requests that can be held to end of stream are taken: the request must
+  // carry a JSON content type (``application/json`` or a ``+json`` suffix) and
+  // must not be gRPC or Connect streaming, an upgrade, or a CONNECT. Holding a
+  // full-duplex request would stall it, since the client may not finish the
+  // request until it sees a response the held upstream cannot produce.
   bool parse_unconfigured_routes = 1;
 }
 

--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -181,6 +181,8 @@ envoy_cc_library(
         "//envoy/stats:stats_interface",
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
+        "//source/common/grpc:common_lib",
+        "//source/common/http:header_utility_lib",
         "//source/common/http:headers_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf:utility_lib",

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -206,9 +206,6 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
   // and buffered body immediately and pass the remainder through unbuffered,
   // rather than buffering to end-of-stream.
   if (!isAiEndpoint() && (!config_->parseUnconfiguredRoutes() || !requestIsHoldable(headers))) {
-    // Nothing will look at this payload, so stay out of the way: offloading it
-    // would cost a store round-trip and withhold the headers meanwhile, for
-    // nothing. Decided once here; decode_manager_ being null carries it.
     ENVOY_LOG(trace, "ai_protocol_manager: route has no payload to inspect, passing through");
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -63,7 +63,7 @@ bool isJsonContentType(absl::string_view content_type) {
 // Content type alone misses those: gRPC and Connect spell their streaming
 // framing with a JSON suffix, and an upgrade or CONNECT can carry plain
 // "application/json". So the protocol is checked first.
-bool requestIsHoldable(const Http::RequestHeaderMap& headers) {
+bool canHoldRequest(const Http::RequestHeaderMap& headers) {
   if (Grpc::Common::isGrpcRequestHeaders(headers) ||
       Grpc::Common::isConnectStreamingRequestHeaders(headers)) {
     return false;
@@ -201,11 +201,11 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
 
   // A declared AI endpoint is parsed strictly. Any other route is parsed only
   // if the filter opted into parsing unconfigured routes, and only for a request
-  // that can be held to end of stream without stalling it (requestIsHoldable).
+  // that can be held to end of stream without stalling it (canHoldRequest).
   // TODO(penguingao): on a best-effort parse failure, release the held headers
   // and buffered body immediately and pass the remainder through unbuffered,
   // rather than buffering to end-of-stream.
-  if (!isAiEndpoint() && (!config_->parseUnconfiguredRoutes() || !requestIsHoldable(headers))) {
+  if (!isAiEndpoint() && (!config_->parseUnconfiguredRoutes() || !canHoldRequest(headers))) {
     ENVOY_LOG(trace, "ai_protocol_manager: route has no payload to inspect, passing through");
     return Http::FilterHeadersStatus::Continue;
   }

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -59,10 +59,6 @@ bool isJsonContentType(absl::string_view content_type) {
 // wants a response. A full-duplex stream -- gRPC or Connect streaming, an
 // upgrade, CONNECT -- may instead wait on a response the held upstream cannot
 // produce, and stall until it times out.
-//
-// Content type alone misses those: gRPC and Connect spell their streaming
-// framing with a JSON suffix, and an upgrade or CONNECT can carry plain
-// "application/json". So the protocol is checked first.
 bool canHoldRequest(const Http::RequestHeaderMap& headers) {
   if (Grpc::Common::isGrpcRequestHeaders(headers) ||
       Grpc::Common::isConnectStreamingRequestHeaders(headers)) {
@@ -199,9 +195,9 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
     }
   }
 
-  // A declared AI endpoint is parsed strictly. Any other route is parsed only
-  // if the filter opted into parsing unconfigured routes, and only for a request
-  // that can be held to end of stream without stalling it (canHoldRequest).
+  // A declared AI endpoint is parsed strictly. Any other route is parsed only if
+  // the filter opted into parsing unconfigured routes, and only for a request
+  // that can be held to end of stream without stalling it.
   // TODO(penguingao): on a best-effort parse failure, release the held headers
   // and buffered body immediately and pass the remainder through unbuffered,
   // rather than buffering to end-of-stream.

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -7,6 +7,8 @@
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/utility.h"
+#include "source/common/grpc/common.h"
+#include "source/common/http/header_utility.h"
 #include "source/common/http/headers.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/utility.h"
@@ -49,6 +51,27 @@ bool isJsonContentType(absl::string_view content_type) {
   const absl::string_view normalized = StringUtil::trim(StringUtil::cropRight(content_type, ";"));
   return absl::EqualsIgnoreCase(normalized, "application/json") ||
          absl::EndsWithIgnoreCase(normalized, "+json");
+}
+
+// Whether an unconfigured route's request can be held to end of stream.
+//
+// Holding the headers is only safe if the client finishes its request before it
+// wants a response. A full-duplex stream -- gRPC or Connect streaming, an
+// upgrade, CONNECT -- may instead wait on a response the held upstream cannot
+// produce, and stall until it times out.
+//
+// Content type alone misses those: gRPC and Connect spell their streaming
+// framing with a JSON suffix, and an upgrade or CONNECT can carry plain
+// "application/json". So the protocol is checked first.
+bool requestIsHoldable(const Http::RequestHeaderMap& headers) {
+  if (Grpc::Common::isGrpcRequestHeaders(headers) ||
+      Grpc::Common::isConnectStreamingRequestHeaders(headers)) {
+    return false;
+  }
+  if (Http::Utility::isUpgrade(headers) || Http::HeaderUtility::isConnect(headers)) {
+    return false;
+  }
+  return isJsonContentType(headers.getContentTypeValue());
 }
 
 // Extraction requires an unencoded body: every entry and comma-separated
@@ -177,15 +200,12 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
   }
 
   // A declared AI endpoint is parsed strictly. Any other route is parsed only
-  // if the filter opted into parsing unconfigured routes -- and only for JSON
-  // payloads: full-duplex protocols (gRPC streaming, upgrades) must not have
-  // their headers held to end of request, since the client may not finish the
-  // request until it sees a response the held upstream cannot produce.
+  // if the filter opted into parsing unconfigured routes, and only for a request
+  // that can be held to end of stream without stalling it (requestIsHoldable).
   // TODO(penguingao): on a best-effort parse failure, release the held headers
   // and buffered body immediately and pass the remainder through unbuffered,
   // rather than buffering to end-of-stream.
-  if (!isAiEndpoint() &&
-      (!config_->parseUnconfiguredRoutes() || !isJsonContentType(headers.getContentTypeValue()))) {
+  if (!isAiEndpoint() && (!config_->parseUnconfiguredRoutes() || !requestIsHoldable(headers))) {
     // Nothing will look at this payload, so stay out of the way: offloading it
     // would cost a store round-trip and withhold the headers meanwhile, for
     // nothing. Decided once here; decode_manager_ being null carries it.

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -174,10 +174,9 @@ private:
 // parse_unconfigured_routes -- offered for compatibility with chains that want
 // a parsed body on ordinary routes, never a reason to fail a request -- and is
 // otherwise untouched. That opt-in covers routes that never asked for it, so it
-// is narrow by construction: only a request that can be held to end of stream
-// without stalling it is taken, which rules out gRPC and Connect streaming,
-// upgrades, and CONNECT (filter.cc, canHoldRequest()). A declared endpoint
-// carries no such gate.
+// takes only a request it can hold to end of stream without stalling it, which
+// rules out gRPC and Connect streaming, upgrades, and CONNECT. A declared
+// endpoint carries no such gate.
 //
 // A declared wire API with a registered payload schema is validated at end of
 // payload (schema/schema_registry.h); normalization comes later.

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -176,7 +176,7 @@ private:
 // otherwise untouched. That opt-in covers routes that never asked for it, so it
 // is narrow by construction: only a request that can be held to end of stream
 // without stalling it is taken, which rules out gRPC and Connect streaming,
-// upgrades, and CONNECT (filter.cc, requestIsHoldable()). A declared endpoint
+// upgrades, and CONNECT (filter.cc, canHoldRequest()). A declared endpoint
 // carries no such gate.
 //
 // A declared wire API with a registered payload schema is validated at end of

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -173,7 +173,11 @@ private:
 // A route without one is parsed only if the filter opted into
 // parse_unconfigured_routes -- offered for compatibility with chains that want
 // a parsed body on ordinary routes, never a reason to fail a request -- and is
-// otherwise untouched.
+// otherwise untouched. That opt-in covers routes that never asked for it, so it
+// is narrow by construction: only a request that can be held to end of stream
+// without stalling it is taken, which rules out gRPC and Connect streaming,
+// upgrades, and CONNECT (filter.cc, requestIsHoldable()). A declared endpoint
+// carries no such gate.
 //
 // A declared wire API with a registered payload schema is validated at end of
 // payload (schema/schema_registry.h); normalization comes later.

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -104,6 +104,20 @@ public:
     ASSERT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
   }
 
+  // decodeHeaders() with these headers, on a filter that parses unconfigured
+  // routes and a route that declared nothing -- the exact combination
+  // requestIsHoldable() gates. The SchedulableCallback is created only when the
+  // stream is expected to engage, since a gated one builds no BufferManager and
+  // would leave the mock's expectation unsatisfied.
+  Http::FilterHeadersStatus decodeHeadersUnconfigured(Http::TestRequestHeaderMapImpl headers,
+                                                      bool expect_engage) {
+    createFilter(/*parse_unconfigured_routes=*/true);
+    if (expect_engage) {
+      replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
+    }
+    return filter_->decodeHeaders(headers, /*end_stream=*/false);
+  }
+
   // Attaches a per-route config declaring the route an AI endpoint with a
   // request payload for the filter to hold.
   void setRouteConfig() {
@@ -1448,6 +1462,114 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortParsingForwardsEmptyBody) {
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_TRUE(injected_end_stream_);
   EXPECT_EQ(injected_.length(), 0);
+}
+
+// A JSON upload is the one shape best effort can hold: the client sends the whole
+// request before it wants a response, so pinning the headers cannot stall it.
+TEST_F(AiProtocolManagerFilterTest, BestEffortEngagesOnJsonContentType) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                               {":path", "/v1/chat"},
+                                               {"content-type", "application/json"}},
+                /*expect_engage=*/true),
+            Http::FilterHeadersStatus::StopIteration);
+}
+
+// Media type parameters are not part of the type, and the type is case-insensitive.
+TEST_F(AiProtocolManagerFilterTest, BestEffortEngagesOnJsonContentTypeWithParameters) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                               {":path", "/v1/chat"},
+                                               {"content-type", "Application/JSON; charset=utf-8"}},
+                /*expect_engage=*/true),
+            Http::FilterHeadersStatus::StopIteration);
+}
+
+// A "+json" structured suffix names a JSON payload just as "application/json" does.
+TEST_F(AiProtocolManagerFilterTest, BestEffortEngagesOnJsonStructuredSuffix) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                               {":path", "/v1/chat"},
+                                               {"content-type", "application/vnd.openai+json"}},
+                /*expect_engage=*/true),
+            Http::FilterHeadersStatus::StopIteration);
+}
+
+// The stall this gate exists for: a gRPC client- or bidi-streaming request may
+// not send end_stream until it has seen a response, so holding its headers would
+// deadlock it. Its content type is JSON-suffixed, so only the protocol check
+// catches this one.
+TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsGrpcRequest) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                               {":path", "/Chat/Complete"},
+                                               {"content-type", "application/grpc+json"}},
+                /*expect_engage=*/false),
+            Http::FilterHeadersStatus::Continue);
+}
+
+// Connect spells its streaming framing with a JSON suffix too, and bidi streaming
+// over it stalls the same way. (Unary Connect sends plain "application/json" and
+// stays eligible.)
+TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsConnectStreamingRequest) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                               {":path", "/Chat/Complete"},
+                                               {"content-type", "application/connect+json"}},
+                /*expect_engage=*/false),
+            Http::FilterHeadersStatus::Continue);
+}
+
+// An upgraded connection is full-duplex from the first byte, whatever content
+// type the request carries.
+TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsUpgrade) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                               {":path", "/ws"},
+                                               {"content-type", "application/json"},
+                                               {"connection", "keep-alive, Upgrade"},
+                                               {"upgrade", "websocket"}},
+                /*expect_engage=*/false),
+            Http::FilterHeadersStatus::Continue);
+}
+
+// So is a CONNECT tunnel, extended or not.
+TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsConnect) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{
+                    {":method", "CONNECT"}, {":path", "/"}, {"content-type", "application/json"}},
+                /*expect_engage=*/false),
+            Http::FilterHeadersStatus::Continue);
+}
+
+// A body the parser could make nothing of is not worth a store round-trip, let
+// alone holding the headers for one.
+TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsNonJsonContentType) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                               {":path", "/upload"},
+                                               {"content-type", "application/octet-stream"}},
+                /*expect_engage=*/false),
+            Http::FilterHeadersStatus::Continue);
+}
+
+// An absent content type says nothing about the payload, so best effort declines it.
+TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsMissingContentType) {
+  EXPECT_EQ(decodeHeadersUnconfigured(
+                Http::TestRequestHeaderMapImpl{{":method", "POST"}, {":path", "/upload"}},
+                /*expect_engage=*/false),
+            Http::FilterHeadersStatus::Continue);
+}
+
+// The gate belongs to best effort alone. A declared AI endpoint is the operator's
+// explicit choice, so its payload is managed whatever the content type says.
+TEST_F(AiProtocolManagerFilterTest, DeclaredEndpointIgnoresHoldableGate) {
+  setRouteConfig();
+  replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/chat/completions"}, {"content-type", "text/plain"}};
+  EXPECT_EQ(filter_->decodeHeaders(headers, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
 }
 
 // A declared endpoint is strict regardless of the filter-level

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -106,7 +106,7 @@ public:
 
   // decodeHeaders() with these headers, on a filter that parses unconfigured
   // routes and a route that declared nothing -- the exact combination
-  // requestIsHoldable() gates. The SchedulableCallback is created only when the
+  // canHoldRequest() gates. The SchedulableCallback is created only when the
   // stream is expected to engage, since a gated one builds no BufferManager and
   // would leave the mock's expectation unsatisfied.
   Http::FilterHeadersStatus decodeHeadersUnconfigured(Http::TestRequestHeaderMapImpl headers,
@@ -1563,7 +1563,7 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsMissingContentType) {
 
 // The gate belongs to best effort alone. A declared AI endpoint is the operator's
 // explicit choice, so its payload is managed whatever the content type says.
-TEST_F(AiProtocolManagerFilterTest, DeclaredEndpointIgnoresHoldableGate) {
+TEST_F(AiProtocolManagerFilterTest, DeclaredEndpointIgnoresGate) {
   setRouteConfig();
   replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
   Http::TestRequestHeaderMapImpl headers{

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -104,11 +104,6 @@ public:
     ASSERT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
   }
 
-  // decodeHeaders() with these headers, on a filter that parses unconfigured
-  // routes and a route that declared nothing -- the exact combination
-  // canHoldRequest() gates. The SchedulableCallback is created only when the
-  // stream is expected to engage, since a gated one builds no BufferManager and
-  // would leave the mock's expectation unsatisfied.
   Http::FilterHeadersStatus decodeHeadersUnconfigured(Http::TestRequestHeaderMapImpl headers,
                                                       bool expect_engage) {
     createFilter(/*parse_unconfigured_routes=*/true);
@@ -1464,8 +1459,8 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortParsingForwardsEmptyBody) {
   EXPECT_EQ(injected_.length(), 0);
 }
 
-// A JSON upload is the one shape best effort can hold: the client sends the whole
-// request before it wants a response, so pinning the headers cannot stall it.
+// The one shape best effort can hold: the whole request arrives before a response
+// is wanted, so pinning the headers cannot stall it.
 TEST_F(AiProtocolManagerFilterTest, BestEffortEngagesOnJsonContentType) {
   EXPECT_EQ(decodeHeadersUnconfigured(
                 Http::TestRequestHeaderMapImpl{{":method", "POST"},
@@ -1495,10 +1490,8 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortEngagesOnJsonStructuredSuffix) {
             Http::FilterHeadersStatus::StopIteration);
 }
 
-// The stall this gate exists for: a gRPC client- or bidi-streaming request may
-// not send end_stream until it has seen a response, so holding its headers would
-// deadlock it. Its content type is JSON-suffixed, so only the protocol check
-// catches this one.
+// The stall this gate exists for. The content type carries a JSON suffix, so
+// only the protocol check catches it.
 TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsGrpcRequest) {
   EXPECT_EQ(decodeHeadersUnconfigured(
                 Http::TestRequestHeaderMapImpl{{":method", "POST"},
@@ -1508,9 +1501,8 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsGrpcRequest) {
             Http::FilterHeadersStatus::Continue);
 }
 
-// Connect spells its streaming framing with a JSON suffix too, and bidi streaming
-// over it stalls the same way. (Unary Connect sends plain "application/json" and
-// stays eligible.)
+// Connect's streaming framing carries a JSON suffix too. (Unary Connect sends
+// plain "application/json" and stays eligible.)
 TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsConnectStreamingRequest) {
   EXPECT_EQ(decodeHeadersUnconfigured(
                 Http::TestRequestHeaderMapImpl{{":method", "POST"},
@@ -1520,8 +1512,7 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsConnectStreamingRequest) {
             Http::FilterHeadersStatus::Continue);
 }
 
-// An upgraded connection is full-duplex from the first byte, whatever content
-// type the request carries.
+// An upgraded connection is full-duplex whatever content type it carries.
 TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsUpgrade) {
   EXPECT_EQ(decodeHeadersUnconfigured(
                 Http::TestRequestHeaderMapImpl{{":method", "GET"},
@@ -1542,8 +1533,7 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsConnect) {
             Http::FilterHeadersStatus::Continue);
 }
 
-// A body the parser could make nothing of is not worth a store round-trip, let
-// alone holding the headers for one.
+// A body the parser could make nothing of is not worth holding the headers for.
 TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsNonJsonContentType) {
   EXPECT_EQ(decodeHeadersUnconfigured(
                 Http::TestRequestHeaderMapImpl{{":method", "POST"},
@@ -1561,8 +1551,8 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortSkipsMissingContentType) {
             Http::FilterHeadersStatus::Continue);
 }
 
-// The gate belongs to best effort alone. A declared AI endpoint is the operator's
-// explicit choice, so its payload is managed whatever the content type says.
+// The gate belongs to best effort alone; a declared endpoint is managed whatever
+// the content type says.
 TEST_F(AiProtocolManagerFilterTest, DeclaredEndpointIgnoresGate) {
   setRouteConfig();
   replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);


### PR DESCRIPTION
Commit Message: ai_protocol_manager: keep best-effort parsing off full-duplex streams

Additional Description:
`parse_unconfigured_routes` holds a request's headers until end of stream so the body can be offloaded and parsed. That is only safe when the client finishes its request before it wants a response. A full-duplex stream -- gRPC client/bidi streaming, Connect streaming, an upgraded connection, CONNECT -- may instead wait on a response the held upstream cannot produce, and stall until it times out.

The existing gate checks only the content type, which does not separate those out:

* `application/grpc+json` -- gRPC framing, passes the `+json` suffix test.
* `application/connect+json` -- Connect streaming framing, same.
* An upgrade or CONNECT carrying `content-type: application/json` outright.

`requestIsHoldable()` now checks the protocol first (`Grpc::Common::isGrpcRequestHeaders`, `Grpc::Common::isConnectStreamingRequestHeaders`, `Http::Utility::isUpgrade`, `Http::HeaderUtility::isConnect`) and only judges what is left over by its content type.

The gate applies to `parse_unconfigured_routes` alone. A route carrying a per-route request declaration is the operator's explicit choice and is unaffected.

Risk Level: Low
Testing: yes

---

AI was used to assist with this change and I fully understand 
