### PR TITLE
ai_protocol_manager: make inline string threshold configurable

### DIFF
--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -69,23 +69,17 @@ message RequestHandling {
 // Per-stream limits for request payload parsing.
 message RequestParsingLimits {
   // Maximum size, in bytes, of a decoded string value kept inline in the
-  // parsed document. A value larger than this is left in the external buffer
-  // and recorded as a reference to its bytes, so a large prompt costs one
-  // small node instead of a per-stream copy. Object keys are always inline
-  // and unaffected.
+  // parsed document; a larger value stays in the external buffer and is
+  // referenced by offset. Object keys are always inline.
   //
-  // Defaults to 1KiB, sized so that ordinary metadata (model names, roles,
-  // tool names) stays inline and directly usable while conversation content
-  // goes to the buffer. Raising it buys inline access to larger values at the
-  // cost of per-stream memory.
+  // This is the deployment-wide default, applied when a declared API's payload
+  // schema does not pin its own threshold. Defaults to 1KiB, which keeps
+  // ordinary metadata (model names, roles, tool names) inline while
+  // conversation content goes to the buffer.
   //
-  // Lowering it is bounded at 64 bytes, which clears every string a payload
-  // schema fixes in size — the ``role`` and ``type`` enumerations are the
-  // longest at 9 bytes. Provider-determined identifiers have no such bound: a
-  // ``model`` name longer than the configured threshold offloads, and
-  // ``model`` is declared non-offloadable, so such a payload fails validation
-  // with a 400 on a declared AI endpoint. Deployments that lower this should
-  // set it above the longest identifier their providers issue.
+  // Set it above the longest identifier the configured providers issue: a
+  // ``model`` name over the threshold offloads, and ``model`` is
+  // non-offloadable, so such a payload is rejected with a 400.
   google.protobuf.UInt32Value inline_string_threshold_bytes = 1
       [(validate.rules).uint32 = {lte: 1048576 gte: 64}];
 }

--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -61,6 +61,20 @@ message RequestHandling {
   // route that declared no AI wire contract has nothing to hold its payload
   // to, so a body that fails to parse is forwarded unchanged.
   bool parse_unconfigured_routes = 1;
+
+  // Maximum size, in bytes, of a decoded request payload string value kept
+  // inline in the parsed document. A value larger than this is left in the
+  // external buffer and recorded as a reference to its bytes, so a large
+  // prompt costs one small node instead of a per-stream copy.
+  //
+  // Defaults to 1KiB, sized so that ordinary metadata (model names, roles,
+  // tool names) stays inline and directly usable while conversation content
+  // goes to the buffer. Raising it buys inline access to larger values at the
+  // cost of per-stream memory. Lowering it past the metadata a payload schema
+  // requires inline — ``model`` and ``role`` are declared non-offloadable —
+  // makes such payloads fail validation with a 400 on declared AI endpoints.
+  google.protobuf.UInt32Value inline_string_threshold_bytes = 2
+      [(validate.rules).uint32 = {lte: 1048576 gte: 1}];
 }
 
 // Response-side processing configuration. Individual response features are

--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -62,19 +62,32 @@ message RequestHandling {
   // to, so a body that fails to parse is forwarded unchanged.
   bool parse_unconfigured_routes = 1;
 
-  // Maximum size, in bytes, of a decoded request payload string value kept
-  // inline in the parsed document. A value larger than this is left in the
-  // external buffer and recorded as a reference to its bytes, so a large
-  // prompt costs one small node instead of a per-stream copy.
+  // Request-path parsing limits. Defaults apply when unset.
+  RequestParsingLimits limits = 2;
+}
+
+// Per-stream limits for request payload parsing.
+message RequestParsingLimits {
+  // Maximum size, in bytes, of a decoded string value kept inline in the
+  // parsed document. A value larger than this is left in the external buffer
+  // and recorded as a reference to its bytes, so a large prompt costs one
+  // small node instead of a per-stream copy. Object keys are always inline
+  // and unaffected.
   //
   // Defaults to 1KiB, sized so that ordinary metadata (model names, roles,
   // tool names) stays inline and directly usable while conversation content
   // goes to the buffer. Raising it buys inline access to larger values at the
-  // cost of per-stream memory. Lowering it past the metadata a payload schema
-  // requires inline — ``model`` and ``role`` are declared non-offloadable —
-  // makes such payloads fail validation with a 400 on declared AI endpoints.
-  google.protobuf.UInt32Value inline_string_threshold_bytes = 2
-      [(validate.rules).uint32 = {lte: 1048576 gte: 1}];
+  // cost of per-stream memory.
+  //
+  // Lowering it is bounded at 64 bytes, which clears every string a payload
+  // schema fixes in size — the ``role`` and ``type`` enumerations are the
+  // longest at 9 bytes. Provider-determined identifiers have no such bound: a
+  // ``model`` name longer than the configured threshold offloads, and
+  // ``model`` is declared non-offloadable, so such a payload fails validation
+  // with a 400 on a declared AI endpoint. Deployments that lower this should
+  // set it above the longest identifier their providers issue.
+  google.protobuf.UInt32Value inline_string_threshold_bytes = 1
+      [(validate.rules).uint32 = {lte: 1048576 gte: 64}];
 }
 
 // Response-side processing configuration. Individual response features are

--- a/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
+++ b/api/envoy/extensions/filters/http/ai_protocol_manager/v3/ai_protocol_manager.proto
@@ -77,9 +77,9 @@ message RequestParsingLimits {
   // ordinary metadata (model names, roles, tool names) inline while
   // conversation content goes to the buffer.
   //
-  // Set it above the longest identifier the configured providers issue: a
-  // ``model`` name over the threshold offloads, and ``model`` is
-  // non-offloadable, so such a payload is rejected with a 400.
+  // Keep it above the longest ``model`` name in use. Values over the threshold
+  // are offloaded, and on a declared AI endpoint the payload schema requires
+  // ``model`` inline, so an offloaded one is rejected with a 400.
   google.protobuf.UInt32Value inline_string_threshold_bytes = 1
       [(validate.rules).uint32 = {lte: 1048576 gte: 64}];
 }

--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -49,7 +49,11 @@ forwarded for the upstream to interpret differently. Parsing is incremental and 
 stream, so an invalid payload fails as soon as the offending byte arrives rather
 than after the whole upload. Oversized string values are left in the external
 buffer and referenced by offset, so a large prompt does not reappear in
-per-stream memory.
+per-stream memory. What counts as oversized is
+:ref:`inline_string_threshold_bytes
+<envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestHandling.inline_string_threshold_bytes>`,
+1KiB by default -- large enough that ordinary metadata stays inline and small
+enough that conversation content does not.
 
 Upon stream completion, the parsed document is validated against the payload
 schema of the route's declared :ref:`wire API

--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -51,7 +51,7 @@ than after the whole upload. Oversized string values are left in the external
 buffer and referenced by offset, so a large prompt does not reappear in
 per-stream memory. What counts as oversized is
 :ref:`inline_string_threshold_bytes
-<envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestHandling.inline_string_threshold_bytes>`,
+<envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestParsingLimits.inline_string_threshold_bytes>`,
 1KiB by default -- large enough that ordinary metadata stays inline and small
 enough that conversation content does not.
 

--- a/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
+++ b/docs/root/configuration/http/http_filters/ai_protocol_manager_filter.rst
@@ -53,7 +53,8 @@ per-stream memory. What counts as oversized is
 :ref:`inline_string_threshold_bytes
 <envoy_v3_api_field_extensions.filters.http.ai_protocol_manager.v3.RequestParsingLimits.inline_string_threshold_bytes>`,
 1KiB by default -- large enough that ordinary metadata stays inline and small
-enough that conversation content does not.
+enough that conversation content does not. A declared API whose payload schema
+pins its own threshold uses that instead.
 
 Upon stream completion, the parsed document is validated against the payload
 schema of the route's declared :ref:`wire API

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -117,7 +117,7 @@ FilterConfig::FilterConfig(
       request_handling_enabled_(proto.has_request_handling()),
       parse_unconfigured_routes_(proto.request_handling().parse_unconfigured_routes()),
       inline_string_threshold_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
-          proto.request_handling(), inline_string_threshold_bytes,
+          proto.request_handling().limits(), inline_string_threshold_bytes,
           JsonWithExtBufParser::kDefaultInlineStringThresholdBytes)),
       token_usage_enabled_(proto.response_handling().has_token_usage()),
       include_unconfigured_routes_(

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -116,6 +116,9 @@ FilterConfig::FilterConfig(
           ALL_AI_PROTOCOL_MANAGER_STATS(POOL_COUNTER_PREFIX(scope, "ai_protocol_manager."))}),
       request_handling_enabled_(proto.has_request_handling()),
       parse_unconfigured_routes_(proto.request_handling().parse_unconfigured_routes()),
