### PR TITLE
wasm/v8: Source wee8 from envoy_toolshed prebuilt via label_flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -92,22 +92,9 @@ build --define absl=1
 # Disable ICU linking for googleurl.
 build --@googleurl//build_config:system_icu=0
 
-# Source the V8/wee8 engine from the envoy_toolshed prebuilt static library
-# instead of building V8 from source (30-120min -> seconds). The label_flag is
-# defined in proxy-wasm-cpp-host (bazel/proxy_wasm_cpp_host.patch); its value is
-# resolved in the root repo mapping, so this works in WORKSPACE and bzlmod. The
-# @envoy_toolshed//v8:wee8 alias falls back to @v8//:wee8 on platforms without a
-# prebuilt.
+# Source wee8 from the envoy_toolshed prebuilt; fall back to source for gcc
+# (libstdc++ ABI) and sanitizers (need instrumented deps).
 build --@proxy-wasm-cpp-host//bazel:v8_engine=@envoy_toolshed//v8:wee8
-
-# The published prebuilt is a clang/libc++, non-instrumented x86_64 build, so it
-# is only ABI/runtime compatible with the default x86_64 clang/libc++ config.
-# Fall back to building wee8 from source where that assumption breaks:
-#   - gcc:       needs a libstdc++ (std::) ABI, not libc++ (std::__1::).
-#   - sanitizer: asan/msan/tsan need instrumented deps (asan/msan/tsan all
-#                expand to --config=sanitizer).
-# (aarch64 is selected by the alias but the current prebuilt is runtime-broken;
-# that is fixed toolshed-side since there is no .bazelrc config hook for cpu.)
 build:gcc --@proxy-wasm-cpp-host//bazel:v8_engine=@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression
 build:sanitizer --@proxy-wasm-cpp-host//bazel:v8_engine=@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -92,12 +92,6 @@ build --define absl=1
 # Disable ICU linking for googleurl.
 build --@googleurl//build_config:system_icu=0
 
-# Source wee8 from the envoy_toolshed prebuilt; fall back to source for gcc
-# (libstdc++ ABI) and sanitizers (need instrumented deps).
-build --@proxy-wasm-cpp-host//bazel:v8_engine=@envoy_toolshed//v8:wee8
-build:gcc --@proxy-wasm-cpp-host//bazel:v8_engine=@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression
-build:sanitizer --@proxy-wasm-cpp-host//bazel:v8_engine=@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression
-
 # Test options
 build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -92,6 +92,14 @@ build --define absl=1
 # Disable ICU linking for googleurl.
 build --@googleurl//build_config:system_icu=0
 
+# Source the V8/wee8 engine from the envoy_toolshed prebuilt static library
+# instead of building V8 from source (30-120min -> seconds). The label_flag is
+# defined in proxy-wasm-cpp-host (bazel/proxy_wasm_cpp_host.patch); its value is
+# resolved in the root repo mapping, so this works in WORKSPACE and bzlmod. The
+# @envoy_toolshed//v8:wee8 alias falls back to @v8//:wee8 on platforms without a
+# prebuilt.
+build --@proxy-wasm-cpp-host//bazel:v8_engine=@envoy_toolshed//v8:wee8
+
 # Test options
 build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -100,6 +100,17 @@ build --@googleurl//build_config:system_icu=0
 # prebuilt.
 build --@proxy-wasm-cpp-host//bazel:v8_engine=@envoy_toolshed//v8:wee8
 
+# The published prebuilt is a clang/libc++, non-instrumented x86_64 build, so it
+# is only ABI/runtime compatible with the default x86_64 clang/libc++ config.
+# Fall back to building wee8 from source where that assumption breaks:
+#   - gcc:       needs a libstdc++ (std::) ABI, not libc++ (std::__1::).
+#   - sanitizer: asan/msan/tsan need instrumented deps (asan/msan/tsan all
+#                expand to --config=sanitizer).
+# (aarch64 is selected by the alias but the current prebuilt is runtime-broken;
+# that is fixed toolshed-side since there is no .bazelrc config hook for cpu.)
+build:gcc --@proxy-wasm-cpp-host//bazel:v8_engine=@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression
+build:sanitizer --@proxy-wasm-cpp-host//bazel:v8_engine=@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression
+
 # Test options
 build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
 

