### PR TITLE
dynamic_modules: add route metadata setters to the cluster specifier

### DIFF
--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -15205,6 +15205,88 @@ bool envoy_dynamic_module_callback_cluster_specifier_set_route_action_override(
     envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
     envoy_dynamic_module_type_module_buffer name);
 
+// ------------------- Cluster Specifier Callbacks - Route Metadata ------------
+
+/**
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number sets the number value
+ * of the route metadata under the given namespace and key. The entry is layered onto the metadata
+ * of the matched route, so consumers that read route metadata, such as the rate limit ROUTE_ENTRY
+ * action or the METADATA(ROUTE) formatter, observe it. An existing entry with the same namespace
+ * and key is overwritten, while the other entries of the matched route stay in effect.
+ *
+ * The metadata takes effect only when the select call reports a decision. A select that reports
+ * none changes nothing, and a decision that sets no metadata drops what an earlier decision set.
+ *
+ * @param context_envoy_ptr is the pointer to the cluster selection context.
+ * @param ns is the namespace of the route metadata.
+ * @param key is the key of the route metadata.
+ * @param value is the number value to set.
+ */
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    double value);
+
+/**
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string sets the string value
+ * of the route metadata under the given namespace and key. It behaves like
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number but stores a string.
+ *
+ * @param context_envoy_ptr is the pointer to the cluster selection context.
+ * @param ns is the namespace of the route metadata.
+ * @param key is the key of the route metadata.
+ * @param value is the string value to set. Envoy copies the buffer.
+ */
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_module_buffer value);
+
+/**
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool sets the bool value of
+ * the route metadata under the given namespace and key. It behaves like
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number but stores a bool.
+ *
+ * @param context_envoy_ptr is the pointer to the cluster selection context.
+ * @param ns is the namespace of the route metadata.
+ * @param key is the key of the route metadata.
+ * @param value is the bool value to set.
+ */
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    bool value);
+
+/**
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct merges a serialized
+ * google.protobuf.Struct into the route metadata under the given namespace. Existing entries with
+ * the same key are overwritten, while the others stay in effect. If the buffer does not parse as a
+ * google.protobuf.Struct, this is a no-op.
+ *
+ * @param context_envoy_ptr is the pointer to the cluster selection context.
+ * @param ns is the namespace of the route metadata.
+ * @param serialized_struct is the serialized google.protobuf.Struct value to set.
+ */
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_struct);
+
+/**
+ * envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata sets the typed route
+ * metadata under the given namespace from a serialized google.protobuf.Any, replacing an existing
+ * entry, so a typed metadata factory registered for the namespace can parse it out of
+ * typedMetadata(). If the buffer does not parse as a google.protobuf.Any, this is a no-op.
+ *
+ * @param context_envoy_ptr is the pointer to the cluster selection context.
+ * @param ns is the namespace of the route metadata.
+ * @param serialized_any is the serialized google.protobuf.Any value to set.
+ */
+void envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_any);
+
 // =============================================================================
 // Cluster Specifier Callbacks - Metrics
 // =============================================================================

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -2982,6 +2982,45 @@ __attribute__((weak)) void envoy_dynamic_module_callback_cluster_specifier_set_t
       "context");
 }
 
+__attribute__((weak)) void
+envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer, double) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number: not "
+               "implemented in this context");
+}
+
+__attribute__((weak)) void
+envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer,
+    envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string: not "
+               "implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer, bool) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool: not "
+               "implemented in this context");
+}
+
+__attribute__((weak)) void
+envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct: not "
+               "implemented in this context");
+}
+
+__attribute__((weak)) void envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer, envoy_dynamic_module_type_module_buffer) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata: not "
+               "implemented in this context");
+}
+
 __attribute__((weak)) envoy_dynamic_module_type_metrics_result
 envoy_dynamic_module_callback_cluster_specifier_config_define_counter(
     envoy_dynamic_module_type_cluster_specifier_config_envoy_ptr,

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster_specifier.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster_specifier.rs
@@ -433,6 +433,78 @@ impl ClusterSpecifierContext {
       )
     }
   }
+
+  /// Set a number-typed route metadata value under the given namespace and key.
+  ///
+  /// The entry is layered onto the metadata of the matched route, so consumers that read route
+  /// metadata, such as the rate limit `ROUTE_ENTRY` action or the `METADATA(ROUTE)` formatter,
+  /// observe it. An existing entry with the same namespace and key is overwritten. Route metadata
+  /// takes effect only when [`ClusterSpecifierConfig::on_select`] returns `true`.
+  pub fn set_route_metadata_number(&mut self, namespace: &str, key: &str, value: f64) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number(
+        self.envoy_ptr,
+        crate::str_to_module_buffer(namespace),
+        crate::str_to_module_buffer(key),
+        value,
+      )
+    }
+  }
+
+  /// Set a string-typed route metadata value under the given namespace and key.
+  ///
+  /// It behaves like [`Self::set_route_metadata_number`] but stores a string.
+  pub fn set_route_metadata_string(&mut self, namespace: &str, key: &str, value: &str) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string(
+        self.envoy_ptr,
+        crate::str_to_module_buffer(namespace),
+        crate::str_to_module_buffer(key),
+        crate::str_to_module_buffer(value),
+      )
+    }
+  }
+
+  /// Set a bool-typed route metadata value under the given namespace and key.
+  ///
+  /// It behaves like [`Self::set_route_metadata_number`] but stores a bool.
+  pub fn set_route_metadata_bool(&mut self, namespace: &str, key: &str, value: bool) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool(
+        self.envoy_ptr,
+        crate::str_to_module_buffer(namespace),
+        crate::str_to_module_buffer(key),
+        value,
+      )
+    }
+  }
+
+  /// Merge a serialized `google.protobuf.Struct` into the route metadata under the given namespace.
+  ///
+  /// Existing entries with the same key are overwritten, while the others stay in effect. A buffer
+  /// that does not parse as a `google.protobuf.Struct` is a no-op.
+  pub fn set_route_metadata_struct(&mut self, namespace: &str, serialized_struct: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+        self.envoy_ptr,
+        crate::str_to_module_buffer(namespace),
+        crate::bytes_to_module_buffer(serialized_struct),
+      )
+    }
+  }
+
+  /// Set the typed route metadata under the given namespace from a `google.protobuf.Any`, replacing
+  /// an existing entry. A typed metadata factory registered for the namespace parses it out of
+  /// `typedMetadata`. A buffer that does not parse as a `google.protobuf.Any` is a no-op.
+  pub fn set_route_typed_metadata(&mut self, namespace: &str, serialized_any: &[u8]) {
+    unsafe {
+      abi::envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(
+        self.envoy_ptr,
+        crate::str_to_module_buffer(namespace),
+        crate::bytes_to_module_buffer(serialized_any),
+      )
+    }
+  }
 }
 
 /// Convert a duration to the millisecond count the ABI takes, saturating instead of wrapping.

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -9100,6 +9100,11 @@ struct StubSpecifierSelection {
   priority: Option<abi::envoy_dynamic_module_type_resource_priority>,
   cluster_not_found_response_code: Option<u32>,
   route_action_override: Option<String>,
+  route_metadata_number: Option<(String, String, f64)>,
+  route_metadata_string: Option<(String, String, String)>,
+  route_metadata_bool: Option<(String, String, bool)>,
+  route_metadata_struct: Option<(String, Vec<u8>)>,
+  route_typed_metadata: Option<(String, Vec<u8>)>,
 }
 
 static STUB_SPECIFIER_SELECTION: std::sync::Mutex<StubSpecifierSelection> =
