### PR TITLE
ai_protocol_manager: add request-path stats

### DIFF
--- a/changelogs/current/new_features/ai_protocol_manager__request-path-stats.rst
+++ b/changelogs/current/new_features/ai_protocol_manager__request-path-stats.rst
@@ -1,0 +1,9 @@
+Added request-path statistics to the :ref:`AI Protocol Manager
+<config_http_filters_ai_protocol_manager>` filter, whose counters previously
+covered only the response path. ``request_payload_parsed``,
+``request_parse_error``, ``request_schema_invalid`` and
+``request_unparsed_passthrough`` make the decode path's outcomes visible --
+in particular telling a malformed payload apart from one that parsed but
+failed its API's payload schema, since the two 400s mean different things to
+act on. ``external_buffer_error`` counts the 500 raised when the external
+buffer fails irrecoverably, on either direction.

--- a/changelogs/current/new_features/ai_protocol_manager__request-path-stats.rst
+++ b/changelogs/current/new_features/ai_protocol_manager__request-path-stats.rst
@@ -1,9 +1,9 @@
 Added request-path statistics to the :ref:`AI Protocol Manager
 <config_http_filters_ai_protocol_manager>` filter, whose counters previously
-covered only the response path. ``request_payload_parsed``,
-``request_parse_error``, ``request_schema_invalid`` and
-``request_unparsed_passthrough`` make the decode path's outcomes visible --
-in particular telling a malformed payload apart from one that parsed but
-failed its API's payload schema, since the two 400s mean different things to
-act on. ``external_buffer_error`` counts the 500 raised when the external
-buffer fails irrecoverably, on either direction.
+covered only the response path. ``request_parsed``, ``request_parse_error``,
+``request_schema_invalid`` and ``request_passthrough`` make the decode path's
+outcomes visible -- in particular telling a malformed payload apart from one
+that parsed but failed its API's payload schema, since the two 400s mean
+different things to act on. ``request_external_buffer_error`` and
+``response_external_buffer_error`` count the 500 raised when the external
+buffer fails irrecoverably on each direction.

--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -396,6 +396,11 @@ The filter outputs statistics in the ``ai_protocol_manager.`` namespace.
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
+  request_payload_parsed, Counter, "A held request payload was parsed into a document, and passed its payload schema where the declared API has one."
+  request_parse_error, Counter, A declared AI endpoint's payload was not well-formed JSON and was rejected with a 400.
+  request_schema_invalid, Counter, "A declared AI endpoint's payload parsed but violated its API's payload schema, and was rejected with a 400."
+  request_unparsed_passthrough, Counter, "A payload on an unconfigured route failed to parse under :ref:`parse_unconfigured_routes <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestHandling.parse_unconfigured_routes>` and was forwarded unchanged; never a request failure."
+  external_buffer_error, Counter, The external buffer failed irrecoverably and the stream was answered with a 500.
   token_usage_found, Counter, A response yielded token usage and metadata was written (includes ``PARTIAL`` records).
   token_usage_partial, Counter, A published record was flagged ``extraction_status: PARTIAL``.
   token_usage_failed, Counter, A status-only record was published (``extraction_status: FAILED``; no counts recovered).

--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -396,11 +396,12 @@ The filter outputs statistics in the ``ai_protocol_manager.`` namespace.
   :header: Name, Type, Description
   :widths: 1, 1, 2
 
-  request_payload_parsed, Counter, "A held request payload was parsed into a document, and passed its payload schema where the declared API has one."
+  request_parsed, Counter, "A held request payload was parsed into a document, and passed its payload schema where the declared API has one."
   request_parse_error, Counter, A declared AI endpoint's payload was not well-formed JSON and was rejected with a 400.
   request_schema_invalid, Counter, "A declared AI endpoint's payload parsed but violated its API's payload schema, and was rejected with a 400."
