### PR TITLE
APM: initial FilterManager implementation without offloaded field streaming support

### DIFF
--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -37,6 +37,7 @@ const static bool should_log = true;
 #define ALL_LOGGER_IDS(FUNCTION)                                                                   \
   FUNCTION(a2a)                                                                                    \
   FUNCTION(admin)                                                                                  \
+  FUNCTION(ai_protocol_manager)                                                                    \
   FUNCTION(alternate_protocols_cache)                                                              \
   FUNCTION(aws)                                                                                    \
   FUNCTION(assert)                                                                                 \

--- a/source/common/coroutine/launch.h
+++ b/source/common/coroutine/launch.h
@@ -146,8 +146,14 @@ inline DetachedHandle startRoot(RootTask root, std::shared_ptr<Executor> exec, S
 /**
  * Start `task` on `exec` from non-coroutine code. `on_done` is invoked with the
  * task's result when the chain completes (including after a cancellation, which
- * delivers an aborted result). Returns a `DetachedHandle` that owns the frame and
- * can `cancel()` it.
+ * delivers an aborted result). Returns a `DetachedHandle` that can `cancel()` it.
+ *
+ * NOTE: The launched root coroutine is self-owning and manages its own lifetime.
+ * Callers and tasks must be careful when capturing raw pointers, references, or
+ * member methods (`this`): if the object owning those resources is destroyed while
+ * the coroutine is suspended (or before `on_done` runs), accessing them will cause a
+ * use-after-free. Use `std::weak_ptr` / `std::shared_ptr` or ensure strict lifecycle
+ * synchronization via `DetachedHandle::cancel()`.
  *
  * `exec` is taken as a `shared_ptr` so the coroutine context can keep it alive.
  * TODO(penguingao): revert to `Executor&` once the executor is guaranteed to

--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -164,6 +164,63 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "ai_request_lib",
+    hdrs = ["ai_request.h"],
+    deps = [
+        ":json_with_ext_buf_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "serializer_lib",
+    srcs = ["serializer.cc"],
+    hdrs = ["serializer.h"],
+    deps = [
+        ":buffer_manager_lib",
+        ":json_with_ext_buf_lib",
+        "//envoy/buffer:buffer_interface",
+        "//envoy/stream_info:filter_state_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/coroutine:leaf_awaitable_lib",
+        "//source/common/coroutine:status_macros_lib",
+        "//source/common/coroutine:task_lib",
+        "@abseil-cpp//absl/functional:any_invocable",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+        "@nlohmann_json//:json",
+    ],
+)
+
+envoy_cc_library(
+    name = "filter_manager_lib",
+    srcs = ["filter_manager.cc"],
+    hdrs = [
+        "ai_filter.h",
+        "filter_manager.h",
+    ],
+    deps = [
+        ":ai_request_lib",
+        ":buffer_manager_lib",
+        ":json_with_ext_buf_lib",
+        ":serializer_lib",
+        "//envoy/http:codes_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:logger_lib",
+        "//source/common/coroutine:async_queue_lib",
+        "//source/common/coroutine:dispatcher_executor_lib",
+        "//source/common/coroutine:launch_lib",
+        "//source/common/coroutine:status_macros_lib",
+        "//source/common/coroutine:task_lib",
+        "@abseil-cpp//absl/functional:any_invocable",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+envoy_cc_library(
     name = "filter_lib",
     srcs = ["filter.cc"],
     hdrs = ["filter.h"],
@@ -171,10 +228,12 @@ envoy_cc_library(
         ":buffer_manager_lib",
         ":external_buffer_interface",
         ":filter_chain_bridge_lib",
+        ":filter_manager_lib",
         ":json_with_ext_buf_lib",
         ":json_with_ext_buf_parser_lib",
         ":response_handler_lib",
         ":schema_lib",
+        ":serializer_lib",
         ":stats_lib",
         "//envoy/http:codes_interface",
         "//envoy/router:router_interface",

--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -206,6 +206,7 @@ envoy_cc_library(
         ":json_with_ext_buf_lib",
         ":serializer_lib",
         "//envoy/http:codes_interface",
+        "//envoy/http:header_map_interface",
         "//envoy/stream_info:stream_info_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",

--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -181,6 +181,7 @@ envoy_cc_library(
         "//envoy/buffer:buffer_interface",
         "//envoy/stream_info:filter_state_interface",
         "//source/common/buffer:buffer_lib",
+        "//source/common/common:thread_lib",
         "//source/common/coroutine:leaf_awaitable_lib",
         "//source/common/coroutine:status_macros_lib",
         "//source/common/coroutine:task_lib",

--- a/source/extensions/filters/http/ai_protocol_manager/ai_filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/ai_filter.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "envoy/http/codes.h"
+
+#include "source/common/common/assert.h"
+#include "source/common/coroutine/task.h"
+#include "source/extensions/filters/http/ai_protocol_manager/ai_request.h"
+
+#include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+// Callable awaitable that delivers the `AiRequest` to a filter. Callable on rvalue only.
+class AiRequestReceiver {
+public:
+  using Impl = absl::AnyInvocable<Coroutine::Task<absl::StatusOr<AiRequestPtr>>() &&>;
+
+  explicit AiRequestReceiver(Impl impl) : impl_(std::move(impl)) {}
+
+  Coroutine::Task<absl::StatusOr<AiRequestPtr>> operator()() && {
+    if (!valid()) {
+      IS_ENVOY_BUG("AiRequestReceiver invoked on an invalid or already moved instance");
+      co_return absl::FailedPreconditionError(
+          "AiRequestReceiver invoked on an invalid or already moved instance");
+    }
+    Impl impl = std::move(impl_);
+    co_return co_await std::move(impl)();
+  }
+
+  bool valid() const { return impl_ != nullptr; }
+
+private:
+  Impl impl_;
+};
+
+// Callable awaitable that forwards the `AiRequest` to the next filter in the chain. Callable on
+// rvalue only.
+class AiRequestPropagator {
+public:
+  using Impl = absl::AnyInvocable<Coroutine::Task<absl::Status>(AiRequestPtr) &&>;
+
+  explicit AiRequestPropagator(Impl impl) : impl_(std::move(impl)) {}
+
+  // Forwards the request index without requesting field streaming.
+  Coroutine::Task<absl::Status> operator()(AiRequestPtr req) && {
+    if (!valid()) {
+      IS_ENVOY_BUG("AiRequestPropagator invoked on an invalid or already moved instance");
+      co_return absl::FailedPreconditionError(
+          "AiRequestPropagator invoked on an invalid or already moved instance");
+    }
+    Impl impl = std::move(impl_);
+    co_return co_await std::move(impl)(std::move(req));
+  }
+
+  // TODO(penguingao): Add overload accepting FieldStreamInterest when field streaming is
+  // introduced.
+
+  bool valid() const { return impl_ != nullptr; }
+
+private:
+  Impl impl_;
+};
+
+// Callable callback to send an immediate HTTP local reply and abort processing.
+using LocalReplier = absl::AnyInvocable<void(Http::Code code, std::string details) &&>;
+
+// Abstract interface implemented by AI filter instances.
+class AiFilter {
+public:
+  virtual ~AiFilter() = default;
+
+  // Invoked when an AI request arrives.
+  // Returns absl::OkStatus() on normal completion, or an error status on failure.
+  virtual Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                               AiRequestPropagator propagate_request,
+                                               LocalReplier reply_locally) = 0;
+};
+
+using AiFilterPtr = std::unique_ptr<AiFilter>;
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/ai_filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/ai_filter.h
@@ -19,7 +19,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
 
-// Callable awaitable that delivers the `AiRequest` to a filter. Callable on rvalue only.
+// Callable awaitable that delivers the `AiRequest` to a filter. Callable on r-value only.
 class AiRequestReceiver {
 public:
   using Impl = absl::AnyInvocable<Coroutine::Task<absl::StatusOr<AiRequestPtr>>() &&>;
@@ -43,7 +43,7 @@ private:
 };
 
 // Callable awaitable that forwards the `AiRequest` to the next filter in the chain. Callable on
-// rvalue only.
+// r-value only.
 class AiRequestPropagator {
 public:
   using Impl = absl::AnyInvocable<Coroutine::Task<absl::Status>(AiRequestPtr) &&>;

--- a/source/extensions/filters/http/ai_protocol_manager/ai_request.h
+++ b/source/extensions/filters/http/ai_protocol_manager/ai_request.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+// AiRequest represents the structured request payload presented to an AiFilter.
+// It wraps a JsonWithExtBuf document as the request payload index.
+// AiRequest is non-copyable and non-movable to ensure strict single-ownership semantics;
+// ownership transfer across the filter pipeline is expressed via std::unique_ptr<AiRequest>.
+class AiRequest {
+public:
+  explicit AiRequest(JsonWithExtBuf request_index) : request_index_(std::move(request_index)) {}
+  ~AiRequest() = default;
+
+  AiRequest(const AiRequest&) = delete;
+  AiRequest& operator=(const AiRequest&) = delete;
+  AiRequest(AiRequest&&) = delete;
+  AiRequest& operator=(AiRequest&&) = delete;
+
+  // Index access
+  const JsonWithExtBuf& request_index() const { return request_index_; }
+  JsonWithExtBuf& request_index() { return request_index_; }
+
+  // TODO(penguingao): Implement field streaming (AiRequest::stream, FieldStreamingSpec,
+  // and FieldStreamingSession).
+
+private:
+  JsonWithExtBuf request_index_;
+};
+
+using AiRequestPtr = std::unique_ptr<AiRequest>;
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -29,8 +29,8 @@ BufferManager::BufferManager(ExternalBufferFactory& buffer_factory, FilterChainB
 void BufferManager::onDestroy() {
   destroyed_ = true;
   bridge_->unregisterReplayWatermarks();
-  // Cancel any pending replay continuation so it cannot fire after teardown.
-  replay_cb_->cancel();
+  // Cancel any requested or in-flight replay operation and disarm callbacks.
+  cancelReplay();
   // Dropping the buffer cancels any pending write/read completion callbacks.
   buffer_.reset();
 }
@@ -65,7 +65,7 @@ void BufferManager::endStream() {
 
 void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback done) {
   // One replay at a time: the caller chains sub-ranges from the done callback.
-  ASSERT(!replaying_ && !replay_requested_);
+  ASSERT(!replay_cancelled_ && !replaying_ && !replay_requested_);
   replay_source_ = ReplaySource::ExternalBuffer;
   replay_offset_ = offset;
   replay_end_ = offset + length;
@@ -85,7 +85,7 @@ void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback 
 }
 
 void BufferManager::replay(Buffer::Instance& data, ReplayDoneCallback done) {
-  ASSERT(!replaying_ && !replay_requested_);
+  ASSERT(!replay_cancelled_ && !replaying_ && !replay_requested_);
   replay_source_ = ReplaySource::InMemory;
   replay_in_memory_data_.move(data);
   replay_done_ = std::move(done);
@@ -98,6 +98,7 @@ void BufferManager::replay(Buffer::Instance& data, ReplayDoneCallback done) {
 }
 
 void BufferManager::cancelReplay() {
+  replay_cancelled_ = true;
   replay_requested_ = false;
   replaying_ = false;
   replay_source_ = ReplaySource::None;
@@ -157,7 +158,8 @@ void BufferManager::onWriteComplete(ExternalBufferStatus status) {
 void BufferManager::maybeStartReplay() {
   // Start only once the caller has requested a replay and every accepted byte is
   // durable. Consumes the request; the range was set by replay().
-  if (replaying_ || !replay_requested_ || write_in_flight_ || pending_.length() > 0) {
+  if (replay_cancelled_ || replaying_ || !replay_requested_ || write_in_flight_ ||
+      pending_.length() > 0) {
     return;
   }
   replay_requested_ = false;
@@ -286,6 +288,9 @@ void BufferManager::maybeReadNextChunk() {
 void BufferManager::onReplayContinuation() {
   // onDestroy() cancels replay_cb_, so the continuation never fires once detached.
   ASSERT(!destroyed_);
+  if (replay_cancelled_) {
+    return;
+  }
   // Off the caller's stack: either start replay deferred from replay() (the
   // offload was already durable when the caller requested it), resume after the
   // per-iteration burst budget was spent, or resume after chain back-pressure
@@ -307,7 +312,7 @@ void BufferManager::onReadComplete(ExternalBufferStatus status, Buffer::Instance
   // below ends the stream -- handled by the runtime check after injectData().)
   ASSERT(!destroyed_);
   read_in_flight_ = false;
-  if (!replaying_) {
+  if (replay_cancelled_ || !replaying_) {
     return;
   }
   if (status != ExternalBufferStatus::Ok) {

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -307,6 +307,9 @@ void BufferManager::onReadComplete(ExternalBufferStatus status, Buffer::Instance
   // below ends the stream -- handled by the runtime check after injectData().)
   ASSERT(!destroyed_);
   read_in_flight_ = false;
+  if (!replaying_) {
+    return;
+  }
   if (status != ExternalBufferStatus::Ok) {
     onExternalBufferError();
     return;

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -65,7 +65,12 @@ void BufferManager::endStream() {
 
 void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback done) {
   // One replay at a time: the caller chains sub-ranges from the done callback.
-  ASSERT(!replay_cancelled_ && !replaying_ && !replay_requested_);
+  if (replay_cancelled_ || replaying_ || replay_requested_) {
+    IS_ENVOY_BUG("replay is in progress, or has been cancelled. currently only one pending replay "
+                 "is supported. and if cancelReplay is called, no more replay is allowed.");
+    done();
+    return;
+  }
   replay_source_ = ReplaySource::ExternalBuffer;
   replay_offset_ = offset;
   replay_end_ = offset + length;

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -68,7 +68,7 @@ void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback 
   if (replay_cancelled_ || replaying_ || replay_requested_) {
     IS_ENVOY_BUG("replay is in progress, or has been cancelled. currently only one pending replay "
                  "is supported. and if cancelReplay is called, no more replay is allowed.");
-    done();
+    done(absl::InternalError("replay is in progress, or has been cancelled"));
     return;
   }
   replay_source_ = ReplaySource::ExternalBuffer;
@@ -90,7 +90,13 @@ void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback 
 }
 
 void BufferManager::replay(Buffer::Instance& data, ReplayDoneCallback done) {
-  ASSERT(!replay_cancelled_ && !replaying_ && !replay_requested_);
+  // One replay at a time: the caller chains sub-ranges from the done callback.
+  if (replay_cancelled_ || replaying_ || replay_requested_) {
+    IS_ENVOY_BUG("replay is in progress, or has been cancelled. currently only one pending replay "
+                 "is supported. and if cancelReplay is called, no more replay is allowed.");
+    done(absl::InternalError("replay is in progress, or has been cancelled"));
+    return;
+  }
   replay_source_ = ReplaySource::InMemory;
   replay_in_memory_data_.move(data);
   replay_done_ = std::move(done);
@@ -362,7 +368,7 @@ void BufferManager::finishReplay() {
   ReplayDoneCallback done = std::move(replay_done_);
   replay_done_ = nullptr;
   if (done) {
-    done();
+    done(absl::OkStatus());
   }
 }
 

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -66,6 +66,7 @@ void BufferManager::endStream() {
 void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback done) {
   // One replay at a time: the caller chains sub-ranges from the done callback.
   ASSERT(!replaying_ && !replay_requested_);
+  replay_source_ = ReplaySource::ExternalBuffer;
   replay_offset_ = offset;
   replay_end_ = offset + length;
   replay_done_ = std::move(done);
@@ -80,6 +81,30 @@ void BufferManager::replay(uint64_t offset, uint64_t length, ReplayDoneCallback 
   // completion starts replay via maybeStartReplay() instead.
   if (!write_in_flight_ && pending_.length() == 0) {
     replay_cb_->scheduleCallbackCurrentIteration();
+  }
+}
+
+void BufferManager::replay(Buffer::Instance& data, ReplayDoneCallback done) {
+  ASSERT(!replaying_ && !replay_requested_);
+  replay_source_ = ReplaySource::InMemory;
+  replay_in_memory_data_.move(data);
+  replay_done_ = std::move(done);
+  replay_requested_ = true;
+  ENVOY_LOG(debug, "ai_protocol_manager: in-memory replay requested for {} bytes",
+            replay_in_memory_data_.length());
+  if (!write_in_flight_ && pending_.length() == 0) {
+    replay_cb_->scheduleCallbackCurrentIteration();
+  }
+}
+
+void BufferManager::cancelReplay() {
+  replay_requested_ = false;
+  replaying_ = false;
+  replay_source_ = ReplaySource::None;
+  replay_done_ = nullptr;
+  replay_in_memory_data_.drain(replay_in_memory_data_.length());
+  if (replay_cb_) {
+    replay_cb_->cancel();
   }
 }
 
@@ -137,8 +162,12 @@ void BufferManager::maybeStartReplay() {
   }
   replay_requested_ = false;
   replaying_ = true;
-  ENVOY_LOG(debug, "ai_protocol_manager: replaying [{}, {})", replay_offset_, replay_end_);
-  maybeReadNextChunk();
+  if (replay_source_ == ReplaySource::InMemory) {
+    maybeDrainInMemoryReplay();
+  } else if (replay_source_ == ReplaySource::ExternalBuffer) {
+    ENVOY_LOG(debug, "ai_protocol_manager: replaying [{}, {})", replay_offset_, replay_end_);
+    maybeReadNextChunk();
+  }
 }
 
 void BufferManager::updateIngestBackpressure() {
@@ -158,6 +187,38 @@ void BufferManager::updateIngestBackpressure() {
     ENVOY_LOG(debug, "ai_protocol_manager: ingest low watermark ({} bytes not durable)", unacked);
     bridge_->resumeSource();
   }
+}
+
+void BufferManager::maybeDrainInMemoryReplay() {
+  ASSERT(!destroyed_);
+  if (!replaying_) {
+    return;
+  }
+
+  replay_sync_chunks_ = 0;
+  while (replay_in_memory_data_.length() > 0) {
+    if (replay_high_watermark_count_ > 0) {
+      ENVOY_LOG(trace, "ai_protocol_manager: in-memory replay paused (chain back-pressure)");
+      return;
+    }
+    if (replay_sync_chunks_ >= ReplayChunksPerIteration) {
+      ENVOY_LOG(trace, "ai_protocol_manager: in-memory replay yielding after {} chunks",
+                replay_sync_chunks_);
+      replay_cb_->scheduleCallbackNextIteration();
+      return;
+    }
+    ++replay_sync_chunks_;
+    const uint64_t to_inject =
+        std::min(ReadChunkSize, static_cast<uint64_t>(replay_in_memory_data_.length()));
+    Buffer::OwnedImpl chunk;
+    chunk.move(replay_in_memory_data_, to_inject);
+    bridge_->injectData(chunk);
+    if (destroyed_) {
+      return;
+    }
+  }
+
+  finishReplay();
 }
 
 void BufferManager::maybeReadNextChunk() {
@@ -233,7 +294,9 @@ void BufferManager::onReplayContinuation() {
   // advancing a fresh burst twice.
   if (!replaying_) {
     maybeStartReplay();
-  } else {
+  } else if (replay_source_ == ReplaySource::InMemory) {
+    maybeDrainInMemoryReplay();
+  } else if (replay_source_ == ReplaySource::ExternalBuffer) {
     maybeReadNextChunk();
   }
 }
@@ -279,7 +342,8 @@ void BufferManager::onReadComplete(ExternalBufferStatus status, Buffer::Instance
 
 void BufferManager::finishReplay() {
   replaying_ = false;
-  ENVOY_LOG(trace, "ai_protocol_manager: replay range [.., {}) complete", replay_end_);
+  replay_source_ = ReplaySource::None;
+  ENVOY_LOG(trace, "ai_protocol_manager: replay complete");
   // Hand control back to the caller. Its callback may start the next sub-range or
   // terminate the stream; move the callback out first so it can re-arm replay().
   ReplayDoneCallback done = std::move(replay_done_);

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -226,7 +226,7 @@ void BufferManager::maybeDrainInMemoryReplay() {
     Buffer::OwnedImpl chunk;
     chunk.move(replay_in_memory_data_, to_inject);
     bridge_->injectData(chunk);
-    if (destroyed_) {
+    if (destroyed_ || !replaying_) {
       return;
     }
   }
@@ -345,7 +345,7 @@ void BufferManager::onReadComplete(ExternalBufferStatus status, Buffer::Instance
   // callback into a torn-down stream) or reading another chunk from the released
   // buffer -- and it is what keeps maybeReadNextChunk()'s ASSERT(!destroyed_) valid.
   bridge_->injectData(*data);
-  if (destroyed_) {
+  if (destroyed_ || !replaying_) {
     return;
   }
   if (replay_offset_ >= replay_end_) {

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.h
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.h
@@ -119,14 +119,14 @@ public:
   // Replays the byte range [offset, offset+length) back into the filter chain as
   // data frames, invoking `done` once the whole range has been injected. The
   // caller may stream further sub-ranges with another replay(). Only one replay may be in flight
-  // at a time. The range must lie within length().
+  // at a time. The range must lie within length(). Must not be called after cancelReplay().
   //
   // Only call after endStream(). It may wait until all write is done before start streaming.
   void replay(uint64_t offset, uint64_t length, ReplayDoneCallback done);
 
   // Replays in-memory `data` (e.g. from serializer's small buffer) back into the filter
   // chain as data frames, pacing against watermark flow control and burst limits,
-  // invoking `done` once all bytes have been drained.
+  // invoking `done` once all bytes have been drained. Must not be called after cancelReplay().
   void replay(Buffer::Instance& data, ReplayDoneCallback done);
 
   // Total number of bytes offloaded so far (durable, queued, and in-flight). The
@@ -142,6 +142,7 @@ public:
   }
 
   // Cancels any in-flight or requested replay operation and disarms callbacks.
+  // Permanent: once cancelled, no further replay operations may be started on this manager.
   void cancelReplay();
 
   // Detaches the manager from the filter chain: releases the external buffer,
@@ -249,6 +250,8 @@ private:
   // True once endStream() has been called; gates flushing the batched backlog (the
   // tail is written even if it is below WriteFlushThreshold).
   bool end_stream_seen_{false};
+  // True once cancelReplay() has been called. Permanent: disables all subsequent replay attempts.
+  bool replay_cancelled_{false};
   // True once replay() has been requested by the caller and not yet started.
   // Replay starts once this is set and the write queue has fully drained (no write
   // in flight, nothing pending).

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.h
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.h
@@ -13,6 +13,7 @@
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer.h"
 
 #include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 namespace Envoy {
@@ -20,9 +21,9 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
 
-// Invoked once a replay() range has been fully injected into the filter chain. The
+// Invoked once a replay() range has been fully injected into the filter chain (or on error). The
 // caller can start to stream further sub-ranges or to terminate the stream.
-using ReplayDoneCallback = absl::AnyInvocable<void()>;
+using ReplayDoneCallback = absl::AnyInvocable<void(absl::Status)>;
 
 // Replay-side flow-control sink. The BufferManager implements this so a
 // FilterChainBridge can forward the path-specific Envoy watermark callback

--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.h
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.h
@@ -13,6 +13,7 @@
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer.h"
 
 #include "absl/functional/any_invocable.h"
+#include "absl/strings/string_view.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -123,6 +124,11 @@ public:
   // Only call after endStream(). It may wait until all write is done before start streaming.
   void replay(uint64_t offset, uint64_t length, ReplayDoneCallback done);
 
+  // Replays in-memory `data` (e.g. from serializer's small buffer) back into the filter
+  // chain as data frames, pacing against watermark flow control and burst limits,
+  // invoking `done` once all bytes have been drained.
+  void replay(Buffer::Instance& data, ReplayDoneCallback done);
+
   // Total number of bytes offloaded so far (durable, queued, and in-flight). The
   // caller uses this to size replay ranges; it is final once endStream() has been
   // called.
@@ -134,6 +140,9 @@ public:
   bool empty() const {
     return buffer_ == nullptr || buffer_->length() + pending_.length() + in_flight_write_size_ == 0;
   }
+
+  // Cancels any in-flight or requested replay operation and disarms callbacks.
+  void cancelReplay();
 
   // Detaches the manager from the filter chain: releases the external buffer,
   // unsubscribes from replay watermarks, and cancels the pending replay
@@ -187,6 +196,9 @@ private:
   // via replay_cb_ and resumes next iteration. An asynchronous store drives one
   // chunk per completion and paces itself.
   void maybeReadNextChunk();
+
+  // Drains in-memory replay data to the filter chain with respect to watermark flow control.
+  void maybeDrainInMemoryReplay();
 
   // Target of replay_cb_. Runs off the caller's stack to either start replay
   // deferred from replay() (the caller may invoke it from a data callback, where
@@ -261,6 +273,10 @@ private:
   // True while the data source is paused for ingest back-pressure; tracked so we
   // pause/resume the source exactly once per crossing.
   bool source_paused_{false};
+
+  enum class ReplaySource { None, ExternalBuffer, InMemory };
+  ReplaySource replay_source_{ReplaySource::None};
+  Buffer::OwnedImpl replay_in_memory_data_;
 
   // True while a replay range is actively being streamed (from maybeStartReplay()
   // until finishReplay()).

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -358,10 +358,8 @@ void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
           decoder_callbacks_->sendLocalReply(code, details, nullptr, std::nullopt,
                                              "ai_protocol_manager_filter_rejected");
         });
-    filter_manager_->start([this, on_complete = std::move(on_complete)](absl::Status status) {
-      if (!status.ok()) {
-        rejectInvalidPayload(status);
-      } else {
+    filter_manager_->start([on_complete = std::move(on_complete)](absl::Status status) {
+      if (status.ok()) {
         on_complete();
       }
     });

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -349,11 +349,10 @@ void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
 
   if (isAiEndpoint() && !decode_manager_->empty() && !payload_rejected_) {
     ASSERT(request_headers_ != nullptr);
-    request_headers_->removeContentLength();
     std::vector<AiFilterPtr> filters;
     filter_manager_ = std::make_unique<FilterManager>(
         std::move(filters), std::move(request_json_), decode_manager_.get(),
-        decoder_callbacks_->dispatcher(), decoder_callbacks_->streamInfo(),
+        decoder_callbacks_->dispatcher(), decoder_callbacks_->streamInfo(), request_headers_,
         [this](Http::Code code, std::string details) {
           ENVOY_LOG(debug, "ai_protocol_manager: rejecting request via local reply: {} {}",
                     static_cast<uint32_t>(code), details);

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -154,6 +154,7 @@ void AiProtocolManagerFilter::onDestroy() {
 
 Http::FilterHeadersStatus AiProtocolManagerFilter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                                  bool end_stream) {
+  request_headers_ = &headers;
   // Request-side processing is off entirely; per-route declarations still
   // matter to the encode path, which resolves them itself.
   if (!config_->requestHandlingEnabled()) {
@@ -347,6 +348,8 @@ void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
   };
 
   if (isAiEndpoint() && !decode_manager_->empty() && !payload_rejected_) {
+    ASSERT(request_headers_ != nullptr);
+    request_headers_->removeContentLength();
     std::vector<AiFilterPtr> filters;
     filter_manager_ = std::make_unique<FilterManager>(
         std::move(filters), std::move(request_json_), decode_manager_.get(),

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -350,6 +350,9 @@ void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
   if (isAiEndpoint() && !decode_manager_->empty() && !payload_rejected_) {
     ASSERT(request_headers_ != nullptr);
     std::vector<AiFilterPtr> filters;
+    // TODO(penguingao): Avoid always passing downstream StreamInfo when constructing
+    // FilterManager; when AI Protocol Manager is placed in an upstream filter chain, it should
+    // behave differently.
     filter_manager_ = std::make_unique<FilterManager>(
         std::move(filters), std::move(request_json_), decode_manager_.get(),
         decoder_callbacks_->dispatcher(), decoder_callbacks_->streamInfo(), request_headers_,

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -334,7 +334,16 @@ Http::FilterTrailersStatus AiProtocolManagerFilter::decodeTrailers(Http::Request
 
 void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
   decode_manager_->endStream();
-  auto on_complete = [this, has_trailers]() {
+  auto on_complete = [this, has_trailers](absl::Status status) {
+    if (!status.ok()) {
+      ENVOY_LOG(error, "ai_protocol_manager: replay failed: {}", status.message());
+      if (!payload_rejected_) {
+        payload_rejected_ = true;
+        decoder_callbacks_->sendLocalReply(Http::Code::BadGateway, status.message(), nullptr,
+                                           std::nullopt, "ai_protocol_manager_replay_error");
+      }
+      return;
+    }
     if (has_trailers) {
       // Body fully replayed; release the held trailers (they carry END_STREAM) so
       // they follow the body in order.
@@ -364,9 +373,7 @@ void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
                                              "ai_protocol_manager_filter_rejected");
         });
     filter_manager_->start([on_complete = std::move(on_complete)](absl::Status status) {
-      if (status.ok()) {
-        on_complete();
-      }
+      on_complete(std::move(status));
     });
   } else {
     decode_manager_->replay(0, decode_manager_->length(), std::move(on_complete));

--- a/source/extensions/filters/http/ai_protocol_manager/filter.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.cc
@@ -12,6 +12,7 @@
 #include "source/common/protobuf/utility.h"
 #include "source/extensions/filters/http/ai_protocol_manager/api_protocol_adapter.h"
 #include "source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.h"
+#include "source/extensions/filters/http/ai_protocol_manager/filter_manager.h"
 #include "source/extensions/filters/http/ai_protocol_manager/schema.h"
 
 #include "absl/strings/match.h"
@@ -135,6 +136,9 @@ FilterConfig::FilterConfig(
                                           max_parsed_sse_events, DefaultMaxParsedSseEvents)) {}
 
 void AiProtocolManagerFilter::onDestroy() {
+  if (filter_manager_ != nullptr) {
+    filter_manager_->cancel();
+  }
   if (decode_manager_ != nullptr) {
     // Detach the manager (releases the external buffer and unsubscribes from
     // watermarks) but do NOT free it here. onDestroy() can run synchronously while
@@ -294,16 +298,7 @@ Http::FilterDataStatus AiProtocolManagerFilter::decodeData(Buffer::Instance& dat
 
   decode_manager_->onData(data);
   if (end_stream) {
-    // The full body has been offloaded. The filter owns replay and end-of-stream:
-    // a future change will assemble and inspect the request here (and may replay
-    // sub-ranges); for now replay the whole body, then emit the terminal frame.
-    decode_manager_->endStream();
-    decode_manager_->replay(0, decode_manager_->length(), [this]() {
-      // Terminate the stream with an empty end_stream data frame after the replayed
-      // body (also releases the held headers when the body was empty).
-      Buffer::OwnedImpl end_marker;
-      decoder_callbacks_->injectDecodedDataToFilterChain(end_marker, /*end_stream=*/true);
-    });
+    finalizeDecode(/*has_trailers=*/false);
   }
   // Hold the chain here; the BufferManager replays the payload once told to.
   return Http::FilterDataStatus::StopIterationNoBuffer;
