### PR TITLE
Update QUICHE from 01408281e to 5c9cc6b37

### DIFF
--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -1007,7 +1007,7 @@ quiche:
   project_name: "QUICHE"
   project_desc: "QUICHE (QUIC, HTTP/2, Etc) is Google‘s implementation of QUIC and related protocols"
   project_url: "https://github.com/google/quiche"
-  release_date: "2026-08-24"
+  release_date: "2026-08-31"
   use_category:
   - controlplane
   - dataplane_core

--- a/bazel/external/quiche.BUILD
+++ b/bazel/external/quiche.BUILD
@@ -1308,6 +1308,7 @@ envoy_cc_library(
         ":quiche_common_callbacks",
         ":quiche_common_circular_deque_lib",
         ":quiche_common_platform",
+        "@abseil-cpp//absl/container:chunked_queue",
     ],
 )
 
@@ -5174,7 +5175,10 @@ envoy_cc_library(
 envoy_cc_library(
     name = "quiche_balsa_balsa_frame_lib",
     srcs = ["quiche/balsa/balsa_frame.cc"],
-    hdrs = ["quiche/balsa/balsa_frame.h"],
+    hdrs = [
+        "quiche/balsa/balsa_frame.h",
+        "quiche/balsa/http_protocol_defects.h",
+    ],
     copts = quiche_copts,
     repository = "@envoy",
     deps = [

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -537,8 +537,8 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         urls = ["https://github.com/simdutf/simdutf/releases/download/v{version}/singleheader.zip"],
     ),
     quiche = dict(
-        version = "01408281e0d4541113cd8c15185d70f30c773b36",
-        sha256 = "d2be8be3c47ccb8bcc96bde210ccddc87c12a2ab6b50cc795399e1bdbea50f0d",
+        version = "5c9cc6b37f55a97071077a6190bf4f0bc7a09c1f",
+        sha256 = "da1f77ceff9ffdf65fdc4ff7fc63ba475e83015ed77fdb02d7fbc0118207d0ba",
         urls = ["https://github.com/google/quiche/archive/{version}.tar.gz"],
         strip_prefix = "quiche-{version}",
     ),


### PR DESCRIPTION
https://github.com/google/quiche/compare/01408281e..5c9cc6b37

```
$ git log 01408281e..5c9cc6b37 --date=short --no-merges --format="%ad %al %s"

2026-08-31 quiche-dev Migrate from the deprecated ABSL_ATTRIBUTE_UNUSED attribute to C++17 [[maybe_unused]]
2026-08-28 apaseltiner Replace direct uses of deprecated ParameterizedMember fields with accessors
2026-08-28 quiche-dev Migrate from the deprecated ABSL_ATTRIBUTE_UNUSED attribute to C++17 [[maybe_unused]]
2026-08-28 ericorth Create AsyncWritePacketExchanger
2026-08-28 vasilvv Remove leftover UNSUBSCRIBE message code.
2026-08-28 jprat Add logging for various policy-controlled HTTP properties.
2026-08-28 apaseltiner Deprecate direct-field access in ParameterizedMember and expose safer accessors
2026-08-27 vasilvv Use a pair of unidirectional streams for control messages.
2026-08-27 ericorth QBONE TUN exchanger async refactor: Pass exchanger an exchanger ;)
2026-08-27 ericorth QBONE TUN exchanger async refactor: Cleanup read write calls interface
2026-08-26 quiche-dev Migrate ABSL_ARRAYSIZE()/arraysize() to std::size(), std::extent_v, or other alternatives where possible
2026-08-26 quiche-dev Document that ProofSource::GetProof is only used for gQUIC.
2026-08-26 apaseltiner Use types instead of indices in Item::GetIf* methods
2026-08-25 jprat Guard internal checks with QUICHE annotations in `balsa_frame_test`.
2026-08-25 asedeno Fix OSS QUICHE build -- add missing dependency to BUILD.bazel
2026-08-25 jprat Add `unknown_transfer_encoding` and `multiple_transfer_encoding_keys` defects and integration tests for `validate_transfer_encoding` flag.
2026-08-25 martinduke Clear QuicPacketCreator::packet_.has_scone_packet.
2026-08-25 apaseltiner Deprecate GetStringStrict method in favor of GetString
2026-08-25 quiche-dev Enabling rolled out flags.
2026-08-25 goldvitaly No public description
2026-08-24 ricea Remove QUIC_BUG in when max_datagram_size is 0
```

Risk Level: low
Testing: CI