-  request_unparsed_passthrough, Counter, "A payload on an unconfigured route failed to parse under :ref:`parse_unconfigured_routes <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestHandling.parse_unconfigured_routes>` and was forwarded unchanged; never a request failure."
-  external_buffer_error, Counter, The external buffer failed irrecoverably and the stream was answered with a 500.
+  request_passthrough, Counter, "A payload on an unconfigured route failed to parse under :ref:`parse_unconfigured_routes <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestHandling.parse_unconfigured_routes>` and was forwarded unchanged; never a request failure."
+  request_external_buffer_error, Counter, The external buffer failed irrecoverably on the request path and the stream was answered with a 500.
+  response_external_buffer_error, Counter, The external buffer failed irrecoverably on the response path and the stream was answered with a 500.
   token_usage_found, Counter, A response yielded token usage and metadata was written (includes ``PARTIAL`` records).
   token_usage_partial, Counter, A published record was flagged ``extraction_status: PARTIAL``.
   token_usage_failed, Counter, A status-only record was published (``extraction_status: FAILED``; no counts recovered).

--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -79,6 +79,7 @@ envoy_cc_library(
     hdrs = ["filter_chain_bridge.h"],
     deps = [
         ":buffer_manager_lib",
+        ":stats_lib",
         "//envoy/http:codes_interface",
         "//envoy/http:filter_interface",
     ],

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -260,9 +260,6 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
         }
       }
     }
-    // The payload parsed, and passed its schema where the declared API has one.
-    // A declared API without a registered schema counts here too: the document
-    // is what later filters work from, whether or not it was schema-checked.
     config_->stats().request_parsed_.inc();
   }
   return true;

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -198,7 +198,8 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
   // for none of it: constructing it subscribes to upstream watermarks and claims
   // a schedulable callback.
   decode_manager_ = std::make_unique<BufferManager>(
-      buffer_factory_, std::make_unique<DecoderFilterChainBridge>(*decoder_callbacks_));
+      buffer_factory_,
+      std::make_unique<DecoderFilterChainBridge>(*decoder_callbacks_, config_->stats()));
 
   // Pin the headers so routing and admission filters do not act on them before
   // the payload is offloaded. decodeData() still fires while iteration is stopped
@@ -229,11 +230,13 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
 
   if (!status.ok()) {
     if (isAiEndpoint()) {
+      config_->stats().request_parse_error_.inc();
       rejectInvalidPayload(status);
       return false;
     }
     // Best effort: the payload is forwarded as it stands, just without a
     // document for later filters to work from.
+    config_->stats().request_unparsed_passthrough_.inc();
     ENVOY_LOG(debug, "ai_protocol_manager: forwarding unparsed payload: {}", status.message());
     request_parser_.reset();
     return true;
@@ -251,11 +254,16 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
           payload_schema != nullptr) {
         const absl::Status validation_status = payload_schema->validateRequest(request_json_);
         if (!validation_status.ok()) {
+          config_->stats().request_schema_invalid_.inc();
           rejectInvalidPayload(validation_status);
           return false;
         }
       }
     }
+    // The payload parsed, and passed its schema where the declared API has one.
+    // A declared API without a registered schema counts here too: the document
+    // is what later filters work from, whether or not it was schema-checked.
+    config_->stats().request_payload_parsed_.inc();
   }
   return true;
 }

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -236,7 +236,7 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
     }
     // Best effort: the payload is forwarded as it stands, just without a
     // document for later filters to work from.
-    config_->stats().request_unparsed_passthrough_.inc();
+    config_->stats().request_passthrough_.inc();
     ENVOY_LOG(debug, "ai_protocol_manager: forwarding unparsed payload: {}", status.message());
     request_parser_.reset();
     return true;
@@ -263,7 +263,7 @@ bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_
     // The payload parsed, and passed its schema where the declared API has one.
     // A declared API without a registered schema counts here too: the document
     // is what later filters work from, whether or not it was schema-checked.
-    config_->stats().request_payload_parsed_.inc();
+    config_->stats().request_parsed_.inc();
   }
   return true;
 }