@@ -330,16 +325,49 @@ Http::FilterTrailersStatus AiProtocolManagerFilter::decodeTrailers(Http::Request
     }
   }
 
-  // The body ended without end_stream on a data frame; the trailers carry it.
-  decode_manager_->endStream();
-  decode_manager_->replay(0, decode_manager_->length(), [this]() {
-    // Body fully replayed; release the held trailers (they carry END_STREAM) so
-    // they follow the body in order.
-    decoder_callbacks_->continueDecoding();
-  });
+  finalizeDecode(/*has_trailers=*/true);
   // Hold the trailers behind the replayed body until the replay-done callback
   // above releases them.
   return Http::FilterTrailersStatus::StopIteration;
+}
+
+void AiProtocolManagerFilter::finalizeDecode(bool has_trailers) {
+  decode_manager_->endStream();
+  auto on_complete = [this, has_trailers]() {
+    if (has_trailers) {
+      // Body fully replayed; release the held trailers (they carry END_STREAM) so
+      // they follow the body in order.
+      decoder_callbacks_->continueDecoding();
+    } else {
+      // Terminate the stream with an empty end_stream data frame after the replayed
+      // body (also releases the held headers when the body was empty).
+      Buffer::OwnedImpl end_marker;
+      decoder_callbacks_->injectDecodedDataToFilterChain(end_marker, /*end_stream=*/true);
+    }
+  };
+
+  if (isAiEndpoint() && !decode_manager_->empty() && !payload_rejected_) {
+    std::vector<AiFilterPtr> filters;
+    filter_manager_ = std::make_unique<FilterManager>(
+        std::move(filters), std::move(request_json_), decode_manager_.get(),
+        decoder_callbacks_->dispatcher(), decoder_callbacks_->streamInfo(),
+        [this](Http::Code code, std::string details) {
+          ENVOY_LOG(debug, "ai_protocol_manager: rejecting request via local reply: {} {}",
+                    static_cast<uint32_t>(code), details);
+          payload_rejected_ = true;
+          decoder_callbacks_->sendLocalReply(code, details, nullptr, std::nullopt,
+                                             "ai_protocol_manager_filter_rejected");
+        });
+    filter_manager_->start([this, on_complete = std::move(on_complete)](absl::Status status) {
+      if (!status.ok()) {
+        rejectInvalidPayload(status);
+      } else {
+        on_complete();
+      }
+    });
+  } else {
+    decode_manager_->replay(0, decode_manager_->length(), std::move(on_complete));
+  }
 }
 
 Http::FilterHeadersStatus AiProtocolManagerFilter::encodeHeaders(Http::ResponseHeaderMap& headers,

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -12,6 +12,7 @@
 #include "source/common/common/logger.h"
 #include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer.h"
+#include "source/extensions/filters/http/ai_protocol_manager/filter_manager.h"
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf_parser.h"
 #include "source/extensions/filters/http/ai_protocol_manager/response_handler.h"
@@ -224,6 +225,10 @@ private:
   // Called exactly once, at response end of stream (data or trailers).
   void finalizeResponseHandling();
 
+  // Finalizes the decode path when the full request body (and optional trailers) has been received.
+  // Sets endStream on decode_manager_ and executes the AI filter chain or replays the body.
+  void finalizeDecode(bool has_trailers);
+
   ExternalBufferFactory& buffer_factory_;
   FilterConfigSharedPtr config_;
 
@@ -247,6 +252,9 @@ private:
 
   // Once set, later frames on the dying stream are dropped, not offloaded.
   bool payload_rejected_{false};
+
+  // FilterManager orchestrating the AI filter chain.
+  std::unique_ptr<FilterManager> filter_manager_;
 
   // Encode-path (response token-usage) state.
   ResponseHandlerPtr response_handler_;

--- a/source/extensions/filters/http/ai_protocol_manager/filter.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter.h
@@ -253,6 +253,9 @@ private:
   // Once set, later frames on the dying stream are dropped, not offloaded.
   bool payload_rejected_{false};
 
+  // Request headers for this stream. Held by pointer during decode path.
+  Http::RequestHeaderMap* request_headers_{nullptr};
+
   // FilterManager orchestrating the AI filter chain.
   std::unique_ptr<FilterManager> filter_manager_;
 

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -25,8 +25,10 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
   };
 
   AsyncState(size_t num_filters, BufferManager* buffer_manager, StreamInfo::StreamInfo& stream_info,
+             Http::RequestHeaderMap* request_headers,
              std::shared_ptr<Coroutine::DispatcherExecutor> executor, LocalReplyFn local_reply_fn)
