### PR TITLE
http: deprecated the legacy HTTP filter factory interfaces

### DIFF
--- a/changelogs/current/deprecated/http__legacy-http-filter-factory-bases.rst
+++ b/changelogs/current/deprecated/http__legacy-http-filter-factory-bases.rst
@@ -1,0 +1,12 @@
+The HTTP filter factory base classes ``FactoryBase``, ``ExceptionFreeFactoryBase``, and
+``DualFactoryBase``, together with the ``createFilterFactoryFromProto()`` entry points on
+``NamedHttpFilterConfigFactory`` and ``UpstreamHttpFilterConfigFactory``, are deprecated in favor
+of ``UnifiedFactoryBase`` and its single ``createHttpFilterFactoryFromProtoTyped()`` entry point,
+which serves both the downstream and the upstream HTTP filter chains. This only affects extension
+code, not configuration. ``createFilterFactoryFromProto()`` is no longer pure virtual: it now
+defaults to delegating to ``createHttpFilterFactoryFromProto()``, so a factory that implements the
+interfaces directly only needs to implement the new entry point. The deprecated classes and methods
+keep working and will be removed once the in-tree and out-of-tree extensions have migrated. Note
+that Envoy itself builds with ``-Wno-deprecated-declarations``, so these deprecations are only
+visible to out-of-tree builds that enable the warning; such builds can pass
+``-Wno-deprecated-declarations`` to keep compiling while the migration is in progress.

--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -411,6 +411,12 @@ public:
    * Create a particular http filter factory implementation. If the implementation is unable to
    * produce a factory with the provided parameters, it should throw an EnvoyException. The returned
    * callback should always be initialized.
+   *
+   * NOTE: this method is deprecated and will be removed once all the in-tree and out-of-tree
+   * extensions are migrated. Extensions should extend
+   * Extensions::HttpFilters::Common::UnifiedFactoryBase and implement
+   * createHttpFilterFactoryFromProto instead.
+   *
    * @param config supplies the general Protobuf message to be marshaled into a filter-specific
    * configuration.
    * @param stat_prefix prefix for stat logging
@@ -418,9 +424,15 @@ public:
    * @return  absl::StatusOr<Http::FilterFactoryCb> the factory creation function or an error if
    * creation fails.
    */
+  [[deprecated("Use createHttpFilterFactoryFromProto instead")]]
   virtual absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
-                               Server::Configuration::FactoryContext& context) PURE;
+                               Server::Configuration::FactoryContext& context) {
+    // Delegate to createHttpFilterFactoryFromProto so that extensions that only implement the
+    // unified entry point keep working when this legacy entry point is called.
+    auto extra_context = ExtraFactoryContext::create(context, stat_prefix);
+    return createHttpFilterFactoryFromProto(config, context.serverFactoryContext(), extra_context);
+  }
 
   /**
    * Create a particular http filter factory implementation. If the implementation is unable to
@@ -474,15 +486,27 @@ public:
    * Create a particular http filter factory implementation. If the implementation is unable to
    * produce a factory with the provided parameters, it should throw an EnvoyException. The returned
    * callback should always be initialized.
+   *
+   * NOTE: this method is deprecated and will be removed once all the in-tree and out-of-tree
+   * extensions are migrated. Extensions should extend
+   * Extensions::HttpFilters::Common::UnifiedFactoryBase and implement
+   * createHttpFilterFactoryFromProto instead.
+   *
    * @param config supplies the general Protobuf message to be marshaled into a filter-specific
    * configuration.
    * @param stat_prefix prefix for stat logging
    * @param context supplies the filter's context.
    * @return Http::FilterFactoryCb the factory creation function.
    */
+  [[deprecated("Use createHttpFilterFactoryFromProto instead")]]
   virtual absl::StatusOr<Http::FilterFactoryCb>
   createFilterFactoryFromProto(const Protobuf::Message& config, const std::string& stat_prefix,
-                               Server::Configuration::UpstreamFactoryContext& context) PURE;
+                               Server::Configuration::UpstreamFactoryContext& context) {
+    // Delegate to createHttpFilterFactoryFromProto so that extensions that only implement the
+    // unified entry point keep working when this legacy entry point is called.
+    auto extra_context = ExtraFactoryContext::create(context, stat_prefix);
+    return createHttpFilterFactoryFromProto(config, context.serverFactoryContext(), extra_context);
+  }
 
   /**
    * Create a particular http filter factory implementation. If the implementation is unable to

--- a/source/extensions/filters/http/common/factory_base.h
+++ b/source/extensions/filters/http/common/factory_base.h
@@ -77,9 +77,16 @@ protected:
   const std::string name_;
 };
 
+/**
+ * DEPRECATED: use UnifiedFactoryBase instead. This base class is only kept to give the
+ * out-of-tree extensions time to migrate to the unified factory interface and will be removed
+ * once the migration is complete.
+ */
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
-class FactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
-                    public Server::Configuration::NamedHttpFilterConfigFactory {
+class [[deprecated(
+    "Extend UnifiedFactoryBase and implement createHttpFilterFactoryFromProtoTyped instead")]]
+FactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
+              public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
   FactoryBase(const std::string& name) : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
 
@@ -133,9 +140,16 @@ public:
   }
 };
 
+/**
+ * DEPRECATED: use UnifiedFactoryBase instead. This base class is only kept to give the
+ * out-of-tree extensions time to migrate to the unified factory interface and will be removed
+ * once the migration is complete.
+ */
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
-class ExceptionFreeFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
-                                 public Server::Configuration::NamedHttpFilterConfigFactory {
+class [[deprecated(
+    "Extend UnifiedFactoryBase and implement createHttpFilterFactoryFromProtoTyped instead")]]
+ExceptionFreeFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
+                           public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
   ExceptionFreeFactoryBase(const std::string& name)
       : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
@@ -173,10 +187,18 @@ public:
   }
 };
 
+/**
+ * DEPRECATED: use UnifiedFactoryBase instead. UnifiedFactoryBase supports both the downstream
+ * and the upstream HTTP filter chains. This base class is only kept to give the out-of-tree
+ * extensions time to migrate to the unified factory interface and will be removed once the
+ * migration is complete.
+ */
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
-class DualFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
-                        public Server::Configuration::NamedHttpFilterConfigFactory,
-                        public Server::Configuration::UpstreamHttpFilterConfigFactory {
+class [[deprecated(
+    "Extend UnifiedFactoryBase and implement createHttpFilterFactoryFromProtoTyped instead")]]
+DualFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
+                  public Server::Configuration::NamedHttpFilterConfigFactory,
+                  public Server::Configuration::UpstreamHttpFilterConfigFactory {
 public:
   DualFactoryBase(const std::string& name)
       : CommonFactoryBase<ConfigProto, RouteConfigProto>(name) {}
@@ -256,6 +278,11 @@ private:
   }
 };
 
+/**
+ * Base class for HTTP filter factory registrations. This is the recommended base class for all
+ * the HTTP filter factories. It supports both the downstream and the upstream HTTP filter chains
+ * and only requires the single createHttpFilterFactoryFromProtoTyped() entry point.
+ */
 template <class ConfigProto, class RouteConfigProto = ConfigProto>
 class UnifiedFactoryBase : public CommonFactoryBase<ConfigProto, RouteConfigProto>,
                            public Server::Configuration::NamedHttpFilterConfigFactory,


### PR DESCRIPTION
Commit Message: http: deprecated the legacy HTTP filter factory interfaces
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
