### PR TITLE
ext_proc: Add config knob to suppress egress client spans while preserving trace context

### DIFF
--- a/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
+++ b/api/envoy/extensions/filters/http/ext_proc/v3/ext_proc.proto
@@ -98,7 +98,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <arch_overview_advanced_filter_state_sharing>` object in a namespace matching the filter
 // name.
 //
-// [#next-free-field: 27]
+// [#next-free-field: 28]
 message ExternalProcessor {
   // Describes the route cache action to be taken when an external processor response
   // is received in response to request headers.
@@ -386,6 +386,13 @@ message ExternalProcessor {
   //    request smuggling. Thus, please use your own discretion when enabling this feature.
   //
   bool allow_content_length_header = 26;
+
+  // Whether to emit client-side spans for external processing requests.
+  // When set to false, client-side egress spans will not be emitted/exported to trace collectors,
+  // but trace context (e.g. ``traceparent``) will still be propagated to the external processor.
+  //
+  // If unset, defaults to ``true``.
+  google.protobuf.BoolValue emit_client_span = 27;
 }
 
 // ExtProcHttpService is used for HTTP communication between the filter and the external processing service.
@@ -467,7 +474,7 @@ message ExtProcPerRoute {
 }
 
 // Overrides that may be set on a per-route basis
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message ExtProcOverrides {
   // Set a different processing mode for this route than the default.
   ProcessingMode processing_mode = 1;
@@ -514,4 +521,7 @@ message ExtProcOverrides {
   // :ref:`processing_request_modifier <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.processing_request_modifier>`.
   config.core.v3.TypedExtensionConfig processing_request_modifier = 9
       [(xds.annotations.v3.field_status).work_in_progress = true];
+
+  // Overrides the filter-level ``emit_client_span`` setting for this route.
+  google.protobuf.BoolValue emit_client_span = 10;
 }

--- a/changelogs/current/new_features/ext_proc__emit_client_span.rst
+++ b/changelogs/current/new_features/ext_proc__emit_client_span.rst
@@ -1,0 +1,1 @@
+ext_proc: added :ref:`emit_client_span <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExternalProcessor.emit_client_span>` and per-route :ref:`emit_client_span <envoy_v3_api_field_extensions.filters.http.ext_proc.v3.ExtProcOverrides.emit_client_span>` to allow suppressing client-side egress spans for external processing calls while preserving trace context propagation.

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -317,7 +317,8 @@ FilterConfig::FilterConfig(const ExternalProcessor& config,
       disable_immediate_response_(config.disable_immediate_response()), is_upstream_(is_upstream),
       graceful_grpc_close_(
           Runtime::runtimeFeatureEnabled("envoy.reloadable_features.ext_proc_graceful_grpc_close")),
-      allow_content_length_header_(config.allow_content_length_header()) {
+      allow_content_length_header_(config.allow_content_length_header()),
+      emit_client_span_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, emit_client_span, true)) {
   if (config.disable_clear_route_cache()) {
     route_cache_action_ = ExternalProcessor::RETAIN;
   }
@@ -662,6 +663,9 @@ FilterConfigPerRoute::FilterConfigPerRoute(
       failure_mode_allow_(config.overrides().has_failure_mode_allow()
                               ? std::optional<bool>(config.overrides().failure_mode_allow().value())
                               : std::nullopt),
+      emit_client_span_(config.overrides().has_emit_client_span()
+                            ? std::optional<bool>(config.overrides().emit_client_span().value())
+                            : std::nullopt),
       processing_request_modifier_factory_cb_(
           createProcessingRequestModifierCb(config.overrides(), builder, context)) {}
 
@@ -695,6 +699,9 @@ FilterConfigPerRoute::FilterConfigPerRoute(const FilterConfigPerRoute& less_spec
       failure_mode_allow_(more_specific.failureModeAllow().has_value()
                               ? more_specific.failureModeAllow()
                               : less_specific.failureModeAllow()),
+      emit_client_span_(more_specific.emitClientSpan().has_value()
+                            ? more_specific.emitClientSpan()
+                            : less_specific.emitClientSpan()),
       processing_request_modifier_factory_cb_(
           more_specific.processing_request_modifier_factory_cb_
               ? more_specific.processing_request_modifier_factory_cb_
@@ -798,7 +805,7 @@ Filter::StreamOpenState Filter::openStream() {
                        .setParentSpan(decoder_callbacks_->activeSpan())
                        .setParentContext(grpc_context)
                        .setBufferBodyForRetry(grpc_service_.has_retry_policy())
-                       .setSampled(std::nullopt)
+                       .setSampled(emit_client_span_ ? std::nullopt : std::make_optional(false))
                        .setRemoteCloseTimeout(config_->remoteCloseTimeout());
 
     ExternalProcessorClient* grpc_client = dynamic_cast<ExternalProcessorClient*>(client_.get());
@@ -2306,6 +2313,12 @@ void Filter::mergePerRouteConfig() {
     ENVOY_STREAM_LOG(trace, "Setting new failureModeAllow from per-route configuration",
                      *decoder_callbacks_);
     failure_mode_allow_ = merged_config->failureModeAllow().value();
+  }
+
+  if (merged_config->emitClientSpan().has_value()) {
+    ENVOY_STREAM_LOG(trace, "Setting new emitClientSpan from per-route configuration",
+                     *decoder_callbacks_);
+    emit_client_span_ = merged_config->emitClientSpan().value();
   }
 
   if (merged_config->hasProcessingRequestModifierConfig()) {

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -371,6 +371,8 @@ public:
 
   bool keepContentLength() const { return allow_content_length_header_; }
 
+  bool emitClientSpan() const { return emit_client_span_; }
+
 private:
   static Http::Code toErrorCode(uint64_t status) {
     const auto code = static_cast<Http::Code>(status);
@@ -442,6 +444,7 @@ private:
   const bool graceful_grpc_close_ = false;
 
   const bool allow_content_length_header_ = false;
+  const bool emit_client_span_ = true;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
@@ -493,6 +496,8 @@ public:
   }
   const std::optional<bool>& failureModeAllow() const { return failure_mode_allow_; }
 
+  const std::optional<bool>& emitClientSpan() const { return emit_client_span_; }
+
   bool hasProcessingRequestModifierConfig() const {
     return processing_request_modifier_factory_cb_ != nullptr;
   }
@@ -519,6 +524,7 @@ private:
       untyped_cluster_metadata_forwarding_namespaces_;
   const std::optional<const std::vector<std::string>> typed_cluster_metadata_forwarding_namespaces_;
   const std::optional<bool> failure_mode_allow_;
+  const std::optional<bool> emit_client_span_;
 
   const std::function<std::unique_ptr<ProcessingRequestModifier>()>
       processing_request_modifier_factory_cb_;
@@ -562,7 +568,8 @@ public:
             config->typedClusterMetadataForwardingNamespaces(), config->keepContentLength()),
         processing_request_modifier_(config->createProcessingRequestModifier()),
         on_processing_response_(config->createOnProcessingResponse()),
-        failure_mode_allow_(config->failureModeAllow()) {}
+        failure_mode_allow_(config->failureModeAllow()),
+        emit_client_span_(config->emitClientSpan()) {}
 
   const FilterConfig& config() const { return *config_; }
   const envoy::config::core::v3::GrpcService& grpcServiceConfig() const {
@@ -762,6 +769,9 @@ private:
 
   // If true, the protocol configurations are already sent to the server.
   bool protocol_config_encoded_ = false;
+
+  // Whether to emit client-side spans for external processing requests.
+  bool emit_client_span_{true};
 };
 
 extern std::string responseCaseToString(

--- a/test/extensions/filters/http/ext_proc/config_test.cc
+++ b/test/extensions/filters/http/ext_proc/config_test.cc
@@ -2,6 +2,7 @@
 // generally should not change or remove existing tests.
 
 #include "source/extensions/filters/http/ext_proc/config.h"
+#include "source/extensions/filters/http/ext_proc/ext_proc.h"
 
 #include "test/mocks/server/factory_context.h"
 #include "test/test_common/status_utility.h"
@@ -573,6 +574,49 @@ TEST(HttpExtProcConfigTest, StatusOnErrorDefaultConfig) {
   Http::MockFilterChainFactoryCallbacks filter_callback;
   EXPECT_CALL(filter_callback, addStreamFilter(_));
   cb(filter_callback);
+}
+
+TEST(HttpExtProcConfigTest, EmitClientSpanConfig) {
+  std::string yaml = R"EOF(
+  grpc_service:
+    google_grpc:
+      target_uri: ext_proc_server
+      stat_prefix: google
+  emit_client_span: false
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor());
+  Http::FilterFactoryCb cb =
+      factory.createFilterFactoryFromProto(*proto_config, "stats", context).value();
+  Http::MockFilterChainFactoryCallbacks filter_callback;
+  EXPECT_CALL(filter_callback, addStreamFilter(_));
+  cb(filter_callback);
+}
+
+TEST(HttpExtProcConfigTest, PerRouteEmitClientSpanConfig) {
+  std::string yaml = R"EOF(
+  overrides:
+    emit_client_span: false
+  )EOF";
+
+  ExternalProcessingFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
+  TestUtility::loadFromYaml(yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Router::RouteSpecificFilterConfigConstSharedPtr route_config =
+      factory
+          .createRouteSpecificFilterConfig(*proto_config, context,
+                                           context.messageValidationVisitor())
+          .value();
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config);
+  EXPECT_TRUE(typed_config.emitClientSpan().has_value());
+  EXPECT_FALSE(typed_config.emitClientSpan().value());
 }
 
 } // namespace

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -3937,6 +3937,28 @@ TEST_F(OverrideTest, ClusterMetadataNamespacesOverride) {
               ElementsAre("more_specific_untyped_ns_2"));
 }
 
+TEST_F(OverrideTest, EmitClientSpanMerge) {
+  ExtProcPerRoute cfg1;
+  cfg1.mutable_overrides()->mutable_emit_client_span()->set_value(false);
+
+  ExtProcPerRoute cfg2;
+  cfg2.mutable_overrides()->mutable_emit_client_span()->set_value(true);
+
+  FilterConfigPerRoute route1(cfg1, builder_, factory_context_);
+  FilterConfigPerRoute route2(cfg2, builder_, factory_context_);
+  FilterConfigPerRoute merged_route(route1, route2);
+
+  ASSERT_TRUE(merged_route.emitClientSpan().has_value());
+  EXPECT_TRUE(*merged_route.emitClientSpan());
+
+  // Empty more specific inherits from less specific.
+  ExtProcPerRoute empty_cfg;
+  FilterConfigPerRoute empty_route(empty_cfg, builder_, factory_context_);
+  FilterConfigPerRoute merged_inherited(route1, empty_route);
+  ASSERT_TRUE(merged_inherited.emitClientSpan().has_value());
+  EXPECT_FALSE(*merged_inherited.emitClientSpan());
+}
+
 // Verify that attempts to change headers that are not allowed to be changed
 // are ignored and a counter is incremented.
 TEST_F(HttpFilterTest, IgnoreInvalidHeaderMutations) {

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -6774,6 +6774,81 @@ TEST_F(HttpFilterTest, LocalResponseStarted) {
   filter_->onDestroy();
 }
 
+TEST_F(HttpFilterTest, EmitClientSpanDefault) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  )EOF");
+
+  EXPECT_CALL(*client_ptr_, start(_, _, _, _))
+      .WillOnce(Invoke(
+          [this](ExternalProcessorCallbacks& callbacks,
+                 const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
+                 const Envoy::Http::AsyncClient::StreamOptions& options,
+                 Envoy::Http::StreamFilterSidestreamWatermarkCallbacks& watermark_callbacks) {
+            EXPECT_EQ(std::nullopt, options.sampled_);
+            return doStart(callbacks, config_with_hash_key, options, watermark_callbacks);
+          }));
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  processRequestHeaders(false, std::nullopt);
+  filter_->onDestroy();
+}
+
+TEST_F(HttpFilterTest, EmitClientSpanDisabled) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  emit_client_span: false
+  )EOF");
+
+  EXPECT_CALL(*client_ptr_, start(_, _, _, _))
+      .WillOnce(Invoke(
+          [this](ExternalProcessorCallbacks& callbacks,
+                 const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
+                 const Envoy::Http::AsyncClient::StreamOptions& options,
+                 Envoy::Http::StreamFilterSidestreamWatermarkCallbacks& watermark_callbacks) {
+            EXPECT_EQ(std::make_optional(false), options.sampled_);
+            return doStart(callbacks, config_with_hash_key, options, watermark_callbacks);
+          }));
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  processRequestHeaders(false, std::nullopt);
+  filter_->onDestroy();
+}
+
+TEST_F(HttpFilterTest, EmitClientSpanPerRouteOverride) {
+  initialize(R"EOF(
+  grpc_service:
+    envoy_grpc:
+      cluster_name: "ext_proc_server"
+  emit_client_span: true
+  )EOF");
+
+  envoy::extensions::filters::http::ext_proc::v3::ExtProcPerRoute route_proto;
+  route_proto.mutable_overrides()->mutable_emit_client_span()->set_value(false);
+  FilterConfigPerRoute route_config(route_proto, builder_, factory_context_);
+  EXPECT_CALL(decoder_callbacks_, perFilterConfigs())
+      .WillRepeatedly(
+          testing::Invoke([&]() -> Router::RouteSpecificFilterConfigs { return {&route_config}; }));
+
+  EXPECT_CALL(*client_ptr_, start(_, _, _, _))
+      .WillOnce(Invoke(
+          [this](ExternalProcessorCallbacks& callbacks,
+                 const Grpc::GrpcServiceConfigWithHashKey& config_with_hash_key,
+                 const Envoy::Http::AsyncClient::StreamOptions& options,
+                 Envoy::Http::StreamFilterSidestreamWatermarkCallbacks& watermark_callbacks) {
+            EXPECT_EQ(std::make_optional(false), options.sampled_);
+            return doStart(callbacks, config_with_hash_key, options, watermark_callbacks);
+          }));
+
+  EXPECT_EQ(FilterHeadersStatus::StopIteration, filter_->decodeHeaders(request_headers_, false));
+  processRequestHeaders(false, std::nullopt);
+  filter_->onDestroy();
+}
+
 } // namespace
 
 } // namespace ExternalProcessing


### PR DESCRIPTION
Adds a boolean emit_client_span configuration knob (defaulting to true to preserve backwards compatibility) to the ext_proc filter configuration protos and their per-route / virtual-host overrides.

When ext_proc filters initiate outbound HTTP or gRPC calls to external authorization or processing services, Envoy's underlying async client automatically creates and records a child egress client span under the active request span.

We would like the ability to control when this takes places since we have some side-streams that are customer-facing and others that are purely internal implementation details that should not have their traces emitted to customers.

Currently, there is no filter-level or route-level mechanism in ext_proc to suppress only the client span emission without breaking context propagation or globally altering tracer behavior.

See #46920. This PR is part 1 of 2. The second PR will make the same change but for ext_authz calls.

Risk Level: low
Testing: Via unit testing

[Disclosed usage of generative AI: Yes, used to assist in code modifications.]