-      : buffer_manager_(buffer_manager), stream_info_(stream_info), executor_(std::move(executor)),
+      : buffer_manager_(buffer_manager), stream_info_(stream_info),
+        request_headers_(request_headers), executor_(std::move(executor)),
         local_reply_fn_(std::move(local_reply_fn)) {
     // num_filters + 1 stages: 0..N-1 are filters, N is the sink.
     for (size_t i = 0; i <= num_filters; ++i) {
@@ -74,15 +76,23 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
     ASSERT(final_req_ != nullptr);
 
     ASSIGN_OR_CO_RETURN(
-        auto new_doc, co_await Serializer::calculateSerializedOffsets(final_req_->request_index()));
+        Serializer::SerializedOffsets serialized_offsets,
+        co_await Serializer::calculateSerializedOffsets(final_req_->request_index()));
 
     if (stream_info_.filterState() != nullptr) {
       stream_info_.filterState()->setData(
           APMRequestPayloadIndex::kFilterStateKey,
-          std::make_shared<APMRequestPayloadIndex>(std::move(new_doc)),
+          std::make_shared<APMRequestPayloadIndex>(std::move(serialized_offsets.doc)),
           StreamInfo::FilterState::LifeSpan::Request);
     }
 
+    if (request_headers_ != nullptr) {
+      request_headers_->setContentLength(serialized_offsets.total_size);
+    }
+
+    // TODO(penguingao): condition the serialization on config. If we want to
+    // normalize the json payload / protocol or the payload is modified, we
+    // re-serialize, if not, we just pass through the oroginal body.
     ASSIGN_OR_CO_RETURN(
         std::ignore, co_await Serializer::serialize(final_req_->request_index(), buffer_manager_));
 
@@ -144,7 +154,7 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
     on_complete_ = nullptr;
 
     if (reply_fn != nullptr) {
-      reply_fn(Http::Code::BadRequest, std::string(status.message()));
+      reply_fn(Http::Code::BadGateway, std::string(status.message()));
     }
     if (on_complete != nullptr) {
       on_complete(std::move(status));
@@ -187,6 +197,7 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
 
   BufferManager* buffer_manager_{nullptr};
   StreamInfo::StreamInfo& stream_info_;
+  Http::RequestHeaderMap* request_headers_{nullptr};
   std::shared_ptr<Coroutine::DispatcherExecutor> executor_;
   LocalReplyFn local_reply_fn_;
   absl::AnyInvocable<void(absl::Status)> on_complete_;
@@ -198,11 +209,13 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
 
 FilterManager::FilterManager(std::vector<AiFilterPtr> filters, JsonWithExtBuf payload_index,
                              BufferManager* buffer_manager, Event::Dispatcher& dispatcher,
-                             StreamInfo::StreamInfo& stream_info, LocalReplyFn local_reply_fn)
+                             StreamInfo::StreamInfo& stream_info,
+                             Http::RequestHeaderMap* request_headers, LocalReplyFn local_reply_fn)
     : filters_(std::move(filters)), payload_index_(std::move(payload_index)),
       executor_(std::make_shared<Coroutine::DispatcherExecutor>(dispatcher)),
       async_state_(std::make_shared<AsyncState>(filters_.size(), buffer_manager, stream_info,
-                                                executor_, std::move(local_reply_fn))) {}
+                                                request_headers, executor_,
+                                                std::move(local_reply_fn))) {}
 
 FilterManager::~FilterManager() { cancel(); }
 

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -86,7 +86,7 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
           StreamInfo::FilterState::LifeSpan::Request);
     }
 
-    if (request_headers_ != nullptr) {
+    if (request_headers_ != nullptr && request_headers_->ContentLength() != nullptr) {
       request_headers_->setContentLength(serialized_offsets.total_size);
     }
 

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -4,6 +4,7 @@
 #include <utility>
 #include <vector>
 
+#include "source/common/common/assert.h"
 #include "source/common/coroutine/async_queue.h"
 #include "source/common/coroutine/dispatcher_executor.h"
 #include "source/common/coroutine/launch.h"
@@ -55,8 +56,12 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
   }
 
   Coroutine::Task<absl::Status> propagateRequest(size_t index, AiRequestPtr req) {
+    if (req == nullptr) {
+      IS_ENVOY_BUG("cannot propagate null AiRequestPtr");
+      co_return absl::InvalidArgumentError("cannot propagate null AiRequestPtr");
+    }
     filter_contexts_[index].propagated = true;
-    return filter_contexts_[index + 1].handoff->push(std::move(req));
+    co_return co_await filter_contexts_[index + 1].handoff->push(std::move(req));
   }
 
   Coroutine::Task<absl::Status> runSink() {
@@ -66,6 +71,7 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
     }
 
     final_req_ = std::move(*res);
+    ASSERT(final_req_ != nullptr);
 
     ASSIGN_OR_CO_RETURN(
         auto new_doc, co_await Serializer::calculateSerializedOffsets(final_req_->request_index()));
@@ -83,6 +89,7 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
     terminated_ = true;
     if (on_complete_ != nullptr) {
       auto cb = std::move(on_complete_);
+      on_complete_ = nullptr;
       cb(absl::OkStatus());
     }
     co_return absl::OkStatus();
@@ -127,11 +134,18 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
     if (terminated_) {
       return;
     }
-    terminated_ = true;
+    cancel();
     ENVOY_LOG(debug, "ai_protocol_manager: filter chain error: {}", status.message());
-    if (on_complete_ != nullptr) {
-      auto cb = std::move(on_complete_);
-      cb(std::move(status));
+    auto reply_fn = std::move(local_reply_fn_);
+    local_reply_fn_ = nullptr;
+    auto on_complete = std::move(on_complete_);
+    on_complete_ = nullptr;
+
+    if (reply_fn != nullptr) {
+      reply_fn(Http::Code::BadRequest, std::string(status.message()));
+    }
+    if (on_complete != nullptr) {
+      on_complete(std::move(status));
     }
   }
 
@@ -139,15 +153,19 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
     if (terminated_) {
       return;
     }
-    terminated_ = true;
+    cancel();
     ENVOY_LOG(debug, "ai_protocol_manager: filter chain triggered local reply: {} {}",
               static_cast<uint32_t>(code), details);
-    if (local_reply_fn_ != nullptr) {
-      local_reply_fn_(code, std::move(details));
+    auto reply_fn = std::move(local_reply_fn_);
+    local_reply_fn_ = nullptr;
+    auto on_complete = std::move(on_complete_);
+    on_complete_ = nullptr;
+
+    if (reply_fn != nullptr) {
+      reply_fn(code, std::move(details));
     }
-    if (on_complete_ != nullptr) {
-      auto cb = std::move(on_complete_);
-      cb(absl::CancelledError("local reply sent"));
+    if (on_complete != nullptr) {
+      on_complete(absl::CancelledError("local reply sent"));
     }
   }
 

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -92,7 +92,7 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
 
     // TODO(penguingao): condition the serialization on config. If we want to
     // normalize the json payload / protocol or the payload is modified, we
-    // re-serialize, if not, we just pass through the oroginal body.
+    // re-serialize, if not, we just passthrough the original body.
     ASSIGN_OR_CO_RETURN(
         std::ignore, co_await Serializer::serialize(final_req_->request_index(), buffer_manager_));
 

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -120,7 +120,9 @@ struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterMan
             }
           },
           Coroutine::StartMode::Inline);
-      handles_.push_back(std::move(handle));
+      if (!terminated_) {
+        handles_.push_back(std::move(handle));
+      }
       return;
     }
 
@@ -207,13 +209,22 @@ FilterManager::~FilterManager() { cancel(); }
 void FilterManager::start(absl::AnyInvocable<void(absl::Status)> on_complete) {
   async_state_->on_complete_ = std::move(on_complete);
   launchFilters();
+  if (async_state_->terminated_) {
+    return;
+  }
   launchSink();
+  if (async_state_->terminated_) {
+    return;
+  }
   async_state_->filter_contexts_[0].handoff->tryPush(
       std::make_unique<AiRequest>(std::move(payload_index_)));
 }
 
 void FilterManager::launchFilters() {
   for (size_t i = 0; i < filters_.size(); ++i) {
+    if (async_state_->terminated_) {
+      break;
+    }
     std::weak_ptr<AsyncState> weak_state = async_state_;
 
     AiRequestReceiver receiver([weak_state, i]() -> Coroutine::Task<absl::StatusOr<AiRequestPtr>> {
@@ -248,7 +259,9 @@ void FilterManager::launchFilters() {
           }
         },
         Coroutine::StartMode::Inline);
-    async_state_->handles_.push_back(std::move(handle));
+    if (!async_state_->terminated_) {
+      async_state_->handles_.push_back(std::move(handle));
+    }
   }
 }
 
@@ -265,7 +278,9 @@ void FilterManager::launchSink() {
         }
       },
       Coroutine::StartMode::Inline);
-  async_state_->handles_.push_back(std::move(handle));
+  if (!async_state_->terminated_) {
+    async_state_->handles_.push_back(std::move(handle));
+  }
 }
 
 void FilterManager::cancel() { async_state_->cancel(); }

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -1,0 +1,258 @@
+#include "source/extensions/filters/http/ai_protocol_manager/filter_manager.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "source/common/coroutine/async_queue.h"
+#include "source/common/coroutine/dispatcher_executor.h"
+#include "source/common/coroutine/launch.h"
+#include "source/common/coroutine/status_macros.h"
+#include "source/extensions/filters/http/ai_protocol_manager/serializer.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+struct FilterManager::AsyncState : public std::enable_shared_from_this<FilterManager::AsyncState>,
+                                   public Logger::Loggable<Logger::Id::ai_protocol_manager> {
+  struct FilterContext {
+    std::shared_ptr<Coroutine::AsyncQueue<AiRequestPtr>> handoff;
+    bool received{false};
+    bool propagated{false};
+  };
+
+  AsyncState(size_t num_filters, BufferManager* buffer_manager, StreamInfo::StreamInfo& stream_info,
+             std::shared_ptr<Coroutine::DispatcherExecutor> executor, LocalReplyFn local_reply_fn)
+      : buffer_manager_(buffer_manager), stream_info_(stream_info), executor_(std::move(executor)),
+        local_reply_fn_(std::move(local_reply_fn)) {
+    // num_filters + 1 stages: 0..N-1 are filters, N is the sink.
+    for (size_t i = 0; i <= num_filters; ++i) {
+      filter_contexts_.push_back({
+          std::make_shared<Coroutine::AsyncQueue<AiRequestPtr>>(/*max_size=*/1),
+          /*received=*/false,
+          /*propagated=*/false,
+      });
+    }
+  }
+
+  Coroutine::Task<absl::StatusOr<AiRequestPtr>> receiveRequest(size_t index) {
+    ASSIGN_OR_CO_RETURN(auto res, co_await filter_contexts_[index].handoff->pop());
+    if (!res.has_value()) {
+      co_return absl::InternalError("request handoff queue closed unexpectedly");
+    }
+    filter_contexts_[index].received = true;
+    co_return std::move(*res);
+  }
+
+  Coroutine::Task<absl::Status> bypassFilter(size_t index) {
+    ASSIGN_OR_CO_RETURN(auto res, co_await filter_contexts_[index].handoff->pop());
+    if (!res.has_value()) {
+      co_return absl::InternalError("request handoff queue closed unexpectedly");
+    }
+    co_return co_await propagateRequest(index, std::move(*res));
+  }
+
+  Coroutine::Task<absl::Status> propagateRequest(size_t index, AiRequestPtr req) {
+    filter_contexts_[index].propagated = true;
+    return filter_contexts_[index + 1].handoff->push(std::move(req));
+  }
+
+  Coroutine::Task<absl::Status> runSink() {
+    ASSIGN_OR_CO_RETURN(auto res, co_await filter_contexts_.back().handoff->pop());
+    if (!res.has_value()) {
+      co_return absl::InternalError("sink handoff queue closed unexpectedly");
+    }
+
+    final_req_ = std::move(*res);
+
+    ASSIGN_OR_CO_RETURN(
+        auto new_doc, co_await Serializer::calculateSerializedOffsets(final_req_->request_index()));
+
+    if (stream_info_.filterState() != nullptr) {
+      stream_info_.filterState()->setData(
+          APMRequestPayloadIndex::kFilterStateKey,
+          std::make_shared<APMRequestPayloadIndex>(std::move(new_doc)),
+          StreamInfo::FilterState::LifeSpan::Request);
+    }
+
+    ASSIGN_OR_CO_RETURN(
+        std::ignore, co_await Serializer::serialize(final_req_->request_index(), buffer_manager_));
+
+    terminated_ = true;
+    if (on_complete_ != nullptr) {
+      auto cb = std::move(on_complete_);
+      cb(absl::OkStatus());
+    }
+    co_return absl::OkStatus();
+  }
+
+  void onFilterCompletion(size_t index, absl::Status status) {
+    if (terminated_) {
+      return;
+    }
+    if (!status.ok()) {
+      onFilterError(std::move(status));
+      return;
+    }
+
+    if (filter_contexts_[index].propagated) {
+      return;
+    }
+
+    if (!filter_contexts_[index].received) {
+      // Filter early-returned without calling receive_request (bypassed itself).
+      // Forward the request in its handoff queue directly to the next stage.
+      std::weak_ptr<AsyncState> weak_self = shared_from_this();
+      auto handle = Coroutine::launch(
+          bypassFilter(index), executor_,
+          [weak_self, index](absl::Status status) {
+            if (auto self = weak_self.lock()) {
+              self->onFilterCompletion(index, std::move(status));
+            }
+          },
+          Coroutine::StartMode::Inline);
+      handles_.push_back(std::move(handle));
+      return;
+    }
+
+    // Filter called receive_request, but completed without calling propagateRequest or
+    // reply_locally.
+    onFilterError(absl::InternalError(
+        "filter consumed request but terminated without propagating or replying locally"));
+  }
+
+  void onFilterError(absl::Status status) {
+    if (terminated_) {
+      return;
+    }
+    terminated_ = true;
+    ENVOY_LOG(debug, "ai_protocol_manager: filter chain error: {}", status.message());
+    if (on_complete_ != nullptr) {
+      auto cb = std::move(on_complete_);
+      cb(std::move(status));
+    }
+  }
+
+  void triggerLocalReply(Http::Code code, std::string details) {
+    if (terminated_) {
+      return;
+    }
+    terminated_ = true;
+    ENVOY_LOG(debug, "ai_protocol_manager: filter chain triggered local reply: {} {}",
+              static_cast<uint32_t>(code), details);
+    if (local_reply_fn_ != nullptr) {
+      local_reply_fn_(code, std::move(details));
+    }
+    if (on_complete_ != nullptr) {
+      auto cb = std::move(on_complete_);
+      cb(absl::CancelledError("local reply sent"));
+    }
+  }
+
+  void cancel() {
+    if (terminated_) {
+      return;
+    }
+    terminated_ = true;
+    for (auto& handle : handles_) {
+      handle.cancel();
+    }
+    handles_.clear();
+    for (auto& ctx : filter_contexts_) {
+      ctx.handoff->close();
+    }
+  }
+
+  BufferManager* buffer_manager_{nullptr};
+  StreamInfo::StreamInfo& stream_info_;
+  std::shared_ptr<Coroutine::DispatcherExecutor> executor_;
+  LocalReplyFn local_reply_fn_;
+  absl::AnyInvocable<void(absl::Status)> on_complete_;
+  AiRequestPtr final_req_;
+  std::vector<FilterContext> filter_contexts_;
+  std::vector<Coroutine::DetachedHandle> handles_;
+  bool terminated_{false};
+};
+
+FilterManager::FilterManager(std::vector<AiFilterPtr> filters, JsonWithExtBuf payload_index,
+                             BufferManager* buffer_manager, Event::Dispatcher& dispatcher,
+                             StreamInfo::StreamInfo& stream_info, LocalReplyFn local_reply_fn)
+    : filters_(std::move(filters)), payload_index_(std::move(payload_index)),
+      executor_(std::make_shared<Coroutine::DispatcherExecutor>(dispatcher)),
+      async_state_(std::make_shared<AsyncState>(filters_.size(), buffer_manager, stream_info,
+                                                executor_, std::move(local_reply_fn))) {}
+
+FilterManager::~FilterManager() { cancel(); }
+
+void FilterManager::start(absl::AnyInvocable<void(absl::Status)> on_complete) {
+  async_state_->on_complete_ = std::move(on_complete);
+  launchFilters();
+  launchSink();
+  async_state_->filter_contexts_[0].handoff->tryPush(
+      std::make_unique<AiRequest>(std::move(payload_index_)));
+}
+
+void FilterManager::launchFilters() {
+  for (size_t i = 0; i < filters_.size(); ++i) {
+    std::weak_ptr<AsyncState> weak_state = async_state_;
+
+    AiRequestReceiver receiver([weak_state, i]() -> Coroutine::Task<absl::StatusOr<AiRequestPtr>> {
+      auto state = weak_state.lock();
+      if (!state || state->terminated_) {
+        co_return absl::CancelledError("filter manager cancelled or destroyed");
+      }
+      co_return co_await state->receiveRequest(i);
+    });
+
+    AiRequestPropagator propagator(
+        [weak_state, i](AiRequestPtr req) -> Coroutine::Task<absl::Status> {
+          auto state = weak_state.lock();
+          if (!state || state->terminated_) {
+            co_return absl::CancelledError("filter manager cancelled or destroyed");
+          }
+          co_return co_await state->propagateRequest(i, std::move(req));
+        });
+
+    LocalReplier replier = [weak_state](Http::Code code, std::string details) {
+      if (auto state = weak_state.lock()) {
+        state->triggerLocalReply(code, std::move(details));
+      }
+    };
+
+    auto task = filters_[i]->decode(std::move(receiver), std::move(propagator), std::move(replier));
+    auto handle = Coroutine::launch(
+        std::move(task), executor_,
+        [weak_state, i](absl::Status status) {
+          if (auto state = weak_state.lock()) {
+            state->onFilterCompletion(i, std::move(status));
+          }
+        },
+        Coroutine::StartMode::Inline);
+    async_state_->handles_.push_back(std::move(handle));
+  }
+}
+
+void FilterManager::launchSink() {
+  std::weak_ptr<AsyncState> weak_state = async_state_;
+  auto task = async_state_->runSink();
+  auto handle = Coroutine::launch(
+      std::move(task), executor_,
+      [weak_state](absl::Status status) {
+        if (!status.ok()) {
+          if (auto state = weak_state.lock()) {
+            state->onFilterError(std::move(status));
+          }
+        }
+      },
+      Coroutine::StartMode::Inline);
+  async_state_->handles_.push_back(std::move(handle));
+}
+
+void FilterManager::cancel() { async_state_->cancel(); }
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.cc
@@ -216,8 +216,9 @@ void FilterManager::start(absl::AnyInvocable<void(absl::Status)> on_complete) {
   if (async_state_->terminated_) {
     return;
   }
-  async_state_->filter_contexts_[0].handoff->tryPush(
+  bool payload_index_pushed = async_state_->filter_contexts_[0].handoff->tryPush(
       std::make_unique<AiRequest>(std::move(payload_index_)));
+  ASSERT(payload_index_pushed);
 }
 
 void FilterManager::launchFilters() {

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "envoy/http/header_map.h"
 #include "envoy/stream_info/stream_info.h"
 
 #include "source/common/common/logger.h"
@@ -26,7 +27,9 @@ public:
 
   FilterManager(std::vector<AiFilterPtr> filters, JsonWithExtBuf payload_index,
                 BufferManager* buffer_manager, Event::Dispatcher& dispatcher,
-                StreamInfo::StreamInfo& stream_info, LocalReplyFn local_reply_fn = nullptr);
+                StreamInfo::StreamInfo& stream_info,
+                Http::RequestHeaderMap* request_headers = nullptr,
+                LocalReplyFn local_reply_fn = nullptr);
   ~FilterManager();
 
   // Launches the filter chain. Invokes `on_complete` with the final completion status.
@@ -38,8 +41,8 @@ public:
   //    are cancelled, `local_reply_fn` is called with the HTTP code and details string, and
   //    `on_complete` is invoked with `absl::CancelledError`.
   // 3. FilterManager internal error: when an `AiFilter` returns a non-OK status or an internal
-  //    error occurs, all coroutines are cancelled, `local_reply_fn` is called with a 400 Bad
-  //    Request local reply, and `on_complete` is invoked with that error status.
+  //    error occurs, all coroutines are cancelled, `local_reply_fn` is called with a 502 Bad
+  //    Gateway local reply, and `on_complete` is invoked with that error status.
   // 4. Cancellation: when `cancel()` is called, all coroutines are cancelled and neither
   //    `local_reply_fn` nor `on_complete` is invoked.
   void start(absl::AnyInvocable<void(absl::Status)> on_complete);

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "envoy/stream_info/stream_info.h"
+
+#include "source/common/common/logger.h"
+#include "source/common/coroutine/dispatcher_executor.h"
+#include "source/extensions/filters/http/ai_protocol_manager/ai_filter.h"
+#include "source/extensions/filters/http/ai_protocol_manager/ai_request.h"
+#include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+
+#include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+class FilterManager : public Logger::Loggable<Logger::Id::ai_protocol_manager> {
+public:
+  using LocalReplyFn = absl::AnyInvocable<void(Http::Code code, std::string details)>;
+
+  FilterManager(std::vector<AiFilterPtr> filters, JsonWithExtBuf payload_index,
+                BufferManager* buffer_manager, Event::Dispatcher& dispatcher,
+                StreamInfo::StreamInfo& stream_info, LocalReplyFn local_reply_fn = nullptr);
+  ~FilterManager();
+
+  // Launches the filter chain. Invokes on_complete with the final completion status.
+  void start(absl::AnyInvocable<void(absl::Status)> on_complete);
+
+  // Cancels all in-flight coroutines and cleans up state on stream reset.
+  // It is safe to destruct the FilterManager immediately after calling cancel().
+  void cancel();
+
+private:
+  struct AsyncState;
+
+  void launchFilters();
+  void launchSink();
+
+  std::vector<AiFilterPtr> filters_;
+  JsonWithExtBuf payload_index_;
+  std::shared_ptr<Coroutine::DispatcherExecutor> executor_;
+  std::shared_ptr<AsyncState> async_state_;
+};
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/filter_manager.h
+++ b/source/extensions/filters/http/ai_protocol_manager/filter_manager.h
@@ -29,7 +29,19 @@ public:
                 StreamInfo::StreamInfo& stream_info, LocalReplyFn local_reply_fn = nullptr);
   ~FilterManager();
 