+      inline_string_threshold_bytes_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          proto.request_handling(), inline_string_threshold_bytes,
+          JsonWithExtBufParser::kDefaultInlineStringThresholdBytes)),
       token_usage_enabled_(proto.response_handling().has_token_usage()),
       include_unconfigured_routes_(
           proto.response_handling().token_usage().include_unconfigured_routes()),
@@ -193,7 +196,9 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
     return Http::FilterHeadersStatus::Continue;
   }
 
-  request_parser_ = std::make_unique<JsonWithExtBufParser>(JsonWithExtBufParser::Config{});
+  JsonWithExtBufParser::Config parser_config;
+  parser_config.inline_string_threshold_bytes = config_->inlineStringThresholdBytes();
+  request_parser_ = std::make_unique<JsonWithExtBufParser>(parser_config);
   // Built here, not at setDecoderFilterCallbacks(), so a pass-through stream pays
   // for none of it: constructing it subscribes to upstream watermarks and claims
   // a schedulable callback.

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -197,7 +197,7 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
   }
 
   JsonWithExtBufParser::Config parser_config;
-  parser_config.inline_string_threshold_bytes = config_->inlineStringThresholdBytes();
+  parser_config.inline_string_threshold_bytes = inlineStringThresholdBytes();
   request_parser_ = std::make_unique<JsonWithExtBufParser>(parser_config);
   // Built here, not at setDecoderFilterCallbacks(), so a pass-through stream pays
   // for none of it: constructing it subscribes to upstream watermarks and claims
