### PR TITLE
quic: change on_can_write_cb in QuicPacketWriterFactory to absl::AnyInvocable<void()>

### DIFF
--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -103,7 +103,7 @@ ActiveQuicListener::ActiveQuicListener(
       *connection_id_generator_, debug_visitor_factory,
       enable_session_idle_list ? std::make_unique<Http::SessionIdleList>(dispatcher) : nullptr);
 
-  absl::AnyInvocable<void() &&> on_can_write_cb = [&]() { quic_dispatcher_->OnCanWrite(); };
+  absl::AnyInvocable<void()> on_can_write_cb = [&]() { quic_dispatcher_->OnCanWrite(); };
 
   // Create quic_packet_writer
   QuicPacketWriterFactory* quic_packet_writer_factory =

--- a/source/common/quic/quic_packet_writer_interface.h
+++ b/source/common/quic/quic_packet_writer_interface.h
@@ -36,7 +36,7 @@ public:
   virtual QuicPacketWriterPtr
   createQuicPacketWriter(Network::IoHandle& io_handle, Stats::Scope& scope,
                          Event::Dispatcher& dispatcher,
-                         absl::AnyInvocable<void() &&> on_can_write_cb) PURE;
+                         absl::AnyInvocable<void()> on_can_write_cb) PURE;
 };
 
 using QuicPacketWriterFactoryPtr = std::unique_ptr<QuicPacketWriterFactory>;

--- a/test/common/listener_manager/listener_manager_impl_quic_only_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_quic_only_test.cc
@@ -22,7 +22,7 @@ class FakeQuicPacketWriterFactory : public Quic::QuicPacketWriterFactory {
 public:
   Quic::QuicPacketWriterPtr createQuicPacketWriter(Network::IoHandle&, Stats::Scope&,
                                                    Event::Dispatcher&,
-                                                   absl::AnyInvocable<void() &&>) override {
+                                                   absl::AnyInvocable<void()>) override {
     return nullptr;
   }
 };

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -786,7 +786,7 @@ public:
 
   MOCK_METHOD(QuicPacketWriterPtr, createQuicPacketWriter,
               (Network::IoHandle & io_handle, Stats::Scope& scope,
-               Envoy::Event::Dispatcher& dispatcher, absl::AnyInvocable<void() &&> on_can_write_cb),
+               Envoy::Event::Dispatcher& dispatcher, absl::AnyInvocable<void()> on_can_write_cb),
               (override));
 };
 
@@ -803,7 +803,7 @@ TEST_P(ActiveQuicListenerTest, DirectQuicPacketWriterCreation) {
   FakeQuicPacketWriter* raw_writer = nullptr;
   EXPECT_CALL(quic_packet_writer_factory, createQuicPacketWriter(_, _, _, _))
       .WillOnce(Invoke([&raw_writer](Network::IoHandle&, Stats::Scope&, Envoy::Event::Dispatcher&,
-                                     absl::AnyInvocable<void() &&>) -> QuicPacketWriterPtr {
+                                     absl::AnyInvocable<void()>) -> QuicPacketWriterPtr {
         auto writer = std::make_unique<FakeQuicPacketWriter>();
         raw_writer = writer.get();
         return writer;


### PR DESCRIPTION
…nvocable<void()>

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: quic: change on_can_write_cb in QuicPacketWriterFactory to absl::AnyInvocable<void()>
Additional Description: This change updates `on_can_write_cb` in `QuicPacketWriterFactory` to `absl::AnyInvocable<void()>`, allowing `QuicPacketWriterFactory` implementations to store and invoke the callback as an lvalue across the lifetime of the listener without requiring adapter wrappers.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
