### PR TITLE
dynmod/bindgen: Simplify bazel paths/flags by mangling in rust

### DIFF
--- a/source/extensions/dynamic_modules/sdk/rust/BUILD
+++ b/source/extensions/dynamic_modules/sdk/rust/BUILD
@@ -29,17 +29,11 @@ cargo_build_script(
         },
         "@platforms//os:linux": {
             "LIBCLANG_PATH": "$(location @llvm_toolchain_llvm//:lib/libclang.so)",
-            "BINDGEN_EXTRA_CLANG_ARGS": " ".join([
-                "-resource-dir $${pwd}/external/llvm_toolchain_llvm/lib/clang/" + LLVM_MAJOR,
-                "-isystem $${pwd}/external/llvm_toolchain_llvm/lib_legacy/clang/" + LLVM_MAJOR + "/include",
-                "-isystem $${pwd}/external/llvm_toolchain_llvm/include/x86_64-unknown-linux-gnu/c++/v1/",
-                "-isystem $${pwd}/external/llvm_toolchain_llvm/include/aarch64-unknown-linux-gnu/c++/v1/",
-                # This allows the cross-compilation of the SDK to succeed by providing the necessary system headers for the target platform.
-                "-isystem $${pwd}/external/sysroot_linux_x86_64/usr/include",
-                "-isystem $${pwd}/external/sysroot_linux_x86_64/usr/include/x86_64-linux-gnu",
-                "-isystem $${pwd}/external/sysroot_linux_arm64/usr/include",
-                "-isystem $${pwd}/external/sysroot_linux_arm64/usr/include/aarch64-linux-gnu",
-            ]),
+            "ENVOY_LLVM_ANCHOR": "$(location @llvm_toolchain_llvm//:lib/libclang.so)",
+            "ENVOY_LLVM_MAJOR": LLVM_MAJOR,
+            # This allows the cross-compilation of the SDK to succeed by providing the necessary system headers for the target platform.
+            "ENVOY_SYSROOT_AMD64_ANCHOR": "$(location @sysroot_linux_amd64//:usr/include/stdio.h)",
+            "ENVOY_SYSROOT_ARM64_ANCHOR": "$(location @sysroot_linux_arm64//:usr/include/stdio.h)",
         },
         "//conditions:default": {},
     }),
@@ -51,6 +45,8 @@ cargo_build_script(
             "@llvm_toolchain_llvm//:include",
             "@llvm_toolchain_llvm//:lib/libclang.so",
             "@llvm_toolchain_llvm//:lib_legacy",
+            "@sysroot_linux_amd64//:usr/include/stdio.h",
+            "@sysroot_linux_arm64//:usr/include/stdio.h",
         ],
         "//conditions:default": [],
     }) + select({

--- a/source/extensions/dynamic_modules/sdk/rust/build.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/build.rs
@@ -1,5 +1,80 @@
 use std::env;
+use std::path::Path;
 use std::path::PathBuf;
+
+// Resolves a `$(location ...)` value produced by Bazel to an absolute path.
+//
+// `$(location ...)` yields a path relative to the execroot, but the current working directory of
+// a Bazel-invoked build script isn't guaranteed to *be* the execroot. So we canonicalize against
+// the current working directory, and if that doesn't exist, we walk up parent directories of the
+// current working directory until the relative path resolves.
+fn resolve_bazel_location(location: &str) -> Option<PathBuf> {
+  let mut dir = env::current_dir().ok()?;
+  loop {
+    let candidate = dir.join(location);
+    if candidate.exists() {
+      return candidate.canonicalize().ok();
+    }
+    if !dir.pop() {
+      return None;
+    }
+  }
+}
+
+// Derives the `BINDGEN_EXTRA_CLANG_ARGS`-equivalent clang arguments from the anchor environment
+// variables set by the `@platforms//os:linux` branch of `build_script_env` in the BUILD file
+// (see there for details). These are only set when building under Bazel on Linux; a plain
+// `cargo build` (or a macOS/Bazel build) leaves them unset, in which case this returns an empty
+// vector and behavior is unchanged.
+fn bazel_clang_args() -> Vec<String> {
+  let mut args = Vec::new();
+
+  if let Ok(llvm_anchor) = env::var("ENVOY_LLVM_ANCHOR") {
+    if let Some(anchor) = resolve_bazel_location(&llvm_anchor) {
+      // The anchor is `<llvm repo root>/lib/libclang.so`, so its grandparent is the repo root.
+      if let Some(root) = anchor.parent().and_then(Path::parent) {
+        let llvm_major = env::var("ENVOY_LLVM_MAJOR").unwrap_or_default();
+        args.push("-resource-dir".to_string());
+        args.push(format!("{}/lib/clang/{}", root.display(), llvm_major));
+        args.push("-isystem".to_string());
+        args.push(format!(
+          "{}/lib_legacy/clang/{}/include",
+          root.display(),
+          llvm_major
+        ));
+        args.push("-isystem".to_string());
+        args.push(format!(
+          "{}/include/x86_64-unknown-linux-gnu/c++/v1",
+          root.display()
+        ));
+        args.push("-isystem".to_string());
+        args.push(format!(
+          "{}/include/aarch64-unknown-linux-gnu/c++/v1",
+          root.display()
+        ));
+      }
+    }
+  }
+
+  // This allows the cross-compilation of the SDK to succeed by providing the necessary system
+  // headers for the target platform.
+  for (env_var, triple) in [
+    ("ENVOY_SYSROOT_AMD64_ANCHOR", "x86_64-linux-gnu"),
+    ("ENVOY_SYSROOT_ARM64_ANCHOR", "aarch64-linux-gnu"),
+  ] {
+    if let Ok(sysroot_anchor) = env::var(env_var) {
+      if let Some(anchor) = resolve_bazel_location(&sysroot_anchor) {
+        // The anchor is `<sysroot>/usr/include/stdio.h`, so its parent is `usr/include`.
+        if let Some(include_dir) = anchor.parent() {
+          args.push(format!("-isystem {}", include_dir.display()));
+          args.push(format!("-isystem {}/{}", include_dir.display(), triple));
+        }
+      }
+    }
+  }
+
+  args
+}
 
 fn main() {
   // This is Envoy CI specific: Check if "/opt/llvm/bin/clang" exists, and if it does, set the
@@ -18,6 +93,7 @@ fn main() {
 
   let bindings = bindgen::Builder::default()
     .header(abi_header.to_str().unwrap())
+    .clang_args(bazel_clang_args())
     .clang_arg("-v")
     .default_enum_style(bindgen::EnumVariation::Rust {
       non_exhaustive: false,


### PR DESCRIPTION
also makes it compatible with bzlmod
