### PR TITLE
tcp_proxy: add load shedding during upstream connection establishment

### DIFF
--- a/changelogs/current/new_features/tcp_proxy__upstream-connect-load-shed-point.rst
+++ b/changelogs/current/new_features/tcp_proxy__upstream-connect-load-shed-point.rst
@@ -1,0 +1,3 @@
+Added load shed point :ref:`envoy.load_shed_points.tcp_proxy_upstream_connect
+<config_overload_manager>` and metric ``downstream_cx_overload_close`` to shed downstream
+connections when establishing upstream connections under resource pressure.

--- a/docs/root/configuration/operations/overload_manager/overload_manager.rst
+++ b/docs/root/configuration/operations/overload_manager/overload_manager.rst
@@ -274,6 +274,10 @@ The following core load shed points are supported:
       (e.g., during early data buffering or active proxying) if Envoy is under resource pressure,
       typically memory.
 
+  * - envoy.load_shed_points.tcp_proxy_upstream_connect
+    - Envoy will close the downstream TCP connection in the TCP proxy filter when establishing an
+      upstream connection if Envoy is under resource pressure, typically memory.
+
 .. _config_overload_manager_reducing_timeouts:
 
 Reducing timeouts

--- a/envoy/server/overload/load_shed_point.h
+++ b/envoy/server/overload/load_shed_point.h
@@ -59,6 +59,9 @@ public:
   // Envoy will close the TCP proxy downstream connection upon receiving
   // data if under memory pressure.
   const std::string TcpProxyOnData = "envoy.load_shed_points.tcp_proxy_on_data";
+
+  // Envoy will stop establishing TCP proxy upstream connections when under resource pressure.
+  const std::string TcpProxyUpstreamConnect = "envoy.load_shed_points.tcp_proxy_upstream_connect";
 };
 
 using LoadShedPointName = ConstSingleton<LoadShedPointNameValues>;

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -12,6 +12,7 @@
 #include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.validate.h"
 #include "envoy/extensions/request_id/uuid/v3/uuid.pb.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/overload/load_shed_point.h"
 #include "envoy/stats/scope.h"
 #include "envoy/stream_info/bool_accessor.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -226,6 +227,11 @@ Config::SharedConfig::SharedConfig(
   ENVOY_LOG_ONCE_MISC_IF(
       trace, tcp_proxy_on_data_loadshed_point_ == nullptr,
       "LoadShedPoint envoy.load_shed_points.tcp_proxy_on_data is not found. Is it configured?");
+  tcp_proxy_upstream_connect_loadshed_point_ =
+      overload_manager.getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyUpstreamConnect);
+  ENVOY_LOG_ONCE_MISC_IF(trace, tcp_proxy_upstream_connect_loadshed_point_ == nullptr,
+                         "LoadShedPoint envoy.load_shed_points.tcp_proxy_upstream_connect is not "
+                         "found. Is it configured?");
 }
 
 Config::Config(const envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy& config,
@@ -670,6 +676,17 @@ void Filter::UpstreamCallbacks::drain(Drainer& drainer) {
 }
 
 Network::FilterStatus Filter::establishUpstreamConnection() {
+  if (config_->tcpProxyUpstreamConnectLoadShedPoint() != nullptr &&
+      config_->tcpProxyUpstreamConnectLoadShedPoint()->shouldShedLoad()) {
+    ENVOY_CONN_LOG(debug, "load shedding in establishUpstreamConnection",
+                   read_callbacks_->connection());
+    config_->stats().downstream_cx_overload_close_.inc();
+    getStreamInfo().setResponseFlag(StreamInfo::CoreResponseFlag::OverloadManager);
+    read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush,
+                                        StreamInfo::LocalCloseReasons::get().OverloadManagerClose);
+    return Network::FilterStatus::StopIteration;
+  }
+
   const std::string& cluster_name = route_ ? route_->clusterName() : EMPTY_STRING;
   ENVOY_CONN_LOG(debug, "establishUpstreamConnection called: cluster_name={}, route_={}",
                  read_callbacks_->connection(), cluster_name, route_ != nullptr);
@@ -1140,7 +1157,12 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool end_stream) {
         }
         // If delay_route_selection_ is unset, route should already be set in onNewConnection().
         ASSERT(route_ != nullptr);
-        establishUpstreamConnection();
+        // If load shedding rejected and closed the downstream connection in
+        // establishUpstreamConnection(), stop iteration immediately to avoid
+        // performing further buffer checks or stats tracking on a closed connection.
+        if (establishUpstreamConnection() == Network::FilterStatus::StopIteration) {
+          return Network::FilterStatus::StopIteration;
+        }
       }
     }
 

--- a/source/common/tcp_proxy/tcp_proxy.h
+++ b/source/common/tcp_proxy/tcp_proxy.h
@@ -276,6 +276,9 @@ public:
     Server::LoadShedPoint* tcpProxyOnDataLoadShedPoint() const {
       return tcp_proxy_on_data_loadshed_point_;
     }
