### PR TITLE
http: fix HTTP/2 chunking race in grpc_json_transcoder for unary requests

### DIFF
--- a/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
+++ b/source/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter.cc
@@ -641,6 +641,13 @@ Http::FilterDataStatus JsonTranscoderFilter::decodeData(Buffer::Instance& data, 
       return Http::FilterDataStatus::StopIterationNoBuffer;
     }
 
+    // For non-streaming unary requests, buffer until we have the complete HTTP/2 payload.
+    // This avoids a race in the underlying Transcoder parser where split JSON chunks 
+    // can cause it to prematurely evaluate the frame boundary and bypass translation.
+    if (!end_stream && !method_->descriptor_->client_streaming()) {
+      return Http::FilterDataStatus::StopIterationAndBuffer;
+    }
+
     if (end_stream) {
       request_in_.finish();
     }

--- a/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
+++ b/test/extensions/filters/http/grpc_json_transcoder/json_transcoder_filter_test.cc
@@ -753,6 +753,36 @@ TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPost) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_.encodeTrailers(response_trailers));
 }
 
+TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPostChunked) {
+  Http::TestRequestHeaderMapImpl request_headers{
+      {"content-type", "application/json"}, {":method", "POST"}, {":path", "/shelf"}};
+
+  EXPECT_CALL(decoder_callbacks_.downstream_callbacks_, clearRouteCache());
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_.decodeHeaders(request_headers, false));
+  EXPECT_EQ("application/grpc", request_headers.get_("content-type"));
+
+  Buffer::OwnedImpl request_data;
+  request_data.add("{\"theme\"");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.decodeData(request_data, false));
+  EXPECT_EQ(request_data.length(), 0); // Consumed
+
+  request_data.add(": \"Children\"}");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_.decodeData(request_data, false));
+  EXPECT_EQ(request_data.length(), 0); // Consumed
+  
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_.decodeData(request_data, true)); // EOS
+
+  Grpc::Decoder decoder;
+  std::vector<Grpc::Frame> frames;
+  std::ignore = decoder.decode(request_data, frames);
+
+  EXPECT_EQ(1, frames.size());
+  bookstore::Shelf shelf;
+  EXPECT_TRUE(shelf.ParseFromString(frames[0].data_->toString()));
+  EXPECT_EQ("Children", shelf.theme());
+}
+
 TEST_F(GrpcJsonTranscoderFilterTest, TranscodingUnaryPostWithPackageServiceMethodPath) {
   Http::TestRequestHeaderMapImpl request_headers{
       {"content-type", "application/json"},


### PR DESCRIPTION
Commit Message: http: fix HTTP/2 chunking race in grpc_json_transcoder for unary requests
Additional Description: 
When clients send HTTP/2 (or HTTP/3) requests to a REST endpoint that maps to a unary gRPC method, the payload is frequently fragmented across multiple data frames. Our internal testing revealed a race condition where specific chunk boundaries trigger a parsing bypass in the underlying `grpc-httpjson-transcoding` library. 
When this happens, the transcoder fails to convert the JSON payload into a gRPC message and unintentionally passes the raw JSON un-transcoded buffer down the filter chain. Downstream filters (like `grpc_field_extraction` or the router) which were already configured during `decodeHeaders` to expect `application/grpc`, attempt to parse the raw JSON (e.g. `{`) as a 5-byte gRPC frame header, causing the proxy to crash the request explicitly with unsupported frame errors.
This PR introduces a safeguard in `JsonTranscoderFilter::decodeData`. If the matched gRPC method is a unary request (`!method_->descriptor_->client_streaming()`), the filter will now return `Http::FilterDataStatus::StopIterationAndBuffer` for incomplete frames (`!end_stream`), aggregating the HTTP/2 frames in Envoy's underlying buffer. The JSON payload is only forwarded to the transcoder once the complete payload has arrived. 
*(AI Transparency Disclosure: This bug fix and PR description was drafted with the assistance of an internal generative AI, and the contributor has fully reviewed and validated the code).*
Risk Level: Low
Testing: Added integration unit-tests `TranscodingUnaryPostChunked` to `json_transcoder_filter_test.cc` to ensure correct HTTP/2 chunk buffering state machine behavior on unary routes.
Docs Changes: N/A
Release Notes: BugFix (grpc_json_transcoder): Fixed a race condition where unary transcoding payloads arriving asynchronously over HTTP/2 could bypass the transcoder parsing phase and trigger downstream gRPC crashes.
Platform Specific Features: N/A
[Optional Runtime guard:] N/A
[Optional Fixes #Issue] N/A