### PR TITLE
reverse_tunnel: deferred-delete handshake wrappers on listener stop

### DIFF
--- a/changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-handshake-wrappers-on-listener-stop.rst
+++ b/changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-handshake-wrappers-on-listener-stop.rst
@@ -1,0 +1,3 @@
+Fixed a use-after-free where reverse-tunnel listener stop left in-flight handshake
+``RCConnectionWrapper`` objects alive until main-thread destruction. Worker
+``resetFileEvents()`` now shuts down those wrappers and deferred-deletes them.

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -410,8 +410,7 @@ void ReverseConnectionIOHandle::resetFileEvents() {
 
   // Handshake connections have their own file events. Tear them down on this worker so
   // main-thread close()/destructor does not destroy in-flight codecs. Skip when
-  // worker_dispatcher_ is null (cleanup() after workers are gone). Do not close() here:
-  // RCConnectionWrapper::shutdown() already closes an open connection.
+  // worker_dispatcher_ is null (cleanup() after workers are gone).
   if (worker_dispatcher_ != nullptr && worker_dispatcher_->isThreadSafe()) {
     conn_wrapper_to_host_map_.clear();
     std::vector<std::unique_ptr<RCConnectionWrapper>> wrappers = std::move(connection_wrappers_);

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.cc
@@ -407,6 +407,24 @@ void ReverseConnectionIOHandle::resetFileEvents() {
   if (worker_dispatcher_ == nullptr || worker_dispatcher_->isThreadSafe()) {
     rev_conn_retry_timer_.reset();
   }
+
+  // Handshake connections have their own file events. Tear them down on this worker so
+  // main-thread close()/destructor does not destroy in-flight codecs. Skip when
+  // worker_dispatcher_ is null (cleanup() after workers are gone). Do not close() here:
+  // RCConnectionWrapper::shutdown() already closes an open connection.
+  if (worker_dispatcher_ != nullptr && worker_dispatcher_->isThreadSafe()) {
+    conn_wrapper_to_host_map_.clear();
+    std::vector<std::unique_ptr<RCConnectionWrapper>> wrappers = std::move(connection_wrappers_);
+    connection_wrappers_.clear();
+    for (auto& wrapper : wrappers) {
+      if (wrapper == nullptr) {
+        continue;
+      }
+      wrapper->shutdown();
+      worker_dispatcher_->deferredDelete(std::move(wrapper));
+    }
+  }
+
   IoSocketHandleImpl::resetFileEvents();
 }
 

--- a/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
+++ b/source/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle.h
@@ -187,7 +187,10 @@ public:
    */
   Api::IoCallUint64Result close() override;
 
-  /** Stop reverse-connection maintenance on listener teardown. */
+  /**
+   * Stop reverse-connection maintenance on listener teardown. On the owning worker this also
+   * shuts down in-flight handshake wrappers and deferred-deletes them.
+   */
   void resetFileEvents() override;
 
   /**

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -3567,6 +3567,44 @@ TEST_F(ReverseConnectionIOHandleTest, ResetFileEventsStopsReplacementDialOnListe
   EXPECT_EQ(getHostConnectionInfo(host).connection_keys.count(connection_key), 0);
 }
 
+// Listener stop must shut down in-flight handshake wrappers on the worker. close() is expected
+// once, from RCConnectionWrapper::shutdown() (not a second time from resetFileEvents()).
+TEST_F(ReverseConnectionIOHandleTest, ResetFileEventsShutsDownHandshakeWrappers) {
+  setupThreadLocalSlot();
+
+  auto config = createDefaultTestConfig();
+  io_handle_ = createTestIOHandle(config);
+  ASSERT_NE(io_handle_, nullptr);
+
+  auto* mock_timer = new NiceMock<Event::MockTimer>();
+  EXPECT_CALL(dispatcher_, createTimer_(_)).WillOnce(Return(mock_timer));
+  EXPECT_CALL(*mock_timer, enableTimer(_, _)).Times(testing::AnyNumber());
+
+  Event::FileReadyCb mock_callback = [](uint32_t) -> absl::Status { return absl::OkStatus(); };
+  io_handle_->initializeFileEvent(dispatcher_, mock_callback, Event::FileTriggerType::Level,
+                                  Event::FileReadyType::Read);
+
+  auto mock_connection = setupMockConnection();
+  EXPECT_CALL(*mock_connection, close(Network::ConnectionCloseType::NoFlush));
+  EXPECT_CALL(*mock_connection, state()).WillRepeatedly(Return(Network::Connection::State::Open));
+  EXPECT_CALL(*mock_connection, id()).WillRepeatedly(Return(42));
+
+  auto mock_host = std::make_shared<NiceMock<Upstream::MockHostDescription>>();
+  auto wrapper = std::make_unique<RCConnectionWrapper>(*io_handle_, std::move(mock_connection),
+                                                       mock_host, "test-cluster");
+  addWrapperToHostMap(wrapper.get(), "192.168.1.1");
+  pushConnectionWrapper(std::move(wrapper));
+  ASSERT_EQ(getConnectionWrappers().size(), 1);
+
+  const size_t deferred_before = dispatcher_.to_delete_.size();
+  io_handle_->resetFileEvents();
+
+  EXPECT_TRUE(getConnectionWrappers().empty());
+  EXPECT_TRUE(getConnWrapperToHostMap().empty());
+  // shutdown() deferred-deletes the connection; resetFileEvents() deferred-deletes the wrapper.
+  EXPECT_EQ(dispatcher_.to_delete_.size(), deferred_before + 2);
+}
+
 } // namespace ReverseConnection
 } // namespace Bootstrap
 } // namespace Extensions


### PR DESCRIPTION
Commit Message: reverse_tunnel: deferred-delete handshake wrappers on listener stop
Additional Description:
Reland of https://github.com/envoyproxy/envoy/pull/47054, which was reverted in https://github.com/envoyproxy/envoy/pull/47146 after postsubmit on `main` failed.

**Why #47054 was reverted**

PR presubmit passed (28 checks). Postsubmit Envoy/Prechecks on `c84f87e` failed:
https://github.com/envoyproxy/envoy/runs/100151058672
https://github.com/envoyproxy/envoy/actions/runs/33599907168

Both `release.test_only` jobs (x64 and arm64) failed:

```
FAIL: //test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface:reverse_connection_io_handle_test
[  FAILED  ] ReverseConnectionIOHandleTest.ResetFileEventsShutsDownHandshakeWrappers
Function call: close(NoFlush)
     Expected: to be called once
       Actual: called twice - over-saturated and active
```

The second `close()` was `RCConnectionWrapper::shutdown()` → `ReverseConnectionIOHandle::resetFileEvents()`.

Root cause: #47054 was written against older `main` where `shutdown()` did **not** close. Meanwhile https://github.com/envoyproxy/envoy/pull/46984 merged first and added `close(NoFlush)` inside `shutdown()`. After squash-merge, `resetFileEvents()` closed and then `shutdown()` closed again. The new test used a one-shot `EXPECT_CALL(close)`.

**This re-land**

On the owning worker only (`worker_dispatcher_ != nullptr && isThreadSafe()`):

* call `shutdown()` (which closes an open handshake connection, after #46984)
* deferred-delete the wrappers

Do **not** `close()` in `resetFileEvents()`. `cleanup()` still nulls `worker_dispatcher_` first, so process shutdown after workers have joined does not tear wrappers down off-thread.

Independent of handshake 403 close-during-dispatch (#46984) and of host-map wrapper deferred-delete (#46732). Listener-stop is not nested under `Http1::dispatch()`, so this path may close via `shutdown()`.

AI assistance: used Cursor; I reviewed and understand the change.
Risk Level: Low
Testing: Added ReverseConnectionIOHandleTest.ResetFileEventsShutsDownHandshakeWrappers, which now expects `close()` once from `shutdown()`. clang-format applied locally; please rely on CI for full format/tests (`tools/local_fix_format.sh` was not run — buildifier/buildozer not available in this environment).
Docs Changes: N/A
Release Notes: changelogs/current/bug_fixes/reverse_tunnel__deferred-delete-handshake-wrappers-on-listener-stop.rst