+    Server::LoadShedPoint* tcpProxyUpstreamConnectLoadShedPoint() const {
+      return tcp_proxy_upstream_connect_loadshed_point_;
+    }
 
     // Evaluate dynamic TLV formatters and combine with static TLVs.
     Network::ProxyProtocolTLVVector
@@ -315,6 +318,7 @@ public:
         proxy_protocol_tlv_merge_policy_{
             envoy::extensions::filters::network::tcp_proxy::v3::ADD_IF_ABSENT};
     Server::LoadShedPoint* tcp_proxy_on_data_loadshed_point_{nullptr};
+    Server::LoadShedPoint* tcp_proxy_upstream_connect_loadshed_point_{nullptr};
   };
 
   using SharedConfigSharedPtr = std::shared_ptr<SharedConfig>;
@@ -394,6 +398,9 @@ public:
   }
   Server::LoadShedPoint* tcpProxyOnDataLoadShedPoint() const {
     return shared_config_->tcpProxyOnDataLoadShedPoint();
+  }
+  Server::LoadShedPoint* tcpProxyUpstreamConnectLoadShedPoint() const {
+    return shared_config_->tcpProxyUpstreamConnectLoadShedPoint();
   }
 
 private:

--- a/test/common/tcp_proxy/tcp_proxy_test.cc
+++ b/test/common/tcp_proxy/tcp_proxy_test.cc
@@ -2916,6 +2916,9 @@ TEST_P(TcpProxyTest, OnDataLoadShedPointCanCloseConnection) {
   EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
               getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
       .WillOnce(Return(&on_data_loadshed_point));
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyUpstreamConnect))
+      .WillOnce(Return(nullptr));
 
   // Configure TCP Proxy
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
@@ -2949,6 +2952,9 @@ TEST_P(TcpProxyTest, OnDataLoadShedPointNotTriggeredWhenNotOverloaded) {
   EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
               getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
       .WillOnce(Return(&on_data_loadshed_point));
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyUpstreamConnect))
+      .WillOnce(Return(nullptr));
 
   envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy config = defaultConfig();
   config.set_upstream_connect_mode(
@@ -2989,6 +2995,9 @@ TEST_P(TcpProxyTest, OnDataLoadShedPointCanCloseConnectionWhenUpstreamConnected)
   EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
               getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
       .WillOnce(Return(&on_data_loadshed_point));
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyUpstreamConnect))
+      .WillOnce(Return(nullptr));
 
   setup(1);
   raiseEventUpstreamConnected(0);