--- a/source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.cc
@@ -22,7 +22,7 @@ void DecoderFilterChainBridge::unregisterReplayWatermarks() {
 }
 
 void DecoderFilterChainBridge::onUnrecoverableError() {
-  stats_.external_buffer_error_.inc();
+  stats_.request_external_buffer_error_.inc();
   callbacks_.sendLocalReply(Http::Code::InternalServerError, "AI protocol buffer error", nullptr,
                             std::nullopt, "ai_protocol_manager_external_buffer_error");
 }
@@ -42,7 +42,7 @@ void EncoderFilterChainBridge::unregisterReplayWatermarks() {
 }
 
 void EncoderFilterChainBridge::onUnrecoverableError() {
-  stats_.external_buffer_error_.inc();
+  stats_.response_external_buffer_error_.inc();
   // On the response path the headers (and possibly some body) may already be in
   // flight. sendLocalReply handles this best-effort: if the response has not
   // started it generates a local reply, otherwise it either ships the reply

--- a/source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.cc
@@ -22,6 +22,7 @@ void DecoderFilterChainBridge::unregisterReplayWatermarks() {
 }
 
 void DecoderFilterChainBridge::onUnrecoverableError() {
+  stats_.external_buffer_error_.inc();
   callbacks_.sendLocalReply(Http::Code::InternalServerError, "AI protocol buffer error", nullptr,
                             std::nullopt, "ai_protocol_manager_external_buffer_error");
 }
@@ -41,6 +42,7 @@ void EncoderFilterChainBridge::unregisterReplayWatermarks() {
 }
 
 void EncoderFilterChainBridge::onUnrecoverableError() {
+  stats_.external_buffer_error_.inc();
   // On the response path the headers (and possibly some body) may already be in
   // flight. sendLocalReply handles this best-effort: if the response has not
   // started it generates a local reply, otherwise it either ships the reply

--- a/source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.h
@@ -3,6 +3,7 @@
 #include "envoy/http/filter.h"
 
 #include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
+#include "source/extensions/filters/http/ai_protocol_manager/stats.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -15,8 +16,9 @@ namespace AiProtocolManager {
 // against upstream back-pressure.
 class DecoderFilterChainBridge : public FilterChainBridge, public Http::UpstreamWatermarkCallbacks {
 public:
-  explicit DecoderFilterChainBridge(Http::StreamDecoderFilterCallbacks& callbacks)
-      : callbacks_(callbacks) {}
+  DecoderFilterChainBridge(Http::StreamDecoderFilterCallbacks& callbacks,
+                           AiProtocolManagerStats& stats)
+      : callbacks_(callbacks), stats_(stats) {}
 
   // FilterChainBridge
   Event::Dispatcher& dispatcher() override { return callbacks_.dispatcher(); }
@@ -44,6 +46,7 @@ public:
 
 private:
   Http::StreamDecoderFilterCallbacks& callbacks_;
+  AiProtocolManagerStats& stats_;
   ReplayWatermarkHandler* handler_{nullptr};
   // Whether *this is currently registered as an UpstreamWatermarkCallbacks.
   bool registered_{false};
@@ -61,8 +64,10 @@ class EncoderFilterChainBridge : public FilterChainBridge,
                                  public Http::DownstreamWatermarkCallbacks {
 public:
   EncoderFilterChainBridge(Http::StreamEncoderFilterCallbacks& encoder_callbacks,
-                           Http::StreamDecoderFilterCallbacks& decoder_callbacks)
-      : encoder_callbacks_(encoder_callbacks), decoder_callbacks_(decoder_callbacks) {}
+                           Http::StreamDecoderFilterCallbacks& decoder_callbacks,
+                           AiProtocolManagerStats& stats)
+      : encoder_callbacks_(encoder_callbacks), decoder_callbacks_(decoder_callbacks),
+        stats_(stats) {}
 
   // FilterChainBridge
   Event::Dispatcher& dispatcher() override { return encoder_callbacks_.dispatcher(); }
@@ -91,6 +96,7 @@ public:
 private:
   Http::StreamEncoderFilterCallbacks& encoder_callbacks_;
   Http::StreamDecoderFilterCallbacks& decoder_callbacks_;
+  AiProtocolManagerStats& stats_;
   ReplayWatermarkHandler* handler_{nullptr};
   // Whether *this is currently registered as a DownstreamWatermarkCallbacks.
   bool registered_{false};

--- a/source/extensions/filters/http/ai_protocol_manager/stats.h
+++ b/source/extensions/filters/http/ai_protocol_manager/stats.h
@@ -11,11 +11,12 @@ namespace AiProtocolManager {
  * All stats for the AI Protocol Manager filter. @see stats_macros.h
  */
 #define ALL_AI_PROTOCOL_MANAGER_STATS(COUNTER)                                                     \
-  COUNTER(request_payload_parsed)                                                                  \
+  COUNTER(request_parsed)                                                                          \
   COUNTER(request_parse_error)                                                                     \
   COUNTER(request_schema_invalid)                                                                  \
-  COUNTER(request_unparsed_passthrough)                                                            \
-  COUNTER(external_buffer_error)                                                                   \
+  COUNTER(request_passthrough)                                                                     \
+  COUNTER(request_external_buffer_error)                                                           \
+  COUNTER(response_external_buffer_error)                                                          \
   COUNTER(token_usage_found)                                                                       \
   COUNTER(token_usage_partial)                                                                     \
   COUNTER(token_usage_failed)                                                                      \

--- a/source/extensions/filters/http/ai_protocol_manager/stats.h
+++ b/source/extensions/filters/http/ai_protocol_manager/stats.h
@@ -11,6 +11,11 @@ namespace AiProtocolManager {
  * All stats for the AI Protocol Manager filter. @see stats_macros.h
  */
 #define ALL_AI_PROTOCOL_MANAGER_STATS(COUNTER)                                                     \
+  COUNTER(request_payload_parsed)                                                                  \
+  COUNTER(request_parse_error)                                                                     \
+  COUNTER(request_schema_invalid)                                                                  \
+  COUNTER(request_unparsed_passthrough)                                                            \
+  COUNTER(external_buffer_error)                                                                   \
   COUNTER(token_usage_found)                                                                       \
   COUNTER(token_usage_partial)                                                                     \
   COUNTER(token_usage_failed)                                                                      \

--- a/test/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/BUILD
@@ -132,6 +132,7 @@ envoy_extension_cc_test(
         "//source/common/buffer:buffer_lib",
         "//source/extensions/filters/http/ai_protocol_manager:filter_chain_bridge_lib",
         "//test/mocks/http:http_mocks",
+        "//test/mocks/stats:stats_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/ai_protocol_manager/filter_chain_bridge_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_chain_bridge_test.cc
@@ -2,6 +2,7 @@
 #include "source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.h"
 
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/stats/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -32,8 +33,11 @@ public:
 // StreamDecoderFilterCallbacks and forwards upstream watermarks.
 class DecoderFilterChainBridgeTest : public testing::Test {
 public:
+  NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  AiProtocolManagerStats stats_{
+      ALL_AI_PROTOCOL_MANAGER_STATS(POOL_COUNTER_PREFIX(*stats_store_.rootScope(), ""))};
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
-  DecoderFilterChainBridge bridge_{callbacks_};
+  DecoderFilterChainBridge bridge_{callbacks_, stats_};
   RecordingHandler handler_;
 };
 
@@ -96,15 +100,19 @@ TEST_F(DecoderFilterChainBridgeTest, UnrecoverableErrorSendsLocalReply) {
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _,
                                          "ai_protocol_manager_external_buffer_error"));
   bridge_.onUnrecoverableError();
+  EXPECT_EQ(stats_.external_buffer_error_.value(), 1);
 }
 
 // EncoderFilterChainBridge maps the bridge surface onto StreamEncoderFilterCallbacks
 // but subscribes to downstream watermarks through the decoder callbacks.
 class EncoderFilterChainBridgeTest : public testing::Test {
 public:
+  NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
+  AiProtocolManagerStats stats_{
+      ALL_AI_PROTOCOL_MANAGER_STATS(POOL_COUNTER_PREFIX(*stats_store_.rootScope(), ""))};
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks_;
-  EncoderFilterChainBridge bridge_{encoder_callbacks_, decoder_callbacks_};
+  EncoderFilterChainBridge bridge_{encoder_callbacks_, decoder_callbacks_, stats_};
   RecordingHandler handler_;
 };
 
@@ -165,6 +173,7 @@ TEST_F(EncoderFilterChainBridgeTest, UnrecoverableErrorSendsLocalReply) {
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _,
                                                  "ai_protocol_manager_external_buffer_error"));
   bridge_.onUnrecoverableError();
+  EXPECT_EQ(stats_.external_buffer_error_.value(), 1);
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/filter_chain_bridge_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_chain_bridge_test.cc
@@ -100,7 +100,7 @@ TEST_F(DecoderFilterChainBridgeTest, UnrecoverableErrorSendsLocalReply) {
   EXPECT_CALL(callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _,
                                          "ai_protocol_manager_external_buffer_error"));
   bridge_.onUnrecoverableError();
-  EXPECT_EQ(stats_.external_buffer_error_.value(), 1);
+  EXPECT_EQ(stats_.request_external_buffer_error_.value(), 1);
 }
 
 // EncoderFilterChainBridge maps the bridge surface onto StreamEncoderFilterCallbacks
@@ -173,7 +173,7 @@ TEST_F(EncoderFilterChainBridgeTest, UnrecoverableErrorSendsLocalReply) {
   EXPECT_CALL(encoder_callbacks_, sendLocalReply(Http::Code::InternalServerError, _, _, _,
                                                  "ai_protocol_manager_external_buffer_error"));
   bridge_.onUnrecoverableError();
-  EXPECT_EQ(stats_.external_buffer_error_.value(), 1);
+  EXPECT_EQ(stats_.response_external_buffer_error_.value(), 1);
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -135,6 +135,11 @@ public:
     }
   }
 
+  uint64_t counterValue(const std::string& name) {
+    const auto counter = TestUtility::findCounter(stats_store_, "ai_protocol_manager." + name);
+    return counter != nullptr ? counter->value() : 0;
+  }
+
   std::deque<Event::PostCb> posted_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   InMemoryExternalBufferFactory factory_;
@@ -1150,6 +1155,9 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_EQ(injected_.toString(), payload);
   EXPECT_TRUE(injected_end_stream_);
+  EXPECT_EQ(counterValue("request_payload_parsed"), 1);
+  EXPECT_EQ(counterValue("request_parse_error"), 0);
+  EXPECT_EQ(counterValue("request_schema_invalid"), 0);
 }
 
 // Malformed JSON is answered with a 400 and never reaches the upstream.