@@ -9111,6 +9116,11 @@ static STUB_SPECIFIER_SELECTION: std::sync::Mutex<StubSpecifierSelection> =
     priority: None,
     cluster_not_found_response_code: None,
     route_action_override: None,
+    route_metadata_number: None,
+    route_metadata_string: None,
+    route_metadata_bool: None,
+    route_metadata_struct: None,
+    route_typed_metadata: None,
   });
 
 // Copies a module buffer into an owned string the way Envoy copies it out of the module.
@@ -9120,6 +9130,11 @@ unsafe fn stub_specifier_string(buffer: abi::envoy_dynamic_module_type_module_bu
     buffer.length,
   ))
   .into_owned()
+}
+
+// Copies a module buffer into owned bytes, used for the serialized metadata setters.
+unsafe fn stub_specifier_bytes(buffer: abi::envoy_dynamic_module_type_module_buffer) -> Vec<u8> {
+  std::slice::from_raw_parts(buffer.ptr as *const u8, buffer.length).to_vec()
 }
 
 // Points the result buffer at a static value and reports it as present.
@@ -9380,6 +9395,82 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_set_route_acti
     .unwrap()
     .route_action_override = Some(name);
   true
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number(
+  _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+  ns: abi::envoy_dynamic_module_type_module_buffer,
+  key: abi::envoy_dynamic_module_type_module_buffer,
+  value: f64,
+) {
+  STUB_SPECIFIER_SELECTION
+    .lock()
+    .unwrap()
+    .route_metadata_number = Some((
+    unsafe { stub_specifier_string(ns) },
+    unsafe { stub_specifier_string(key) },
+    value,
+  ));
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string(
+  _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+  ns: abi::envoy_dynamic_module_type_module_buffer,
+  key: abi::envoy_dynamic_module_type_module_buffer,
+  value: abi::envoy_dynamic_module_type_module_buffer,
+) {
+  STUB_SPECIFIER_SELECTION
+    .lock()
+    .unwrap()
+    .route_metadata_string = Some((
+    unsafe { stub_specifier_string(ns) },
+    unsafe { stub_specifier_string(key) },
+    unsafe { stub_specifier_string(value) },
+  ));
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool(
+  _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+  ns: abi::envoy_dynamic_module_type_module_buffer,
+  key: abi::envoy_dynamic_module_type_module_buffer,
+  value: bool,
+) {
+  STUB_SPECIFIER_SELECTION.lock().unwrap().route_metadata_bool = Some((
+    unsafe { stub_specifier_string(ns) },
+    unsafe { stub_specifier_string(key) },
+    value,
+  ));
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+  _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+  ns: abi::envoy_dynamic_module_type_module_buffer,
+  serialized_struct: abi::envoy_dynamic_module_type_module_buffer,
+) {
+  STUB_SPECIFIER_SELECTION
+    .lock()
+    .unwrap()
+    .route_metadata_struct = Some((unsafe { stub_specifier_string(ns) }, unsafe {
+    stub_specifier_bytes(serialized_struct)
+  }));
+}
+
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(
+  _context_envoy_ptr: abi::envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr,
+  ns: abi::envoy_dynamic_module_type_module_buffer,
+  serialized_any: abi::envoy_dynamic_module_type_module_buffer,
+) {
+  STUB_SPECIFIER_SELECTION
+    .lock()
+    .unwrap()
+    .route_typed_metadata = Some((unsafe { stub_specifier_string(ns) }, unsafe {
+    stub_specifier_bytes(serialized_any)
+  }));
 }
 
 #[test]
@@ -9661,6 +9752,11 @@ fn test_cluster_specifier_context_records_selection() {
   ctx.set_priority(ResourcePriority::High);
   assert!(ctx.set_cluster_not_found_response_code(404));
   assert!(ctx.set_route_action_override(STUB_SPECIFIER_OVERRIDE_NAME));
+  ctx.set_route_metadata_number("envoy.lb", "weight", 0.75);
+  ctx.set_route_metadata_string("envoy.lb", "shard", "a");
+  ctx.set_route_metadata_bool("envoy.lb", "canary", true);
+  ctx.set_route_metadata_struct("envoy.filters.http.ext_authz", b"struct-bytes");
+  ctx.set_route_typed_metadata("envoy.filters.http.ext_authz", b"any-bytes");
 
   {
     let selection = STUB_SPECIFIER_SELECTION.lock().unwrap();
@@ -9676,6 +9772,32 @@ fn test_cluster_specifier_context_records_selection() {
     assert_eq!(
       Some(STUB_SPECIFIER_OVERRIDE_NAME.to_string()),
       selection.route_action_override
+    );
+    assert_eq!(
+      Some(("envoy.lb".to_string(), "weight".to_string(), 0.75)),
+      selection.route_metadata_number
+    );
+    assert_eq!(
+      Some(("envoy.lb".to_string(), "shard".to_string(), "a".to_string())),
+      selection.route_metadata_string
+    );
+    assert_eq!(
+      Some(("envoy.lb".to_string(), "canary".to_string(), true)),
+      selection.route_metadata_bool
+    );
+    assert_eq!(
+      Some((
+        "envoy.filters.http.ext_authz".to_string(),
+        b"struct-bytes".to_vec()
+      )),
+      selection.route_metadata_struct
+    );
+    assert_eq!(
+      Some((
+        "envoy.filters.http.ext_authz".to_string(),
+        b"any-bytes".to_vec()
+      )),
+      selection.route_typed_metadata
     );
   }
 

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/BUILD
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/BUILD
@@ -28,8 +28,10 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:statusor_lib",
+        "//source/common/config:metadata_lib",
         "//source/common/config:well_known_names",
         "//source/common/http:hash_policy_lib",
+        "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
         "//source/common/router:config_lib",
         "//source/common/router:delegating_route_lib",
@@ -40,6 +42,7 @@ envoy_cc_library(
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "@abseil-cpp//absl/container:flat_hash_map",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/router/cluster_specifiers/dynamic_modules/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/abi_impl.cc
@@ -4,6 +4,8 @@
 #include <limits>
 
 #include "source/common/common/logger.h"
+#include "source/common/config/metadata.h"
+#include "source/common/protobuf/protobuf.h"
 #include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
 #include "source/extensions/dynamic_modules/abi_context_accessors.h"
@@ -47,6 +49,16 @@ Envoy::Stats::StatNameTagVector buildTagsForClusterSpecifierMetric(
     tags.push_back(Envoy::Stats::StatNameTag(label_names[i], label_value));
   }
   return tags;
+}
+
+// Returns a mutable handle to the route metadata value the module is setting, creating the
+// namespace and key when they are absent.
+Protobuf::Value& mutableRouteMetadataValue(ClusterSpecifierContext* context,
+                                           envoy_dynamic_module_type_module_buffer ns,
+                                           envoy_dynamic_module_type_module_buffer key) {
+  return Envoy::Config::Metadata::mutableMetadataValue(context->selection.route_metadata,
+                                                       std::string(ns.ptr, ns.length),
+                                                       std::string(key.ptr, key.length));
 }
 
 } // namespace
@@ -240,6 +252,67 @@ bool envoy_dynamic_module_callback_cluster_specifier_set_route_action_override(
   }
   context->selection.route_action_override = entry;
   return true;
+}
+
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    double value) {
+  mutableRouteMetadataValue(clusterSpecifierContext(context_envoy_ptr), ns, key)
+      .set_number_value(value);
+}
+
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    envoy_dynamic_module_type_module_buffer value) {
+  mutableRouteMetadataValue(clusterSpecifierContext(context_envoy_ptr), ns, key)
+      .set_string_value(std::string(value.ptr, value.length));
+}
+
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns, envoy_dynamic_module_type_module_buffer key,
+    bool value) {
+  mutableRouteMetadataValue(clusterSpecifierContext(context_envoy_ptr), ns, key)
+      .set_bool_value(value);
+}
+
+void envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_struct) {
+  Protobuf::Struct metadata_value;
+  if (!metadata_value.ParseFromArray(serialized_struct.ptr,
+                                     static_cast<int>(serialized_struct.length))) {
+    ENVOY_LOG_EVERY_POW_2_TO_LOGGER(
+        Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), warn,
+        "dynamic module set route metadata with a buffer that does not parse as a "
+        "google.protobuf.Struct, so the call is ignored");
+    return;
+  }
+  auto* context = clusterSpecifierContext(context_envoy_ptr);
+  (*context->selection.route_metadata.mutable_filter_metadata())[std::string(ns.ptr, ns.length)]
+      .MergeFrom(metadata_value);
+}
+
+void envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(
+    envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_module_buffer ns,
+    envoy_dynamic_module_type_module_buffer serialized_any) {
+  Protobuf::Any typed_value;
+  if (!typed_value.ParseFromArray(serialized_any.ptr, static_cast<int>(serialized_any.length))) {
+    ENVOY_LOG_EVERY_POW_2_TO_LOGGER(
+        Envoy::Logger::Registry::getLog(Envoy::Logger::Id::dynamic_modules), warn,
+        "dynamic module set typed route metadata with a buffer that does not parse as a "
+        "google.protobuf.Any, so the call is ignored");
+    return;
+  }
+  auto* context = clusterSpecifierContext(context_envoy_ptr);
+  // Assign rather than merge so the whole Any is swapped at once. Merging an Any field by field
+  // could keep the type URL of one call with the value of another.
+  (*context->selection.route_metadata
+        .mutable_typed_filter_metadata())[std::string(ns.ptr, ns.length)] = typed_value;
 }
 
 envoy_dynamic_module_type_metrics_result

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.cc
@@ -6,6 +6,7 @@
 #include "envoy/common/exception.h"
 
 #include "source/common/common/assert.h"
