### PR TITLE
http: prefer to call new unified factory directly 2

### DIFF
--- a/source/extensions/filters/http/composite/action.cc
+++ b/source/extensions/filters/http/composite/action.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/http/composite/action.h"
 
+#include "envoy/server/filter_config.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -151,8 +153,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionDown
 
   // First, try to create the filter factory creation function from factory context (if exists).
   if (context.factory_context_.has_value()) {
-    auto callback_or_status = factory.createFilterFactoryFromProto(
-        *message, context.stat_prefix_, context.factory_context_.value());
+    auto callback_or_status = Server::Configuration::createHttpFilterFactory(
+        factory, *message, context.stat_prefix_, context.factory_context_.ref());
     THROW_IF_NOT_OK_REF(callback_or_status.status());
     callback = callback_or_status.value();
   }
@@ -186,8 +188,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createStaticActionUpst
   // First, try to create the filter factory creation function from upstream factory context (if
   // exists).
   if (context.upstream_factory_context_.has_value()) {
-    auto callback_or_status = factory.createFilterFactoryFromProto(
-        *message, context.stat_prefix_, context.upstream_factory_context_.value());
+    auto callback_or_status = Server::Configuration::createHttpFilterFactory(
+        factory, *message, context.stat_prefix_, context.upstream_factory_context_.ref());
     THROW_IF_NOT_OK_REF(callback_or_status.status());
     callback = callback_or_status.value();
   }
@@ -220,8 +222,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainActio
 
       // First, try to create from factory context.
       if (context.factory_context_.has_value()) {
-        auto callback_or_status = factory.createFilterFactoryFromProto(
-            *message, context.stat_prefix_, context.factory_context_.value());
+        auto callback_or_status = Server::Configuration::createHttpFilterFactory(
+            factory, *message, context.stat_prefix_, context.factory_context_.ref());
         THROW_IF_NOT_OK_REF(callback_or_status.status());
         callback = callback_or_status.value();
       }
@@ -248,8 +250,8 @@ Matcher::ActionConstSharedPtr ExecuteFilterActionFactory::createFilterChainActio
           filter_config.typed_config(), validation_visitor, factory);
 
       if (context.upstream_factory_context_.has_value()) {
-        auto callback_or_status = factory.createFilterFactoryFromProto(
-            *message, context.stat_prefix_, context.upstream_factory_context_.value());
+        auto callback_or_status = Server::Configuration::createHttpFilterFactory(
+            factory, *message, context.stat_prefix_, context.upstream_factory_context_.ref());
         THROW_IF_NOT_OK_REF(callback_or_status.status());
         callback = callback_or_status.value();
       }

--- a/source/extensions/filters/http/composite/config.cc
+++ b/source/extensions/filters/http/composite/config.cc
@@ -63,8 +63,8 @@ CompositeFilterFactory::compileNamedFilterChains(
               filter_config);
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
           filter_config.typed_config(), context.messageValidationVisitor(), factory);
-      auto callback_or_status = Server::Configuration::createHttpFilterFactory(
-          factory, *message, stats_prefix, context);
+      auto callback_or_status =
+          Server::Configuration::createHttpFilterFactory(factory, *message, stats_prefix, context);
       if (!callback_or_status.status().ok()) {
         return absl::InvalidArgumentError(
             fmt::format("Failed to create filter factory for filter '{}' in named filter chain "

--- a/source/extensions/filters/http/composite/config.cc
+++ b/source/extensions/filters/http/composite/config.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/common/exception.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
 
 #include "source/common/config/utility.h"
 #include "source/extensions/filters/http/composite/filter.h"
@@ -62,8 +63,8 @@ CompositeFilterFactory::compileNamedFilterChains(
               filter_config);
       ProtobufTypes::MessagePtr message = Config::Utility::translateAnyToFactoryConfig(
           filter_config.typed_config(), context.messageValidationVisitor(), factory);
-      auto callback_or_status =
-          factory.createFilterFactoryFromProto(*message, stats_prefix, context);
+      auto callback_or_status = Server::Configuration::createHttpFilterFactory(
+          factory, *message, stats_prefix, context);
       if (!callback_or_status.status().ok()) {
         return absl::InvalidArgumentError(
             fmt::format("Failed to create filter factory for filter '{}' in named filter chain "

--- a/source/extensions/filters/http/filter_chain/filter.cc
+++ b/source/extensions/filters/http/filter_chain/filter.cc
@@ -64,7 +64,8 @@ absl::StatusOr<FilterFactoriesVector> createFilterFactoriesFromConfig(
 
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         filter_config, context.messageValidationVisitor(), factory);
-    auto callback_or_error = factory.createFilterFactoryFromProto(*message, stats_prefix, context);
+    auto callback_or_error =
+        Server::Configuration::createHttpFilterFactory(factory, *message, stats_prefix, context);
     RETURN_IF_NOT_OK_REF(callback_or_error.status());
 
     auto filter_config_provider =

--- a/source/extensions/filters/http/match_delegate/config.cc
+++ b/source/extensions/filters/http/match_delegate/config.cc
@@ -284,7 +284,8 @@ absl::StatusOr<Envoy::Http::FilterFactoryCb> MatchDelegateConfig::createFilterFa
     FilterCfgFactory& factory) {
   auto message = Config::Utility::translateAnyToFactoryConfig(
       proto_config.extension_config().typed_config(), validation, factory);
-  auto filter_factory_or_error = factory.createFilterFactoryFromProto(*message, prefix, context);
+  auto filter_factory_or_error =
+      Server::Configuration::createHttpFilterFactory(factory, *message, prefix, context);
   RETURN_IF_NOT_OK_REF(filter_factory_or_error.status());
   auto filter_factory = filter_factory_or_error.value();
 


### PR DESCRIPTION
Commit Message: http: prefer to call new unified factory directly 2
Additional Description:

The left part of https://github.com/envoyproxy/envoy/pull/47050.

> Now, if the HTTP filter implemented UnifiedFactoryBase, the caller will call the createHttpFilterFactoryFromProto to create HTTP filter factory directly rather than to call the legacy createFilterFactoryFromProto.
By this way, we could gradually deprecate the legacy createFilterFactoryFromProto and migrate to new createHttpFilterFactoryFromProto smoothly.
This PR self won't change any existing behavior, and won't break out-of-tree extensions.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.