--- a/api/bazel/deps.yaml
+++ b/api/bazel/deps.yaml
@@ -43,11 +43,7 @@ envoy_toolshed:
   - sysroot_linux_arm64
   - tsan_libs
   - msan_libs
-  # Prebuilt wee8 static-library repos defined by setup_wee8_prebuilt()
-  # (bazel/repositories_extra.bzl); the @envoy_toolshed//v8:wee8 alias selects
-  # the right one per platform. Kept in sync with bazel/deps.yaml because the
-  # merged metadata (bazel/BUILD:legacy_all_repository_locations) uses jq `*`,
-  # which replaces arrays with this (right-hand) operand's value.
+  # Prebuilt wee8 repos; must mirror bazel/deps.yaml (jq `*` merge replaces this array).
   - wee8_prebuilt_x86_64
   - wee8_prebuilt_x86_64_libstdcxx
   - wee8_prebuilt_aarch64

--- a/api/bazel/deps.yaml
+++ b/api/bazel/deps.yaml
@@ -43,6 +43,14 @@ envoy_toolshed:
   - sysroot_linux_arm64
   - tsan_libs
   - msan_libs
+  # Prebuilt wee8 static-library repos defined by setup_wee8_prebuilt()
+  # (bazel/repositories_extra.bzl); the @envoy_toolshed//v8:wee8 alias selects
+  # the right one per platform. Kept in sync with bazel/deps.yaml because the
+  # merged metadata (bazel/BUILD:legacy_all_repository_locations) uses jq `*`,
+  # which replaces arrays with this (right-hand) operand's value.
+  - wee8_prebuilt_x86_64
+  - wee8_prebuilt_x86_64_libstdcxx
+  - wee8_prebuilt_aarch64
   license: "Apache-2.0"
   license_url: "https://github.com/envoyproxy/toolshed/blob/bazel-v{version}/LICENSE"
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -555,6 +555,19 @@ label_flag(
     build_setting_default = "@boringssl//:crypto",
 )
 
+# wee8 engine: envoy_toolshed prebuilt by default, source for configs the
+# prebuilt is incompatible with (gcc libstdc++ ABI; sanitizers need instrumented deps).
+alias(
+    name = "wee8_engine",
+    actual = select({
+        ":gcc_build": "@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression",
+        ":asan_build": "@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression",
+        ":msan_build": "@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression",
+        ":tsan_build": "@proxy-wasm-cpp-host//bazel:wee8_no_pointer_compression",
+        "//conditions:default": "@envoy_toolshed//v8:wee8",
+    }),
+)
+
 bool_flag(
     name = "fips",
     build_setting_default = False,

--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -306,9 +306,7 @@ envoy_toolshed:
   - sysroot_linux_arm64
   - tsan_libs
   - msan_libs
-  # Prebuilt wee8 static-library repos defined by setup_wee8_prebuilt()
-  # (bazel/repositories_extra.bzl); the @envoy_toolshed//v8:wee8 alias selects
-  # the right one per platform.
+  # Prebuilt wee8 repos; must mirror api/bazel/deps.yaml.
   - wee8_prebuilt_x86_64
   - wee8_prebuilt_x86_64_libstdcxx
   - wee8_prebuilt_aarch64

--- a/bazel/deps.yaml
+++ b/bazel/deps.yaml
@@ -306,6 +306,12 @@ envoy_toolshed:
   - sysroot_linux_arm64
   - tsan_libs
   - msan_libs
+  # Prebuilt wee8 static-library repos defined by setup_wee8_prebuilt()
+  # (bazel/repositories_extra.bzl); the @envoy_toolshed//v8:wee8 alias selects
+  # the right one per platform.
+  - wee8_prebuilt_x86_64
+  - wee8_prebuilt_x86_64_libstdcxx
+  - wee8_prebuilt_aarch64
   license: "Apache-2.0"
   license_url: "https://github.com/envoyproxy/toolshed/blob/bazel-v{version}/LICENSE"
 

--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -138,7 +138,7 @@ diff --git a/bazel/BUILD b/bazel/BUILD
  )
  
  config_setting(
-@@ -77,4 +124,21 @@ v8_lib_no_pointer_compression(
+@@ -77,4 +124,15 @@ v8_lib_no_pointer_compression(
      library = "@v8//:wee8",
  )
  
@@ -147,13 +147,7 @@ diff --git a/bazel/BUILD b/bazel/BUILD
 +    build_setting_default = "@envoy//bazel:crypto",
 +)
 +
-+# Source of the V8/wee8 engine library, selectable by the consuming (root)
-+# module. Defaults to building wee8 from @v8 source (with pointer compression
-+# disabled). A consumer can point this at a prebuilt drop-in, e.g.
-+#   --//bazel:v8_engine=@envoy_toolshed//v8:wee8
-+# The value is resolved in the root module's repo mapping, so this works in both
-+# WORKSPACE and bzlmod modes without patching this repo to reference a foreign
-+# repository directly.
++# v8/wee8 engine source; the root module can point this at a prebuilt drop-in.
 +label_flag(
 +    name = "v8_engine",
 +    build_setting_default = ":wee8_no_pointer_compression",

--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -1,7 +1,7 @@
 diff --git a/BUILD b/BUILD
 --- a/BUILD
 +++ b/BUILD
-@@ -93,7 +93,7 @@
+@@ -93,7 +93,7 @@ cc_library(
          "@com_google_absl//absl/cleanup",
      ] + select({
          "//bazel:crypto_system": [],
@@ -10,7 +10,16 @@ diff --git a/BUILD b/BUILD
      }),
      alwayslink = 1,
  )
-@@ -158,7 +158,7 @@
+@@ -136,7 +136,7 @@ cc_library(
+     deps = [
+         ":base_lib",
+         ":wasm_vm_headers",
+-        "//bazel:wee8_no_pointer_compression",
++        "//bazel:v8_engine",
+     ],
+ )
+ 
+@@ -158,7 +158,7 @@ cc_library(
      }),
      deps = [
          ":wasm_vm_headers",
@@ -19,7 +28,7 @@ diff --git a/BUILD b/BUILD
      ],
  )
  