+#include "source/common/common/thread.h"
 #include "source/common/config/well_known_names.h"
 #include "source/common/http/hash_policy.h"
 #include "source/common/protobuf/utility.h"
@@ -186,6 +187,36 @@ void DynamicModuleRouteEntry::refreshRouteCluster(const Http::RequestHeaderMap& 
   // The new selection replaces the previous one, so properties the module left unset on this call
   // fall back to the matched route.
   selection_ = std::move(context.selection);
+  // Layer the module metadata onto the matched route so both metadata accessors observe it. It is
+  // rebuilt from scratch here, so a decision that sets none drops what an earlier one set.
+  if (selection_.route_metadata.filter_metadata().empty() &&
+      selection_.route_metadata.typed_filter_metadata().empty()) {
+    active_metadata_pack_ = nullptr;
+  } else {
+    envoy::config::core::v3::Metadata merged = DelegatingRouteEntry::metadata();
+    // Merge per namespace so an entry replaces only its own key while the other keys of the matched
+    // route stay in effect. A top-level merge would replace the whole namespace instead.
+    for (const auto& [name, fields] : selection_.route_metadata.filter_metadata()) {
+      (*merged.mutable_filter_metadata())[name].MergeFrom(fields);
+    }
+    for (const auto& [name, typed] : selection_.route_metadata.typed_filter_metadata()) {
+      (*merged.mutable_typed_filter_metadata())[name] = typed;
+    }
+    // Building the pack runs the registered typed metadata factories, which can throw on
+    // module-supplied input, so fall back to the matched route rather than let it reach the worker.
+    TRY_NEEDS_AUDIT {
+      metadata_packs_.push_back(std::make_unique<Envoy::Router::RouteMetadataPack>(merged));
+      active_metadata_pack_ = metadata_packs_.back().get();
+    }
+    END_TRY
+    CATCH(const EnvoyException& e, {
+      ENVOY_LOG_EVERY_POW_2(warn,
+                            "dynamic module route metadata rejected by a typed metadata factory, "
+                            "using the matched route instead: {}",
+                            e.what());
+      active_metadata_pack_ = nullptr;
+    });
+  }
   ENVOY_LOG(debug, "dynamic module selected cluster '{}'", clusterName());
 }
 

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.h
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "envoy/common/optref.h"
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/extensions/router/cluster_specifiers/dynamic_modules/v3/dynamic_modules.pb.h"
 #include "envoy/http/codes.h"
 #include "envoy/http/hash_policy.h"