@@ -1165,6 +1173,11 @@ TEST_F(AiProtocolManagerFilterTest, RejectsMalformedJson) {
   EXPECT_EQ(local_reply_code_, Http::Code::BadRequest);
   EXPECT_EQ(local_reply_details_, "ai_protocol_manager_invalid_json");
   EXPECT_EQ(inject_calls_, 0);
+  // A body that is not JSON at all is a parse error, not a schema failure: the
+  // two 400s are counted apart because they mean different things to operate on.
+  EXPECT_EQ(counterValue("request_parse_error"), 1);
+  EXPECT_EQ(counterValue("request_schema_invalid"), 0);
+  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
 }
 
 // Where Envoy and the backend could otherwise read the same body differently.
@@ -1212,6 +1225,9 @@ TEST_F(AiProtocolManagerFilterTest, EmptyBodyOnDeclaredEndpointIsPassedThrough) 
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_TRUE(injected_end_stream_);
   EXPECT_EQ(injected_.length(), 0);
+  // No payload arrived, so there is no document and nothing to count parsed.
+  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
+  EXPECT_EQ(counterValue("request_parse_error"), 0);
 }
 
 // Only a stream with no body at all is exempt. Once bytes have arrived they are
@@ -1266,6 +1282,10 @@ TEST_F(AiProtocolManagerFilterTest, RejectsPayloadFailingSchemaValidation) {
   EXPECT_EQ(local_reply_code_, Http::Code::BadRequest);
   EXPECT_EQ(local_reply_details_, "ai_protocol_manager_invalid_json");
   EXPECT_EQ(inject_calls_, 0);
+  // Well-formed JSON that the declared API rejects: schema drift, not garbage.
+  EXPECT_EQ(counterValue("request_schema_invalid"), 1);
+  EXPECT_EQ(counterValue("request_parse_error"), 0);
+  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
 }
 
 // Unknown fields are permitted and pass through untouched.