-  // Launches the filter chain. Invokes on_complete with the final completion status.
+  // Launches the filter chain. Invokes `on_complete` with the final completion status.
+  //
+  // Contract between caller (`AiProtocolManagerFilter`) and `FilterManager`:
+  // 1. Success: when the filter chain completes and the payload is serialized and replayed,
+  //    `on_complete` is invoked with `absl::OkStatus()`.
+  // 2. Filter-initiated local reply: when an `AiFilter` invokes `LocalReplier`, all coroutines
+  //    are cancelled, `local_reply_fn` is called with the HTTP code and details string, and
+  //    `on_complete` is invoked with `absl::CancelledError`.
+  // 3. FilterManager internal error: when an `AiFilter` returns a non-OK status or an internal
+  //    error occurs, all coroutines are cancelled, `local_reply_fn` is called with a 400 Bad
+  //    Request local reply, and `on_complete` is invoked with that error status.
+  // 4. Cancellation: when `cancel()` is called, all coroutines are cancelled and neither
+  //    `local_reply_fn` nor `on_complete` is invoked.
   void start(absl::AnyInvocable<void(absl::Status)> on_complete);
 
   // Cancels all in-flight coroutines and cleans up state on stream reset.

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.cc
@@ -10,6 +10,7 @@
 #include "source/common/coroutine/status_macros.h"
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -108,6 +109,17 @@ private:
       co_return ref_or.status();
     }
     const auto& ref = *ref_or;
+    if (mode_ == SerializationMode::Emit) {
+      if (buffer_manager_ == nullptr) {
+        co_return absl::InternalError("buffer_manager is null for ExternalRef node");
+      }
+      if (ref.offset > buffer_manager_->length() ||
+          ref.length > buffer_manager_->length() - ref.offset) {
+        co_return absl::InvalidArgumentError(
+            absl::StrCat("external buffer reference [", ref.offset, ", ", ref.offset + ref.length,
+                         ") exceeds buffer length ", buffer_manager_->length()));
+      }
+    }
     small_buf_.add("\"");
     uint64_t new_offset = byte_counter_ + small_buf_.length();
     new_node = JsonWithExtBuf::makeExternalRef({new_offset, ref.length});
@@ -116,9 +128,6 @@ private:
       byte_counter_ += ref.length;
       switch (mode_) {
       case SerializationMode::Emit:
-        if (buffer_manager_ == nullptr) {
-          co_return absl::InternalError("buffer_manager is null for ExternalRef node");
-        }
         CO_RETURN_IF_ERROR(co_await ReplayAwaitable(*buffer_manager_, ref.offset, ref.length));
         break;
       case SerializationMode::Counting:

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.cc
@@ -109,7 +109,7 @@ private:
           co_return absl::InternalError("buffer_manager is null during flushBuffer");
         }
         // TODO(penguingao): if the replay becomes too fragmented between
-        // external buffer and reserialization, we could change the interface to
+        // external buffer and re-serialization, we could change the interface to
         // BufferManager take hint from the serializer's potential next replay
         // ranges, this way, it can then internally coalescing reads to save
         // I/O.

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.cc
@@ -88,6 +88,8 @@ public:
     co_return co_await flushBuffer();
   }
 
+  uint64_t totalBytes() const { return byte_counter_; }
+
 private:
   static constexpr size_t kMaxSmallBufferSize = 4096;
 
@@ -106,6 +108,11 @@ private:
         if (buffer_manager_ == nullptr) {
           co_return absl::InternalError("buffer_manager is null during flushBuffer");
         }
+        // TODO(penguingao): if the replay becomes too fragmented between
+        // external buffer and reserialization, we could change the interface to
+        // BufferManager take hint from the serializer's potential next replay
+        // ranges, this way, it can then internally coalescing reads to save
+        // I/O.
         CO_RETURN_IF_ERROR(co_await ReplayAwaitable(*buffer_manager_, small_buf_));
         break;
       case SerializationMode::Counting:
@@ -235,7 +242,7 @@ private:
 
 } // namespace
 
-Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>
+Coroutine::Task<absl::StatusOr<Serializer::SerializedOffsets>>
 Serializer::calculateSerializedOffsets(const JsonWithExtBuf& doc) {
   SerializerImpl impl(nullptr, SerializationMode::Counting);
   nlohmann::json new_json;
@@ -243,7 +250,7 @@ Serializer::calculateSerializedOffsets(const JsonWithExtBuf& doc) {
 
   JsonWithExtBuf new_doc;
   new_doc.setJson(std::move(new_json));
-  co_return new_doc;
+  co_return SerializedOffsets{std::move(new_doc), impl.totalBytes()};
 }
 
 Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.cc
@@ -1,0 +1,242 @@
+#include "source/extensions/filters/http/ai_protocol_manager/serializer.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "source/common/common/assert.h"
+#include "source/common/coroutine/leaf_awaitable.h"
+#include "source/common/coroutine/status_macros.h"
+
+#include "absl/status/status.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+namespace {
+
+enum class SerializationMode {
+  Counting,
+  Emit,
+};
+
+class ReplayAwaitable : public Coroutine::LeafAwaitable<absl::Status> {
+public:
+  ReplayAwaitable(BufferManager& buffer_manager, uint64_t offset, uint64_t length)
+      : buffer_manager_(buffer_manager), offset_(offset), length_(length), is_in_memory_(false) {}
+
+  ReplayAwaitable(BufferManager& buffer_manager, Buffer::Instance& data)
+      : buffer_manager_(buffer_manager), is_in_memory_(true) {
+    data_.move(data);
+  }
+
+protected:
+  // Fast path: complete immediately without suspending if nothing needs to be replayed.
+  std::optional<absl::Status> tryImmediate() override {
+    if ((is_in_memory_ && data_.length() == 0) || (!is_in_memory_ && length_ == 0)) {
+      return absl::OkStatus();
+    }
+    return std::nullopt;
+  }
+
+  // TODO(penguingao): Consider updating LeafAwaitable::onStart to return a bool (indicating
+  // whether to suspend) so that if buffer_manager_.replay completes synchronously on-stack, we can
+  // avoid await_suspend as defense-in-depth without splitting state across tryImmediate.
+  void onStart() override {
+    if (is_in_memory_) {
+      buffer_manager_.replay(data_, [this]() { complete(absl::OkStatus()); });
+    } else {
+      buffer_manager_.replay(offset_, length_, [this]() { complete(absl::OkStatus()); });
+    }
+  }
+
+  void onCancel() override { buffer_manager_.cancelReplay(); }
+
+private:
+  BufferManager& buffer_manager_;
+  uint64_t offset_{0};
+  uint64_t length_{0};
+  bool is_in_memory_{false};
+  Buffer::OwnedImpl data_;
+};
+
+class SerializerImpl {
+public:
+  SerializerImpl(BufferManager* buffer_manager, SerializationMode mode)
+      : buffer_manager_(buffer_manager), mode_(mode) {}
+
+  Coroutine::Task<absl::Status> serialize(const nlohmann::json& node, nlohmann::json& new_node) {
+    CO_RETURN_IF_ERROR(co_await serializeNode(node, new_node));
+    co_return co_await flushBuffer();
+  }
+
+private:
+  static constexpr size_t kMaxSmallBufferSize = 4096;
+
+  Coroutine::Task<absl::Status> maybeFlushBuffer() {
+    if (small_buf_.length() >= kMaxSmallBufferSize) {
+      co_return co_await flushBuffer();
+    }
+    co_return absl::OkStatus();
+  }
+
+  Coroutine::Task<absl::Status> flushBuffer() {
+    if (small_buf_.length() > 0) {
+      byte_counter_ += small_buf_.length();
+      switch (mode_) {
+      case SerializationMode::Emit:
+        if (buffer_manager_ == nullptr) {
+          co_return absl::InternalError("buffer_manager is null during flushBuffer");
+        }
+        CO_RETURN_IF_ERROR(co_await ReplayAwaitable(*buffer_manager_, small_buf_));
+        break;
+      case SerializationMode::Counting:
+        small_buf_.drain(small_buf_.length());
+        break;
+      }
+    }
+    co_return absl::OkStatus();
+  }
+
+  Coroutine::Task<absl::Status> serializeExternalRef(const nlohmann::json& node,
+                                                     nlohmann::json& new_node) {
+    auto ref_or = JsonWithExtBuf::externalRef(node);
+    if (!ref_or.ok()) {
+      co_return ref_or.status();
+    }
+    const auto& ref = *ref_or;
+    small_buf_.add("\"");
+    uint64_t new_offset = byte_counter_ + small_buf_.length();
+    new_node = JsonWithExtBuf::makeExternalRef({new_offset, ref.length});
+    if (ref.length > 0) {
+      CO_RETURN_IF_ERROR(co_await flushBuffer());
+      byte_counter_ += ref.length;
+      switch (mode_) {
+      case SerializationMode::Emit:
+        if (buffer_manager_ == nullptr) {
+          co_return absl::InternalError("buffer_manager is null for ExternalRef node");
+        }
+        CO_RETURN_IF_ERROR(co_await ReplayAwaitable(*buffer_manager_, ref.offset, ref.length));
+        break;
+      case SerializationMode::Counting:
+        break;
+      }
+    }
+    small_buf_.add("\"");
+    CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+    co_return absl::OkStatus();
+  }
+
+  Coroutine::Task<absl::Status> serializeNode(const nlohmann::json& node,
+                                              nlohmann::json& new_node) {
+    if (JsonWithExtBuf::isExternalRef(node)) {
+      co_return co_await serializeExternalRef(node, new_node);
+    }
+
+    switch (node.type()) {
+    case nlohmann::json::value_t::null:
+      small_buf_.add("null");
+      new_node = nullptr;
+      CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+      break;
+    case nlohmann::json::value_t::boolean:
+      small_buf_.add(node.get<bool>() ? "true" : "false");
+      new_node = node.get<bool>();
+      CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+      break;
+    case nlohmann::json::value_t::number_integer:
+    case nlohmann::json::value_t::number_unsigned:
+    case nlohmann::json::value_t::number_float:
+    case nlohmann::json::value_t::string:
+      small_buf_.add(node.dump());
+      new_node = node;
+      CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+      break;
+    case nlohmann::json::value_t::array: {
+      new_node = nlohmann::json::array();
+      small_buf_.add("[");
+      bool first = true;
+      for (const auto& item : node) {
+        if (!first) {
+          small_buf_.add(",");
+        }
+        first = false;
+        nlohmann::json child;
+        CO_RETURN_IF_ERROR(co_await serializeNode(item, child));
+        new_node.push_back(std::move(child));
+      }
+      small_buf_.add("]");
+      CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+      break;
+    }
+    case nlohmann::json::value_t::object: {
+      new_node = nlohmann::json::object();
+      small_buf_.add("{");
+      bool first = true;
+      for (auto it = node.begin(); it != node.end(); ++it) {
+        if (!first) {
+          small_buf_.add(",");
+        }
+        first = false;
+        small_buf_.add(nlohmann::json(it.key()).dump());
+        small_buf_.add(":");
+        nlohmann::json child;
+        CO_RETURN_IF_ERROR(co_await serializeNode(it.value(), child));
+        new_node[it.key()] = std::move(child);
+      }
+      small_buf_.add("}");
+      CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+      break;
+    }
+    case nlohmann::json::value_t::binary:
+      small_buf_.add(node.dump());
+      new_node = node;
+      CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
+      break;
+    case nlohmann::json::value_t::discarded:
+      co_return absl::InvalidArgumentError("cannot serialize discarded JSON node");
+    }
+
+    co_return absl::OkStatus();
+  }
+
+  BufferManager* buffer_manager_{nullptr};
+  SerializationMode mode_{SerializationMode::Emit};
+  Buffer::OwnedImpl small_buf_;
+  uint64_t byte_counter_{0};
+};
+
+} // namespace
+
+Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>
+Serializer::calculateSerializedOffsets(const JsonWithExtBuf& doc) {
+  SerializerImpl impl(nullptr, SerializationMode::Counting);
+  nlohmann::json new_json;
+  CO_RETURN_IF_ERROR(co_await impl.serialize(doc.json(), new_json));
+
+  JsonWithExtBuf new_doc;
+  new_doc.setJson(std::move(new_json));
+  co_return new_doc;
+}
+
+Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>
+Serializer::serialize(const JsonWithExtBuf& doc, BufferManager* buffer_manager) {
+  if (buffer_manager == nullptr) {
+    co_return absl::InvalidArgumentError("buffer_manager must not be null for serialize");
+  }
+  SerializerImpl impl(buffer_manager, SerializationMode::Emit);
+  nlohmann::json new_json;
+  CO_RETURN_IF_ERROR(co_await impl.serialize(doc.json(), new_json));
+
+  JsonWithExtBuf new_doc;
+  new_doc.setJson(std::move(new_json));
+  co_return new_doc;
+}
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.cc
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "source/common/common/assert.h"
+#include "source/common/common/thread.h"
 #include "source/common/coroutine/leaf_awaitable.h"
 #include "source/common/coroutine/status_macros.h"
 
