### PR TITLE
Pass in worker_index to QuicPacketWriter

### DIFF
--- a/source/common/quic/active_quic_listener.cc
+++ b/source/common/quic/active_quic_listener.cc
@@ -112,7 +112,7 @@ ActiveQuicListener::ActiveQuicListener(
   if (quic_packet_writer_factory != nullptr) {
     QuicPacketWriterPtr quic_writer = quic_packet_writer_factory->createQuicPacketWriter(
         listen_socket_.ioHandle(), listener_config.listenerScope(), dispatcher,
-        std::move(on_can_write_cb));
+        std::move(on_can_write_cb), worker_index);
     if (quic_writer != nullptr) {
       quic_packet_writer_ = quic_writer.get();
       quic_dispatcher_->InitializeWithWriter(quic_writer.release());

--- a/source/common/quic/quic_packet_writer_interface.h
+++ b/source/common/quic/quic_packet_writer_interface.h
@@ -31,12 +31,14 @@ public:
    * @param scope the stats scope to write stats to.
    * @param dispatcher the dispatcher for the thread.
    * @param on_can_write_cb callback to invoke when the writer becomes writable.
+   * @param worker_index index of the worker thread.
    * @return the QuicPacketWriter created.
    */
-  virtual QuicPacketWriterPtr
-  createQuicPacketWriter(Network::IoHandle& io_handle, Stats::Scope& scope,
-                         Event::Dispatcher& dispatcher,
-                         absl::AnyInvocable<void()> on_can_write_cb) PURE;
+  virtual QuicPacketWriterPtr createQuicPacketWriter(Network::IoHandle& io_handle,
+                                                     Stats::Scope& scope,
+                                                     Event::Dispatcher& dispatcher,
+                                                     absl::AnyInvocable<void()> on_can_write_cb,
+                                                     uint32_t worker_index) PURE;
 };
 
 using QuicPacketWriterFactoryPtr = std::unique_ptr<QuicPacketWriterFactory>;

--- a/test/common/listener_manager/listener_manager_impl_quic_only_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_quic_only_test.cc
@@ -21,8 +21,7 @@ using ::testing::Return;
 class FakeQuicPacketWriterFactory : public Quic::QuicPacketWriterFactory {
 public:
   Quic::QuicPacketWriterPtr createQuicPacketWriter(Network::IoHandle&, Stats::Scope&,
-                                                   Event::Dispatcher&,
-                                                   absl::AnyInvocable<void()>,
+                                                   Event::Dispatcher&, absl::AnyInvocable<void()>,
                                                    uint32_t) override {
     return nullptr;
   }

--- a/test/common/listener_manager/listener_manager_impl_quic_only_test.cc
+++ b/test/common/listener_manager/listener_manager_impl_quic_only_test.cc
@@ -22,7 +22,8 @@ class FakeQuicPacketWriterFactory : public Quic::QuicPacketWriterFactory {
 public:
   Quic::QuicPacketWriterPtr createQuicPacketWriter(Network::IoHandle&, Stats::Scope&,
                                                    Event::Dispatcher&,
-                                                   absl::AnyInvocable<void()>) override {
+                                                   absl::AnyInvocable<void()>,
+                                                   uint32_t) override {
     return nullptr;
   }
 };

--- a/test/common/quic/active_quic_listener_test.cc
+++ b/test/common/quic/active_quic_listener_test.cc
@@ -786,7 +786,8 @@ public:
 
   MOCK_METHOD(QuicPacketWriterPtr, createQuicPacketWriter,
               (Network::IoHandle & io_handle, Stats::Scope& scope,
-               Envoy::Event::Dispatcher& dispatcher, absl::AnyInvocable<void()> on_can_write_cb),
+               Envoy::Event::Dispatcher& dispatcher, absl::AnyInvocable<void()> on_can_write_cb,
+               uint32_t worker_index),
               (override));
 };
 
@@ -801,9 +802,9 @@ TEST_P(ActiveQuicListenerTest, DirectQuicPacketWriterCreation) {
 
   // Expect createQuicPacketWriter to be called, and return our dummy writer.
   FakeQuicPacketWriter* raw_writer = nullptr;
-  EXPECT_CALL(quic_packet_writer_factory, createQuicPacketWriter(_, _, _, _))
+  EXPECT_CALL(quic_packet_writer_factory, createQuicPacketWriter(_, _, _, _, _))
       .WillOnce(Invoke([&raw_writer](Network::IoHandle&, Stats::Scope&, Envoy::Event::Dispatcher&,
-                                     absl::AnyInvocable<void()>) -> QuicPacketWriterPtr {
+                                     absl::AnyInvocable<void()>, uint32_t) -> QuicPacketWriterPtr {
         auto writer = std::make_unique<FakeQuicPacketWriter>();
         raw_writer = writer.get();
         return writer;
@@ -827,7 +828,7 @@ TEST_P(ActiveQuicListenerTest, DirectQuicPacketWriterCreationNullWriter) {
       .WillRepeatedly(Return(&quic_packet_writer_factory));
 
   // Expect createQuicPacketWriter to return nullptr.
-  EXPECT_CALL(quic_packet_writer_factory, createQuicPacketWriter(_, _, _, _))
+  EXPECT_CALL(quic_packet_writer_factory, createQuicPacketWriter(_, _, _, _, _))
       .Times(testing::AnyNumber())
       .WillRepeatedly(testing::InvokeWithoutArgs([]() -> QuicPacketWriterPtr { return nullptr; }));
 


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Pass in worker_index to QuicPacketWriter
Additional Description: Explicitly passes worker_index from ActiveQuicListener into QuicPacketWriterFactory::createQuicPacketWriter. This avoids writer implementations having to parse the worker index from the dispatcher name.
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
