### PR TITLE
Integration test deflake attempt

### DIFF
--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -472,6 +472,24 @@ FakeHttpConnection::FakeHttpConnection(
 
 FakeHttpConnection::~FakeHttpConnection() { shared_connection_.clearDisconnectCallback(); }
 
+AssertionResult FakeHttpConnection::halfCloseForCleanup(std::chrono::milliseconds timeout) {
+  ENVOY_LOG(trace, "FakeHttpConnection half-close for cleanup");
+  if (!shared_connection_.connected()) {
+    return AssertionSuccess();
+  }
+
+  return shared_connection_.executeOnDispatcher(
+      [this](Network::Connection& connection) {
+        shutting_down_for_cleanup_ = true;
+        if (!connection.isHalfCloseEnabled()) {
+          connection.enableHalfClose(true);
+        }
+        Buffer::OwnedImpl empty;
+        connection.write(empty, true);
+      },
+      timeout);
+}
+
 void FakeHttpConnection::initialize() {
   FakeConnectionBase::initialize();
   if (deferred_read_enable_ && shared_connection_.connected() &&
@@ -503,23 +521,6 @@ AssertionResult FakeConnectionBase::close(Network::ConnectionCloseType close_typ
   }
   return shared_connection_.executeOnDispatcher(
       [&close_type](Network::Connection& connection) { connection.close(close_type); }, timeout);
-}
-
-AssertionResult FakeConnectionBase::halfClose(std::chrono::milliseconds timeout) {
-  ENVOY_LOG(trace, "FakeConnectionBase half-close");
-  if (!shared_connection_.connected()) {
-    return AssertionSuccess();
-  }
-
-  return shared_connection_.executeOnDispatcher(
-      [](Network::Connection& connection) {
-        if (!connection.isHalfCloseEnabled()) {
-          connection.enableHalfClose(true);
-        }
-        Buffer::OwnedImpl empty;
-        connection.write(empty, true);
-      },
-      timeout);
 }
 
 AssertionResult

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -462,9 +462,15 @@ FakeHttpConnection::FakeHttpConnection(
     ASSERT(false, "running a QUIC integration test without compiling QUIC");
 #endif
   }
+  // The codec holds a reference to the network connection. Destroy it from the disconnect callback,
+  // while the connection is guaranteed to still be alive and before waitForDisconnect() can wake
+  // the test thread.
+  shared_connection_.setDisconnectCallback([this]() { codec_.reset(); });
   shared_connection_.connection().addReadFilter(
       Network::ReadFilterSharedPtr{new ReadFilter(*this)});
 }
+
+FakeHttpConnection::~FakeHttpConnection() { shared_connection_.clearDisconnectCallback(); }
 
 void FakeHttpConnection::initialize() {
   FakeConnectionBase::initialize();
@@ -499,6 +505,23 @@ AssertionResult FakeConnectionBase::close(Network::ConnectionCloseType close_typ
       [&close_type](Network::Connection& connection) { connection.close(close_type); }, timeout);
 }
 
+AssertionResult FakeConnectionBase::halfClose(std::chrono::milliseconds timeout) {
+  ENVOY_LOG(trace, "FakeConnectionBase half-close");
+  if (!shared_connection_.connected()) {
+    return AssertionSuccess();
+  }
+
+  return shared_connection_.executeOnDispatcher(
+      [](Network::Connection& connection) {
+        if (!connection.isHalfCloseEnabled()) {
+          connection.enableHalfClose(true);
+        }
+        Buffer::OwnedImpl empty;
+        connection.write(empty, true);
+      },
+      timeout);
+}
+
 AssertionResult
 FakeConnectionBase::halfCloseAndWaitForDisconnect(std::chrono::milliseconds timeout) {
   ENVOY_LOG(trace, "FakeConnectionBase half-close and wait for disconnect");
@@ -506,8 +529,13 @@ FakeConnectionBase::halfCloseAndWaitForDisconnect(std::chrono::milliseconds time
     return AssertionSuccess();
   }
 
+  bool half_close_was_enabled = false;
   AssertionResult result = shared_connection_.executeOnDispatcher(
-      [](Network::Connection& connection) {
+      [&half_close_was_enabled](Network::Connection& connection) {
+        half_close_was_enabled = connection.isHalfCloseEnabled();
+        if (half_close_was_enabled) {
+          return;
+        }
         connection.enableHalfClose(true);
         Buffer::OwnedImpl empty;
         connection.write(empty, true);
@@ -515,6 +543,10 @@ FakeConnectionBase::halfCloseAndWaitForDisconnect(std::chrono::milliseconds time
       timeout);
   if (!result) {
     return result;
+  }
+  if (half_close_was_enabled) {
+    return AssertionFailure()
+           << "Cannot wait for a reciprocal close on a connection configured for half-close.";
   }
   return waitForDisconnect(timeout);
 }

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -499,6 +499,26 @@ AssertionResult FakeConnectionBase::close(Network::ConnectionCloseType close_typ
       [&close_type](Network::Connection& connection) { connection.close(close_type); }, timeout);
 }
 
+AssertionResult
+FakeConnectionBase::halfCloseAndWaitForDisconnect(std::chrono::milliseconds timeout) {
+  ENVOY_LOG(trace, "FakeConnectionBase half-close and wait for disconnect");
+  if (!shared_connection_.connected()) {
+    return AssertionSuccess();
+  }
+
+  AssertionResult result = shared_connection_.executeOnDispatcher(
+      [](Network::Connection& connection) {
+        connection.enableHalfClose(true);
+        Buffer::OwnedImpl empty;
+        connection.write(empty, true);
+      },
+      timeout);
+  if (!result) {
+    return result;
+  }
+  return waitForDisconnect(timeout);
+}
+
 AssertionResult FakeConnectionBase::readDisable(bool disable, std::chrono::milliseconds timeout) {
   return shared_connection_.executeOnDispatcher(
       [disable](Network::Connection& connection) { connection.readDisable(disable); }, timeout);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -498,11 +498,6 @@ public:
   testing::AssertionResult close(Network::ConnectionCloseType close_type,
                                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
-  // Half-close the write side of a TCP connection without waiting for the peer to close.
-  ABSL_MUST_USE_RESULT
-  testing::AssertionResult
-  halfClose(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
-
   // Half-close the write side of a TCP connection and wait for the peer to close its side.
   // Successful completion proves that the peer observed the shutdown, unlike close(). The peer
   // must have half-close disabled so that it responds to the shutdown with a full close. Fails
@@ -621,12 +616,24 @@ public:
   Http::ServerHeaderValidatorPtr makeHeaderValidator();
   Http::CodecType type() const { return type_; }
 
+  // Stop dispatching HTTP data and half-close the write side of this connection. Both operations
+  // happen in one dispatcher callback so an EOF cannot be dispatched to an incomplete HTTP codec
+  // after the fake upstream has sent its FIN. Network reads remain enabled so cleanup can observe
+  // the peer's reciprocal FIN.
+  ABSL_MUST_USE_RESULT
+  testing::AssertionResult
+  halfCloseForCleanup(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
 private:
   struct ReadFilter : public Network::ReadFilterBaseImpl {
     ReadFilter(FakeHttpConnection& parent) : parent_(parent) {}
 
     // Network::ReadFilter
     Network::FilterStatus onData(Buffer::Instance& data, bool) override {
+      if (parent_.shutting_down_for_cleanup_) {
+        data.drain(data.length());
+        return Network::FilterStatus::StopIteration;
+      }
       Http::Status status = parent_.codec_->dispatch(data);
 
       if (Http::isCodecProtocolError(status)) {
@@ -649,6 +656,8 @@ private:
   };
 
   const Http::CodecType type_;
+  // Accessed only from the fake upstream connection's dispatcher thread.
+  bool shutting_down_for_cleanup_{false};
   bool deferred_read_enable_;
   Http::ServerConnectionPtr codec_;
   std::list<FakeStreamPtr> new_streams_ ABSL_GUARDED_BY(lock_);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -483,6 +483,12 @@ public:
   testing::AssertionResult close(Network::ConnectionCloseType close_type,
                                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
+  // Half-close the write side of a TCP connection and wait for the peer to close its side. Unlike
+  // close(), successful completion proves that the peer observed the shutdown.
+  ABSL_MUST_USE_RESULT
+  testing::AssertionResult
+  halfCloseAndWaitForDisconnect(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
   ABSL_MUST_USE_RESULT
   testing::AssertionResult
   readDisable(bool disable, std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -373,11 +373,25 @@ public:
         rst_disconnected_ = true;
       }
       disconnected_ = true;
+      if (disconnect_callback_) {
+        disconnect_callback_();
+      }
     }
   }
 
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
+
+  void setDisconnectCallback(DisconnectCallback callback) {
+    absl::MutexLock lock(lock_);
+    ASSERT(!disconnect_callback_);
+    disconnect_callback_ = std::move(callback);
+  }
+
+  void clearDisconnectCallback() {
+    absl::MutexLock lock(lock_);
+    disconnect_callback_ = nullptr;
+  }
 
   Event::Dispatcher& dispatcher() { return dispatcher_; }
 
@@ -461,6 +475,7 @@ private:
   bool parented_ ABSL_GUARDED_BY(lock_){};
   bool disconnected_ ABSL_GUARDED_BY(lock_){};
   bool rst_disconnected_ ABSL_GUARDED_BY(lock_){};
+  DisconnectCallback disconnect_callback_ ABSL_GUARDED_BY(lock_);
 };
 
 using SharedConnectionWrapperPtr = std::unique_ptr<SharedConnectionWrapper>;
@@ -483,9 +498,16 @@ public:
   testing::AssertionResult close(Network::ConnectionCloseType close_type,
                                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
+  // Half-close the write side of a TCP connection without waiting for the peer to close.
+  ABSL_MUST_USE_RESULT
+  testing::AssertionResult
+  halfClose(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
   // Half-close the write side of a TCP connection and wait for the peer to close its side.
   // Successful completion proves that the peer observed the shutdown, unlike close(). The peer
-  // must have half-close disabled so that it responds to the shutdown with a full close.
+  // must have half-close disabled so that it responds to the shutdown with a full close. Fails
+  // immediately if this connection was already configured for half-close, since that indicates
+  // that the caller expects half-close semantics and cannot rely on a reciprocal full close.
   ABSL_MUST_USE_RESULT
   testing::AssertionResult
   halfCloseAndWaitForDisconnect(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
@@ -563,6 +585,7 @@ public:
                      envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
                          headers_with_underscores_action,
                      bool deferred_read_enable = false);
+  ~FakeHttpConnection() override;
 
   void initialize() override;
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -483,8 +483,9 @@ public:
   testing::AssertionResult close(Network::ConnectionCloseType close_type,
                                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
 
-  // Half-close the write side of a TCP connection and wait for the peer to close its side. Unlike
-  // close(), successful completion proves that the peer observed the shutdown.
+  // Half-close the write side of a TCP connection and wait for the peer to close its side.
+  // Successful completion proves that the peer observed the shutdown, unlike close(). The peer
+  // must have half-close disabled so that it responds to the shutdown with a full close.
   ABSL_MUST_USE_RESULT
   testing::AssertionResult
   halfCloseAndWaitForDisconnect(std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -508,32 +508,34 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
   // subject to the same failure mode.
   if (fake_upstream_connection_) {
     AssertionResult result = AssertionSuccess();
-    if (fake_upstream_connection_->type() == Http::CodecType::HTTP3) {
+    const bool is_http3 = fake_upstream_connection_->type() == Http::CodecType::HTTP3;
+    if (is_http3) {
       // QUIC connections do not support half-close.
       result = fake_upstream_connection_->close();
-      RELEASE_ASSERT(result, result.message());
-      result = fake_upstream_connection_->waitForDisconnect();
     } else {
-      // A local close only proves that the fake upstream dispatcher closed its socket. Envoy's HTTP
-      // upstream connections do not enable half-close, so half-close the fake upstream and wait for
-      // Envoy to close the other direction, proving it observed the FIN. If close-through-filter-
-      // manager defers the close, the reciprocal close is deferred with it. Envoy closes its socket
-      // before raising connection callbacks, so also run a worker barrier to ensure the callback
-      // has removed the connection from its connection pool.
-      result = fake_upstream_connection_->halfCloseAndWaitForDisconnect();
-      RELEASE_ASSERT(result, result.message());
-      // Some fixtures stop the server before cleaning up their fake upstreams. They cannot issue
-      // another request, so no worker barrier is needed.
-      if (test_server_) {
-        test_server_->waitForWorkerThreads();
-      }
+      // A local close only proves that the fake upstream dispatcher closed its socket. Initiate a
+      // fake-upstream FIN; closing the downstream below also makes TCP proxy and CONNECT paths that
+      // enable upstream half-close fully close their paired upstream.
+      result = fake_upstream_connection_->halfClose();
     }
     RELEASE_ASSERT(result, result.message());
+    if (codec_client_) {
+      codec_client_->close();
+    }
+    result = fake_upstream_connection_->waitForDisconnect();
+    RELEASE_ASSERT(result, result.message());
+
+    // Envoy closes its socket before raising connection callbacks, so run a worker barrier after
+    // observing its close to ensure the callback has removed the connection from its connection
+    // pool. Some fixtures stop the server before cleaning up their fake upstreams; they cannot
+    // issue another request, so no worker barrier is needed.
+    if (!is_http3 && test_server_) {
+      test_server_->waitForWorkerThreads();
+    }
     result = fake_upstream_connection_->waitForNoPost();
     RELEASE_ASSERT(result, result.message());
     fake_upstream_connection_.reset();
-  }
-  if (codec_client_) {
+  } else if (codec_client_) {
     codec_client_->close();
   }
 }

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -507,9 +507,21 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
   // will interpret that as an unexpected disconnect. The codec client is not
   // subject to the same failure mode.
   if (fake_upstream_connection_) {
-    AssertionResult result = fake_upstream_connection_->close();
-    RELEASE_ASSERT(result, result.message());
-    result = fake_upstream_connection_->waitForDisconnect();
+    AssertionResult result = AssertionSuccess();
+    if (fake_upstream_connection_->type() == Http::CodecType::HTTP3) {
+      // QUIC connections do not support half-close.
+      result = fake_upstream_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = fake_upstream_connection_->waitForDisconnect();
+    } else {
+      // A local close only proves that the fake upstream dispatcher closed its socket. Half-close
+      // the fake upstream and wait for Envoy to close the other direction, proving Envoy observed
+      // the FIN. Envoy closes its socket before raising connection callbacks, so also run a worker
+      // barrier to ensure the callback has removed the connection from its connection pool.
+      result = fake_upstream_connection_->halfCloseAndWaitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      test_server_->waitForWorkerThreads();
+    }
     RELEASE_ASSERT(result, result.message());
     result = fake_upstream_connection_->waitForNoPost();
     RELEASE_ASSERT(result, result.message());

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -514,13 +514,19 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
       RELEASE_ASSERT(result, result.message());
       result = fake_upstream_connection_->waitForDisconnect();
     } else {
-      // A local close only proves that the fake upstream dispatcher closed its socket. Half-close
-      // the fake upstream and wait for Envoy to close the other direction, proving Envoy observed
-      // the FIN. Envoy closes its socket before raising connection callbacks, so also run a worker
-      // barrier to ensure the callback has removed the connection from its connection pool.
+      // A local close only proves that the fake upstream dispatcher closed its socket. Envoy's HTTP
+      // upstream connections do not enable half-close, so half-close the fake upstream and wait for
+      // Envoy to close the other direction, proving it observed the FIN. If close-through-filter-
+      // manager defers the close, the reciprocal close is deferred with it. Envoy closes its socket
+      // before raising connection callbacks, so also run a worker barrier to ensure the callback
+      // has removed the connection from its connection pool.
       result = fake_upstream_connection_->halfCloseAndWaitForDisconnect();
       RELEASE_ASSERT(result, result.message());
-      test_server_->waitForWorkerThreads();
+      // Some fixtures stop the server before cleaning up their fake upstreams. They cannot issue
+      // another request, so no worker barrier is needed.
+      if (test_server_) {
+        test_server_->waitForWorkerThreads();
+      }
     }
     RELEASE_ASSERT(result, result.message());
     result = fake_upstream_connection_->waitForNoPost();

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -516,7 +516,7 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
       // A local close only proves that the fake upstream dispatcher closed its socket. Initiate a
       // fake-upstream FIN; closing the downstream below also makes TCP proxy and CONNECT paths that
       // enable upstream half-close fully close their paired upstream.
-      result = fake_upstream_connection_->halfClose();
+      result = fake_upstream_connection_->halfCloseForCleanup();
     }
     RELEASE_ASSERT(result, result.message());
     if (codec_client_) {

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -513,6 +513,28 @@ TEST_P(IntegrationTest, RouterHeaderOnlyRequestAndResponseNoBuffer) {
   testRouterHeaderOnlyRequestAndResponse();
 }
 
+TEST_P(IntegrationTest, CleanupWithIncompleteUpstreamRequest) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto encoder_decoder =
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"content-length", "10"}});
+  Http::RequestEncoder& encoder = encoder_decoder.first;
+
+  Buffer::OwnedImpl partial_body("a");
+  codec_client_->sendData(encoder, partial_body, false);
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForData(*dispatcher_, 1));
+
+  // Cleanup must not interpret the resulting EOF as part of the incomplete HTTP/1 request.
+  cleanupUpstreamAndDownstream();
+}
+
 TEST_P(IntegrationTest, RouterUpstreamDisconnectBeforeRequestcomplete) {
   testRouterUpstreamDisconnectBeforeRequestComplete();
 }

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -101,6 +101,23 @@ void IntegrationTestServer::waitUntilListenersReady() {
   ENVOY_LOG(info, "listener wait complete");
 }
 
+void IntegrationTestServer::waitForWorkerThreads() {
+  absl::Notification done;
+  ThreadLocal::TypedSlotPtr<> slot;
+  server().dispatcher().post([&] {
+    slot = ThreadLocal::TypedSlot<>::makeUnique(server().threadLocal());
+    slot->set([](Event::Dispatcher&) -> std::shared_ptr<ThreadLocal::ThreadLocalObject> {
+      return nullptr;
+    });
+    slot->runOnAllThreads([](OptRef<ThreadLocal::ThreadLocalObject>) {},
+                          [&] {
+                            slot.reset(nullptr);
+                            done.Notify();
+                          });
+  });
+  done.WaitForNotification();
+}
+
 void IntegrationTestServer::setDynamicContextParam(absl::string_view resource_type_url,
                                                    absl::string_view key, absl::string_view value) {
   server().dispatcher().post([this, resource_type_url, key, value]() {

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -450,6 +450,9 @@ public:
 
   void waitUntilListenersReady();
 
+  // Wait until callbacks already running or queued on every server worker have completed.
+  void waitForWorkerThreads();
+
   void setDynamicContextParam(absl::string_view resource_type_url, absl::string_view key,
                               absl::string_view value);
   void unsetDynamicContextParam(absl::string_view resource_type_url, absl::string_view key);


### PR DESCRIPTION
Commit Message: Integration test deflake attempt
Additional Description: The specific integration test this is targeting was `test/extensions/filters/http/on_demand:on_demand_integration_test`, which is flaky about 1/1000. An example failure can be seen [here](https://github.com/envoyproxy/envoy/actions/runs/33410166780/job/99547577287) or [here](https://mordenite.cluster.engflow.com/actions/executions/ChB2N1ZVMpJHK4_9l1Z-2xVzEgdkZWZhdWx0GiUKINCPT4uyt_PlqlFcPUOCGYYfgQpXTBSMrjzdX1EDoaPVEKADIAAoAQ==).
```
[ RUN      ] IpVersionsClientType/OnDemandVhdsIntegrationTest.MultipleUpdates/IPv4_EnvoyGrpc_Unified_Rds
[2026-08-31 15:58:17.696][59507][critical][assert] [test/integration/http_integration.cc:574] assert failure: 0. Details: Timed out waiting for new connection.
[2026-08-31 15:58:17.696][59507][error][envoy_bug] [./source/common/common/assert.h:60] stacktrace for envoy bug
[2026-08-31 15:58:17.735][59507][error][envoy_bug] [./source/common/common/assert.h:64] #0 Envoy::HttpIntegrationTest::waitForNextUpstreamConnection() [0x56186bb8a1a9]
[2026-08-31 15:58:17.756][59507][error][envoy_bug] [./source/common/common/assert.h:64] #1 Envoy::HttpIntegrationTest::waitForNextUpstreamRequest() [0x56186bb88308]
[2026-08-31 15:58:17.782][59507][error][envoy_bug] [./source/common/common/assert.h:64] #2 Envoy::HttpIntegrationTest::waitForNextUpstreamRequest() [0x56186bb8ab31]
[2026-08-31 15:58:17.797][59507][error][envoy_bug] [./source/common/common/assert.h:64] #3 Envoy::(anonymous namespace)::OnDemandVhdsIntegrationTest_MultipleUpdates_Test::TestBody() [0x56186ba2b865]
[2026-08-31 15:58:17.814][59507][error][envoy_bug] [./source/common/common/assert.h:64] #4 testing::internal::HandleSehExceptionsInMethodIfSupported<>() [0x56186f366344]
[2026-08-31 15:58:17.829][59507][error][envoy_bug] [./source/common/common/assert.h:64] #5 testing::internal::HandleExceptionsInMethodIfSupported<>() [0x56186f34af86]
[2026-08-31 15:58:17.849][59507][error][envoy_bug] [./source/common/common/assert.h:64] #6 testing::Test::Run() [0x56186f332347]
[2026-08-31 15:58:17.868][59507][error][envoy_bug] [./source/common/common/assert.h:64] #7 testing::TestInfo::Run() [0x56186f332c31]
[2026-08-31 15:58:17.884][59507][error][envoy_bug] [./source/common/common/assert.h:64] #8 testing::TestSuite::Run() [0x56186f3333ca]
[2026-08-31 15:58:17.900][59507][error][envoy_bug] [./source/common/common/assert.h:64] #9 testing::internal::UnitTestImpl::RunAllTests() [0x56186f340f53]
[2026-08-31 15:58:17.915][59507][error][envoy_bug] [./source/common/common/assert.h:64] #10 testing::internal::HandleSehExceptionsInMethodIfSupported<>() [0x56186f368d34]
[2026-08-31 15:58:17.932][59507][error][envoy_bug] [./source/common/common/assert.h:64] #11 testing::internal::HandleExceptionsInMethodIfSupported<>() [0x56186f34cfd6]
[2026-08-31 15:58:17.948][59507][error][envoy_bug] [./source/common/common/assert.h:64] #12 testing::UnitTest::Run() [0x56186f34085b]
[2026-08-31 15:58:17.965][59507][error][envoy_bug] [./source/common/common/assert.h:64] #13 RUN_ALL_TESTS() [0x56186df8b9a1]
[2026-08-31 15:58:17.982][59507][error][envoy_bug] [./source/common/common/assert.h:64] #14 Envoy::TestRunner::runTests() [0x56186df8af59]
[2026-08-31 15:58:17.998][59507][error][envoy_bug] [./source/common/common/assert.h:64] #15 main [0x56186df88e20]
```

The theory of this fix is from a deep AI inspection using GPT Sol. I understand what the change is doing and have reviewed it, but I wouldn't bet heavily on it actually fixing the problem.

The explanation is, `cleanupUpstreamAndDownstream()` previously waited only for the fake upstream’s local socket close. This did not guarantee that Envoy’s worker had received the FIN and removed the connection from its HTTP connection pool. A subsequent request could therefore briefly reuse the closed connection instead of creating a new one, causing waitForNextUpstreamConnection() to time out as the request never provokes a new connection.

For TCP upstreams, this cleanup now half-closes the fake upstream and waits for Envoy to close the reverse direction, thereby proving Envoy observed the shutdown so it's *really* cleaned up. It then runs a worker-thread barrier that effectively drains the events in the dispatchers, to ensure Envoy’s connection-close callbacks have removed the old pool client, before cleanup returns.

HTTP/3 still retains the previous behavior because QUIC does not support half-close, so the same race-flake might still be available if any test uses HTTP/3 upstreams with a similar sequence of events.

For some cases where half-close isn't supported, the worker-barrier is still included, which may suffice to make even those cases less flaky, given that the flakiness this targets was already around a 1/1000 case.

Risk Level: Test-only.
Testing: Yes it is.
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
