### PR TITLE
rate_limit_quota: make usage reporting interval configurable

### DIFF
--- a/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
+++ b/api/envoy/extensions/filters/http/rate_limit_quota/v3/rate_limit_quota.proto
@@ -31,7 +31,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //
 // Can be overridden in the per-route and per-host configurations.
 // The more specific definition completely overrides the less specific definition.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RateLimitQuotaFilterConfig {
   // Configures the gRPC Rate Limit Quota Service (RLQS) RateLimitQuotaService.
   config.core.v3.GrpcService rlqs_server = 1 [(validate.rules).message = {required: true}];
@@ -134,6 +134,18 @@ message RateLimitQuotaFilterConfig {
   // filter is enabled but not enforced.
   repeated config.core.v3.HeaderValueOption request_headers_to_add_when_not_enforced = 6
       [(validate.rules).repeated = {max_items: 10}];
+
+  // The interval at which the data plane reports quota usage to the RLQS server for the buckets
+  // managed by this filter.
+  //
+  // The data plane keeps a single RLQS client (and therefore a single reporting timer) per unique
+  // combination of RLQS server target and :ref:`domain
+  // <envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig.domain>`.
+  // When several filter configurations share the same target and domain, the value from the first
+  // initialized configuration is used.
+  //
+  // If not set, defaults to 5 seconds.
+  google.protobuf.Duration reporting_interval = 7 [(validate.rules).duration = {gt {}}];
 }
 
 // Per-route and per-host configuration overrides. The more specific definition completely

--- a/changelogs/current/new_features/ratelimit__rlqs-configurable-reporting-interval.rst
+++ b/changelogs/current/new_features/ratelimit__rlqs-configurable-reporting-interval.rst
@@ -1,0 +1,4 @@
+Added :ref:`reporting_interval
+<envoy_v3_api_field_extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaFilterConfig.reporting_interval>`
+to the Rate Limit Quota (RLQS) filter, allowing the quota usage reporting interval to be configured.
+It previously defaulted to a hardcoded 5 seconds, which remains the default when the field is unset.

--- a/source/extensions/filters/http/rate_limit_quota/config.cc
+++ b/source/extensions/filters/http/rate_limit_quota/config.cc
@@ -14,6 +14,7 @@
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/type/v3/ratelimit_strategy.pb.h"
 
+#include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/http/rate_limit_quota/client_impl.h"
 #include "source/extensions/filters/http/rate_limit_quota/filter.h"
 #include "source/extensions/filters/http/rate_limit_quota/filter_persistence.h"
@@ -60,9 +61,13 @@ RateLimitQuotaFilterFactory::createHttpFilterFactoryFromProtoTyped(
                                        ? config->rlqs_server().envoy_grpc().cluster_name()
                                        : config->rlqs_server().google_grpc().target_uri();
 
+  // Defaults to 5 seconds when the reporting interval is not set.
+  std::chrono::milliseconds reporting_interval(
+      PROTOBUF_GET_MS_OR_DEFAULT(filter_config, reporting_interval, 5000));
+
   // Get the TLS store from the global map, or create one if it doesn't exist.
-  auto tls_store_or = GlobalTlsStores::getTlsStore(config_with_hash_key, context,
-                                                   rlqs_server_target, filter_config.domain());
+  auto tls_store_or = GlobalTlsStores::getTlsStore(
+      config_with_hash_key, context, rlqs_server_target, filter_config.domain(), reporting_interval);
   RETURN_IF_NOT_OK_REF(tls_store_or.status());
   std::shared_ptr<TlsStore> tls_store = std::move(tls_store_or.value());
 

--- a/source/extensions/filters/http/rate_limit_quota/filter_persistence.cc
+++ b/source/extensions/filters/http/rate_limit_quota/filter_persistence.cc
@@ -27,7 +27,7 @@ using TlsStore = GlobalTlsStores::TlsStore;
 absl::StatusOr<std::shared_ptr<TlsStore>>
 initTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
              Server::Configuration::ServerFactoryContext& context, absl::string_view target_address,
-             absl::string_view domain) {
+             absl::string_view domain, std::chrono::milliseconds reporting_interval) {
   // Quota bucket & global client TLS objects are created with the config and
   // kept alive via shared_ptr to a storage struct. The local rate limit client
   // in each filter instance assumes that the slot will outlive them.
@@ -41,8 +41,7 @@ initTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
 
   // TODO(bsurber): Implement report timing & usage aggregation based on each
   // bucket's reporting_interval field. Currently this is not supported and all
-  // usage is reported on a hardcoded interval.
-  std::chrono::milliseconds reporting_interval(5000);
+  // usage is reported on the filter-level interval passed in here.
 
   // Create the global client resource to be shared via TLS to all worker
   // threads (accessed through a filter-specific LocalRateLimitClient).
@@ -59,7 +58,8 @@ initTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
 absl::StatusOr<std::shared_ptr<TlsStore>>
 GlobalTlsStores::getTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
                              Server::Configuration::ServerFactoryContext& context,
-                             absl::string_view target_address, absl::string_view domain) {
+                             absl::string_view target_address, absl::string_view domain,
+                             std::chrono::milliseconds reporting_interval) {
   TlsStoreIndex index = std::make_pair(std::string(target_address), std::string(domain));
   // Find existing TlsStore or initialize a new one.
   auto it = stores().find(index);
@@ -70,7 +70,8 @@ GlobalTlsStores::getTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_wi
   }
   ENVOY_LOG(debug, "Creating a new cache & RLQS client for target ({}) and domain ({}).",
             index.first, index.second);