@@ -18,6 +19,19 @@ namespace HttpFilters {
 namespace AiProtocolManager {
 
 namespace {
+
+absl::StatusOr<std::string> dumpJson(const nlohmann::json& node) noexcept {
+  TRY_NEEDS_AUDIT { return node.dump(); }
+  END_TRY
+  CATCH(const nlohmann::json::exception& e, {
+    return absl::InvalidArgumentError(absl::StrCat("JSON serialization error: ", e.what()));
+  })
+  CATCH(const std::exception& e, {
+    return absl::InvalidArgumentError(absl::StrCat("JSON serialization error: ", e.what()));
+  })
+  CATCH(..., { return absl::InvalidArgumentError("unknown error during JSON serialization"); })
+  return absl::InternalError("unexpected flow in dumpJson");
+}
 
 enum class SerializationMode {
   Counting,
@@ -104,11 +118,7 @@ private:
 
   Coroutine::Task<absl::Status> serializeExternalRef(const nlohmann::json& node,
                                                      nlohmann::json& new_node) {
-    auto ref_or = JsonWithExtBuf::externalRef(node);
-    if (!ref_or.ok()) {
-      co_return ref_or.status();
-    }
-    const auto& ref = *ref_or;
+    ASSIGN_OR_CO_RETURN(const JsonWithExtBuf::ExternalRef ref, JsonWithExtBuf::externalRef(node));
     if (mode_ == SerializationMode::Emit) {
       if (buffer_manager_ == nullptr) {
         co_return absl::InternalError("buffer_manager is null for ExternalRef node");
@@ -159,11 +169,13 @@ private:
     case nlohmann::json::value_t::number_integer:
     case nlohmann::json::value_t::number_unsigned:
     case nlohmann::json::value_t::number_float:
-    case nlohmann::json::value_t::string:
-      small_buf_.add(node.dump());
+    case nlohmann::json::value_t::string: {
+      ASSIGN_OR_CO_RETURN(const std::string dumped, dumpJson(node));
+      small_buf_.add(dumped);
       new_node = node;
       CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
       break;
+    }
     case nlohmann::json::value_t::array: {
       new_node = nlohmann::json::array();
       small_buf_.add("[");
@@ -190,7 +202,8 @@ private:
           small_buf_.add(",");
         }
         first = false;
-        small_buf_.add(nlohmann::json(it.key()).dump());
+        ASSIGN_OR_CO_RETURN(const std::string dumped_key, dumpJson(nlohmann::json(it.key())));
+        small_buf_.add(dumped_key);
         small_buf_.add(":");
         nlohmann::json child;
         CO_RETURN_IF_ERROR(co_await serializeNode(it.value(), child));
@@ -200,11 +213,13 @@ private:
       CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
       break;
     }
-    case nlohmann::json::value_t::binary:
-      small_buf_.add(node.dump());
+    case nlohmann::json::value_t::binary: {
+      ASSIGN_OR_CO_RETURN(const std::string dumped, dumpJson(node));
+      small_buf_.add(dumped);
       new_node = node;
       CO_RETURN_IF_ERROR(co_await maybeFlushBuffer());
       break;
+    }
     case nlohmann::json::value_t::discarded:
       co_return absl::InvalidArgumentError("cannot serialize discarded JSON node");
     }

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.cc
@@ -62,9 +62,10 @@ protected:
   // avoid await_suspend as defense-in-depth without splitting state across tryImmediate.
   void onStart() override {
     if (is_in_memory_) {
-      buffer_manager_.replay(data_, [this]() { complete(absl::OkStatus()); });
+      buffer_manager_.replay(data_, [this](absl::Status status) { complete(std::move(status)); });
     } else {
-      buffer_manager_.replay(offset_, length_, [this]() { complete(absl::OkStatus()); });
+      buffer_manager_.replay(offset_, length_,
+                             [this](absl::Status status) { complete(std::move(status)); });
     }
   }
 

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.h
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.h
@@ -17,7 +17,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
 
-// Filter state object holding the reserialized JsonWithExtBuf index.
+// Filter state object holding the serialized JsonWithExtBuf index.
 class APMRequestPayloadIndex : public StreamInfo::FilterState::Object {
 public:
   explicit APMRequestPayloadIndex(JsonWithExtBuf index) : index_(std::move(index)) {}
@@ -34,7 +34,7 @@ private:
 class Serializer {
 public:
   // Dry-run calculation: computes new byte offsets for all ExternalRef nodes in doc as they
-  // will appear in the reserialized output stream, returning a new JsonWithExtBuf instance.
+  // will appear in the serialized output stream, returning a new JsonWithExtBuf instance.
   static Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>
   calculateSerializedOffsets(const JsonWithExtBuf& doc);
 

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.h
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/stream_info/filter_state.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/coroutine/task.h"
+#include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+// Filter state object holding the reserialized JsonWithExtBuf index.
+class APMRequestPayloadIndex : public StreamInfo::FilterState::Object {
+public:
+  explicit APMRequestPayloadIndex(JsonWithExtBuf index) : index_(std::move(index)) {}
+
+  const JsonWithExtBuf& index() const { return index_; }
+
+  static constexpr absl::string_view kFilterStateKey =
+      "envoy.filters.http.ai_protocol_manager.request_json";
+
+private:
+  JsonWithExtBuf index_;
+};
+
+class Serializer {
+public:
+  // Dry-run calculation: computes new byte offsets for all ExternalRef nodes in doc as they
+  // will appear in the reserialized output stream, returning a new JsonWithExtBuf instance.
+  static Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>
+  calculateSerializedOffsets(const JsonWithExtBuf& doc);
+
+  // Streaming serialization: replays JSON tokens and offloaded buffer slices directly through
+  // the BufferManager into the filter chain with watermark flow control, and returns a new
+  // JsonWithExtBuf with updated byte offsets reflecting the emitted serialization.
+  static Coroutine::Task<absl::StatusOr<JsonWithExtBuf>> serialize(const JsonWithExtBuf& doc,
+                                                                   BufferManager* buffer_manager);
+};
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/ai_protocol_manager/serializer.h
+++ b/source/extensions/filters/http/ai_protocol_manager/serializer.h
@@ -33,9 +33,15 @@ private:
 
 class Serializer {
 public:
+  struct SerializedOffsets {
+    JsonWithExtBuf doc;
+    uint64_t total_size{0};
+  };
+
   // Dry-run calculation: computes new byte offsets for all ExternalRef nodes in doc as they
-  // will appear in the serialized output stream, returning a new JsonWithExtBuf instance.
-  static Coroutine::Task<absl::StatusOr<JsonWithExtBuf>>
+  // will appear in the serialized output stream, returning a new JsonWithExtBuf instance and
+  // the total serialized byte length.
+  static Coroutine::Task<absl::StatusOr<SerializedOffsets>>
   calculateSerializedOffsets(const JsonWithExtBuf& doc);
 
   // Streaming serialization: replays JSON tokens and offloaded buffer slices directly through

--- a/test/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/BUILD
@@ -3,6 +3,7 @@ load(
     "envoy_benchmark_test",
     "envoy_cc_benchmark_binary",
     "envoy_cc_fuzz_test",
+    "envoy_cc_test_library",
     "envoy_package",
 )
 load(
@@ -13,6 +14,16 @@ load(
 licenses(["notice"])  # Apache 2
 
 envoy_package()
+
+envoy_cc_test_library(
+    name = "fake_bridge_lib",
+    hdrs = ["fake_bridge.h"],
+    deps = [
+        "//envoy/event:dispatcher_interface",
+        "//source/common/buffer:buffer_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:filter_chain_bridge_lib",
+    ],
+)
 
 envoy_extension_cc_test(
     name = "external_buffer_impl_test",
@@ -68,6 +79,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.filters.http.ai_protocol_manager"],
     rbe_pool = "linux_x64_small",
     deps = [
+        ":fake_bridge_lib",
         "//source/common/buffer:buffer_lib",
         "//source/extensions/filters/http/ai_protocol_manager:buffer_manager_lib",
         "//source/extensions/filters/http/ai_protocol_manager:external_buffer_impl_lib",
@@ -114,12 +126,57 @@ envoy_extension_cc_test(
         "//source/common/buffer:buffer_lib",
         "//source/extensions/filters/http/ai_protocol_manager:external_buffer_impl_lib",
         "//source/extensions/filters/http/ai_protocol_manager:filter_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:serializer_lib",
         "//test/mocks/http:http_mocks",
         "//test/mocks/stats:stats_mocks",
         "//test/test_common:logging_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/data/ai/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/ai_protocol_manager/v3:pkg_cc_proto",
+        "@nlohmann_json//:json",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "serializer_test",
+    srcs = ["serializer_test.cc"],
+    extension_names = ["envoy.filters.http.ai_protocol_manager"],
+    rbe_pool = "linux_x64_small",
+    deps = [
+        ":fake_bridge_lib",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/coroutine:dispatcher_executor_lib",
+        "//source/common/coroutine:launch_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:buffer_manager_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:external_buffer_impl_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:json_with_ext_buf_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:serializer_lib",
+        "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
+        "@nlohmann_json//:json",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "filter_manager_test",
+    srcs = ["filter_manager_test.cc"],
+    extension_names = ["envoy.filters.http.ai_protocol_manager"],
+    rbe_pool = "linux_x64_small",
+    deps = [
+        ":fake_bridge_lib",
+        "//source/common/buffer:buffer_lib",
+        "//source/common/coroutine:async_queue_lib",
+        "//source/common/coroutine:dispatcher_executor_lib",
+        "//source/common/coroutine:launch_lib",
+        "//source/common/coroutine:status_macros_lib",
+        "//source/common/stream_info:stream_info_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:buffer_manager_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:external_buffer_impl_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:filter_manager_lib",
+        "//source/extensions/filters/http/ai_protocol_manager:serializer_lib",
+        "//test/test_common:status_utility_lib",
+        "//test/test_common:utility_lib",
+        "@nlohmann_json//:json",
     ],
 )
 

--- a/test/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/BUILD
@@ -84,6 +84,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/http/ai_protocol_manager:buffer_manager_lib",
         "//source/extensions/filters/http/ai_protocol_manager:external_buffer_impl_lib",
         "//test/mocks/event:event_mocks",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -9,6 +9,7 @@
 
 #include "test/extensions/filters/http/ai_protocol_manager/fake_bridge.h"
 #include "test/mocks/event/mocks.h"
+#include "test/test_common/status_utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -879,6 +879,52 @@ TEST_F(BufferManagerTest, CancelReplayPermanentlyPreventsFurtherReplay) {
   EXPECT_DEBUG_DEATH(manager_->replay(in_mem, [](absl::Status) {}), ".*");
 }
 
+// If in-memory replay is cancelled synchronously during injectData, draining stops immediately.
+TEST_F(BufferManagerTest, SynchronousCancelReplayStopsInMemoryDrainImmediately) {
+  Buffer::OwnedImpl body("initial");
+  manager_->onData(body);
+  manager_->endStream();
+  drain();
+
+  const std::string big_payload(200 * 1024, 'z'); // Multiple 64KB chunks
+  Buffer::OwnedImpl in_memory_data(big_payload);
+  bool in_mem_done = false;
+
+  bridge_->on_inject_ = [this]() { manager_->cancelReplay(); };
+
+  manager_->replay(in_memory_data, [&in_mem_done](absl::Status) { in_mem_done = true; });
+
+  ASSERT_TRUE(replay_cb_->enabled());
+  replay_cb_->invokeCallback();
+
+  // Draining stopped after the first chunk was injected; no further chunks or done callback ran.
+  EXPECT_EQ(bridge_->inject_calls_, 1);
+  EXPECT_EQ(bridge_->injected_.length(), 64 * 1024);
+  EXPECT_FALSE(in_mem_done);
+}
+
+// If external buffer replay is cancelled synchronously during injectData, replay stops immediately.
+TEST_F(BufferManagerTest, SynchronousCancelReplayStopsExternalBufferReplayImmediately) {
+  const std::string big_payload(200 * 1024, 'z');
+  Buffer::OwnedImpl body(big_payload);
+  manager_->onData(body);
+  manager_->endStream();
+  drain();
+
+  bool replay_done = false;
+  bridge_->on_inject_ = [this]() { manager_->cancelReplay(); };
+
+  manager_->replay(0, big_payload.size(), [&replay_done](absl::Status) { replay_done = true; });
+
+  ASSERT_TRUE(replay_cb_->enabled());
+  replay_cb_->invokeCallback();
+
+  // Replay stopped after the first chunk was injected.
+  EXPECT_EQ(bridge_->inject_calls_, 1);
+  EXPECT_EQ(bridge_->injected_.length(), 64 * 1024);
+  EXPECT_FALSE(replay_done);
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -190,7 +190,11 @@ public:
   // (End-of-stream handling lives in the filter, not the manager, so the unit
   // tests just observe that the requested range was injected and done fired.)
   void replayAll() {
-    manager_->replay(0, manager_->length(), [this]() { replay_done_ = true; });
+    manager_->replay(0, manager_->length(), [this](absl::Status status) {
+      if (status.ok()) {
+        replay_done_ = true;
+      }
+    });
   }
 
   // Run all posted callbacks, including ones enqueued while draining.
@@ -381,9 +385,13 @@ TEST_F(BufferManagerTest, ReplaysSubRangesInSequence) {
 
   bool second_done = false;
   // Replay the first half, then chain the second half from its done callback.
-  manager_->replay(0, 5, [&]() {
+  manager_->replay(0, 5, [&](absl::Status status) {
+    ASSERT_OK(status);
     EXPECT_EQ(bridge_->injected_.toString(), "HELLO");
-    manager_->replay(5, 5, [&second_done]() { second_done = true; });
+    manager_->replay(5, 5, [&second_done](absl::Status status2) {
+      ASSERT_OK(status2);
+      second_done = true;
+    });
   });
 
   // First range was deferred (offload already durable).
@@ -428,7 +436,8 @@ TEST_F(BufferManagerTest, TerminalReplayDoneDetachesManagerSynchronously) {
   // The write is still in flight (posted) when replay() is requested, so replay
   // starts from the write completion during drain() and runs synchronously through
   // the in-memory store into this done callback.
-  manager_->replay(0, manager_->length(), [&]() {
+  manager_->replay(0, manager_->length(), [&](absl::Status status) {
+    ASSERT_OK(status);
     done_ran = true;
     injected = bridge_->injected_.toString();
     // Mirror the filter's teardown: detach on-stack, mid-read.
@@ -747,7 +756,10 @@ TEST_F(BufferManagerTest, ReplaysInMemoryDataVerbatim) {
 
   Buffer::OwnedImpl in_memory_data("{\"modified\":true}");
   bool in_mem_done = false;
-  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+  manager_->replay(in_memory_data, [&in_mem_done](absl::Status status) {
+    ASSERT_OK(status);
+    in_mem_done = true;
+  });
 
   ASSERT_TRUE(replay_cb_->enabled());
   replay_cb_->invokeCallback();
@@ -769,7 +781,10 @@ TEST_F(BufferManagerTest, ReplaysInMemoryDataWithWatermarkBackpressure) {
   const std::string big_payload(200 * 1024, 'z'); // Multiple 64KB chunks
   Buffer::OwnedImpl in_memory_data(big_payload);
   bool in_mem_done = false;
-  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+  manager_->replay(in_memory_data, [&in_mem_done](absl::Status status) {
+    ASSERT_OK(status);
+    in_mem_done = true;
+  });
 
   ASSERT_TRUE(replay_cb_->enabled());
   replay_cb_->invokeCallback();
@@ -820,7 +835,7 @@ TEST_F(BufferManagerTest, CancelReplayCancelsPendingExternalBufferReplay) {
 TEST_F(BufferManagerTest, CancelReplayCancelsPendingInMemoryReplay) {
   Buffer::OwnedImpl in_memory_data("{\"modified\":true}");
   bool in_mem_done = false;
-  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+  manager_->replay(in_memory_data, [&in_mem_done](absl::Status) { in_mem_done = true; });
 
   ASSERT_TRUE(replay_cb_->enabled());
   manager_->cancelReplay();
@@ -836,7 +851,7 @@ TEST_F(BufferManagerTest, CancelReplayCancelsPendingInMemoryReplay) {
 TEST_F(BufferManagerTest, DestroyCancelsPendingInMemoryReplay) {
   Buffer::OwnedImpl in_memory_data("{\"modified\":true}");
   bool in_mem_done = false;
-  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+  manager_->replay(in_memory_data, [&in_mem_done](absl::Status) { in_mem_done = true; });
 
   ASSERT_TRUE(replay_cb_->enabled());
   manager_->onDestroy();
@@ -857,10 +872,10 @@ TEST_F(BufferManagerTest, CancelReplayPermanentlyPreventsFurtherReplay) {
   manager_->cancelReplay();
 
   // Attempting to replay after cancelReplay triggers an assert in debug builds.
-  EXPECT_DEBUG_DEATH(manager_->replay(0, 5, []() {}), ".*");
+  EXPECT_DEBUG_DEATH(manager_->replay(0, 5, [](absl::Status) {}), ".*");
 
   Buffer::OwnedImpl in_mem("test");
-  EXPECT_DEBUG_DEATH(manager_->replay(in_mem, []() {}), ".*");
+  EXPECT_DEBUG_DEATH(manager_->replay(in_mem, [](absl::Status) {}), ".*");
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -788,6 +788,49 @@ TEST_F(BufferManagerTest, ReplaysInMemoryDataWithWatermarkBackpressure) {
   EXPECT_EQ(bridge_->injected_.toString(), big_payload);
 }
 
+// cancelReplay cancels in-flight external buffer replay so late read completions are dropped.
+TEST_F(BufferManagerTest, CancelReplayCancelsPendingExternalBufferReplay) {
+  resetManager(posting_factory_);
+
+  Buffer::OwnedImpl body("message data for offload");
+  manager_->onData(body);
+  manager_->endStream();
+  drain();
+
+  replayAll();
+
+  // A deferred replay was scheduled; fire replay_cb_ to issue read().
+  ASSERT_TRUE(replay_cb_->enabled());
+  replay_cb_->invokeCallback();
+
+  // The read callback was posted to dispatcher, so read is currently in flight.
+  EXPECT_FALSE(posted_.empty());
+
+  // Now cancel replay before the posted read callback completes.
+  manager_->cancelReplay();
+
+  // Run the remaining posted read callback.
+  drain();
+
+  EXPECT_FALSE(replay_done_);
+  EXPECT_EQ(bridge_->injected_.length(), 0);
+}
+
+// cancelReplay cancels in-flight in-memory replay so scheduled callbacks do not inject.
+TEST_F(BufferManagerTest, CancelReplayCancelsPendingInMemoryReplay) {
+  Buffer::OwnedImpl in_memory_data("{\"modified\":true}");
+  bool in_mem_done = false;
+  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+
+  ASSERT_TRUE(replay_cb_->enabled());
+  manager_->cancelReplay();
+  EXPECT_FALSE(replay_cb_->enabled());
+
+  drain();
+  EXPECT_FALSE(in_mem_done);
+  EXPECT_EQ(bridge_->injected_.length(), 0);
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -831,6 +831,38 @@ TEST_F(BufferManagerTest, CancelReplayCancelsPendingInMemoryReplay) {
   EXPECT_EQ(bridge_->injected_.length(), 0);
 }
 
+// onDestroy cancels in-flight in-memory replay so scheduled callbacks do not inject or trigger
+// done.
+TEST_F(BufferManagerTest, DestroyCancelsPendingInMemoryReplay) {
+  Buffer::OwnedImpl in_memory_data("{\"modified\":true}");
+  bool in_mem_done = false;
+  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+
+  ASSERT_TRUE(replay_cb_->enabled());
+  manager_->onDestroy();
+  EXPECT_FALSE(replay_cb_->enabled());
+
+  drain();
+  EXPECT_FALSE(in_mem_done);
+  EXPECT_EQ(bridge_->injected_.length(), 0);
+}
+
+// cancelReplay permanently disables starting any new replay.
+TEST_F(BufferManagerTest, CancelReplayPermanentlyPreventsFurtherReplay) {
+  Buffer::OwnedImpl body("some payload");
+  manager_->onData(body);
+  manager_->endStream();
+  drain();
+
+  manager_->cancelReplay();
+
+  // Attempting to replay after cancelReplay triggers an assert in debug builds.
+  EXPECT_DEBUG_DEATH(manager_->replay(0, 5, []() {}), ".*");
+
+  Buffer::OwnedImpl in_mem("test");
+  EXPECT_DEBUG_DEATH(manager_->replay(in_mem, []() {}), ".*");
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -7,6 +7,7 @@
 #include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.h"
 
+#include "test/extensions/filters/http/ai_protocol_manager/fake_bridge.h"
 #include "test/mocks/event/mocks.h"
 
 #include "gmock/gmock.h"
@@ -20,45 +21,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace AiProtocolManager {
 namespace {
-
-// Hand-written FilterChainBridge that records everything the BufferManager does
-// to the (notional) filter chain, so the path-agnostic offload/replay logic can
-// be unit-tested without any HTTP filter mocks. Tests drive replay back-pressure
-// through the captured ReplayWatermarkHandler, exactly as a real decoder/encoder
-// bridge would when the connection manager raises a watermark.
-class FakeBridge : public FilterChainBridge {
-public:
-  explicit FakeBridge(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
-
-  Event::Dispatcher& dispatcher() override { return dispatcher_; }
-  uint32_t bufferLimit() override { return buffer_limit_; }
-  void injectData(Buffer::Instance& data) override {
-    injected_.add(data);
-    ++inject_calls_;
-    // Simulate downstream back-pressure arising mid-replay: when configured, raise
-    // the replay high watermark right after the Nth injected chunk, as a real
-    // chain would when its write buffer fills.
-    if (handler_ != nullptr && inject_calls_ == raise_replay_watermark_at_inject_) {
-      handler_->onReplayAboveHighWatermark();
-    }
-  }
-  void pauseSource() override { ++pause_source_calls_; }
-  void resumeSource() override { ++resume_source_calls_; }
-  void registerReplayWatermarks(ReplayWatermarkHandler& handler) override { handler_ = &handler; }
-  void unregisterReplayWatermarks() override { handler_ = nullptr; }
-  void onUnrecoverableError() override { ++error_calls_; }
-
-  Event::Dispatcher& dispatcher_;
-  uint32_t buffer_limit_{1024 * 1024};
-  ReplayWatermarkHandler* handler_{nullptr};
-
-  Buffer::OwnedImpl injected_;
-  int inject_calls_{0};
-  int pause_source_calls_{0};
-  int resume_source_calls_{0};
-  int error_calls_{0};
-  int raise_replay_watermark_at_inject_{0}; // 0 = never.
-};
 
 // An ExternalBuffer that completes both write and read asynchronously, via
 // dispatcher.post() -- modelling a network/disk-backed store. Used to exercise
@@ -773,6 +735,57 @@ TEST_F(BufferManagerTest, ResumeSkipsReadWhileOneInFlight) {
   drain();
   EXPECT_TRUE(replay_done_);
   EXPECT_EQ(bridge_->injected_.toString(), big);
+}
+
+// In-memory replay injects small buffer data into the filter chain verbatim and triggers done
+// callback.
+TEST_F(BufferManagerTest, ReplaysInMemoryDataVerbatim) {
+  Buffer::OwnedImpl body("{\"messages\":[\"hello\"]}");
+  manager_->onData(body);
+  manager_->endStream();
+  drain();
+
+  Buffer::OwnedImpl in_memory_data("{\"modified\":true}");
+  bool in_mem_done = false;
+  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+
+  ASSERT_TRUE(replay_cb_->enabled());
+  replay_cb_->invokeCallback();
+
+  EXPECT_TRUE(in_mem_done);
+  EXPECT_EQ(bridge_->injected_.toString(), "{\"modified\":true}");
+}
+
+// In-memory replay pauses when high watermark is hit and resumes when low watermark drains.
+TEST_F(BufferManagerTest, ReplaysInMemoryDataWithWatermarkBackpressure) {
+  Buffer::OwnedImpl body("initial");
+  manager_->onData(body);
+  manager_->endStream();
+  drain();
+
+  // Set bridge to raise high watermark on the first injected chunk.
+  bridge_->raise_replay_watermark_at_inject_ = 1;
+
+  const std::string big_payload(200 * 1024, 'z'); // Multiple 64KB chunks
+  Buffer::OwnedImpl in_memory_data(big_payload);
+  bool in_mem_done = false;
+  manager_->replay(in_memory_data, [&in_mem_done]() { in_mem_done = true; });
+
+  ASSERT_TRUE(replay_cb_->enabled());
+  replay_cb_->invokeCallback();
+
+  // The first chunk injected and triggered high watermark, pausing replay.
+  EXPECT_FALSE(in_mem_done);
+  EXPECT_EQ(bridge_->injected_.length(), 64 * 1024);
+
+  // Now clear the watermark: low watermark schedules continuation to resume draining.
+  ASSERT_NE(bridge_->handler_, nullptr);
+  bridge_->handler_->onReplayBelowLowWatermark();
+  ASSERT_TRUE(replay_cb_->enabled());
+  replay_cb_->invokeCallback();
+
+  EXPECT_TRUE(in_mem_done);
+  EXPECT_EQ(bridge_->injected_.toString(), big_payload);
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/fake_bridge.h
+++ b/test/extensions/filters/http/ai_protocol_manager/fake_bridge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "envoy/event/dispatcher.h"
 
 #include "source/common/buffer/buffer_impl.h"
@@ -24,6 +26,9 @@ public:
   void injectData(Buffer::Instance& data) override {
     injected_.add(data);
     ++inject_calls_;
+    if (on_inject_ != nullptr) {
+      on_inject_();
+    }
     // Simulate downstream back-pressure arising mid-replay: when configured, raise
     // the replay high watermark right after the Nth injected chunk, as a real
     // chain would when its write buffer fills.
@@ -47,6 +52,7 @@ public:
   int resume_source_calls_{0};
   int error_calls_{0};
   int raise_replay_watermark_at_inject_{0}; // 0 = never.
+  std::function<void()> on_inject_;
 };
 
 } // namespace AiProtocolManager

--- a/test/extensions/filters/http/ai_protocol_manager/fake_bridge.h
+++ b/test/extensions/filters/http/ai_protocol_manager/fake_bridge.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/extensions/filters/http/ai_protocol_manager/filter_chain_bridge.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+
+// Hand-written FilterChainBridge that records everything the BufferManager / FilterManager does
+// to the (notional) filter chain, so the path-agnostic offload/replay logic can
+// be unit-tested without any HTTP filter mocks. Tests drive replay back-pressure
+// through the captured ReplayWatermarkHandler, exactly as a real decoder/encoder
+// bridge would when the connection manager raises a watermark.
+class FakeBridge : public FilterChainBridge {
+public:
+  explicit FakeBridge(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
+
+  Event::Dispatcher& dispatcher() override { return dispatcher_; }
+  uint32_t bufferLimit() override { return buffer_limit_; }
+  void injectData(Buffer::Instance& data) override {
+    injected_.add(data);
+    ++inject_calls_;
+    // Simulate downstream back-pressure arising mid-replay: when configured, raise
+    // the replay high watermark right after the Nth injected chunk, as a real
+    // chain would when its write buffer fills.
+    if (handler_ != nullptr && inject_calls_ == raise_replay_watermark_at_inject_) {
+      handler_->onReplayAboveHighWatermark();
+    }
+  }
+  void pauseSource() override { ++pause_source_calls_; }
+  void resumeSource() override { ++resume_source_calls_; }
+  void registerReplayWatermarks(ReplayWatermarkHandler& handler) override { handler_ = &handler; }
+  void unregisterReplayWatermarks() override { handler_ = nullptr; }
+  void onUnrecoverableError() override { ++error_calls_; }
+
+  Event::Dispatcher& dispatcher_;
+  uint32_t buffer_limit_{1024 * 1024};
+  ReplayWatermarkHandler* handler_{nullptr};
+
+  Buffer::OwnedImpl injected_;
+  int inject_calls_{0};
+  int pause_source_calls_{0};
+  int resume_source_calls_{0};
+  int error_calls_{0};
+  int raise_replay_watermark_at_inject_{0}; // 0 = never.
+};
+
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
@@ -665,7 +665,8 @@ TEST_F(FilterManagerTest, SetsContentLengthOnRequestHeadersAfterMutation) {
   JsonWithExtBuf doc;
   doc.setJson(nlohmann::json{{"model", "gpt-3.5"}});
 
-  Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/chat/completions"}};
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/chat/completions"}, {"content-length", "10"}};
 
   std::vector<AiFilterPtr> filters;
   filters.push_back(std::make_unique<TestMutationFilter>("gpt-4-turbo-extra-long"));
@@ -686,6 +687,30 @@ TEST_F(FilterManagerTest, SetsContentLengthOnRequestHeadersAfterMutation) {
 
   std::string output = bridge_raw_->injected_.toString();
   EXPECT_EQ(headers.getContentLengthValue(), absl::StrCat(output.size()));
+}
+
+TEST_F(FilterManagerTest, DoesNotSetContentLengthWhenNotPreviouslyPresent) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/chat/completions"}};
+
+  std::vector<AiFilterPtr> filters;
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_, &headers);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  EXPECT_EQ(headers.ContentLength(), nullptr);
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
@@ -297,6 +297,7 @@ TEST_F(FilterManagerTest, FilterLocalReply) {
 
   FilterManager manager(
       std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_, stream_info_,
+      /*request_headers=*/nullptr,
       [&local_reply_code, &local_reply_details](Http::Code code, std::string details) {
         local_reply_code = code;
         local_reply_details = std::move(details);
@@ -328,6 +329,7 @@ TEST_F(FilterManagerTest, FilterErrorTriggersLocalReply) {
 
   FilterManager manager(
       std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_, stream_info_,
+      /*request_headers=*/nullptr,
       [&local_reply_code, &local_reply_details](Http::Code code, std::string details) {
         local_reply_code = code;
         local_reply_details = std::move(details);
@@ -343,7 +345,7 @@ TEST_F(FilterManagerTest, FilterErrorTriggersLocalReply) {
   drain();
   EXPECT_TRUE(completed);
   EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
-  EXPECT_EQ(local_reply_code, Http::Code::BadRequest);
+  EXPECT_EQ(local_reply_code, Http::Code::BadGateway);
   EXPECT_EQ(local_reply_details, "intentional filter error");
 }
 
@@ -441,6 +443,7 @@ TEST_F(FilterManagerTest, SynchronousFilterLocalReplyStopsSubsequentFilterLaunch
 
   FilterManager manager(
       std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_, stream_info_,
+      /*request_headers=*/nullptr,
       [&local_reply_code, &local_reply_details](Http::Code code, std::string details) {
         local_reply_code = code;
         local_reply_details = std::move(details);
@@ -630,6 +633,59 @@ TEST_F(FilterManagerTest, FilterNullPropagationFails) {
         EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInvalidArgument));
       },
       "cannot propagate null AiRequestPtr");
+}
+
+TEST_F(FilterManagerTest, SetsContentLengthOnRequestHeaders) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "POST"}, {":path", "/chat/completions"}, {"content-length", "1000"}};
+
+  std::vector<AiFilterPtr> filters;
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_, &headers);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  std::string output = bridge_raw_->injected_.toString();
+  EXPECT_EQ(headers.getContentLengthValue(), absl::StrCat(output.size()));
+}
+
+TEST_F(FilterManagerTest, SetsContentLengthOnRequestHeadersAfterMutation) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-3.5"}});
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"}, {":path", "/chat/completions"}};
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestMutationFilter>("gpt-4-turbo-extra-long"));
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_, &headers);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  std::string output = bridge_raw_->injected_.toString();
+  EXPECT_EQ(headers.getContentLengthValue(), absl::StrCat(output.size()));
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
@@ -316,6 +316,59 @@ TEST_F(FilterManagerTest, FilterLocalReply) {
   EXPECT_EQ(local_reply_details, "access denied by auth filter");
 }
 
+TEST_F(FilterManagerTest, FilterErrorTriggersLocalReply) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  Http::Code local_reply_code = Http::Code::OK;
+  std::string local_reply_details;
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestErrorFilter>());
+
+  FilterManager manager(
+      std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_, stream_info_,
+      [&local_reply_code, &local_reply_details](Http::Code code, std::string details) {
+        local_reply_code = code;
+        local_reply_details = std::move(details);
+      });
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
+  EXPECT_EQ(local_reply_code, Http::Code::BadRequest);
+  EXPECT_EQ(local_reply_details, "intentional filter error");
+}
+
+TEST_F(FilterManagerTest, FilterLocalReplyWithoutLocalReplyFnInvokesCompletionWithCancelled) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestLocalReplyFilter>());
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_, /*local_reply_fn=*/nullptr);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kCancelled));
+}
+
 TEST_F(FilterManagerTest, CancelCancelsCoroutines) {
   JsonWithExtBuf doc;
   doc.setJson(nlohmann::json{{"model", "gpt-4"}});
@@ -351,7 +404,8 @@ TEST_F(FilterManagerTest, DestructWhileSuspendedIsSafe) {
       EXPECT_THAT(req_or.status(), HasStatusCode(absl::StatusCode::kCancelled));
 
       // Calling propagate_request should also safely return CancelledError.
-      auto status = co_await std::move(propagate_request)(nullptr);
+      auto status =
+          co_await std::move(propagate_request)(std::make_unique<AiRequest>(JsonWithExtBuf()));
       EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kCancelled));
 
       // Calling reply_locally should safely no-op without crashing.
@@ -440,16 +494,51 @@ TEST_F(FilterManagerTest, InvalidReceiverAndPropagatorInvocation) {
           AiRequestPropagator p2(
               [](AiRequestPtr) -> Coroutine::Task<absl::Status> { co_return absl::OkStatus(); });
           EXPECT_TRUE(p2.valid());
-          auto status2 = co_await std::move(p2)(nullptr);
+          auto status2 = co_await std::move(p2)(std::make_unique<AiRequest>(JsonWithExtBuf()));
           EXPECT_TRUE(status2.ok());
           EXPECT_FALSE(p2.valid());
-          std::ignore = co_await std::move(p2)(nullptr);
+          std::ignore = co_await std::move(p2)(std::make_unique<AiRequest>(JsonWithExtBuf()));
           co_return absl::OkStatus();
         };
         auto handle =
             Coroutine::launch(test_coro(), executor, [](auto) {}, Coroutine::StartMode::Inline);
       },
       "AiRequestPropagator invoked on an invalid or already moved instance");
+}
+
+class TestNullPropagatorFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                       AiRequestPropagator propagate_request,
+                                       LocalReplier) override {
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    co_return co_await std::move(propagate_request)(nullptr);
+  }
+};
+
+TEST_F(FilterManagerTest, FilterNullPropagationFails) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestNullPropagatorFilter>());
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  EXPECT_ENVOY_BUG(
+      {
+        absl::Status status;
+        bool completed = false;
+        manager.start([&status, &completed](absl::Status s) {
+          status = std::move(s);
+          completed = true;
+        });
+        drain();
+        EXPECT_TRUE(completed);
+        EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInvalidArgument));
+      },
+      "cannot propagate null AiRequestPtr");
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
@@ -369,6 +369,97 @@ TEST_F(FilterManagerTest, FilterLocalReplyWithoutLocalReplyFnInvokesCompletionWi
   EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kCancelled));
 }
 
+class TestImmediateErrorFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver, AiRequestPropagator,
+                                       LocalReplier) override {
+    co_return absl::InternalError("synchronous filter startup error");
+  }
+};
+
+class TestCountingFilter : public AiFilter {
+public:
+  explicit TestCountingFilter(int& start_count) : start_count_(start_count) {}
+
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                       AiRequestPropagator propagate_request,
+                                       LocalReplier) override {
+    ++start_count_;
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    co_return co_await std::move(propagate_request)(std::move(req));
+  }
+
+private:
+  int& start_count_;
+};
+
+class TestImmediateLocalReplyFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver, AiRequestPropagator,
+                                       LocalReplier reply_locally) override {
+    std::move(reply_locally)(Http::Code::Unauthorized, "synchronous auth rejection");
+    co_return absl::OkStatus();
+  }
+};
+
+TEST_F(FilterManagerTest, SynchronousFilterErrorStopsSubsequentFilterLaunches) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  int filter2_started = 0;
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestImmediateErrorFilter>());
+  filters.push_back(std::make_unique<TestCountingFilter>(filter2_started));
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
+  EXPECT_EQ(filter2_started, 0);
+}
+
+TEST_F(FilterManagerTest, SynchronousFilterLocalReplyStopsSubsequentFilterLaunches) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  Http::Code local_reply_code = Http::Code::OK;
+  std::string local_reply_details;
+  int filter2_started = 0;
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestImmediateLocalReplyFilter>());
+  filters.push_back(std::make_unique<TestCountingFilter>(filter2_started));
+
+  FilterManager manager(
+      std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_, stream_info_,
+      [&local_reply_code, &local_reply_details](Http::Code code, std::string details) {
+        local_reply_code = code;
+        local_reply_details = std::move(details);
+      });
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_EQ(local_reply_code, Http::Code::Unauthorized);
+  EXPECT_EQ(local_reply_details, "synchronous auth rejection");
+  EXPECT_EQ(filter2_started, 0);
+}
+
 TEST_F(FilterManagerTest, CancelCancelsCoroutines) {
   JsonWithExtBuf doc;
   doc.setJson(nlohmann::json{{"model", "gpt-4"}});

--- a/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
@@ -1,0 +1,459 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/coroutine/async_queue.h"
+#include "source/common/coroutine/dispatcher_executor.h"
+#include "source/common/coroutine/launch.h"
+#include "source/common/stream_info/stream_info_impl.h"
+#include "source/extensions/filters/http/ai_protocol_manager/ai_filter.h"
+#include "source/extensions/filters/http/ai_protocol_manager/ai_request.h"
+#include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
+#include "source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.h"
+#include "source/extensions/filters/http/ai_protocol_manager/filter_manager.h"
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+#include "source/extensions/filters/http/ai_protocol_manager/serializer.h"
+
+#include "test/extensions/filters/http/ai_protocol_manager/fake_bridge.h"
+#include "test/test_common/status_utility.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace {
+
+using ::Envoy::StatusHelpers::HasStatusCode;
+
+class FilterManagerTest : public testing::Test {
+public:
+  FilterManagerTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test")), factory_(),
+        bridge_raw_(new FakeBridge(*dispatcher_)),
+        buffer_manager_(factory_, std::unique_ptr<FakeBridge>(bridge_raw_)),
+        stream_info_(api_->timeSource(), nullptr, StreamInfo::FilterState::LifeSpan::FilterChain) {}
+
+  ~FilterManagerTest() override { buffer_manager_.onDestroy(); }
+
+  void drain() {
+    for (int i = 0; i < 20; ++i) {
+      dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    }
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  InMemoryExternalBufferFactory factory_;
+  FakeBridge* bridge_raw_{nullptr};
+  BufferManager buffer_manager_;
+  StreamInfo::StreamInfoImpl stream_info_;
+};
+
+// 0-filter pass-through
+TEST_F(FilterManagerTest, ZeroFilterPassThrough) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  auto parsed = nlohmann::json::parse(bridge_raw_->injected_.toString());
+  EXPECT_EQ(parsed["model"], "gpt-4");
+
+  auto* fs = stream_info_.filterState()->getDataReadOnly<APMRequestPayloadIndex>(
+      APMRequestPayloadIndex::kFilterStateKey);
+  ASSERT_NE(fs, nullptr);
+  EXPECT_EQ(fs->index().json()["model"], "gpt-4");
+}
+
+class TestMutationFilter : public AiFilter {
+public:
+  explicit TestMutationFilter(std::string target_model) : target_model_(std::move(target_model)) {}
+
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                       AiRequestPropagator propagate_request,
+                                       LocalReplier) override {
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    req->request_index().json()["model"] = target_model_;
+    co_return co_await std::move(propagate_request)(std::move(req));
+  }
+
+private:
+  std::string target_model_;
+};
+
+TEST_F(FilterManagerTest, SingleFilterMutation) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-3.5"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestMutationFilter>("gpt-4-turbo"));
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  auto parsed = nlohmann::json::parse(bridge_raw_->injected_.toString());
+  EXPECT_EQ(parsed["model"], "gpt-4-turbo");
+}
+
+class TestFieldAdderFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                       AiRequestPropagator propagate_request,
+                                       LocalReplier) override {
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    req->request_index().json()["temperature"] = 0.5;
+    co_return co_await std::move(propagate_request)(std::move(req));
+  }
+};
+
+class TestFieldModifierFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                       AiRequestPropagator propagate_request,
+                                       LocalReplier) override {
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    EXPECT_DOUBLE_EQ(req->request_index().json()["temperature"].get<double>(), 0.5);
+    req->request_index().json()["temperature"] = 0.9;
+    co_return co_await std::move(propagate_request)(std::move(req));
+  }
+};
+
+TEST_F(FilterManagerTest, MultiFilterPipeline) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestFieldAdderFilter>());
+  filters.push_back(std::make_unique<TestFieldModifierFilter>());
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  auto parsed = nlohmann::json::parse(bridge_raw_->injected_.toString());
+  EXPECT_EQ(parsed["model"], "gpt-4");
+  EXPECT_DOUBLE_EQ(parsed["temperature"].get<double>(), 0.9);
+}
+
+class TestErrorFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request, AiRequestPropagator,
+                                       LocalReplier) override {
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    co_return absl::InternalError("intentional filter error");
+  }
+};
+
+TEST_F(FilterManagerTest, FilterErrorPropagation) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestErrorFilter>());
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
+}
+
+class TestBypassFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver, AiRequestPropagator,
+                                       LocalReplier) override {
+    // Early returns without calling receive_request or propagate_request or reply_locally
+    co_return absl::OkStatus();
+  }
+};
+
+TEST_F(FilterManagerTest, FilterBypassEarlyReturnPassesThrough) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-3.5"}});
+
+  std::vector<AiFilterPtr> filters;
+  // Filter 0 bypasses itself
+  filters.push_back(std::make_unique<TestBypassFilter>());
+  // Filter 1 still receives and modifies the request
+  filters.push_back(std::make_unique<TestMutationFilter>("gpt-4-turbo"));
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  ASSERT_OK(status);
+
+  auto parsed = nlohmann::json::parse(bridge_raw_->injected_.toString());
+  EXPECT_EQ(parsed["model"], "gpt-4-turbo");
+}
+
+class TestDropFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request, AiRequestPropagator,
+                                       LocalReplier) override {
+    // Receives request but never propagates or sends local reply
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    co_return absl::OkStatus();
+  }
+};
+
+TEST_F(FilterManagerTest, FilterConsumedWithoutPropagationFails) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestDropFilter>());
+
+  FilterManager manager(std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_,
+                        stream_info_);
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kInternal));
+}
+
+class TestLocalReplyFilter : public AiFilter {
+public:
+  Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request, AiRequestPropagator,
+                                       LocalReplier reply_locally) override {
+    ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
+    std::move(reply_locally)(Http::Code::Unauthorized, "access denied by auth filter");
+    co_return absl::OkStatus();
+  }
+};
+
+TEST_F(FilterManagerTest, FilterLocalReply) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  Http::Code local_reply_code = Http::Code::OK;
+  std::string local_reply_details;
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestLocalReplyFilter>());
+
+  FilterManager manager(
+      std::move(filters), std::move(doc), &buffer_manager_, *dispatcher_, stream_info_,
+      [&local_reply_code, &local_reply_details](Http::Code code, std::string details) {
+        local_reply_code = code;
+        local_reply_details = std::move(details);
+      });
+
+  absl::Status status;
+  bool completed = false;
+  manager.start([&status, &completed](absl::Status s) {
+    status = std::move(s);
+    completed = true;
+  });
+
+  drain();
+  EXPECT_TRUE(completed);
+  EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kCancelled));
+  EXPECT_EQ(local_reply_code, Http::Code::Unauthorized);
+  EXPECT_EQ(local_reply_details, "access denied by auth filter");
+}
+
+TEST_F(FilterManagerTest, CancelCancelsCoroutines) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<TestFieldAdderFilter>());
+
+  auto manager = std::make_unique<FilterManager>(std::move(filters), std::move(doc),
+                                                 &buffer_manager_, *dispatcher_, stream_info_);
+
+  manager->cancel();
+  manager.reset();
+}
+
+TEST_F(FilterManagerTest, DestructWhileSuspendedIsSafe) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{{"model", "gpt-4"}});
+
+  class SuspendingFilter : public AiFilter {
+  public:
+    explicit SuspendingFilter(std::shared_ptr<Coroutine::AsyncQueue<bool>> queue)
+        : queue_(std::move(queue)) {}
+
+    Coroutine::Task<absl::Status> decode(AiRequestReceiver receive_request,
+                                         AiRequestPropagator propagate_request,
+                                         LocalReplier reply_locally) override {
+      // Wait on an external suspension point (e.g. async gRPC / queue).
+      std::ignore = co_await queue_->pop();
+
+      // Manager is destructed during the above suspension point.
+      // Calling receive_request should now safely return CancelledError without UAF.
+      auto req_or = co_await std::move(receive_request)();
+      EXPECT_THAT(req_or.status(), HasStatusCode(absl::StatusCode::kCancelled));
+
+      // Calling propagate_request should also safely return CancelledError.
+      auto status = co_await std::move(propagate_request)(nullptr);
+      EXPECT_THAT(status, HasStatusCode(absl::StatusCode::kCancelled));
+
+      // Calling reply_locally should safely no-op without crashing.
+      std::move(reply_locally)(Http::Code::Unauthorized, "too late");
+
+      co_return absl::OkStatus();
+    }
+
+  private:
+    std::shared_ptr<Coroutine::AsyncQueue<bool>> queue_;
+  };
+
+  auto queue = std::make_shared<Coroutine::AsyncQueue<bool>>(1);
+  std::vector<AiFilterPtr> filters;
+  filters.push_back(std::make_unique<SuspendingFilter>(queue));
+
+  auto manager = std::make_unique<FilterManager>(std::move(filters), std::move(doc),
+                                                 &buffer_manager_, *dispatcher_, stream_info_);
+
+  bool completed = false;
+  manager->start([&completed](absl::Status) { completed = true; });
+  drain();
+
+  // Destruct the manager while the filter is still suspended in queue_->pop().
+  manager.reset();
+
+  // Now resume the suspended filter coroutine.
+  queue->tryPush(true);
+  drain();
+}
+
+TEST_F(FilterManagerTest, InvalidReceiverAndPropagatorInvocation) {
+  AiRequestReceiver empty_receiver(nullptr);
+  EXPECT_FALSE(empty_receiver.valid());
+
+  AiRequestPropagator empty_propagator(nullptr);
+  EXPECT_FALSE(empty_propagator.valid());
+
+  auto executor = std::make_shared<Coroutine::DispatcherExecutor>(*dispatcher_);
+
+  EXPECT_ENVOY_BUG(
+      {
+        auto test_coro = []() -> Coroutine::Task<absl::Status> {
+          AiRequestReceiver r(nullptr);
+          std::ignore = co_await std::move(r)();
+          co_return absl::OkStatus();
+        };
+        auto handle =
+            Coroutine::launch(test_coro(), executor, [](auto) {}, Coroutine::StartMode::Inline);
+      },
+      "AiRequestReceiver invoked on an invalid or already moved instance");
+
+  EXPECT_ENVOY_BUG(
+      {
+        auto test_coro = []() -> Coroutine::Task<absl::Status> {
+          AiRequestPropagator p(nullptr);
+          std::ignore = co_await std::move(p)(nullptr);
+          co_return absl::OkStatus();
+        };
+        auto handle =
+            Coroutine::launch(test_coro(), executor, [](auto) {}, Coroutine::StartMode::Inline);
+      },
+      "AiRequestPropagator invoked on an invalid or already moved instance");
+
+  EXPECT_ENVOY_BUG(
+      {
+        auto test_coro = []() -> Coroutine::Task<absl::Status> {
+          AiRequestReceiver r2([]() -> Coroutine::Task<absl::StatusOr<AiRequestPtr>> {
+            co_return std::make_unique<AiRequest>(JsonWithExtBuf());
+          });
+          EXPECT_TRUE(r2.valid());
+          auto res2 = co_await std::move(r2)();
+          EXPECT_TRUE(res2.ok());
+          EXPECT_FALSE(r2.valid());
+          std::ignore = co_await std::move(r2)();
+          co_return absl::OkStatus();
+        };
+        auto handle =
+            Coroutine::launch(test_coro(), executor, [](auto) {}, Coroutine::StartMode::Inline);
+      },
+      "AiRequestReceiver invoked on an invalid or already moved instance");
+
+  EXPECT_ENVOY_BUG(
+      {
+        auto test_coro = []() -> Coroutine::Task<absl::Status> {
+          AiRequestPropagator p2(
+              [](AiRequestPtr) -> Coroutine::Task<absl::Status> { co_return absl::OkStatus(); });
+          EXPECT_TRUE(p2.valid());
+          auto status2 = co_await std::move(p2)(nullptr);
+          EXPECT_TRUE(status2.ok());
+          EXPECT_FALSE(p2.valid());
+          std::ignore = co_await std::move(p2)(nullptr);
+          co_return absl::OkStatus();
+        };
+        auto handle =
+            Coroutine::launch(test_coro(), executor, [](auto) {}, Coroutine::StartMode::Inline);
+      },
+      "AiRequestPropagator invoked on an invalid or already moved instance");
+}
+
+} // namespace
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -10,6 +10,7 @@
 #include "source/common/buffer/buffer_impl.h"
 #include "source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.h"
 #include "source/extensions/filters/http/ai_protocol_manager/filter.h"