-@@ -224,7 +224,7 @@
+@@ -224,7 +224,7 @@ cc_library(
      deps = [
          ":base_lib",
          ":wasm_vm_headers",
@@ -129,13 +138,20 @@ diff --git a/bazel/BUILD b/bazel/BUILD
  )
  
  config_setting(
-@@ -77,4 +124,9 @@
+@@ -77,4 +124,16 @@ v8_lib_no_pointer_compression(
      library = "@v8//:wee8",
  )
  
++# Source of the V8/wee8 engine library, selectable by the consuming (root)
++# module. Defaults to building wee8 from @v8 source (with pointer compression
++# disabled). A consumer can point this at a prebuilt drop-in, e.g.
++#   --//bazel:v8_engine=@envoy_toolshed//v8:wee8
++# The value is resolved in the root module's repo mapping, so this works in both
++# WORKSPACE and bzlmod modes without patching this repo to reference a foreign
++# repository directly.
 +label_flag(
-+    name = "crypto_lib",
-+    build_setting_default = "@envoy//bazel:crypto",
++    name = "v8_engine",
++    build_setting_default = ":wee8_no_pointer_compression",
 +)
 +
  exports_files(["tsan_suppressions.txt"])

--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -138,7 +138,7 @@ diff --git a/bazel/BUILD b/bazel/BUILD
  )
  
  config_setting(
-@@ -77,4 +124,15 @@ v8_lib_no_pointer_compression(
+@@ -77,4 +124,14 @@ v8_lib_no_pointer_compression(
      library = "@v8//:wee8",
  )
  
@@ -147,10 +147,9 @@ diff --git a/bazel/BUILD b/bazel/BUILD
 +    build_setting_default = "@envoy//bazel:crypto",
 +)
 +
-+# v8/wee8 engine source; the root module can point this at a prebuilt drop-in.
 +label_flag(
 +    name = "v8_engine",
-+    build_setting_default = ":wee8_no_pointer_compression",
++    build_setting_default = "@envoy//bazel:wee8_engine",
 +)
 +
  exports_files(["tsan_suppressions.txt"])

--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -138,10 +138,15 @@ diff --git a/bazel/BUILD b/bazel/BUILD
  )
  
  config_setting(
-@@ -77,4 +124,16 @@ v8_lib_no_pointer_compression(
+@@ -77,4 +124,21 @@ v8_lib_no_pointer_compression(
      library = "@v8//:wee8",
  )
  
++label_flag(
++    name = "crypto_lib",
++    build_setting_default = "@envoy//bazel:crypto",
++)
++
 +# Source of the V8/wee8 engine library, selectable by the consuming (root)
 +# module. Defaults to building wee8 from @v8 source (with pointer compression
 +# disabled). A consumer can point this at a prebuilt drop-in, e.g.

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -3,6 +3,7 @@ load("@emsdk//:deps.bzl", emsdk_deps = "deps")
 load("@envoy_toolshed//compile:libcxx_libs.bzl", "setup_libcxx_libs")
 load("@envoy_toolshed//compile:llvm_minimal.bzl", "llvm_toolchain_alias", "setup_llvm_minimal")
 load("@envoy_toolshed//sysroot:sysroot.bzl", "setup_sysroots")
+load("@envoy_toolshed//v8:wee8_prebuilt.bzl", "setup_wee8_prebuilt")
 load("@protobuf//bazel/private/oss:proto_bazel_features.bzl", "proto_bazel_features")
 load("@proxy-wasm-cpp-host//bazel/cargo/wasmtime/remote:crates.bzl", wasmtime_crate_repositories = "crate_repositories")
 load("@rules_cc//cc:extensions.bzl", "compatibility_proxy_repo")
@@ -39,6 +40,13 @@ def envoy_dependencies_extra(
             minimal_macos_arm64 = "@llvm_minimal_macos_arm64//:BUILD.bazel",
         )
     setup_sysroots(glibc_version = glibc_version)
+
+    # Prebuilt wee8 static libraries (@wee8_prebuilt_*), injected into
+    # proxy-wasm-cpp-host's v8_lib via the //bazel:v8_engine label_flag (see
+    # .bazelrc). Falls back to building @v8//:wee8 from source on unsupported
+    # platforms.
+    setup_wee8_prebuilt()
+
     emsdk_deps()
     wasm_examples_crate_repositories()
     wasmtime_crate_repositories()

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -41,10 +41,7 @@ def envoy_dependencies_extra(
         )
     setup_sysroots(glibc_version = glibc_version)
 
-    # Prebuilt wee8 static libraries (@wee8_prebuilt_*), injected into
-    # proxy-wasm-cpp-host's v8_lib via the //bazel:v8_engine label_flag (see
-    # .bazelrc). Falls back to building @v8//:wee8 from source on unsupported
-    # platforms.
+    # Prebuilt wee8 (@wee8_prebuilt_*), selected via the //bazel:v8_engine flag.
     setup_wee8_prebuilt()
 
     emsdk_deps()

--- a/test/tools/wee8_compile/BUILD
+++ b/test/tools/wee8_compile/BUILD
@@ -24,11 +24,7 @@ envoy_cc_library(
         "-Wno-unused-parameter",
     ],
     deps = [
-        # The toolshed prebuilt wee8 excludes abseil from libwee8.a by design
-        # (consumers provide their own to avoid ODR/ABI clashes), so this
-        # minimal v8_lib consumer must supply the absl symbols wee8 references.
-        # The from-source @v8//:wee8 propagates these transitively; the prebuilt
-        # does not.
+        # abseil is excluded from the prebuilt wee8; supply it at the consumer.
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/hash",

--- a/test/tools/wee8_compile/BUILD
+++ b/test/tools/wee8_compile/BUILD
@@ -24,6 +24,15 @@ envoy_cc_library(
         "-Wno-unused-parameter",
     ],
     deps = [
+        # The toolshed prebuilt wee8 excludes abseil from libwee8.a by design
+        # (consumers provide their own to avoid ODR/ABI clashes), so this
+        # minimal v8_lib consumer must supply the absl symbols wee8 references.
+        # The from-source @v8//:wee8 propagates these transitively; the prebuilt
+        # does not.
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/hash",
+        "@abseil-cpp//absl/synchronization",
         "@proxy-wasm-cpp-host//:base_lib",
         "@proxy-wasm-cpp-host//:v8_lib",
     ],


### PR DESCRIPTION
**Commit Message:** wasm/v8: Source wee8 from envoy_toolshed prebuilt via label_flag

**Additional Description:**

This wires Envoy's proxy-wasm V8 engine to consume the **prebuilt `wee8` static
library** published by `envoy_toolshed`, instead of building V8 from source
(~30–120 min → seconds), while keeping the change working in **both WORKSPACE
and bzlmod** modes.

### Mechanism — a `label_flag`, not a hardcoded rewrite

proxy-wasm-cpp-host's `v8_lib` depends on `//bazel:wee8_no_pointer_compression`,
which wraps `@v8//:wee8` and therefore builds V8 from source. To use the prebuilt
that dep must be redirected to `@envoy_toolshed//v8:wee8`.

The previous WORKSPACE-only approach hardcoded that redirect inside proxy-wasm's
`BUILD` — which only works because WORKSPACE has a flat, global repo namespace.
Under bzlmod's strict per-module repo visibility, a label inside proxy-wasm
resolves against proxy-wasm's *own* repo mapping, which does not declare
`@envoy_toolshed` (fails with `No repository visible as '@envoy_toolshed'`).
`override_repo`/overrides are root-module-only, so the redirect can't live in the
`envoy_toolshed` dep either.

The portable fix: proxy-wasm's v8 engine dep becomes a
`label_flag //bazel:v8_engine` (default `:wee8_no_pointer_compression`, preserving
upstream from-source behaviour). The **root** module (Envoy) sets the flag value to
`@envoy_toolshed//v8:wee8`. A root-set `label_flag` *value* resolves in the root's
repo mapping — where `@envoy_toolshed` is a `bazel_dep` — so the same seam works in
WORKSPACE and bzlmod. The patch bakes in no Envoy-specific repo, making it a
candidate to upstream into proxy-wasm-cpp-host.

This is complementary to the existing `//bazel:engine` `string_flag` (which selects
*which* wasm engine): the new `//bazel:v8_engine` `label_flag` selects *which V8
source* (prebuilt vs from-source).

`@envoy_toolshed//v8:wee8` is a platform-agnostic alias that selects the right
prebuilt per platform (linux x86_64/aarch64, libcxx/libstdc++) and **falls back to
`@v8//:wee8` from-source on unsupported platforms** — so no platform loses support.

### Changes
- `bazel/proxy_wasm_cpp_host.patch`: add `label_flag(name = "v8_engine",
  build_setting_default = ":wee8_no_pointer_compression")`; point `v8_lib` deps at
  `//bazel:v8_engine`. (Regenerated from pristine proxy-wasm; round-trip verified.)
- `.bazelrc`: `build --@proxy-wasm-cpp-host//bazel:v8_engine=@envoy_toolshed//v8:wee8`.
- `bazel/repositories_extra.bzl`: `setup_wee8_prebuilt()` to define the
  `@wee8_prebuilt_*` repos. Requires `envoy_toolshed >= 0.4.9` (already pinned on main).

### Status / follow-ups (draft PR — showcasing the milestone)
- ✅ Works end-to-end in the real Envoy tree today (WORKSPACE mode). See Testing.
- ⬜ Full Envoy-in-bzlmod wiring is staged follow-up gated on the broader bzlmod
  migration: `envoy_toolshed` as a `bazel_dep`, swapping `setup_wee8_prebuilt()`
  for the `wee8_prebuilt_extension` `use_repo`, and proxy-wasm gaining a
  `MODULE.bazel`. The `label_flag` seam is ready for all of that today.
- ⬜ Optionally upstream the generic `label_flag` to proxy-wasm-cpp-host.

**Risk Level:** Low — default flag value preserves upstream from-source behaviour;
prebuilt path falls back to source on unsupported platforms; no BUILD/source edits
outside the patch and dependency wiring.

**Testing:** Full `./ci/do_ci.sh dev` (docker, WORKSPACE, published `envoy_toolshed`
0.4.9 prebuilt): `envoy-static` and all test binaries link against the prebuilt
`libwee8.a` with no undefined symbols. **1695/1702 tests pass**; the 7 failures are
unrelated env/flaky integration tests (IPv6-less docker on DNS/forward-proxy cases,
a mount-permissions shell test, redis fake-upstream segfaults, one flaky geoip) — no
wasm/v8 targets among them. `cquery` on `@proxy-wasm-cpp-host//:v8_lib` shows
`@wee8_prebuilt_x86_64//:wee8` + `lib/libwee8.a` and zero `@v8//` references.

**Docs Changes:** N/A

**Release Notes:** N/A (build/dependency wiring; no user-facing behaviour change)

**Platform Specific Features:** Prebuilt wee8 available for linux x86_64 (libcxx +
libstdc++) and aarch64 (libcxx); other platforms transparently fall back to building
V8 from source.