@@ -1351,6 +1371,9 @@ TEST_F(AiProtocolManagerFilterTest, PassesThroughUndeclaredRoute) {
   EXPECT_EQ(body.toString(), R"({"model":"gpt-4"})");
   EXPECT_EQ(inject_calls_, 0);
   EXPECT_EQ(local_reply_calls_, 0);
+  // A stream the filter never engages on touches none of the request counters.
+  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
+  EXPECT_EQ(counterValue("request_unparsed_passthrough"), 0);
 }
 
 // Nor does it subscribe to watermarks or claim any replay machinery.
@@ -1402,6 +1425,10 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortParsingAcceptsValidPayload) {
 
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_EQ(injected_.toString(), R"({"model":"gpt-4"})");
+  // An unconfigured route has no schema to check, but the document is still
+  // there for later filters, so it counts as parsed.
+  EXPECT_EQ(counterValue("request_payload_parsed"), 1);
+  EXPECT_EQ(counterValue("request_unparsed_passthrough"), 0);
 }
 
 // Best effort means exactly that: a payload that does not parse is forwarded
@@ -1417,6 +1444,10 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortParsingForwardsMalformedPayload) {
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_EQ(injected_.toString(), R"({"model" "gpt-4"})");
   EXPECT_TRUE(injected_end_stream_);
+  // Forwarded, not failed -- so it is counted apart from the rejecting paths.
+  EXPECT_EQ(counterValue("request_unparsed_passthrough"), 1);
+  EXPECT_EQ(counterValue("request_parse_error"), 0);
+  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
 }
 
 // A payload abandoned mid-upload is still offloaded and replayed in full.

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -1155,7 +1155,7 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_EQ(injected_.toString(), payload);
   EXPECT_TRUE(injected_end_stream_);