+#include "source/extensions/filters/http/ai_protocol_manager/serializer.h"
 
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
@@ -19,6 +20,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
 
 using testing::Invoke;
 using testing::NiceMock;
@@ -1148,7 +1150,7 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(), payload);
+  EXPECT_EQ(nlohmann::json::parse(injected_.toString()), nlohmann::json::parse(payload));
   EXPECT_TRUE(injected_end_stream_);
 }
 
@@ -1280,7 +1282,7 @@ TEST_F(AiProtocolManagerFilterTest, PassesThroughUnknownFields) {
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(), payload);
+  EXPECT_EQ(nlohmann::json::parse(injected_.toString()), nlohmann::json::parse(payload));
   EXPECT_TRUE(injected_end_stream_);
 }
 
@@ -1299,8 +1301,9 @@ TEST_F(AiProtocolManagerFilterTest, ChunkedBodyWithEmptyTerminalFrame) {
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(),
-            R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
+  EXPECT_EQ(
+      nlohmann::json::parse(injected_.toString()),
+      nlohmann::json::parse(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})"));
 }
 
 // With trailers, no data frame carries end_stream, so the trailers close it.
@@ -1315,8 +1318,9 @@ TEST_F(AiProtocolManagerFilterTest, TrailerTerminatedJsonIsParsed) {
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(),
-            R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
+  EXPECT_EQ(
+      nlohmann::json::parse(injected_.toString()),
+      nlohmann::json::parse(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})"));
   EXPECT_EQ(continue_calls_, 1);
 }
 
