### PR TITLE
http: optimization check cheap conditions before the filter manager guard

### DIFF
--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -234,11 +234,11 @@ bool ActiveStreamFilterBase::commonHandleAfterDataCallback(
       // frame) or that empty the frame without calling addData (e.g. a compressor buffering
       // internally) do not match and are handled by the existing path. See
       // https://github.com/envoyproxy/envoy/issues/46841.
-      if (Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.filter_manager_forward_added_data_on_continue") &&
-          parent_.state_.filter_added_data_in_data_callback_ &&
+      if (parent_.state_.filter_added_data_in_data_callback_ &&
           provided_data_nonempty_before_callback && provided_data.length() == 0 && bufferedData() &&
-          bufferedData().get() != &provided_data && bufferedData()->length() > 0) {
+          bufferedData().get() != &provided_data && bufferedData()->length() > 0 &&
+          Runtime::runtimeFeatureEnabled(
+              "envoy.reloadable_features.filter_manager_forward_added_data_on_continue")) {
         provided_data.move(*bufferedData());
       }
     }


### PR DESCRIPTION
commonHandleAfterDataCallback() paid a runtime guard lookup (string hash plus flag read) on every Continue from an already-iterating filter, ahead of the bool and buffer-length checks that reject nearly all of them. All operands are side-effect free, so evaluate the guard last.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