-  EXPECT_EQ(counterValue("request_payload_parsed"), 1);
+  EXPECT_EQ(counterValue("request_parsed"), 1);
   EXPECT_EQ(counterValue("request_parse_error"), 0);
   EXPECT_EQ(counterValue("request_schema_invalid"), 0);
 }
@@ -1177,7 +1177,7 @@ TEST_F(AiProtocolManagerFilterTest, RejectsMalformedJson) {
   // two 400s are counted apart because they mean different things to operate on.
   EXPECT_EQ(counterValue("request_parse_error"), 1);
   EXPECT_EQ(counterValue("request_schema_invalid"), 0);
-  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
+  EXPECT_EQ(counterValue("request_parsed"), 0);
 }
 
 // Where Envoy and the backend could otherwise read the same body differently.
@@ -1226,7 +1226,7 @@ TEST_F(AiProtocolManagerFilterTest, EmptyBodyOnDeclaredEndpointIsPassedThrough) 
   EXPECT_TRUE(injected_end_stream_);
   EXPECT_EQ(injected_.length(), 0);
   // No payload arrived, so there is no document and nothing to count parsed.
-  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
+  EXPECT_EQ(counterValue("request_parsed"), 0);
   EXPECT_EQ(counterValue("request_parse_error"), 0);
 }
 