@@ -1478,8 +1482,24 @@ TEST_F(AiProtocolManagerFilterTest, PassThroughEndpointIsParsedAndForwarded) {
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(injected_.toString(),
-            R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
+  EXPECT_EQ(
+      nlohmann::json::parse(injected_.toString()),
+      nlohmann::json::parse(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})"));
+}
+
+TEST_F(AiProtocolManagerFilterTest, SetsFilterStateObjectOnParsedPayload) {
+  setRouteConfig();
+  EXPECT_EQ(decodeHeadersEngaging(), Http::FilterHeadersStatus::StopIteration);
+
+  Buffer::OwnedImpl body(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 0);
+  auto* fs = callbacks_.stream_info_.filterState()->getDataReadOnly<APMRequestPayloadIndex>(
+      APMRequestPayloadIndex::kFilterStateKey);
+  ASSERT_NE(fs, nullptr);
+  EXPECT_EQ(fs->index().json()["model"], "gpt-4");
 }
 
 // A payload with valid JSON syntax but violating the route's schema is rejected with 400.

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -1155,24 +1155,27 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
   EXPECT_TRUE(injected_end_stream_);
 }
 
-// Content-Length header is removed when the filter manager serializes the payload.
-TEST_F(AiProtocolManagerFilterTest, RemovesContentLengthOnReplay) {
+// Content-Length header is set to the recalculated length when the filter manager serializes the
+// payload.
+TEST_F(AiProtocolManagerFilterTest, SetsContentLengthOnReplay) {
   setRouteConfig();
   replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
   request_headers_ = Http::TestRequestHeaderMapImpl{{":method", "POST"},
                                                     {":path", "/chat/completions"},
                                                     {"content-type", "application/json"},
-                                                    {"content-length", "61"}};
+                                                    {"content-length", "999"}};
   ASSERT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
             Http::FilterHeadersStatus::StopIteration);
-  EXPECT_NE(request_headers_.ContentLength(), nullptr);
+  EXPECT_EQ(request_headers_.getContentLengthValue(), "999");
 
-  Buffer::OwnedImpl body(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
+  const std::string payload = R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})";
+  Buffer::OwnedImpl body(payload);
   EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
   drain();
 
   EXPECT_EQ(local_reply_calls_, 0);
-  EXPECT_EQ(request_headers_.ContentLength(), nullptr);
+  EXPECT_NE(request_headers_.ContentLength(), nullptr);
+  EXPECT_EQ(request_headers_.getContentLengthValue(), absl::StrCat(injected_.length()));
 }
 
 // Malformed JSON is answered with a 400 and never reaches the upstream.

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -94,8 +94,8 @@ public:
   // its expectation goes unsatisfied.
   Http::FilterHeadersStatus decodeHeadersEngaging() {
     replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
-    Http::TestRequestHeaderMapImpl headers = requestHeaders();
-    return filter_->decodeHeaders(headers, /*end_stream=*/false);
+    request_headers_ = requestHeaders();
+    return filter_->decodeHeaders(request_headers_, /*end_stream=*/false);
   }
 
   // Engages the filter where the payload is not what the test is about:
@@ -148,6 +148,7 @@ public:
   NiceMock<Event::MockSchedulableCallback>* replay_cb_{nullptr};
   std::unique_ptr<RouteConfig> route_config_;
   std::unique_ptr<AiProtocolManagerFilter> filter_;
