### PR TITLE
Add separate test macros for dynamic modules

### DIFF
--- a/bazel/envoy_build_system.bzl
+++ b/bazel/envoy_build_system.bzl
@@ -55,6 +55,8 @@ load(
     ":envoy_test.bzl",
     _envoy_benchmark_test = "envoy_benchmark_test",
     _envoy_cc_benchmark_binary = "envoy_cc_benchmark_binary",
+    _envoy_cc_benchmark_dyn_module_binary = "envoy_cc_benchmark_dyn_module_binary",
+    _envoy_cc_dyn_module_test = "envoy_cc_dyn_module_test",
     _envoy_cc_fuzz_test = "envoy_cc_fuzz_test",
     _envoy_cc_mock = "envoy_cc_mock",
     _envoy_cc_test = "envoy_cc_test",
@@ -257,12 +259,14 @@ envoy_proto_library = _envoy_proto_library
 envoy_pch_library = _envoy_pch_library
 
 # Test wrappers (from envoy_test.bzl)
+envoy_cc_dyn_module_test = _envoy_cc_dyn_module_test
 envoy_cc_fuzz_test = _envoy_cc_fuzz_test
 envoy_cc_mock = _envoy_cc_mock
 envoy_cc_test = _envoy_cc_test
 envoy_cc_test_binary = _envoy_cc_test_binary
 envoy_cc_test_library = _envoy_cc_test_library
 envoy_cc_benchmark_binary = _envoy_cc_benchmark_binary
+envoy_cc_benchmark_dyn_module_binary = _envoy_cc_benchmark_dyn_module_binary
 envoy_benchmark_test = _envoy_benchmark_test
 envoy_py_test = _envoy_py_test
 envoy_py_test_binary = _envoy_py_test_binary

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -14,7 +14,6 @@ load(
     "envoy_exported_symbols_input",
     "envoy_external_dep_path",
     "envoy_linkstatic",
-    "envoy_select_exported_symbols",
     "envoy_select_force_libcpp",
     "envoy_stdlib_deps",
     "tcmalloc_external_dep",
@@ -63,6 +62,24 @@ def _envoy_cc_test_infrastructure_library(
         **kargs
     )
 
+def _envoy_test_default_exported_symbols():
+    return select({
+        "@envoy//bazel:linux": [
+            "-Wl,--dynamic-list=$(location @envoy//bazel:exported_symbols.txt)",
+        ],
+        "@envoy//bazel:apple": [
+            "-Wl,-exported_symbols_list,$(location @envoy//bazel:exported_symbols_apple.txt)",
+        ],
+        "//conditions:default": [],
+    })
+
+# Select the given values if exporting is enabled in the current build.
+def envoy_test_select_exported_symbols(xs):
+    return select({
+        "@envoy//bazel:enable_exported_symbols": xs,
+        "//conditions:default": [],
+    })
+
 # Compute the test linkopts based on various options.
 def _envoy_test_linkopts():
     return select({
@@ -76,7 +93,7 @@ def _envoy_test_linkopts():
         # TODO(mattklein123): It's not great that we universally link against the following libs.
         # In particular, -latomic and -lrt are not needed on all platforms. Make this more granular.
         "//conditions:default": ["-pthread", "-lrt", "-ldl"],
-    }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"]) + envoy_dbg_linkopts() + envoy_select_exported_symbols(["-Wl,-E"])
+    }) + envoy_select_force_libcpp([], ["-lstdc++fs", "-latomic"]) + envoy_dbg_linkopts() + envoy_test_select_exported_symbols(["-Wl,-E"])
 
 # Envoy C++ fuzz test targets. These are not included in coverage runs.
 def envoy_cc_fuzz_test(
@@ -215,6 +232,16 @@ def envoy_cc_test(
         exec_properties = exec_properties,
     )
 
+# Envoy C++ test targets loading dynamic modules should be specified with this macro.
+def envoy_cc_dyn_module_test(
+        name,
+        **kargs):
+    envoy_cc_test(
+        name,
+        linkopts = _envoy_test_default_exported_symbols(),
+        **kargs
+    )
+
 # Envoy C++ test related libraries (that want gtest, gmock) should be specified
 # with this function.
 def envoy_cc_test_library(
@@ -260,13 +287,14 @@ def envoy_cc_test_binary(
         name,
         tags = [],
         deps = [],
+        linkopts = [],
         stamp = 0,
         linkstatic = True,
         **kargs):
     envoy_cc_binary(
         name,
         testonly = 1,
-        linkopts = _envoy_test_linkopts(),
+        linkopts = _envoy_test_linkopts() + linkopts,
         tags = tags + ["compilation_db_dep"],
         deps = deps + [
             "@envoy//test/test_common:test_version_linkstamp",
@@ -287,6 +315,21 @@ def envoy_cc_benchmark_binary(
         name,
         deps = deps + [repository + "//test/benchmark:main"],
         repository = repository,
+        **kargs
+    )
+
+# Envoy benchmark binaries loading dynamic modules should be specified with this function. bazel run
+# these targets to measure performance.
+def envoy_cc_benchmark_dyn_module_binary(
+        name,
+        deps = [],
+        repository = "",
+        **kargs):
+    envoy_cc_test_binary(
+        name,
+        deps = deps + [repository + "//test/benchmark:main"],
+        repository = repository,
+        linkopts = _envoy_test_default_exported_symbols(),
         **kargs
     )
 

--- a/contrib/golang/filters/http/test/BUILD
+++ b/contrib/golang/filters/http/test/BUILD
@@ -1,7 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_fuzz_test",
-    "envoy_cc_test",
     "envoy_contrib_package",
     "envoy_proto_library",
 )
@@ -10,7 +10,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [
@@ -26,7 +26,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "golang_filter_test",
     srcs = ["golang_filter_test.cc"],
     data = [
@@ -52,7 +52,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "golang_integration_test",
     srcs = ["golang_integration_test.cc"],
     data = [
@@ -106,7 +106,7 @@ envoy_cc_fuzz_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "websocket_integration_test",
     size = "large",
     srcs = ["websocket_integration_test.cc"],

--- a/contrib/golang/router/cluster_specifier/test/BUILD
+++ b/contrib/golang/router/cluster_specifier/test/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_contrib_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "golang_integration_test",
     srcs = ["golang_integration_test.cc"],
     data = [

--- a/contrib/golang/upstreams/http/tcp/test/BUILD
+++ b/contrib/golang/upstreams/http/tcp/test/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_contrib_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_contrib_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "golang_bridge_integration_test",
     size = "large",
     srcs = [

--- a/test/config_test/BUILD
+++ b/test/config_test/BUILD
@@ -2,7 +2,7 @@ load("@base_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test_library",
     "envoy_package",
 )
@@ -42,7 +42,7 @@ envoy_cc_test_library(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "config_test",
     size = "large",
     coverage = False,

--- a/test/extensions/access_loggers/dynamic_modules/BUILD
+++ b/test/extensions/access_loggers/dynamic_modules/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -8,7 +9,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [
@@ -67,7 +68,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "cluster_test",
     srcs = ["cluster_test.cc"],
     data = [
@@ -52,7 +52,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -6,6 +6,7 @@ load(
 )
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
@@ -15,7 +16,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "dynamic_modules_test",
     srcs = ["dynamic_modules_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/bootstrap/BUILD
+++ b/test/extensions/dynamic_modules/bootstrap/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "extension_config_test",
     srcs = ["extension_config_test.cc"],
     data = [
@@ -46,7 +46,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "abi_impl_test",
     srcs = ["abi_impl_test.cc"],
     data = [
@@ -77,7 +77,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "extension_test",
     srcs = ["extension_test.cc"],
     data = [
@@ -97,7 +97,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "factory_test",
     srcs = ["factory_test.cc"],
     data = [
@@ -115,7 +115,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -68,7 +69,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "filter_test",
     srcs = ["filter_test.cc"],
     data = [
@@ -141,7 +142,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/listener/BUILD
+++ b/test/extensions/dynamic_modules/listener/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -76,7 +77,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/network/BUILD
+++ b/test/extensions/dynamic_modules/network/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -74,7 +75,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/stat_sink/BUILD
+++ b/test/extensions/dynamic_modules/stat_sink/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
@@ -74,7 +75,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/extensions_build_system.bzl
+++ b/test/extensions/extensions_build_system.bzl
@@ -1,5 +1,5 @@
 load("@envoy_build_config//:extensions_build_config.bzl", "EXTENSIONS")
-load("//bazel:envoy_build_system.bzl", "envoy_benchmark_test", "envoy_cc_benchmark_binary", "envoy_cc_fuzz_test", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library", "envoy_py_test")
+load("//bazel:envoy_build_system.bzl", "envoy_benchmark_test", "envoy_cc_benchmark_binary", "envoy_cc_dyn_module_test", "envoy_cc_fuzz_test", "envoy_cc_mock", "envoy_cc_test", "envoy_cc_test_binary", "envoy_cc_test_library", "envoy_py_test")
 
 def _apply_to_extension_allow_for_test(func, name, extension_names, **kwargs):
     for extension_name in extension_names:
@@ -16,6 +16,12 @@ def envoy_extension_cc_test(
         extension_names,
         **kwargs):
     _apply_to_extension_allow_for_test(envoy_cc_test, name, extension_names, **kwargs)
+
+def envoy_extension_cc_dyn_module_test(
+        name,
+        extension_names,
+        **kwargs):
+    _apply_to_extension_allow_for_test(envoy_cc_dyn_module_test, name, extension_names, **kwargs)
 
 def envoy_extension_cc_test_library(
         name,

--- a/test/extensions/formatter/dynamic_modules/BUILD
+++ b/test/extensions/formatter/dynamic_modules/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [
@@ -36,7 +36,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/health_checkers/dynamic_modules/BUILD
+++ b/test/extensions/health_checkers/dynamic_modules/BUILD
@@ -4,6 +4,7 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_dyn_module_test",
     "envoy_extension_cc_test",
 )
 
@@ -11,7 +12,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [
@@ -37,7 +38,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "health_checker_test",
     srcs = ["health_checker_test.cc"],
     data = [

--- a/test/extensions/load_balancing_policies/dynamic_modules/BUILD
+++ b/test/extensions/load_balancing_policies/dynamic_modules/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [

--- a/test/extensions/matching/http/dynamic_modules/BUILD
+++ b/test/extensions/matching/http/dynamic_modules/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -8,7 +9,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [
@@ -38,7 +39,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "string_data_input_test",
     srcs = ["string_data_input_test.cc"],
     data = [

--- a/test/extensions/matching/input_matchers/dynamic_modules/BUILD
+++ b/test/extensions/matching/input_matchers/dynamic_modules/BUILD
@@ -1,5 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
+    "envoy_cc_dyn_module_test",
     "envoy_cc_test",
     "envoy_package",
 )
@@ -8,7 +9,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [
@@ -30,7 +31,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "matcher_test",
     srcs = ["matcher_test.cc"],
     data = [
@@ -54,7 +55,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/network/dns_resolver/benchmark/BUILD
+++ b/test/extensions/network/dns_resolver/benchmark/BUILD
@@ -1,7 +1,7 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_benchmark_test",
-    "envoy_cc_benchmark_binary",
+    "envoy_cc_benchmark_dyn_module_binary",
     "envoy_package",
 )
 
@@ -25,7 +25,7 @@ HICKORY_ABI_IMPL_DEPS = [
     "//source/extensions/upstreams/http/dynamic_modules:abi_impl",
 ]
 
-envoy_cc_benchmark_binary(
+envoy_cc_benchmark_dyn_module_binary(
     name = "dns_resolver_benchmark",
     srcs = ["dns_resolver_benchmark.cc"],
     rbe_pool = "linux_x64_small",

--- a/test/extensions/network/dns_resolver/hickory/BUILD
+++ b/test/extensions/network/dns_resolver/hickory/BUILD
@@ -4,7 +4,7 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_extension_cc_test",
+    "envoy_extension_cc_dyn_module_test",
 )
 
 licenses(["notice"])  # Apache 2
@@ -28,7 +28,7 @@ HICKORY_ABI_IMPL_DEPS = [
     "//source/extensions/upstreams/http/dynamic_modules:abi_impl",
 ]
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "hickory_dns_impl_test",
     srcs = ["hickory_dns_impl_test.cc"],
     data = [
@@ -63,7 +63,7 @@ envoy_extension_cc_test(
     ] + HICKORY_ABI_IMPL_DEPS,
 )
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "hickory_dns_integration_test",
     srcs = ["hickory_dns_integration_test.cc"],
     extension_names = ["envoy.network.dns_resolver.hickory"],

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
@@ -4,14 +4,14 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_extension_cc_test",
+    "envoy_extension_cc_dyn_module_test",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "cluster_specifier_test",
     srcs = ["cluster_specifier_test.cc"],
     data = [
@@ -41,7 +41,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/transport_sockets/dynamic_modules/BUILD
+++ b/test/extensions/transport_sockets/dynamic_modules/BUILD
@@ -4,14 +4,14 @@ load(
 )
 load(
     "//test/extensions:extensions_build_system.bzl",
-    "envoy_extension_cc_test",
+    "envoy_extension_cc_dyn_module_test",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "config_test",
     srcs = ["config_test.cc"],
     data = [
@@ -41,7 +41,7 @@ envoy_extension_cc_test(
     ],
 )
 
-envoy_extension_cc_test(
+envoy_extension_cc_dyn_module_test(
     name = "integration_test",
     size = "large",
     srcs = ["integration_test.cc"],

--- a/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/BUILD
+++ b/test/extensions/transport_sockets/tls/cert_validator/dynamic_modules/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "dynamic_modules_cert_validator_test",
     srcs = ["dynamic_modules_cert_validator_test.cc"],
     data = [

--- a/test/extensions/upstreams/http/dynamic_modules/BUILD
+++ b/test/extensions/upstreams/http/dynamic_modules/BUILD
@@ -1,6 +1,6 @@
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
+    "envoy_cc_dyn_module_test",
     "envoy_package",
 )
 
@@ -8,7 +8,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "upstream_request_test",
     srcs = ["upstream_request_test.cc"],
     data = [
@@ -39,7 +39,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dyn_module_test(
     name = "integration_test",
     size = "large",
     srcs = ["integration_test.cc"],


### PR DESCRIPTION
This PR adds macros for tests that load dynamic modules. These tests link with the export file for dynamic module symbols. This is to resolve link errors in unit tests on Windows where linker requires exported symbols to be defined. 

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