@@ -4063,6 +4072,52 @@ TEST_P(TcpProxyTest, AppendToDownstreamTlvsPreservesDuplicates) {
 
   EXPECT_EQ(0xF0, tlvs[4].type);
   EXPECT_EQ("tcp_proxy_f0", std::string(tlvs[4].value.begin(), tlvs[4].value.end()));
+}
+
+// Test load shedding in establishUpstreamConnection() during onNewConnection().
+TEST_P(TcpProxyTest, UpstreamConnectLoadShedPointCanCloseConnection) {
+  Server::MockLoadShedPoint upstream_connect_loadshed_point;
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyUpstreamConnect))
+      .WillOnce(Return(&upstream_connect_loadshed_point));
+
+  // Use setup(0) to instantiate and initialize filter_ without automatically calling
+  // onNewConnection(), preventing setup() from triggering the connection flow before mock
+  // expectations are configured and allowing this test to explicitly verify onNewConnection().
+  setup(0);
+
+  EXPECT_CALL(upstream_connect_loadshed_point, shouldShedLoad()).WillOnce(Return(true));
+  EXPECT_CALL(filter_callbacks_.connection_,
+              close(Network::ConnectionCloseType::NoFlush,
+                    StreamInfo::LocalCloseReasons::get().OverloadManagerClose));
+
+  EXPECT_EQ(Network::FilterStatus::StopIteration, filter_->onNewConnection());
+
+  EXPECT_EQ(1U, config_->stats().downstream_cx_overload_close_.value());
+  EXPECT_TRUE(filter_callbacks_.connection_.stream_info_.hasResponseFlag(
+      StreamInfo::CoreResponseFlag::OverloadManager));
+}
+
+// Test load shedding in establishUpstreamConnection() is bypassed when shouldShedLoad() returns
+// false.
+TEST_P(TcpProxyTest, UpstreamConnectLoadShedPointBypassedWhenFalse) {
+  Server::MockLoadShedPoint upstream_connect_loadshed_point;
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyOnData))
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(factory_context_.server_factory_context_.overload_manager_,
+              getLoadShedPoint(Server::LoadShedPointName::get().TcpProxyUpstreamConnect))
+      .WillOnce(Return(&upstream_connect_loadshed_point));
+
+  EXPECT_CALL(upstream_connect_loadshed_point, shouldShedLoad()).WillOnce(Return(false));
+  setup(1);
+
+  EXPECT_EQ(0U, config_->stats().downstream_cx_overload_close_.value());
+  EXPECT_FALSE(filter_callbacks_.connection_.stream_info_.hasResponseFlag(
+      StreamInfo::CoreResponseFlag::OverloadManager));
 }
 
 } // namespace

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1940,6 +1940,7 @@ envoy_cc_test(
     deps = [
         ":base_overload_integration_test_lib",
         ":http_protocol_integration_lib",
+        "//source/extensions/filters/network/tcp_proxy:config",
         "//test/common/config:dummy_config_proto_cc_proto",
         "//test/integration/filters:block_filter_lib",
         "//test/test_common:test_runtime_lib",

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -5,6 +5,7 @@
 
 #include "source/common/protobuf/utility.h"
 
+#include "test/config/utility.h"
 #include "test/integration/base_overload_integration_test.h"
 #include "test/integration/filters/block_filter.pb.h"
 #include "test/integration/http_protocol_integration.h"
@@ -1665,6 +1666,72 @@ TEST_P(OverloadIntegrationTest, WorkerWatchdogMegaMissDisabled) {
 
   EXPECT_TRUE(response->waitForEndStream(std::chrono::seconds(20)));
   EXPECT_TRUE(response->complete());
+}
+
+class TcpProxyLoadShedPointIntegrationTest
+    : public BaseOverloadIntegrationTest,
+      public BaseIntegrationTest,
+      public testing::TestWithParam<Network::Address::IpVersion> {
+public:
+  TcpProxyLoadShedPointIntegrationTest()
+      : BaseIntegrationTest(GetParam(), ConfigHelper::tcpProxyConfig()) {
+    // Disable half-close so server-initiated closes trigger a full RemoteClose on the client.
+    enableHalfClose(false);
+  }
+
+  void
+  initializeOverloadManager(const envoy::config::overload::v3::LoadShedPoint& load_shed_point) {
+    setupOverloadManagerConfig(load_shed_point);
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      *bootstrap.mutable_overload_manager() = this->overload_manager_config_;
+    });
+    initialize();
+    updateResource(0);
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, TcpProxyLoadShedPointIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(TcpProxyLoadShedPointIntegrationTest, TcpProxyUpstreamConnectShedsLoad) {
+  initializeOverloadManager(
+      TestUtility::parseYaml<envoy::config::overload::v3::LoadShedPoint>(R"EOF(
+      name: "envoy.load_shed_points.tcp_proxy_upstream_connect"
+      triggers:
+        - name: "envoy.resource_monitors.testonly.fake_resource_monitor"
+          threshold:
+            value: 0.90
+    )EOF"));
+
+  // Put envoy in overloaded state and check that it drops the downstream connection
+  // when establishing upstream connection.
+  updateResource(0.95);
+  test_server_->waitForGauge(
+      "overload.envoy.load_shed_points.tcp_proxy_upstream_connect.scale_percent", Eq(100));
+
+  IntegrationTcpClientPtr tcp_client = makeTcpConnection(lookupPort("listener_0"));
+  // Pass ignore_spurious_events = true to loop until disconnected_ == true.
+  // In heavily loaded CI environments (especially under MSAN/ASAN/TSAN), the socket's Connected
+  // event and RemoteClose event can arrive in separate dispatcher iterations. Without this flag,
+  // the default single block step unblocks on the Connected event and immediately asserts
+  // EXPECT_TRUE(disconnected_) before the second iteration has a chance to process the disconnect.
+  tcp_client->waitForDisconnect(/*ignore_spurious_events=*/true);
+  test_server_->waitForCounter("tcp.tcpproxy_stats.downstream_cx_overload_close", Eq(1));
+
+  // Disable overload, connections should succeed.
+  updateResource(0.80);
+  test_server_->waitForGauge(
+      "overload.envoy.load_shed_points.tcp_proxy_upstream_connect.scale_percent", Eq(0));
+
+  IntegrationTcpClientPtr tcp_client2 = makeTcpConnection(lookupPort("listener_0"));
+  FakeRawConnectionPtr fake_upstream_connection;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection));
+  ASSERT_TRUE(tcp_client2->write("hello"));
+  std::string data;
+  ASSERT_TRUE(fake_upstream_connection->waitForData(5, &data));
+  EXPECT_EQ("hello", data);
+  tcp_client2->close();
 }
 
 } // namespace Envoy


### PR DESCRIPTION
Commit Message:
   * Add the TcpProxyUpstreamConnect load shed point to reject and close
downstream connections immediately in establishUpstreamConnection()
when under resource pressure

Risk Level:
   * Low

Testing:
   * Unit Test in tcp_proxy_test.cc
   * Integration Test