@@ -211,6 +211,24 @@ Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHe
   // for an empty/trailer-only body, when the manager continues iteration).
   ENVOY_LOG(trace, "ai_protocol_manager: holding headers until payload is offloaded");
   return Http::FilterHeadersStatus::StopIteration;
+}
+
+uint32_t AiProtocolManagerFilter::inlineStringThresholdBytes() const {
+  // The filter's configured value is the default. A declared endpoint's payload
+  // schema may pin its own, because what has to stay inline for the payload to
+  // validate is a property of the wire API, not of the deployment.
+  if (isAiEndpoint()) {
+    if (const PayloadSchema* payload_schema =
+            AdapterRegistry::get(route_request_protocol_).schema();
+        payload_schema != nullptr) {
+      if (const std::optional<uint32_t> pinned =
+              payload_schema->requestInlineStringThresholdBytes();
+          pinned.has_value()) {
+        return *pinned;
+      }
+    }
+  }
+  return config_->inlineStringThresholdBytes();
 }
 
 bool AiProtocolManagerFilter::feedParser(const Buffer::Instance& data, bool end_stream) {

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -77,6 +77,7 @@ public:
 
   bool requestHandlingEnabled() const { return request_handling_enabled_; }
   bool parseUnconfiguredRoutes() const { return parse_unconfigured_routes_; }
+  uint32_t inlineStringThresholdBytes() const { return inline_string_threshold_bytes_; }
   bool tokenUsageEnabled() const { return token_usage_enabled_; }
   bool includeUnconfiguredRoutes() const { return include_unconfigured_routes_; }
   ApiProtocol defaultApiProtocol() const { return default_api_protocol_; }
@@ -92,6 +93,7 @@ private:
   mutable AiProtocolManagerStats stats_;
   const bool request_handling_enabled_ = false;
   const bool parse_unconfigured_routes_ = false;
+  const uint32_t inline_string_threshold_bytes_ = 0;
   const bool token_usage_enabled_ = false;
   const bool include_unconfigured_routes_ = false;
   const ApiProtocol default_api_protocol_ = ApiProtocol::Unspecified;

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -222,6 +222,10 @@ private:
   // what makes a parse failure fatal.
   bool isAiEndpoint() const { return route_has_request_; }
 
+  // The inline-string threshold for this stream: the route's payload schema
+  // when it pins one, otherwise the filter's configured default.
+  uint32_t inlineStringThresholdBytes() const;
+
   // Publish the accumulated token usage as dynamic metadata and account stats.
   // Called exactly once, at response end of stream (data or trailers).
   void finalizeResponseHandling();

--- a/source/extensions/filters/http/ai_protocol_manager/schema.h
+++ b/source/extensions/filters/http/ai_protocol_manager/schema.h
@@ -173,6 +173,18 @@ public:
 
   const Schema& rootSchema() const { return root_schema_; }
 
+  // Pins the inline-string threshold for payloads on this schema, overriding
+  // the filter's configured default. Declare it where what must stay inline is
+  // a property of the wire API rather than of the deployment; left unset, the
+  // filter's default applies.
+  RequestSchema& inlineStringThresholdBytes(uint32_t bytes) {
+    inline_string_threshold_bytes_ = bytes;
+    return *this;
+  }
+  std::optional<uint32_t> inlineStringThresholdBytes() const {
+    return inline_string_threshold_bytes_;
+  }
+
   // Returns the declared canonical ordering of streamable / offloadable field paths.
   const std::vector<std::string>& streamableFieldOrder() const { return streamable_field_order_; }
 
@@ -191,6 +203,7 @@ public:
 private:
   Schema root_schema_;
   std::vector<std::string> streamable_field_order_;
+  std::optional<uint32_t> inline_string_threshold_bytes_;
 };
 
 // Response schema definition. Left empty / placeholder for now as response