+  Http::TestRequestHeaderMapImpl request_headers_;
 
   Buffer::OwnedImpl injected_;
   bool injected_end_stream_{false};
@@ -1152,6 +1153,26 @@ TEST_F(AiProtocolManagerFilterTest, ParsesDeclaredEndpointPayloadAndReplaysItVer
   EXPECT_EQ(local_reply_calls_, 0);
   EXPECT_EQ(nlohmann::json::parse(injected_.toString()), nlohmann::json::parse(payload));
   EXPECT_TRUE(injected_end_stream_);
+}
+
+// Content-Length header is removed when the filter manager serializes the payload.
+TEST_F(AiProtocolManagerFilterTest, RemovesContentLengthOnReplay) {
+  setRouteConfig();
+  replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
+  request_headers_ = Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                    {":path", "/chat/completions"},
+                                                    {"content-type", "application/json"},
+                                                    {"content-length", "61"}};
+  ASSERT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  EXPECT_NE(request_headers_.ContentLength(), nullptr);
+
+  Buffer::OwnedImpl body(R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})");
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 0);
+  EXPECT_EQ(request_headers_.ContentLength(), nullptr);
 }
 
 // Malformed JSON is answered with a 400 and never reaches the upstream.

--- a/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_test.cc
@@ -1178,6 +1178,25 @@ TEST_F(AiProtocolManagerFilterTest, SetsContentLengthOnReplay) {
   EXPECT_EQ(request_headers_.getContentLengthValue(), absl::StrCat(injected_.length()));
 }
 
+// Content-Length header is not added if it was not previously present on request headers.
+TEST_F(AiProtocolManagerFilterTest, DoesNotSetContentLengthOnReplayWhenAbsent) {
+  setRouteConfig();
+  replay_cb_ = new NiceMock<Event::MockSchedulableCallback>(&callbacks_.dispatcher_);
+  request_headers_ = Http::TestRequestHeaderMapImpl{
+      {":method", "POST"}, {":path", "/chat/completions"}, {"content-type", "application/json"}};
+  ASSERT_EQ(filter_->decodeHeaders(request_headers_, /*end_stream=*/false),
+            Http::FilterHeadersStatus::StopIteration);
+  EXPECT_EQ(request_headers_.ContentLength(), nullptr);
+
+  const std::string payload = R"({"model":"gpt-4","messages":[{"role":"user","content":"hi"}]})";
+  Buffer::OwnedImpl body(payload);
+  EXPECT_EQ(filter_->decodeData(body, true), Http::FilterDataStatus::StopIterationNoBuffer);
+  drain();
+
+  EXPECT_EQ(local_reply_calls_, 0);
+  EXPECT_EQ(request_headers_.ContentLength(), nullptr);
+}
+
 // Malformed JSON is answered with a 400 and never reaches the upstream.
 TEST_F(AiProtocolManagerFilterTest, RejectsMalformedJson) {
   setRouteConfig();

--- a/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
@@ -1,0 +1,235 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "source/common/buffer/buffer_impl.h"
+#include "source/common/coroutine/dispatcher_executor.h"
+#include "source/common/coroutine/launch.h"
+#include "source/extensions/filters/http/ai_protocol_manager/buffer_manager.h"
+#include "source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.h"
+#include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
+#include "source/extensions/filters/http/ai_protocol_manager/serializer.h"
+
+#include "test/extensions/filters/http/ai_protocol_manager/fake_bridge.h"
+#include "test/test_common/status_utility.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace {
+
+using ::Envoy::StatusHelpers::HasStatusCode;
+
+class SerializerTest : public testing::Test {
+public:
+  SerializerTest()
+      : api_(Api::createApiForTest()), dispatcher_(api_->allocateDispatcher("test")), factory_(),
+        bridge_raw_(new FakeBridge(*dispatcher_)),
+        buffer_manager_(factory_, std::unique_ptr<FakeBridge>(bridge_raw_)) {}
+
+  ~SerializerTest() override { buffer_manager_.onDestroy(); }
+
+  void drain() {
+    for (int i = 0; i < 10; ++i) {
+      dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    }
+  }
+
+  absl::StatusOr<JsonWithExtBuf> runSerialize(const JsonWithExtBuf& doc,
+                                              BufferManager* buffer_manager) {
+    auto executor = std::make_shared<Coroutine::DispatcherExecutor>(*dispatcher_);
+    absl::StatusOr<JsonWithExtBuf> final_result;
+    bool completed = false;
+
+    auto handle = Coroutine::launch(
+        Serializer::serialize(doc, buffer_manager), executor,
+        [&completed, &final_result](absl::StatusOr<JsonWithExtBuf> result) {
+          final_result = std::move(result);
+          completed = true;
+        },
+        Coroutine::StartMode::Inline);
+
+    drain();
+    EXPECT_TRUE(completed);
+    return final_result;
+  }
+
+  absl::StatusOr<JsonWithExtBuf> runCalculateOffsets(const JsonWithExtBuf& doc) {
+    auto executor = std::make_shared<Coroutine::DispatcherExecutor>(*dispatcher_);
+    absl::StatusOr<JsonWithExtBuf> final_result;
+    bool completed = false;
+
+    auto handle = Coroutine::launch(
+        Serializer::calculateSerializedOffsets(doc), executor,
+        [&completed, &final_result](absl::StatusOr<JsonWithExtBuf> result) {
+          final_result = std::move(result);
+          completed = true;
+        },
+        Coroutine::StartMode::Inline);
+
+    drain();
+    EXPECT_TRUE(completed);
+    return final_result;
+  }
+
+  Api::ApiPtr api_;
+  Event::DispatcherPtr dispatcher_;
+  InMemoryExternalBufferFactory factory_;
+  FakeBridge* bridge_raw_{nullptr};
+  BufferManager buffer_manager_;
+};
+
+TEST_F(SerializerTest, PureJsonSerialization) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"model", "gpt-4"},
+      {"temperature", 0.7},
+      {"stream", false},
+      {"tags", {"a", "b", "c"}},
+      {"extra", nullptr},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  ASSERT_OK(result_or);
+  std::string output = bridge_raw_->injected_.toString();
+
+  auto parsed = nlohmann::json::parse(output);
+  EXPECT_EQ(parsed["model"], "gpt-4");
+  EXPECT_DOUBLE_EQ(parsed["temperature"].get<double>(), 0.7);
+  EXPECT_EQ(parsed["stream"], false);
+  EXPECT_EQ(parsed["tags"], (std::vector<std::string>{"a", "b", "c"}));
+  EXPECT_TRUE(parsed["extra"].is_null());
+
+  auto offset_doc_or = runCalculateOffsets(doc);
+  ASSERT_OK(offset_doc_or);
+}
+
+TEST_F(SerializerTest, ExternalRefSerializationAndOffsetRecalculation) {
+  std::string secret = "This is a very long offloaded prompt text.";
+  Buffer::OwnedImpl secret_buf(secret);
+  buffer_manager_.onData(secret_buf);
+  buffer_manager_.endStream();
+  drain();
+
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"model", "claude-3"},
+      {"prompt", JsonWithExtBuf::makeExternalRef({0, secret.size()})},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  ASSERT_OK(result_or);
+  std::string output = bridge_raw_->injected_.toString();
+
+  auto parsed = nlohmann::json::parse(output);
+  EXPECT_EQ(parsed["model"], "claude-3");
+  EXPECT_EQ(parsed["prompt"], secret);
+
+  auto offset_doc_or = runCalculateOffsets(doc);
+  ASSERT_OK(offset_doc_or);
+  const auto& new_json = offset_doc_or->json();
+  ASSERT_TRUE(JsonWithExtBuf::isExternalRef(new_json["prompt"]));
+  auto ref = *JsonWithExtBuf::externalRef(new_json["prompt"]);
+  EXPECT_EQ(ref.length, secret.size());
+
+  // Verify the calculated offset matches the exact substring in output
+  EXPECT_LE(ref.offset + ref.length, output.size());
+  EXPECT_EQ(output.substr(ref.offset, ref.length), secret);
+}
+
+TEST_F(SerializerTest, ExternalRefNullBufferFails) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"prompt", JsonWithExtBuf::makeExternalRef({0, 10})},
+  });
+
+  auto result_or = runSerialize(doc, nullptr);
+  EXPECT_THAT(result_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
+}
+
+TEST_F(SerializerTest, NestedStructureWithMultipleRefs) {
+  std::string part1 = "System instructions";
+  std::string part2 = "User query text";
+
+  Buffer::OwnedImpl part1_buf(part1);
+  buffer_manager_.onData(part1_buf);
+  Buffer::OwnedImpl part2_buf(part2);
+  buffer_manager_.onData(part2_buf);
+  buffer_manager_.endStream();
+  drain();
+
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"messages",
+       nlohmann::json::array({
+           {{"role", "system"}, {"content", JsonWithExtBuf::makeExternalRef({0, part1.size()})}},
+           {{"role", "user"},
+            {"content", JsonWithExtBuf::makeExternalRef({part1.size(), part2.size()})}},
+       })},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  ASSERT_OK(result_or);
+  std::string output = bridge_raw_->injected_.toString();
+
+  auto parsed = nlohmann::json::parse(output);
+  ASSERT_TRUE(parsed["messages"].is_array());
+  EXPECT_EQ(parsed["messages"][0]["content"], part1);
+  EXPECT_EQ(parsed["messages"][1]["content"], part2);
+
+  auto offset_doc_or = runCalculateOffsets(doc);
+  ASSERT_OK(offset_doc_or);
+  const auto& new_json = offset_doc_or->json();
+  auto ref1 = *JsonWithExtBuf::externalRef(new_json["messages"][0]["content"]);
+  auto ref2 = *JsonWithExtBuf::externalRef(new_json["messages"][1]["content"]);
+
+  EXPECT_EQ(output.substr(ref1.offset, ref1.length), part1);
+  EXPECT_EQ(output.substr(ref2.offset, ref2.length), part2);
+}
+
+TEST_F(SerializerTest, LargeExternalRefMultiChunk) {
+  std::string large_payload(150 * 1024, 'x'); // 150KB > 2 chunks of 64KB
+  Buffer::OwnedImpl large_buf(large_payload);
+  buffer_manager_.onData(large_buf);
+  buffer_manager_.endStream();
+  drain();
+
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"large_field", JsonWithExtBuf::makeExternalRef({0, large_payload.size()})},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  ASSERT_OK(result_or);
+
+  std::string output = bridge_raw_->injected_.toString();
+  auto ref = *JsonWithExtBuf::externalRef(result_or->json()["large_field"]);
+  EXPECT_EQ(ref.length, large_payload.size());
+  EXPECT_EQ(output.substr(ref.offset, ref.length), large_payload);
+}
+
+TEST_F(SerializerTest, SpecialCharactersEscaping) {
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"quote\"key", "value\nwith\tspecial \"quotes\" and /slashes/ and \\backslashes\\"},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  ASSERT_OK(result_or);
+  std::string output = bridge_raw_->injected_.toString();
+
+  auto parsed = nlohmann::json::parse(output);
+  EXPECT_EQ(parsed["quote\"key"],
+            "value\nwith\tspecial \"quotes\" and /slashes/ and \\backslashes\\");
+}
+
+} // namespace
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
@@ -263,6 +263,37 @@ TEST_F(SerializerTest, SpecialCharactersEscaping) {
             "value\nwith\tspecial \"quotes\" and /slashes/ and \\backslashes\\");
 }
 
+TEST_F(SerializerTest, InvalidUtf8StringReturnsError) {
+  JsonWithExtBuf doc;
+  std::string invalid_utf8 = "invalid \xff\xff byte";
+  doc.setJson(nlohmann::json{
+      {"invalid_str", invalid_utf8},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  EXPECT_FALSE(result_or.ok());
+  EXPECT_THAT(result_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(result_or.status().message(), testing::HasSubstr("JSON serialization error"));
+
+  auto offset_or = runCalculateOffsets(doc);
+  EXPECT_FALSE(offset_or.ok());
+  EXPECT_THAT(offset_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(offset_or.status().message(), testing::HasSubstr("JSON serialization error"));
+}
+
+TEST_F(SerializerTest, InvalidUtf8KeyReturnsError) {
+  JsonWithExtBuf doc;
+  std::string invalid_utf8_key = "invalid \xff\xff key";
+  nlohmann::json j = nlohmann::json::object();
+  j[invalid_utf8_key] = "value";
+  doc.setJson(std::move(j));
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  EXPECT_FALSE(result_or.ok());
+  EXPECT_THAT(result_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(result_or.status().message(), testing::HasSubstr("JSON serialization error"));
+}
+
 } // namespace
 } // namespace AiProtocolManager
 } // namespace HttpFilters

--- a/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
@@ -152,6 +152,41 @@ TEST_F(SerializerTest, ExternalRefNullBufferFails) {
   EXPECT_THAT(result_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
 }
 
+TEST_F(SerializerTest, ExternalRefOutOfBoundsFails) {
+  std::string secret = "hello world";
+  Buffer::OwnedImpl secret_buf(secret);
+  buffer_manager_.onData(secret_buf);
+  buffer_manager_.endStream();
+  drain();
+
+  // ref offset + length exceeds buffer length (11 bytes)
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"prompt", JsonWithExtBuf::makeExternalRef({5, 100})},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  EXPECT_THAT(result_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
+  EXPECT_THAT(result_or.status().message(), testing::HasSubstr("exceeds buffer length"));
+}
+
+TEST_F(SerializerTest, ExternalRefOffsetOutOfBoundsFails) {
+  std::string secret = "hello world";
+  Buffer::OwnedImpl secret_buf(secret);
+  buffer_manager_.onData(secret_buf);
+  buffer_manager_.endStream();
+  drain();
+
+  // ref offset itself exceeds buffer length (11 bytes)
+  JsonWithExtBuf doc;
+  doc.setJson(nlohmann::json{
+      {"prompt", JsonWithExtBuf::makeExternalRef({100, 0})},
+  });
+
+  auto result_or = runSerialize(doc, &buffer_manager_);
+  EXPECT_THAT(result_or.status(), HasStatusCode(absl::StatusCode::kInvalidArgument));
+}
+
 TEST_F(SerializerTest, NestedStructureWithMultipleRefs) {
   std::string part1 = "System instructions";
   std::string part2 = "User query text";

--- a/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/serializer_test.cc
@@ -59,14 +59,14 @@ public:
     return final_result;
   }
 
-  absl::StatusOr<JsonWithExtBuf> runCalculateOffsets(const JsonWithExtBuf& doc) {
+  absl::StatusOr<Serializer::SerializedOffsets> runCalculateOffsets(const JsonWithExtBuf& doc) {
     auto executor = std::make_shared<Coroutine::DispatcherExecutor>(*dispatcher_);
-    absl::StatusOr<JsonWithExtBuf> final_result;
+    absl::StatusOr<Serializer::SerializedOffsets> final_result;
     bool completed = false;
 
     auto handle = Coroutine::launch(
         Serializer::calculateSerializedOffsets(doc), executor,
-        [&completed, &final_result](absl::StatusOr<JsonWithExtBuf> result) {
+        [&completed, &final_result](absl::StatusOr<Serializer::SerializedOffsets> result) {
           final_result = std::move(result);
           completed = true;
         },
@@ -107,6 +107,7 @@ TEST_F(SerializerTest, PureJsonSerialization) {
 
   auto offset_doc_or = runCalculateOffsets(doc);
   ASSERT_OK(offset_doc_or);
+  EXPECT_EQ(offset_doc_or->total_size, output.size());
 }
 
 TEST_F(SerializerTest, ExternalRefSerializationAndOffsetRecalculation) {
@@ -132,7 +133,8 @@ TEST_F(SerializerTest, ExternalRefSerializationAndOffsetRecalculation) {
 
   auto offset_doc_or = runCalculateOffsets(doc);
   ASSERT_OK(offset_doc_or);
-  const auto& new_json = offset_doc_or->json();
+  EXPECT_EQ(offset_doc_or->total_size, output.size());
+  const auto& new_json = offset_doc_or->doc.json();
   ASSERT_TRUE(JsonWithExtBuf::isExternalRef(new_json["prompt"]));
   auto ref = *JsonWithExtBuf::externalRef(new_json["prompt"]);
   EXPECT_EQ(ref.length, secret.size());
@@ -219,7 +221,8 @@ TEST_F(SerializerTest, NestedStructureWithMultipleRefs) {
 
   auto offset_doc_or = runCalculateOffsets(doc);
   ASSERT_OK(offset_doc_or);
-  const auto& new_json = offset_doc_or->json();
+  EXPECT_EQ(offset_doc_or->total_size, output.size());
+  const auto& new_json = offset_doc_or->doc.json();
   auto ref1 = *JsonWithExtBuf::externalRef(new_json["messages"][0]["content"]);
   auto ref2 = *JsonWithExtBuf::externalRef(new_json["messages"][1]["content"]);
 


### PR DESCRIPTION
Commit Message:
Initial implementation of APM's FilterManager that coordinates sending the parsed JSON object through AI filters. This version only supports streaming the JSON object itself, without the ability to stream the offloaded payload through the filter chain yet. The offloaded payload streaming is a TODO.

We also add re-serialization, so that a JSON object can be normalized / transcoded by the filter chain. 

There is desire to run two instances of APM in legacy deployments, where one APM runs at early point of downstream filter chain, one runs on the upstream filter chain. The idea is to be able to perform other normal HTTP functionalities after APM, and once the routing decision is made, an upstream filter performs transcoding to the final model provider. To support this, and help filters between the two APMs to access the parsed JSON, we provide a `JsonWithExtBuf` that correctly indexes the payload that goes through the filters. This index is also useful for the later APM to avoid another pass of parsing.

This is part of #44681

Additional Description: https://github.com/penguingao/thoughts/blob/main/20260727_AI_FILTER.md
Risk Level: medium
Testing: unit tests
Docs Changes: n/a WIP filter
Release Notes: n/a WIP filter
Platform Specific Features: no