@@ -1285,7 +1285,7 @@ TEST_F(AiProtocolManagerFilterTest, RejectsPayloadFailingSchemaValidation) {
   // Well-formed JSON that the declared API rejects: schema drift, not garbage.
   EXPECT_EQ(counterValue("request_schema_invalid"), 1);
   EXPECT_EQ(counterValue("request_parse_error"), 0);
-  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
+  EXPECT_EQ(counterValue("request_parsed"), 0);
 }
 
 // Unknown fields are permitted and pass through untouched.
@@ -1372,8 +1372,8 @@ TEST_F(AiProtocolManagerFilterTest, PassesThroughUndeclaredRoute) {
   EXPECT_EQ(inject_calls_, 0);
   EXPECT_EQ(local_reply_calls_, 0);
   // A stream the filter never engages on touches none of the request counters.
-  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
-  EXPECT_EQ(counterValue("request_unparsed_passthrough"), 0);
+  EXPECT_EQ(counterValue("request_parsed"), 0);
+  EXPECT_EQ(counterValue("request_passthrough"), 0);
 }
 
 // Nor does it subscribe to watermarks or claim any replay machinery.
@@ -1427,8 +1427,8 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortParsingAcceptsValidPayload) {
   EXPECT_EQ(injected_.toString(), R"({"model":"gpt-4"})");
   // An unconfigured route has no schema to check, but the document is still
   // there for later filters, so it counts as parsed.
-  EXPECT_EQ(counterValue("request_payload_parsed"), 1);
-  EXPECT_EQ(counterValue("request_unparsed_passthrough"), 0);
+  EXPECT_EQ(counterValue("request_parsed"), 1);
+  EXPECT_EQ(counterValue("request_passthrough"), 0);
 }
 
 // Best effort means exactly that: a payload that does not parse is forwarded
@@ -1445,9 +1445,9 @@ TEST_F(AiProtocolManagerFilterTest, BestEffortParsingForwardsMalformedPayload) {
   EXPECT_EQ(injected_.toString(), R"({"model" "gpt-4"})");
   EXPECT_TRUE(injected_end_stream_);
   // Forwarded, not failed -- so it is counted apart from the rejecting paths.
-  EXPECT_EQ(counterValue("request_unparsed_passthrough"), 1);
+  EXPECT_EQ(counterValue("request_passthrough"), 1);
   EXPECT_EQ(counterValue("request_parse_error"), 0);
-  EXPECT_EQ(counterValue("request_payload_parsed"), 0);
+  EXPECT_EQ(counterValue("request_parsed"), 0);
 }
 
 // A payload abandoned mid-upload is still offloaded and replayed in full.


### PR DESCRIPTION
Commit Message:
ai_protocol_manager: add request-path stats

Additional Description:
Adds request-path counters that distinguish malformed JSON from payload schema failures:

* `request_payload_parsed`: parsed successfully and passed schema validation, when applicable
* `request_parse_error`: malformed JSON on a declared AI endpoint → 400
* `request_schema_invalid`: parsed JSON failed payload schema validation → 400
* `request_unparsed_passthrough`: unconfigured route failed best-effort parsing and was forwarded unchanged
* `external_buffer_error`: irrecoverable external-buffer failure → 500

The parse/schema split distinguishes malformed client traffic from potential schema drift. Declared APIs without a registered payload schema count as parsed.

Stats are passed into both decoder and encoder bridges. The encoder side remains unused until the encode path is wired.

Risk Level: Low
Counters only; no behavior changes.

Testing: Unit tests
Covers all decode outcomes and external-buffer failures on both bridges. Relevant test suites pass; formatting required no changes.

Docs Changes: Updated the AI Protocol Manager statistics table.

Release Notes: Added a new-feature entry.

Platform Specific Features: N/A

https://github.com/envoyproxy/envoy/issues/44681

AI assisted with this change. I reviewed and understand the submitted code.