@@ -234,6 +247,11 @@ public:
   // Returns all offloadable field paths declared in the request schema.
   std::vector<std::string> requestOffloadableFieldPaths() const {
     return request_schema_.offloadableFieldPaths();
+  }
+
+  // The request schema's own inline-string threshold, if it declares one.
+  std::optional<uint32_t> requestInlineStringThresholdBytes() const {
+    return request_schema_.inlineStringThresholdBytes();
   }
 
   absl::Status validateRequest(const JsonWithExtBuf& payload) const {

--- a/test/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/BUILD
@@ -174,6 +174,7 @@ envoy_extension_cc_test(
     deps = [
         "//source/extensions/filters/http/ai_protocol_manager:config",
         "//test/mocks/server:factory_context_mocks",
+        "//test/mocks/stats:stats_mocks",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/ai_protocol_manager/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/ai_protocol_manager/config_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/config_test.cc
@@ -5,6 +5,7 @@
 #include "source/extensions/filters/http/ai_protocol_manager/filter.h"
 
 #include "test/mocks/server/factory_context.h"
+#include "test/mocks/stats/mocks.h"
 #include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
@@ -123,6 +124,40 @@ TEST(AiProtocolManagerConfigTest, RejectsZeroCaps) {
         ->mutable_limits()
         ->mutable_max_parsed_sse_events()
         ->set_value(0);
+    EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).IgnoreError(),
+                 EnvoyException);
+  }
+}
+
+// The parser's inline-string threshold comes from the request-handling config,
+// falling back to the parser's own default when unset.
+TEST(AiProtocolManagerConfigTest, InlineStringThresholdDefaultsAndOverrides) {
+  NiceMock<Stats::MockIsolatedStatsStore> stats_store;
+  {
+    envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto_config;
+    proto_config.mutable_request_handling();
+    const FilterConfig config(proto_config, *stats_store.rootScope());
+    EXPECT_EQ(config.inlineStringThresholdBytes(),
+              JsonWithExtBufParser::kDefaultInlineStringThresholdBytes);
+  }
+  {
+    envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto_config;
+    proto_config.mutable_request_handling()->mutable_inline_string_threshold_bytes()->set_value(
+        4096);
+    const FilterConfig config(proto_config, *stats_store.rootScope());
+    EXPECT_EQ(config.inlineStringThresholdBytes(), 4096);
+  }
+}
+
+// The threshold is bounded on both ends: zero would offload every non-empty
+// string, and an unbounded value would defeat the offload it gates.
+TEST(AiProtocolManagerConfigTest, RejectsOutOfRangeInlineStringThreshold) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  AiProtocolManagerFilterConfigFactory factory;
+  for (const uint32_t value : {0u, 2u * 1024u * 1024u}) {
+    envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto_config;
+    proto_config.mutable_request_handling()->mutable_inline_string_threshold_bytes()->set_value(
+        value);
     EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).IgnoreError(),
                  EnvoyException);
   }

