### PR TITLE
add support for cookie in jwt claims descriptor extenstion

### DIFF
--- a/api/envoy/extensions/rate_limit_descriptors/jwt_claim/v3/jwt_claim.proto
+++ b/api/envoy/extensions/rate_limit_descriptors/jwt_claim/v3/jwt_claim.proto
@@ -15,7 +15,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // [#extension: envoy.rate_limit_descriptors.jwt_claim]
 
 // The following descriptor entry is appended with a value extracted from a
-// named claim in a JWT found in an HTTP request header.
+// named claim in a JWT found in an HTTP request header or cookie.
 //
 // .. code-block:: cpp
 //
@@ -50,20 +50,31 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 //    or :ref:`metadata
 //    <envoy_v3_api_field_config.route.v3.RateLimit.Action.metadata>`
 //    descriptor action instead of this extension.
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message Descriptor {
   // The key to use in the descriptor entry.
   string descriptor_key = 1 [(validate.rules).string = {min_len: 1}];
 
   // The name of the HTTP header containing the JWT, e.g. "authorization".
+  //
+  // Exactly one of ``header_name`` or ``cookie`` must be set.
   string header_name = 2
-      [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
+      [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
+
+  // The name of the cookie containing the JWT, e.g. "auth_token". The cookie
+  // is looked up in the request's ``Cookie`` header.
+  //
+  // Exactly one of ``header_name`` or ``cookie`` must be set.
+  string cookie = 7 [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME strict: false}];
 
   // The value prefix to strip before parsing the remainder as a JWT, e.g.
   // "Bearer " (with a trailing space) for an "authorization" header
-  // formatted as "Authorization: Bearer <token>". If the header value does
-  // not start with this prefix, the descriptor is not populated (falls
-  // through to ``default_value``/``skip_if_absent`` below).
+  // formatted as "Authorization: Bearer <token>". If the header or cookie
+  // value does not start with this prefix, the descriptor is not populated
+  // (falls through to ``default_value``/``skip_if_absent`` below).
+  //
+  // This is typically only needed for ``header_name``; cookie values do not
+  // usually carry a prefix.
   string value_prefix = 3
       [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE strict: false}];
 
@@ -76,13 +87,13 @@ message Descriptor {
   // claim populates the descriptor with an empty value.
   string claim_name = 4 [(validate.rules).string = {min_len: 1}];
 
-  // The default value to use if the header is absent, is not a
+  // The default value to use if the header or cookie is absent, is not a
   // structurally valid JWT, or the named claim is absent/non-string.
   string default_value = 5;
 
   // If true, Envoy skips this descriptor entry (rather than aborting the
-  // whole descriptor for this action list) when the header is absent, the
-  // JWT cannot be parsed, or the named claim is absent/non-string, and
+  // whole descriptor for this action list) when the header or cookie is
+  // absent, the JWT cannot be parsed, or the named claim is absent/non-string, and
   // ``default_value`` is not specified. An empty string-valued claim is
   // present and produces an entry with an empty value regardless of this
   // setting.

--- a/changelogs/current/new_features/rate_limit_descriptors__added-jwt-claim-descriptor.rst
+++ b/changelogs/current/new_features/rate_limit_descriptors__added-jwt-claim-descriptor.rst
@@ -1,6 +1,6 @@
 Added a new :ref:`envoy.rate_limit_descriptors.jwt_claim
 <envoy_v3_api_msg_extensions.rate_limit_descriptors.jwt_claim.v3.Descriptor>` rate limit descriptor
-extension that extracts a named claim from a JWT found in an HTTP header and uses it as a
-descriptor value. This is useful when JWT validation is performed elsewhere (e.g. by the
+extension that extracts a named claim from a JWT found in an HTTP header or cookie and uses it as
+a descriptor value. This is useful when JWT validation is performed elsewhere (e.g. by the
 application, or by an upstream mTLS-authenticated service) and Envoy only needs to rate limit
 based on the claim value. Note that this extension does not verify the JWT signature.

--- a/source/extensions/rate_limit_descriptors/jwt_claim/BUILD
+++ b/source/extensions/rate_limit_descriptors/jwt_claim/BUILD
@@ -16,6 +16,7 @@ envoy_cc_extension(
         "//envoy/ratelimit:ratelimit_interface",
         "//envoy/registry",
         "//source/common/http:header_map_lib",
+        "//source/common/http:utility_lib",
         "//source/common/jwt:jwt_lib",
         "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/extensions/rate_limit_descriptors/jwt_claim/v3:pkg_cc_proto",

--- a/source/extensions/rate_limit_descriptors/jwt_claim/config.cc
+++ b/source/extensions/rate_limit_descriptors/jwt_claim/config.cc
@@ -3,6 +3,7 @@
 #include "envoy/extensions/rate_limit_descriptors/jwt_claim/v3/jwt_claim.pb.h"
 #include "envoy/extensions/rate_limit_descriptors/jwt_claim/v3/jwt_claim.pb.validate.h"
 
+#include "source/common/http/utility.h"
 #include "source/common/jwt/jwt.h"
 #include "source/common/jwt/struct_utils.h"
 #include "source/common/protobuf/utility.h"
@@ -30,7 +31,7 @@ std::optional<std::string> claimValueAsString(const Protobuf::Value& value) {
 
 /**
  * Descriptor producer that extracts a named (possibly nested) claim from an
- * unverified JWT found in an HTTP header.
+ * unverified JWT found in an HTTP header or cookie.
  *
  * SECURITY WARNING: this producer does not verify the JWT signature. See the
  * warning in jwt_claim.proto for details.
@@ -40,7 +41,7 @@ public:
   explicit JwtClaimDescriptor(
       const envoy::extensions::rate_limit_descriptors::jwt_claim::v3::Descriptor& config)
       : descriptor_key_(config.descriptor_key()),
-        header_name_(Http::LowerCaseString(config.header_name())),
+        header_name_(Http::LowerCaseString(config.header_name())), cookie_(config.cookie()),
         value_prefix_(config.value_prefix()), claim_name_(config.claim_name()),
         default_value_(config.default_value()), skip_if_absent_(config.skip_if_absent()) {}
 
@@ -61,12 +62,30 @@ public:
   }
 
 private:
-  std::optional<std::string> extractClaimValue(const Http::RequestHeaderMap& headers) const {
+  // Returns the raw (unparsed) JWT string from the configured header or
+  // cookie, whichever was configured. Exactly one of the two is set,
+  // enforced at config validation time.
+  std::optional<std::string> extractRawValue(const Http::RequestHeaderMap& headers) const {
+    if (!cookie_.empty()) {
+      std::string value = Http::Utility::parseCookieValue(headers, cookie_);
+      if (value.empty()) {
+        return std::nullopt;
+      }
+      return value;
+    }
     const auto header_value = headers.get(header_name_);
     if (header_value.empty()) {
       return std::nullopt;
     }
-    absl::string_view value = header_value[0]->value().getStringView();
+    return std::string(header_value[0]->value().getStringView());
+  }
+
+  std::optional<std::string> extractClaimValue(const Http::RequestHeaderMap& headers) const {
+    std::optional<std::string> raw_value = extractRawValue(headers);
+    if (!raw_value.has_value()) {
+      return std::nullopt;
+    }
+    absl::string_view value = *raw_value;
     if (!value_prefix_.empty()) {
       if (!absl::StartsWith(value, value_prefix_)) {
         return std::nullopt;
@@ -89,6 +108,7 @@ private:
 
   const std::string descriptor_key_;
   const Http::LowerCaseString header_name_;
+  const std::string cookie_;
   const std::string value_prefix_;
   const std::string claim_name_;
   const std::string default_value_;
@@ -109,6 +129,10 @@ JwtClaimDescriptorFactory::createDescriptorProducerFromProto(
   const auto& config = MessageUtil::downcastAndValidate<
       const envoy::extensions::rate_limit_descriptors::jwt_claim::v3::Descriptor&>(
       message, context.messageValidationVisitor());
+  if (config.header_name().empty() == config.cookie().empty()) {
+    return absl::InvalidArgumentError(
+        "jwt_claim descriptor: exactly one of header_name or cookie must be set");
+  }
   return std::make_unique<JwtClaimDescriptor>(config);
 }
 

--- a/test/extensions/rate_limit_descriptors/jwt_claim/config_test.cc
+++ b/test/extensions/rate_limit_descriptors/jwt_claim/config_test.cc
@@ -273,6 +273,98 @@ actions:
               testing::ContainerEq(descriptors_));
 }
 
+TEST_F(JwtClaimDescriptorTest, ExtractsClaimFromCookie) {
+  const std::string yaml = absl::StrCat(R"EOF(
+actions:
+- extension:
+    name: jwt_claim_descriptor
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.rate_limit_descriptors.jwt_claim.v3.Descriptor
+      descriptor_key: my_descriptor_name
+      cookie: auth_token
+      claim_name: sub
+)EOF");
+  setupTest(yaml);
+  const std::string jwt = makeJwt(R"({"sub":"user-123"})");
+  Http::TestRequestHeaderMapImpl header{
+      {"cookie", absl::StrCat("other=1; auth_token=", jwt, "; more=2")}};
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "service_cluster", header, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"my_descriptor_name", "user-123"}}}}),
+              testing::ContainerEq(descriptors_));
+}
+
+TEST_F(JwtClaimDescriptorTest, ExtractsClaimFromCookieWithValuePrefix) {
+  const std::string yaml = absl::StrCat(R"EOF(
+actions:
+- extension:
+    name: jwt_claim_descriptor
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.rate_limit_descriptors.jwt_claim.v3.Descriptor
+      descriptor_key: my_descriptor_name
+      cookie: auth_token
+      value_prefix: "Bearer "
+      claim_name: sub
+)EOF");
+  setupTest(yaml);
+  const std::string jwt = makeJwt(R"({"sub":"user-123"})");
+  Http::TestRequestHeaderMapImpl header{{"cookie", absl::StrCat("auth_token=Bearer ", jwt)}};
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "service_cluster", header, stream_info_);
+  EXPECT_THAT(std::vector<Envoy::RateLimit::Descriptor>({{{{"my_descriptor_name", "user-123"}}}}),
+              testing::ContainerEq(descriptors_));
+}
+
+TEST_F(JwtClaimDescriptorTest, MissingCookieNoDefaultAbortsDescriptor) {
+  const std::string yaml = absl::StrCat(R"EOF(
+actions:
+- extension:
+    name: jwt_claim_descriptor
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.rate_limit_descriptors.jwt_claim.v3.Descriptor
+      descriptor_key: my_descriptor_name
+      cookie: auth_token
+      claim_name: sub
+)EOF");
+  setupTest(yaml);
+  Http::TestRequestHeaderMapImpl header{{"cookie", "other=1"}};
+
+  rate_limit_entry_->populateDescriptors(descriptors_, "service_cluster", header, stream_info_);
+  EXPECT_TRUE(descriptors_.empty());
+}
+
+TEST_F(JwtClaimDescriptorTest, RejectsConfigWithBothHeaderAndCookie) {
+  const std::string yaml = absl::StrCat(R"EOF(
+actions:
+- extension:
+    name: jwt_claim_descriptor
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.rate_limit_descriptors.jwt_claim.v3.Descriptor
+      descriptor_key: my_descriptor_name
+      header_name: authorization
+      cookie: auth_token
+      claim_name: sub
+)EOF");
+  EXPECT_THROW_WITH_MESSAGE(
+      setupTest(yaml), EnvoyException,
+      "jwt_claim descriptor: exactly one of header_name or cookie must be set");
+}
+
+TEST_F(JwtClaimDescriptorTest, RejectsConfigWithNeitherHeaderNorCookie) {
+  const std::string yaml = absl::StrCat(R"EOF(
+actions:
+- extension:
+    name: jwt_claim_descriptor
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.rate_limit_descriptors.jwt_claim.v3.Descriptor
+      descriptor_key: my_descriptor_name
+      claim_name: sub
+)EOF");
+  EXPECT_THROW_WITH_MESSAGE(
+      setupTest(yaml), EnvoyException,
+      "jwt_claim descriptor: exactly one of header_name or cookie must be set");
+}
+
 TEST_F(JwtClaimDescriptorTest, ForgedJwtStillExtractsUnverifiedClaim) {
   // Demonstrates that this extension does not verify the JWT signature: an
   // arbitrary, unsigned token with a made-up claim value is still accepted.


### PR DESCRIPTION
Commit Message: add support for cookie in jwt claims descriptor
Additional Description:  add support for cookie in jwt claims descriptor
Risk Level: Low
Testing: Added
Docs Changes: Added
Release Notes: Added

