### PR TITLE
dynamic_modules: export host callbacks for module-hosting tests on Windows

### DIFF
--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -175,7 +175,8 @@ def envoy_cc_test(
         flaky = False,
         env = {},
         rbe_pool = None,
-        exec_properties = {}):
+        exec_properties = {},
+        win_def_file = None):
     coverage_tags = tags + ([] if coverage else ["nocoverage"])
     exec_properties = exec_properties | select({
         repository + "//bazel:engflow_rbe_x86_64": {"Pool": rbe_pool} if rbe_pool else {},
@@ -193,6 +194,7 @@ def envoy_cc_test(
         additional_linker_inputs = envoy_exported_symbols_input(),
         linkopts = _envoy_test_linkopts() + linkopts,
         linkstatic = envoy_linkstatic(),
+        win_def_file = win_def_file,
         malloc = tcmalloc_external_dep(repository),
         deps = envoy_stdlib_deps() + deps + [envoy_external_dep_path(dep) for dep in external_deps] + [
             repository + "//test:main",

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -9,6 +9,22 @@ licenses(["notice"])  # Apache 2
 
 envoy_extension_package()
 
+# Generates the Windows module-definition file that exports the host callbacks so a loaded module
+# can resolve them. The list is derived from the callbacks defined in abi_impl.cc (the abi_impl
+# target), which are present in any binary that links it. Extension-specific callbacks defined in
+# other abi_impl.cc files are not included; the Windows module loader will need the full union.
+genrule(
+    name = "windows_exports_def",
+    srcs = ["abi_impl.cc"],
+    outs = ["dynamic_modules_windows_exports.def"],
+    cmd = "$(location //tools/dynamic_modules:generate_windows_exports_def) $(location abi_impl.cc) $@",
+    tools = ["//tools/dynamic_modules:generate_windows_exports_def"],
+    visibility = [
+        "//test/extensions/dynamic_modules:__subpackages__",
+        "//tools/dynamic_modules:__pkg__",
+    ],
+)
+
 envoy_cc_library(
     name = "dynamic_modules_lib",
     srcs = [

--- a/test/extensions/dynamic_modules/BUILD
+++ b/test/extensions/dynamic_modules/BUILD
@@ -6,16 +6,16 @@ load(
 )
 load(
     "//bazel:envoy_build_system.bzl",
-    "envoy_cc_test",
     "envoy_cc_test_library",
     "envoy_package",
 )
+load("//test/extensions/dynamic_modules:dynamic_module_test.bzl", "envoy_cc_dynamic_module_test")
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "dynamic_modules_test",
     srcs = ["dynamic_modules_test.cc"],
     data = [
@@ -52,7 +52,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "abi_impl_test",
     size = "large",
     srcs = ["abi_impl_test.cc"],

--- a/test/extensions/dynamic_modules/dynamic_module_test.bzl
+++ b/test/extensions/dynamic_modules/dynamic_module_test.bzl
@@ -1,0 +1,18 @@
+"""Bazel macro for tests that load dynamic modules."""
+
+load("//bazel:envoy_build_system.bzl", "envoy_cc_test")
+
+def envoy_cc_dynamic_module_test(name, **kwargs):
+    """Defines an envoy_cc_test whose binary hosts dynamic modules.
+
+    A loaded module resolves the host callbacks against the test binary, so the binary must export
+    them. On Linux and macOS this happens through the global exported-symbols lists. Windows has no
+    wildcard export and rejects a module-definition file that names an undefined symbol, so the
+    export list cannot be applied to every test. This macro passes a module-definition file on
+    Windows so only the tests that host dynamic modules export the callbacks.
+    """
+    envoy_cc_test(
+        name = name,
+        win_def_file = "//source/extensions/dynamic_modules:windows_exports_def",
+        **kwargs
+    )

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test",
     "envoy_package",
 )
+load("//test/extensions/dynamic_modules:dynamic_module_test.bzl", "envoy_cc_dynamic_module_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -68,7 +69,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "filter_test",
     srcs = ["filter_test.cc"],
     data = [
@@ -109,7 +110,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "abi_impl_test",
     srcs = ["abi_impl_test.cc"],
     data = [
@@ -141,7 +142,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/listener/BUILD
+++ b/test/extensions/dynamic_modules/listener/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test",
     "envoy_package",
 )
+load("//test/extensions/dynamic_modules:dynamic_module_test.bzl", "envoy_cc_dynamic_module_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -76,7 +77,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/test/extensions/dynamic_modules/network/BUILD
+++ b/test/extensions/dynamic_modules/network/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_cc_test",
     "envoy_package",
 )
+load("//test/extensions/dynamic_modules:dynamic_module_test.bzl", "envoy_cc_dynamic_module_test")
 
 licenses(["notice"])  # Apache 2
 
@@ -74,7 +75,7 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_test(
+envoy_cc_dynamic_module_test(
     name = "integration_test",
     srcs = ["integration_test.cc"],
     data = [

--- a/tools/dynamic_modules/BUILD
+++ b/tools/dynamic_modules/BUILD
@@ -1,0 +1,20 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+
+licenses(["notice"])  # Apache 2
+
+py_binary(
+    name = "generate_windows_exports_def",
+    srcs = ["generate_windows_exports_def.py"],
+    imports = ["."],
+    visibility = ["//source/extensions/dynamic_modules:__pkg__"],
+)
+
+py_test(
+    name = "generate_windows_exports_def_test",
+    srcs = ["generate_windows_exports_def_test.py"],
+    data = ["//source/extensions/dynamic_modules:windows_exports_def"],
+    env = {
+        "WINDOWS_EXPORTS_DEF": "$(location //source/extensions/dynamic_modules:windows_exports_def)",
+    },
+    deps = [":generate_windows_exports_def"],
+)

--- a/tools/dynamic_modules/generate_windows_exports_def.py
+++ b/tools/dynamic_modules/generate_windows_exports_def.py
@@ -1,0 +1,30 @@
+"""Generates the Windows module-definition file for dynamic module host callbacks.
+
+The Windows linker rejects a .def that names an undefined symbol and has no wildcard export. The
+callbacks defined in abi_impl.cc are present in any binary that links the base abi_impl target, so
+deriving the list from that file keeps it in sync with the ABI and keeps every exported name
+resolvable. The names are emitted undecorated, which matches Envoy's x64-only Windows target.
+"""
+
+import re
+import sys
+
+# Matches a callback definition: the name followed by an argument list and an opening brace.
+# Anchoring on the definition keeps references in comments, strings, or calls out of the export
+# list, where a name that is not defined in the binary would break the Windows link.
+_CALLBACK_DEFINITION = re.compile(
+    r"(?<![A-Za-z0-9_])(envoy_dynamic_module_callback_[a-z0-9_]+)\s*\([^{};]*\)\s*\{")
+
+
+def generate(abi_impl_source):
+    """Returns the module-definition contents exporting the callbacks defined in the source."""
+    names = sorted(set(_CALLBACK_DEFINITION.findall(abi_impl_source)))
+    return "EXPORTS\n" + "".join("  {}\n".format(name) for name in names)
+
+
+if __name__ == "__main__":
+    input_path, output_path = sys.argv[1], sys.argv[2]
+    with open(input_path, encoding="utf-8") as input_file:
+        contents = input_file.read()
+    with open(output_path, "w", encoding="utf-8") as output_file:
+        output_file.write(generate(contents))

--- a/tools/dynamic_modules/generate_windows_exports_def_test.py
+++ b/tools/dynamic_modules/generate_windows_exports_def_test.py
@@ -1,0 +1,60 @@
+"""Tests the Windows module-definition file generator for dynamic module host callbacks."""
+
+import os
+import re
+import sys
+import unittest
+
+import generate_windows_exports_def
+
+_EXPORT_LINE = re.compile(r"^  (envoy_dynamic_module_callback_[a-z0-9_]+)$")
+
+
+class GenerateWindowsExportsDefTest(unittest.TestCase):
+
+    def test_sorts_and_deduplicates_definitions(self):
+        source = ("void envoy_dynamic_module_callback_b(int x) {}\n"
+                  "void envoy_dynamic_module_callback_a(int x) {}\n"
+                  "void envoy_dynamic_module_callback_a(int x) {}\n")
+        expected = ("EXPORTS\n"
+                    "  envoy_dynamic_module_callback_a\n"
+                    "  envoy_dynamic_module_callback_b\n")
+        self.assertEqual(generate_windows_exports_def.generate(source), expected)
+
+    def test_ignores_references_that_are_not_definitions(self):
+        source = ("// See envoy_dynamic_module_callback_commented(ctx) for details.\n"
+                  'IS_ENVOY_BUG("envoy_dynamic_module_callback_wrapped_"\n'
+                  '             "string: not implemented");\n'
+                  "  envoy_dynamic_module_callback_called(ctx);\n"
+                  "void envoy_dynamic_module_callback_defined(int x) {}\n")
+        expected = "EXPORTS\n  envoy_dynamic_module_callback_defined\n"
+        self.assertEqual(generate_windows_exports_def.generate(source), expected)
+
+    def test_empty_source_returns_only_the_exports_header(self):
+        self.assertEqual(generate_windows_exports_def.generate(""), "EXPORTS\n")
+
+    def test_generated_file_from_real_abi_impl_is_well_formed(self):
+        # Validates the file produced from the real abi_impl.cc, guarding against a parsing
+        # regression that silently drops callbacks from the Windows export list.
+        with open(os.environ["WINDOWS_EXPORTS_DEF"], encoding="utf-8") as def_file:
+            lines = def_file.read().splitlines()
+        self.assertTrue(lines, "the module-definition file is empty")
+        self.assertEqual(lines[0], "EXPORTS")
+
+        names = []
+        for line in lines[1:]:
+            match = _EXPORT_LINE.match(line)
+            self.assertIsNotNone(match, "malformed export line: {}".format(line))
+            names.append(match.group(1))
+
+        self.assertIn("envoy_dynamic_module_callback_log", names)
+        self.assertIn("envoy_dynamic_module_callback_log_enabled", names)
+        self.assertGreater(len(names), 100, "the export list looks truncated")
+        self.assertEqual(names, sorted(names), "exports must be sorted")
+        self.assertEqual(len(names), len(set(names)), "exports must be unique")
+
+
+if __name__ == "__main__":
+    # Ignore any test-runner arguments (for example the "-l trace --log-path" that coverage builds
+    # pass to every test binary) so unittest does not treat them as test names.
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
## Background

On Linux and macOS the dynamic module host callbacks are exported to every test through the wildcard exported-symbols lists, which tolerate absent symbols. Windows has no wildcard export and its linker rejects a module-definition file that names an undefined symbol, so the export cannot be applied to every test without breaking the ones that do not define the callbacks.

## Description

This PR adds `envoy_cc_dynamic_module_test`, which wraps `envoy_cc_test` and, on Windows, passes a generated module-definition file that exports the callbacks defined in `abi_impl.cc`.

---

**Commit Message:** dynamic_modules: export host callbacks for module-hosting tests on Windows
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added