### PR TITLE
compat/openssl: fix discards-qualifiers warning in `SSL_get_negotiated_group`

### DIFF
--- a/compat/openssl/source/SSL_get_negotiated_group.c
+++ b/compat/openssl/source/SSL_get_negotiated_group.c
@@ -1,0 +1,13 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * BoringSSL declares this with a `const SSL *`, but OpenSSL's
+ * ossl_SSL_get_negotiated_group() is a macro that expands to ossl_SSL_ctrl(),
+ * which takes a non-const `ossl_SSL *`. Cast away const to avoid the
+ * -Wincompatible-pointer-types-discards-qualifiers warning.
+ */
+int SSL_get_negotiated_group(const SSL *ssl) {
+  return ossl.ossl_SSL_get_negotiated_group((SSL*)ssl);
+}


### PR DESCRIPTION
The auto-generated forwarder for `SSL_get_negotiated_group` passed the `const SSL *` argument straight through to OpenSSL's `ossl_SSL_get_negotiated_group`, which is a macro expanding to `ossl_SSL_ctrl` and takes a non-const `ossl_SSL *`. This produced a `-Wincompatible-pointer-types-discards-qualifiers` warning.

Add a handwritten mapping source that casts away const, mirroring the existing `SSL_get_curve_id.c` shim which calls the same OpenSSL macro.