@@ -19,6 +20,7 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/common/statusor.h"
+#include "source/common/config/metadata.h"
 #include "source/common/router/delegating_route_impl.h"
 #include "source/common/stats/utility.h"
 #include "source/extensions/dynamic_modules/abi/abi.h"
@@ -327,6 +329,9 @@ struct ClusterSpecifierSelection {
   // Points into the override map of the cluster specifier configuration, which is immutable after
   // construction.
   const RouteActionOverride* route_action_override{nullptr};
+  // Metadata the module layered onto the matched route, keyed by namespace. Empty when the module
+  // set none, so metadata() and typedMetadata() fall back to the matched route.
+  envoy::config::core::v3::Metadata route_metadata;
 };
 
 /**
@@ -392,6 +397,14 @@ public:
     return entry != nullptr && entry->hash_policy != nullptr ? entry->hash_policy.get()
                                                              : DelegatingRouteEntry::hashPolicy();
   }
+  const envoy::config::core::v3::Metadata& metadata() const override {
+    return active_metadata_pack_ != nullptr ? active_metadata_pack_->proto_metadata_
+                                            : DelegatingRouteEntry::metadata();
+  }
+  const Envoy::Config::TypedMetadata& typedMetadata() const override {
+    return active_metadata_pack_ != nullptr ? active_metadata_pack_->typed_metadata_
+                                            : DelegatingRouteEntry::typedMetadata();
+  }
   void refreshRouteCluster(const Http::RequestHeaderMap& headers,
                            const StreamInfo::StreamInfo& stream_info) const override;
 
@@ -400,6 +413,15 @@ private:
   const uint64_t random_value_;
   // Only accessed from the worker thread that owns the request, so no synchronization is needed.
   mutable ClusterSpecifierSelection selection_;
+  // Metadata packs built across refreshes. A pack is kept until the entry is destroyed so the
+  // reference that metadata() and typedMetadata() return stays valid past a refresh, the way
+  // cluster_name does. active_metadata_pack_ points at the pack of the current decision, or is null
+  // so both accessors fall back to the matched route. Only the worker thread that owns the request
+  // touches these.
+  mutable std::vector<Envoy::Config::MetadataPackPtr<Envoy::Router::HttpRouteTypedMetadataFactory>>
+      metadata_packs_;
+  mutable const Envoy::Config::MetadataPack<Envoy::Router::HttpRouteTypedMetadataFactory>*
+      active_metadata_pack_{nullptr};
 };
 
 /**

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -1841,6 +1841,23 @@ WEAK_STUB(ClusterSpecifierSetRequestBodyBufferLimit,
 WEAK_STUB(ClusterSpecifierSetRouteActionOverride,
           envoy_dynamic_module_callback_cluster_specifier_set_route_action_override(nullptr,
                                                                                     {nullptr, 0}))
+WEAK_STUB(ClusterSpecifierSetRouteMetadataBool,
+          envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_bool(
+              nullptr, {nullptr, 0}, {nullptr, 0}, false))
+WEAK_STUB(ClusterSpecifierSetRouteMetadataNumber,
+          envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_number(
+              nullptr, {nullptr, 0}, {nullptr, 0}, 0))
+WEAK_STUB(ClusterSpecifierSetRouteMetadataString,
+          envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_string(
+              nullptr, {nullptr, 0}, {nullptr, 0}, {nullptr, 0}))
+WEAK_STUB(ClusterSpecifierSetRouteMetadataStruct,
+          envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(nullptr,
+                                                                                    {nullptr, 0},
+                                                                                    {nullptr, 0}))
+WEAK_STUB(ClusterSpecifierSetRouteTypedMetadata,
+          envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(nullptr,
+                                                                                   {nullptr, 0},
+                                                                                   {nullptr, 0}))
 WEAK_STUB(ClusterSpecifierSetTimeout,
           envoy_dynamic_module_callback_cluster_specifier_set_timeout(nullptr, 0))
 WEAK_STUB(ClusterSpecifierConfigDefineCounter,

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
@@ -5,8 +5,8 @@
 //! can control every branch, and it exercises the full cluster specifier context ABI surface:
 //! request headers (single value, indexed value, count, and bulk iteration), stream info attributes
 //! (string, int, and bool), dynamic metadata, the route name, the random value, the scalar route
-//! action setters, the named route action overrides, and the configuration metrics recorded on each
-//! selection.
+//! action setters, the named route action overrides, the route metadata setters, and the
+//! configuration metrics recorded on each selection.
 //!
 //! The headers the module reads are:
 //!   `env`               the cluster to route to, prefixed with the `specifier_config` bytes.
@@ -22,6 +22,13 @@
 //!                       a test can assert on what the module read across the ABI boundary.
 //!   `x-retry-cluster`   the cluster to route to once the first upstream attempt has been made, so
 //!                       that a test can tell that a retry re-entered the module.
+//!   `x-route-meta-string` a string value set as route metadata under `envoy.test.route`.
+//!   `x-route-meta-number` a number value set as route metadata under `envoy.test.route`.
+//!   `x-route-meta-bool`   a bool value set as route metadata under `envoy.test.route`.
+//!   `x-route-meta-struct` merges a fixed `google.protobuf.Struct` into the route metadata under
+//!                         `envoy.test.route`.
+//!   `x-route-typed-meta`  a serialized `google.protobuf.Any` set as typed route metadata. A value
+//!                         of `throw` picks one the registered factory rejects.
 //!
 //! A scalar header holding `max` selects the largest value the SDK type can express, which exercises
 //! the saturating conversion at the ABI boundary.
@@ -201,6 +208,54 @@ impl ClusterSpecifierConfig for TestClusterSpecifierConfig {
       });
     if let Some(priority) = priority {
       ctx.set_priority(priority);
+    }
+
+    // Route metadata setters, each guarded by its own header so a test can drive them in isolation.
+    // The values are layered onto the matched route so filters and access logs observe them.
+    if let Some(value) = ctx.get_request_header("x-route-meta-string") {
+      ctx.set_route_metadata_string("envoy.test.route", "string_key", &buffer_to_string(value));
+    }
+    if let Some(value) = ctx
+      .get_request_header("x-route-meta-number")
+      .and_then(|buffer| {
+        std::str::from_utf8(buffer.as_slice())
+          .ok()?
+          .parse::<f64>()
+          .ok()
+      })
+    {
+      ctx.set_route_metadata_number("envoy.test.route", "number_key", value);
+    }
+    if let Some(value) = ctx.get_request_header("x-route-meta-bool") {
+      ctx.set_route_metadata_bool("envoy.test.route", "bool_key", value.as_slice() == b"true");
+    }
+    if ctx.get_request_header("x-route-meta-struct").is_some() {
+      // Hand-encoded google.protobuf.Struct because the test module has no protobuf dependency.
+      //   0a 1a                      field 1 (fields) length 26
+      //     0a 0a "struct_key"       entry key
+      //     12 0c 1a 0a "struct-val" entry value, a string Value
+      let serialized_struct: &[u8] = &[
+        0x0a, 0x1a, 0x0a, 0x0a, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74, 0x5f, 0x6b, 0x65, 0x79, 0x12,
+        0x0c, 0x1a, 0x0a, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74, 0x2d, 0x76, 0x61, 0x6c,
+      ];
+      ctx.set_route_metadata_struct("envoy.test.route", serialized_struct);
+    }
+    if let Some(value) = ctx.get_request_header("x-route-typed-meta") {
+      // Hand-encoded google.protobuf.Any because the test module has no protobuf dependency. A
+      // `throw` value picks a type_url the registered factory rejects, any other value picks one it
+      // accepts.
+      let serialized_any: &[u8] = if value.as_slice() == b"throw" {
+        //   0a 07 74 2f 74 68 72 6f 77   field 1 (type_url) = "t/throw"
+        //   12 02 01 02                  field 2 (value)    = 0x01 0x02
+        &[
+          0x0a, 0x07, 0x74, 0x2f, 0x74, 0x68, 0x72, 0x6f, 0x77, 0x12, 0x02, 0x01, 0x02,
+        ]
+      } else {
+        //   0a 03 74 2f 78   field 1 (type_url) = "t/x"
+        //   12 02 01 02      field 2 (value)    = 0x01 0x02
+        &[0x0a, 0x03, 0x74, 0x2f, 0x78, 0x12, 0x02, 0x01, 0x02]
+      };
+      ctx.set_route_typed_metadata("envoy.test.typed_route", serialized_any);
     }
 
     // Record the selection so an integration test can observe the values that crossed the ABI

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/BUILD
@@ -50,6 +50,7 @@ envoy_extension_cc_dyn_module_test(
     extension_names = ["envoy.router.cluster_specifier_plugin.dynamic_modules"],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//source/extensions/formatter/metadata:config",
         "//source/extensions/load_balancing_policies/subset:config",
         "//source/extensions/router/cluster_specifiers/dynamic_modules:config",
         "//test/integration:http_integration_lib",

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
@@ -3,6 +3,7 @@
 
 #include "envoy/extensions/router/cluster_specifiers/dynamic_modules/v3/dynamic_modules.pb.h"
 #include "envoy/registry/registry.h"
+#include "envoy/router/router.h"
 
 #include "source/common/common/fmt.h"
 #include "source/common/protobuf/utility.h"
@@ -866,14 +867,261 @@ route_action_overrides:
   EXPECT_EQ(7, entry->retryPolicy()->numRetries());
 }
 
-class DynamicModuleClusterSpecifierHostCountAbiTest : public testing::Test {
+// A typed metadata object that keeps the type URL of the Any it was parsed from, so a test can tell
+// the module set typed route metadata that the pack parsed out of typedMetadata().
+struct TestTypedRouteMetadata : public Envoy::Config::TypedMetadata::Object {
+  explicit TestTypedRouteMetadata(std::string type_url) : type_url_(std::move(type_url)) {}
+  const std::string type_url_;
+};
+
+// Parses the typed route metadata the module sets under envoy.test.typed_route so that a test can
+// read it back through typedMetadata().
+class TestTypedRouteMetadataFactory : public Envoy::Router::HttpRouteTypedMetadataFactory {
 public:
-  DynamicModuleClusterSpecifierHostCountAbiTest() {
+  std::string name() const override { return "envoy.test.typed_route"; }
+  std::unique_ptr<const Envoy::Config::TypedMetadata::Object>
+  parse(const Protobuf::Struct&) const override {
+    return nullptr;
+  }
+  std::unique_ptr<const Envoy::Config::TypedMetadata::Object>
+  parse(const Protobuf::Any& any) const override {
+    // A sentinel type URL lets a test drive the parse failure that the pack build guards against.
+    if (any.type_url() == "t/throw") {
+      throw EnvoyException("typed route metadata rejected by the test factory");
+    }
+    return std::make_unique<TestTypedRouteMetadata>(any.type_url());
+  }
+};
+
+REGISTER_FACTORY(TestTypedRouteMetadataFactory, Envoy::Router::HttpRouteTypedMetadataFactory);
+
+// Tests for the route metadata the module layers onto the matched route. The reference module sets
+// entries under envoy.test.route from the x-route-meta-* headers and a typed entry under
+// envoy.test.typed_route from x-route-typed-meta.
+class DynamicModuleRouteMetadataTest : public DynamicModuleClusterSpecifierTest {
+public:
+  // Returns the value of a string field of the route metadata under the given namespace and key, or
+  // "absent" when it is missing, so a test can assert on both the merged and the fallback outcome.
+  std::string routeMetadataString(absl::string_view ns, absl::string_view key) {
+    const auto& filter_metadata = resolved_route_->metadata().filter_metadata();
+    const auto ns_it = filter_metadata.find(ns);
+    if (ns_it == filter_metadata.end()) {
+      return "absent";
+    }
+    const auto field_it = ns_it->second.fields().find(key);
+    return field_it == ns_it->second.fields().end() ? "absent" : field_it->second.string_value();
+  }
+};
+
+// The scalar setters layer number, string and bool entries onto the matched route so consumers that
+// read route metadata observe them.
+TEST_F(DynamicModuleRouteMetadataTest, ScalarMetadataLayeredOntoMatchedRoute) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"},
+                                         {"env", "prod"},
+                                         {"x-route-meta-string", "shard-a"},
+                                         {"x-route-meta-number", "0.5"},
+                                         {"x-route-meta-bool", "true"}};
+  resolveRouteEntry(headers);
+  const auto& filter_metadata = resolved_route_->metadata().filter_metadata();
+  ASSERT_NE(filter_metadata.end(), filter_metadata.find("envoy.test.route"));
+  const auto& fields = filter_metadata.at("envoy.test.route").fields();
+  ASSERT_TRUE(fields.contains("string_key"));
+  ASSERT_TRUE(fields.contains("number_key"));
+  ASSERT_TRUE(fields.contains("bool_key"));
+  EXPECT_EQ("shard-a", fields.at("string_key").string_value());
+  EXPECT_DOUBLE_EQ(0.5, fields.at("number_key").number_value());
+  EXPECT_TRUE(fields.at("bool_key").bool_value());
+}
+
+// Module metadata is layered onto the matched route. An entry under the same namespace and key is
+// overwritten, an untouched entry under that namespace stays, and another namespace is preserved.
+TEST_F(DynamicModuleRouteMetadataTest, ModuleMetadataMergesWithMatchedRoute) {
+  setUpPlugin();
+  Protobuf::Struct same_namespace;
+  (*same_namespace.mutable_fields())["string_key"] = ValueUtil::stringValue("base-value");
+  (*same_namespace.mutable_fields())["kept"] = ValueUtil::stringValue("yes");
+  (*parent_->metadata_.mutable_filter_metadata())["envoy.test.route"] = same_namespace;
+  Protobuf::Struct other_namespace;
+  (*other_namespace.mutable_fields())["kept"] = ValueUtil::stringValue("yes");
+  (*parent_->metadata_.mutable_filter_metadata())["envoy.other"] = other_namespace;
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-meta-string", "shard-a"}};
+  resolveRouteEntry(headers);
+  EXPECT_EQ("shard-a", routeMetadataString("envoy.test.route", "string_key"));
+  EXPECT_EQ("yes", routeMetadataString("envoy.test.route", "kept"));
+  EXPECT_EQ("yes", routeMetadataString("envoy.other", "kept"));
+}
+
+// Without any setter the accessors return the references of the matched route rather than a merged
+// copy, so a consumer sees exactly what the route configures.
+TEST_F(DynamicModuleRouteMetadataTest, NoMetadataFallsBackToMatchedRoute) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"env", "prod"}};
+  resolveRouteEntry(headers);
+  EXPECT_EQ(&parent_->metadata_, &resolved_route_->metadata());
+  EXPECT_EQ(&parent_->typed_metadata_, &resolved_route_->typedMetadata());
+}
+
+// A refresh replaces the whole decision, so metadata an earlier call layered on goes back to the
+// matched route when the refreshed decision sets none.
+TEST_F(DynamicModuleRouteMetadataTest, RefreshWithoutMetadataRevertsToMatchedRoute) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-meta-string", "shard-a"}};
+  const auto* entry = resolveRouteEntry(headers);
+  EXPECT_EQ("shard-a", routeMetadataString("envoy.test.route", "string_key"));
+
+  headers.remove(Http::LowerCaseString("x-route-meta-string"));
+  entry->refreshRouteCluster(headers, stream_info_);
+  EXPECT_EQ(&parent_->metadata_, &resolved_route_->metadata());
+  EXPECT_EQ(&parent_->typed_metadata_, &resolved_route_->typedMetadata());
+}
+
+// A refresh rebuilds the metadata from scratch, so a key an earlier decision layered on is gone
+// once the refreshed decision sets a different one.
+TEST_F(DynamicModuleRouteMetadataTest, RefreshRebuildsMetadataFromScratch) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-meta-string", "shard-a"}};
+  const auto* entry = resolveRouteEntry(headers);
+  EXPECT_EQ("shard-a", routeMetadataString("envoy.test.route", "string_key"));
+
+  headers.remove(Http::LowerCaseString("x-route-meta-string"));
+  headers.setCopy(Http::LowerCaseString("x-route-meta-number"), "0.5");
+  entry->refreshRouteCluster(headers, stream_info_);
+  EXPECT_EQ("absent", routeMetadataString("envoy.test.route", "string_key"));
+  const auto& fields =
+      resolved_route_->metadata().filter_metadata().at("envoy.test.route").fields();
+  ASSERT_TRUE(fields.contains("number_key"));
+  EXPECT_DOUBLE_EQ(0.5, fields.at("number_key").number_value());
+}
+
+// The typed setter merges an Any that a registered factory parses, so typedMetadata() exposes the
+// object the module set while the Any also reaches the proto metadata.
+TEST_F(DynamicModuleRouteMetadataTest, TypedMetadataLayeredOntoMatchedRoute) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-typed-meta", "set"}};
+  resolveRouteEntry(headers);
+  const auto& typed_filter_metadata = resolved_route_->metadata().typed_filter_metadata();
+  ASSERT_NE(typed_filter_metadata.end(), typed_filter_metadata.find("envoy.test.typed_route"));
+  EXPECT_EQ("t/x", typed_filter_metadata.at("envoy.test.typed_route").type_url());
+  const auto* parsed =
+      resolved_route_->typedMetadata().get<TestTypedRouteMetadata>("envoy.test.typed_route");
+  ASSERT_NE(nullptr, parsed);
+  EXPECT_EQ("t/x", parsed->type_url_);
+}
+
+// The overlay copies the matched route metadata whole, so a typed entry the matched route carries
+// survives when the module layers only untyped metadata on top.
+TEST_F(DynamicModuleRouteMetadataTest, MatchedRouteTypedMetadataPreserved) {
+  setUpPlugin();
+  Protobuf::Any base_typed;
+  base_typed.set_type_url("t/base");
+  (*parent_->metadata_.mutable_typed_filter_metadata())["envoy.test.typed_route"] = base_typed;
+
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-meta-string", "shard-a"}};
+  resolveRouteEntry(headers);
+  const auto* parsed =
+      resolved_route_->typedMetadata().get<TestTypedRouteMetadata>("envoy.test.typed_route");
+  ASSERT_NE(nullptr, parsed);
+  EXPECT_EQ("t/base", parsed->type_url_);
+}
+
+// A typed entry the matched route carries under the same namespace is replaced wholesale by the one
+// the module sets, matching the assign semantics of the typed setter. The same decision also layers
+// an untyped entry, so both merge loops run together.
+TEST_F(DynamicModuleRouteMetadataTest, ModuleTypedMetadataOverwritesMatchedRoute) {
+  setUpPlugin();
+  Protobuf::Any base_typed;
+  base_typed.set_type_url("t/base");
+  (*parent_->metadata_.mutable_typed_filter_metadata())["envoy.test.typed_route"] = base_typed;
+
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"},
+                                         {"env", "prod"},
+                                         {"x-route-typed-meta", "set"},
+                                         {"x-route-meta-string", "shard-a"}};
+  resolveRouteEntry(headers);
+  const auto& typed = resolved_route_->metadata().typed_filter_metadata();
+  EXPECT_EQ("t/x", typed.at("envoy.test.typed_route").type_url());
+  const auto* parsed =
+      resolved_route_->typedMetadata().get<TestTypedRouteMetadata>("envoy.test.typed_route");
+  ASSERT_NE(nullptr, parsed);
+  EXPECT_EQ("t/x", parsed->type_url_);
+  EXPECT_EQ("shard-a", routeMetadataString("envoy.test.route", "string_key"));
+}
+
+// A pack is kept for the life of the entry, so a metadata reference taken before a refresh stays
+// valid after it and still holds the value of the decision it was taken from.
+TEST_F(DynamicModuleRouteMetadataTest, MetadataReferenceStaysValidAcrossRefresh) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-meta-string", "shard-a"}};
+  const auto* entry = resolveRouteEntry(headers);
+  const auto& first_fields =
+      resolved_route_->metadata().filter_metadata().at("envoy.test.route").fields();
+  EXPECT_EQ("shard-a", first_fields.at("string_key").string_value());
+
+  headers.remove(Http::LowerCaseString("x-route-meta-string"));
+  headers.setCopy(Http::LowerCaseString("x-route-meta-number"), "0.5");
+  entry->refreshRouteCluster(headers, stream_info_);
+
+  // The earlier reference stays valid and holds its own decision, while the current view reflects
+  // the new one.
+  EXPECT_EQ("shard-a", first_fields.at("string_key").string_value());
+  const auto& second_fields =
+      resolved_route_->metadata().filter_metadata().at("envoy.test.route").fields();
+  EXPECT_FALSE(second_fields.contains("string_key"));
+  EXPECT_DOUBLE_EQ(0.5, second_fields.at("number_key").number_value());
+}
+
+// A refreshed decision that reports nothing leaves the active pack untouched, so metadata an
+// earlier decision layered on stays in effect.
+TEST_F(DynamicModuleRouteMetadataTest, RefreshWithoutDecisionKeepsLayeredMetadata) {
+  setUpPlugin();
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-meta-string", "shard-a"}};
+  const auto* entry = resolveRouteEntry(headers);
+  EXPECT_EQ("shard-a", routeMetadataString("envoy.test.route", "string_key"));
+
+  // Dropping env makes the module report no decision, so the previous metadata stays in effect.
+  headers.remove(Http::LowerCaseString("env"));
+  entry->refreshRouteCluster(headers, stream_info_);
+  EXPECT_EQ("shard-a", routeMetadataString("envoy.test.route", "string_key"));
+}
+
+// A typed metadata factory can reject the Any the module sets. The pack build catches that, so a
+// refresh reverts to the matched route rather than keeping the earlier pack or letting the
+// exception reach the worker.
+TEST_F(DynamicModuleRouteMetadataTest, TypedMetadataParseFailureFallsBackToMatchedRoute) {
+  setUpPlugin();
+  // A first decision layers a typed entry the factory accepts, so the active pack is non-null.
+  Http::TestRequestHeaderMapImpl headers{
+      {":path", "/"}, {"env", "prod"}, {"x-route-typed-meta", "set"}};
+  const auto* entry = resolveRouteEntry(headers);
+  ASSERT_NE(nullptr,
+            resolved_route_->typedMetadata().get<TestTypedRouteMetadata>("envoy.test.typed_route"));
+
+  // A refresh whose typed Any the factory rejects reverts to the matched route.
+  headers.setCopy(Http::LowerCaseString("x-route-typed-meta"), "throw");
+  EXPECT_LOG_CONTAINS("warn", "rejected by a typed metadata factory",
+                      { entry->refreshRouteCluster(headers, stream_info_); });
+  EXPECT_EQ(&parent_->metadata_, &resolved_route_->metadata());
+  EXPECT_EQ(&parent_->typed_metadata_, &resolved_route_->typedMetadata());
+}
+
+// Shared scaffolding for tests that call the cluster specifier callbacks directly against a no-op
+// module, so a test can drive a single callback and inspect the selection it fills in.
+class DynamicModuleClusterSpecifierAbiTest : public testing::Test {
+public:
+  DynamicModuleClusterSpecifierAbiTest() {
     TestEnvironment::setEnvVar("ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
                                TestEnvironment::substitute(
                                    "{{ test_rundir }}/test/extensions/dynamic_modules/test_data/c"),
                                1);
-    EXPECT_CALL(context_, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager_));
     mockCustomStatNamespaces(context_, custom_stat_namespaces_);
   }
 
@@ -895,11 +1143,70 @@ public:
 
   NiceMock<Server::Configuration::MockServerFactoryContext> context_;
   Stats::CustomStatNamespacesImpl custom_stat_namespaces_;
-  Upstream::MockClusterManager cluster_manager_;
-  NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster_;
   NiceMock<StreamInfo::MockStreamInfo> stream_info_;
   Http::TestRequestHeaderMapImpl headers_;
   const std::string route_name_{"named-route"};
+};
+
+// ABI level tests for the serialized metadata setters. The reference module cannot drive these
+// because it has no protobuf dependency to encode an arbitrary Struct or a malformed buffer.
+
+// A serialized Struct is merged into the namespace, overwriting an existing key and keeping the
+// others.
+TEST_F(DynamicModuleClusterSpecifierAbiTest, StructMetadataMerged) {
+  auto config = makeConfig();
+  auto context = makeContext(config);
+  auto& existing =
+      (*context.selection.route_metadata.mutable_filter_metadata())["envoy.test.route"];
+  (*existing.mutable_fields())["shard"] = ValueUtil::stringValue("old");
+  (*existing.mutable_fields())["kept"] = ValueUtil::stringValue("yes");
+
+  Protobuf::Struct value;
+  (*value.mutable_fields())["shard"] = ValueUtil::stringValue("a");
+  const std::string serialized = value.SerializeAsString();
+  envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+      static_cast<void*>(&context), metricBuffer("envoy.test.route"), metricBuffer(serialized));
+
+  const auto& filter_metadata = context.selection.route_metadata.filter_metadata();
+  ASSERT_NE(filter_metadata.end(), filter_metadata.find("envoy.test.route"));
+  const auto& fields = filter_metadata.at("envoy.test.route").fields();
+  EXPECT_EQ("a", fields.at("shard").string_value());
+  EXPECT_EQ("yes", fields.at("kept").string_value());
+}
+
+// A buffer that does not parse as a Struct leaves the metadata untouched and is logged.
+TEST_F(DynamicModuleClusterSpecifierAbiTest, MalformedStructIgnored) {
+  auto config = makeConfig();
+  auto context = makeContext(config);
+  EXPECT_LOG_CONTAINS("warn", "does not parse as a google.protobuf.Struct", {
+    envoy_dynamic_module_callback_cluster_specifier_set_route_metadata_struct(
+        static_cast<void*>(&context), metricBuffer("envoy.test.route"),
+        metricBuffer(absl::string_view("\x0f", 1)));
+  });
+  EXPECT_TRUE(context.selection.route_metadata.filter_metadata().empty());
+}
+
+// A buffer that does not parse as an Any leaves the typed metadata untouched and is logged.
+TEST_F(DynamicModuleClusterSpecifierAbiTest, MalformedTypedMetadataIgnored) {
+  auto config = makeConfig();
+  auto context = makeContext(config);
+  EXPECT_LOG_CONTAINS("warn", "does not parse as a google.protobuf.Any", {
+    envoy_dynamic_module_callback_cluster_specifier_set_route_typed_metadata(
+        static_cast<void*>(&context), metricBuffer("envoy.test.typed_route"),
+        metricBuffer(absl::string_view("\x0f", 1)));
+  });
+  EXPECT_TRUE(context.selection.route_metadata.typed_filter_metadata().empty());
+}
+
+// Adds the cluster manager the host count callback reads to the shared ABI scaffolding.
+class DynamicModuleClusterSpecifierHostCountAbiTest : public DynamicModuleClusterSpecifierAbiTest {
+public:
+  DynamicModuleClusterSpecifierHostCountAbiTest() {
+    EXPECT_CALL(context_, clusterManager()).WillRepeatedly(testing::ReturnRef(cluster_manager_));
+  }
+
+  Upstream::MockClusterManager cluster_manager_;
+  NiceMock<Upstream::MockThreadLocalCluster> thread_local_cluster_;
 };
 
 TEST_F(DynamicModuleClusterSpecifierHostCountAbiTest, UnknownClusterReturnsFalse) {

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/integration_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/integration_test.cc
@@ -408,6 +408,44 @@ TEST_P(DynamicModuleClusterSpecifierIntegrationTest, NoOverrideDoesNotMirrorRequ
   EXPECT_EQ(0, test_server_->counter("cluster.mirror-cluster.upstream_rq_total")->value());
 }
 
+// The route metadata the module set is layered onto the matched route, so the METADATA(ROUTE)
+// formatter that a response header uses observes every metadata entry end to end.
+TEST_P(DynamicModuleClusterSpecifierIntegrationTest, ModuleRouteMetadataVisibleToFormatter) {
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* virtual_host = hcm.mutable_route_config()->mutable_virtual_hosts(0);
+        const auto add_header = [virtual_host](absl::string_view name, absl::string_view key) {
+          auto* header = virtual_host->add_response_headers_to_add()->mutable_header();
+          header->set_key(std::string(name));
+          header->set_value(absl::StrCat("%METADATA(ROUTE:envoy.test.route:", key, ")%"));
+        };
+        add_header("x-route-metadata-string", "string_key");
+        add_header("x-route-metadata-number", "number_key");
+        add_header("x-route-metadata-bool", "bool_key");
+        add_header("x-route-metadata-struct", "struct_key");
+      });
+  setupTest();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response =
+      codec_client_->makeHeaderOnlyRequest(requestHeaders({{"env", "prod"},
+                                                           {"x-route-meta-string", "shard-a"},
+                                                           {"x-route-meta-number", "0.5"},
+                                                           {"x-route-meta-bool", "true"},
+                                                           {"x-route-meta-struct", "1"}}));
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+  const auto header_value = [&response](absl::string_view name) -> std::string {
+    const auto values = response->headers().get(Http::LowerCaseString(name));
+    return values.empty() ? "" : std::string(values[0]->value().getStringView());
+  };
+  EXPECT_EQ("shard-a", header_value("x-route-metadata-string"));
+  EXPECT_EQ("0.5", header_value("x-route-metadata-number"));
+  EXPECT_EQ("true", header_value("x-route-metadata-bool"));
+  EXPECT_EQ("struct-val", header_value("x-route-metadata-struct"));
+}
+
 // Tests that drive the upstream response so that the properties the module selected are observable.
 class DynamicModuleClusterSpecifierUpstreamIntegrationTest
     : public DynamicModuleClusterSpecifierIntegrationTest {

--- a/tools/code_format/config.yaml
+++ b/tools/code_format/config.yaml
@@ -332,6 +332,7 @@ paths:
     - test/tools/router_check/router_check.cc
     - source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper.cc
     - test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+    - test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
 
   # Files in these paths can use std::regex
   std_regex:


### PR DESCRIPTION
## Description

The dynamic module cluster specifier today could override cluster, timeout, retry, hash, and mirroring on the selected route but had no way to set route metadata. In this PR, we are adding additional callbacks and Rust SDK wrappers to add this support.

---
**Commit Message:** dynamic_modules: add route metadata setters to the cluster specifier
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes**: Added
**Release Notes**: Added