--- a/test/extensions/filters/http/ai_protocol_manager/config_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/config_test.cc
@@ -142,22 +142,27 @@ TEST(AiProtocolManagerConfigTest, InlineStringThresholdDefaultsAndOverrides) {
   }
   {
     envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto_config;
-    proto_config.mutable_request_handling()->mutable_inline_string_threshold_bytes()->set_value(
-        4096);
+    proto_config.mutable_request_handling()
+        ->mutable_limits()
+        ->mutable_inline_string_threshold_bytes()
+        ->set_value(4096);
     const FilterConfig config(proto_config, *stats_store.rootScope());
     EXPECT_EQ(config.inlineStringThresholdBytes(), 4096);
   }
 }
 
-// The threshold is bounded on both ends: zero would offload every non-empty
-// string, and an unbounded value would defeat the offload it gates.
+// The threshold is bounded on both ends: a value under the floor offloads
+// strings a payload schema fixes in size, and an unbounded value would defeat
+// the offload it gates.
 TEST(AiProtocolManagerConfigTest, RejectsOutOfRangeInlineStringThreshold) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   AiProtocolManagerFilterConfigFactory factory;
-  for (const uint32_t value : {0u, 2u * 1024u * 1024u}) {
+  for (const uint32_t value : {0u, 32u, 2u * 1024u * 1024u}) {
     envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto_config;
-    proto_config.mutable_request_handling()->mutable_inline_string_threshold_bytes()->set_value(
-        value);
+    proto_config.mutable_request_handling()
+        ->mutable_limits()
+        ->mutable_inline_string_threshold_bytes()
+        ->set_value(value);
     EXPECT_THROW(factory.createFilterFactoryFromProto(proto_config, "stats", context).IgnoreError(),
                  EnvoyException);
   }

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -84,8 +84,10 @@ public:
     envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto;
     proto.mutable_request_handling()->set_parse_unconfigured_routes(parse_unconfigured_routes);
     if (inline_string_threshold_bytes != 0) {
-      proto.mutable_request_handling()->mutable_inline_string_threshold_bytes()->set_value(
-          inline_string_threshold_bytes);
+      proto.mutable_request_handling()
+          ->mutable_limits()
+          ->mutable_inline_string_threshold_bytes()
+          ->set_value(inline_string_threshold_bytes);
     }
     filter_ = std::make_unique<AiProtocolManagerFilter>(
         factory_, std::make_shared<const FilterConfig>(proto, *stats_store_.rootScope()));

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -74,13 +74,19 @@ public:
   // Run at trace so debug/trace-log argument expressions execute too.
   LogLevelSetter log_level_setter_{spdlog::level::trace};
 
-  // A test wanting a different filter-level config calls this again first.
-  void createFilter(bool parse_unconfigured_routes = false) {
+  // A test wanting a different filter-level config calls this again first. A
+  // zero threshold leaves the field unset, so the default applies.
+  void createFilter(bool parse_unconfigured_routes = false,
+                    uint32_t inline_string_threshold_bytes = 0) {
     if (filter_ != nullptr) {
       filter_->onDestroy();
     }
     envoy::extensions::filters::http::ai_protocol_manager::v3::AiProtocolManager proto;
     proto.mutable_request_handling()->set_parse_unconfigured_routes(parse_unconfigured_routes);
+    if (inline_string_threshold_bytes != 0) {
+      proto.mutable_request_handling()->mutable_inline_string_threshold_bytes()->set_value(
+          inline_string_threshold_bytes);
+    }
     filter_ = std::make_unique<AiProtocolManagerFilter>(
         factory_, std::make_shared<const FilterConfig>(proto, *stats_store_.rootScope()));
     filter_->setDecoderFilterCallbacks(callbacks_);
@@ -112,6 +118,14 @@ public:
     route_config_ = std::make_unique<RouteConfig>(proto);
     ON_CALL(callbacks_, mostSpecificPerFilterConfig())
         .WillByDefault(testing::Return(route_config_.get()));
+  }
+
+  // A valid chat-completions payload whose `model` sits between the default
+  // 1KiB inline-string threshold and 4KiB, so which side of the threshold it
+  // lands on is the configured value's doing.
+  static std::string oversizedModelPayload() {
+    return R"({"model":")" + std::string(2000, 'm') +
+           R"(","messages":[{"role":"user","content":"hi"}]})";
   }
 
   static Http::TestRequestHeaderMapImpl requestHeaders() {
@@ -1143,6 +1157,40 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
 
   const std::string payload =
       R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":256})";
+  Buffer::OwnedImpl body(payload);
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 0);
+  EXPECT_EQ(injected_.toString(), payload);
+  EXPECT_TRUE(injected_end_stream_);
+}
+
+// A payload whose `model` is larger than the inline-string threshold: the
+// parser offloads the value, and the schema declares `model` non-offloadable,
+// so the default 1KiB threshold rejects it.
+TEST_F(AiProtocolManagerFilterTest, ModelOverInlineStringThresholdIsRejected) {
+  setRouteConfig();
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  Buffer::OwnedImpl body(oversizedModelPayload());
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 1);
+  EXPECT_EQ(local_reply_code_, Http::Code::BadRequest);
+  EXPECT_EQ(local_reply_details_, "ai_protocol_manager_invalid_json");
+  EXPECT_EQ(inject_calls_, 0);
+}
+
+// The same payload is accepted once the configured threshold is raised above
+// the value: the configured threshold, not the default, reaches the parser.
+TEST_F(AiProtocolManagerFilterTest, RaisedInlineStringThresholdKeepsLargeValuesInline) {
+  createFilter(/*parse_unconfigured_routes=*/false, /*inline_string_threshold_bytes=*/4096);
+  setRouteConfig();
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  const std::string payload = oversizedModelPayload();
   Buffer::OwnedImpl body(payload);
   EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
   drain();

--- a/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/schema_test.cc
@@ -328,10 +328,12 @@ TEST(SchemaTest, NullableValidation) {
 }
 
 TEST(SchemaTest, RequestResponseAndPayloadSchema) {
-  // Default RequestSchema.
+  // Default RequestSchema. An unpinned inline-string threshold reads as absent,
+  // which is what leaves the filter's configured default in force.
   RequestSchema default_req;
   EXPECT_TRUE(default_req.streamableFieldOrder().empty());
   EXPECT_TRUE(default_req.offloadableFieldPaths().empty());
+  EXPECT_FALSE(default_req.inlineStringThresholdBytes().has_value());
   EXPECT_THAT(default_req.validate(nlohmann::json::object()), IsOk());
 
   // Default ResponseSchema.
@@ -356,6 +358,14 @@ TEST(SchemaTest, RequestResponseAndPayloadSchema) {
             std::vector<std::string>{"prompt"});
   EXPECT_EQ(payload_schema.responseSchema().streamableFieldOrder(),
             std::vector<std::string>{"data"});
+  EXPECT_FALSE(payload_schema.requestInlineStringThresholdBytes().has_value());
+
+  // A pinned threshold is carried through the payload schema, which is what the
+  // filter reads in preference to its configured default.
+  RequestSchema pinned_req(Schema::object({{"prompt", Schema::string().offloadable()}}));
+  pinned_req.inlineStringThresholdBytes(256);
+  EXPECT_EQ(pinned_req.inlineStringThresholdBytes(), 256);
+  EXPECT_EQ(PayloadSchema(pinned_req).requestInlineStringThresholdBytes(), 256);
 
   // Validate request via JsonWithExtBuf and nlohmann::json.
   JsonWithExtBuf doc;


### PR DESCRIPTION
The request-path JSON parser (JsonWithExtBufParser) keeps a string value inline in the
parsed document up to a threshold and records anything larger as a reference into the
external buffer. The threshold was a parser Config field, but the filter always built the
parser with Config{}, so the 1KiB default was effectively hardcoded and no configuration
could reach it.

Expose it as RequestHandling.inline_string_threshold_bytes (UInt32Value, 1 byte to
1MiB), defaulting to the parser's own constant so the 1KiB default stays single-sourced.

https://github.com/envoyproxy/envoy/issues/44681

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