-  auto tls_store_or = initTlsStore(config_with_hash_key, context, index.first, index.second);
+  auto tls_store_or =
+      initTlsStore(config_with_hash_key, context, index.first, index.second, reporting_interval);
   RETURN_IF_NOT_OK_REF(tls_store_or.status());
   std::shared_ptr<TlsStore> tls_store = std::move(tls_store_or.value());
   // Save weak_ptr as an unowned reference.

--- a/source/extensions/filters/http/rate_limit_quota/filter_persistence.h
+++ b/source/extensions/filters/http/rate_limit_quota/filter_persistence.h
@@ -3,6 +3,7 @@
 #ifndef THIRD_PARTY_ENVOY_SRC_SOURCE_EXTENSIONS_FILTERS_HTTP_RATE_LIMIT_QUOTA_FILTER_PERSISTENCE_H_
 #define THIRD_PARTY_ENVOY_SRC_SOURCE_EXTENSIONS_FILTERS_HTTP_RATE_LIMIT_QUOTA_FILTER_PERSISTENCE_H_
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -65,11 +66,15 @@ public:
     Envoy::Event::Dispatcher& main_dispatcher_;
   };
 
-  // Get an existing TLS store by index, or create one if not found.
+  // Get an existing TLS store by index, or create one if not found. The
+  // reporting_interval is only applied when a new store (and its RLQS client) is
+  // created; if a store already exists for the index, the existing client's
+  // interval is retained.
   static absl::StatusOr<std::shared_ptr<TlsStore>>
   getTlsStore(const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
               Server::Configuration::ServerFactoryContext& context,
-              absl::string_view target_address, absl::string_view domain);
+              absl::string_view target_address, absl::string_view domain,
+              std::chrono::milliseconds reporting_interval);
 
   // Register a callback to be called when the last TLS store index is cleared.
   // This is intended primarily for test synchronization after filter deletion.

--- a/test/extensions/filters/http/rate_limit_quota/config_test.cc
+++ b/test/extensions/filters/http/rate_limit_quota/config_test.cc
@@ -75,6 +75,56 @@ TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithCorrectProto) {
   GlobalTlsStores::clear();
 }
 
+TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithReportingInterval) {
+  std::string filter_config_yaml = R"EOF(
+  rlqs_server:
+    envoy_grpc:
+      cluster_name: "rate_limit_quota_server"
+  domain: test
+  reporting_interval: 1s
+  bucket_matchers:
+    matcher_list:
+      matchers:
+        predicate:
+          single_predicate:
+            input:
+              name: envoy.matching.inputs.request_headers
+              typed_config:
+                "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                header_name: environment
+            value_match:
+              exact: staging
+        on_match:
+          action:
+            name: rate_limit_quota
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.rate_limit_quota.v3.RateLimitQuotaBucketSettings
+              bucket_id_builder:
+                bucket_id_builder:
+                  "name":
+                      string_value: "prod"
+              reporting_interval: 60s
+  )EOF";
+  envoy::extensions::filters::http::rate_limit_quota::v3::RateLimitQuotaFilterConfig filter_config;
+  TestUtility::loadFromYaml(filter_config_yaml, filter_config);
+
+  auto mock_stream_client = std::make_unique<RateLimitTestClient>();
+  mock_stream_client->expectClientCreationWithFactory();
+
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+
+  RateLimitQuotaFilterFactory factory;
+  std::string stats_prefix = "test";
+  auto cb_or = factory.createFilterFactoryFromProto(filter_config, stats_prefix,
+                                                    mock_stream_client->context_);
+  ASSERT_TRUE(cb_or.ok()) << cb_or.status();
+  Http::FilterFactoryCb cb = std::move(cb_or).value();
+  cb(filter_callback);
+
+  GlobalTlsStores::clear();
+}
+
 TEST(RateLimitQuotaFilterConfigTest, RateLimitQuotaFilterWithInvalidMatcher) {
   std::string filter_config_yaml = R"EOF(
   rlqs_server:


### PR DESCRIPTION
Commit Message:
rate_limit_quota: make usage reporting interval configurable

Additional Description:
The RLQS filter reports quota usage to the server on a fixed 5s interval that is hardcoded in `filter_persistence.cc`. This adds an optional `reporting_interval` field to `RateLimitQuotaFilterConfig` and plumbs it through to the global client. When the field is unset the behavior is unchanged (5s default).

The data plane keeps one RLQS client per (server target, domain) pair, so the interval takes effect when that client is first created. This matches the sharing model already documented for other per-client settings on the same index.

Per-bucket reporting intervals (the existing `TODO(bsurber)`) are out of scope here.

Risk Level: Low — additive optional field, default preserves current behavior.
Testing: Added a config unit test for the configured-interval path; existing tests cover the default.
Docs Changes: API field doc comment plus a changelog entry.
Release Notes: changelogs/current/new_features/ratelimit__rlqs-configurable-reporting-interval.rst
Platform Specific Features: None
Fixes #46033
API Considerations: Additive optional field on an existing message; no changes to defaults or existing fields.

I used an AI assistant to help write and review this change. I understand the code and take responsibility for it.
