### PR TITLE
ci: fix invalid bazel query patterns in openssl presubmit

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -336,9 +336,19 @@ function build_openssl_presubmit() {
             .bazelrc|.bazelversion|WORKSPACE|WORKSPACE.bazel|MODULE.bazel|MODULE.bazel.lock|bazel/*)
                 global_config_changed=true
                 ;;
-            # BUILD/.bzl changes affect the whole package.
+            # BUILD/.bzl changes affect the whole package. A root-level one
+            # (dirname ".") would yield the invalid pattern "//./..."; treat it
+            # as global build config instead. Only add the package pattern if it
+            # actually contains targets -- a .bzl in a non-package dir would
+            # otherwise make the rdeps set() query fail.
             *BUILD|*BUILD.bazel|*.bzl)
-                changed_labels+=("//$(dirname "$file")/...")
+                local dir
+                dir="$(dirname "$file")"
+                if [[ "$dir" == "." ]]; then
+                    global_config_changed=true
+                elif bazel query "${BAZEL_QUERY_OPTIONS[@]}" "//${dir}/..." >/dev/null 2>&1; then
+                    changed_labels+=("//${dir}/...")
+                fi
                 ;;
             # Tolerate files Bazel doesn't know about (docs, unwired sources).
             *)


### PR DESCRIPTION
A root-level BUILD/.bzl change produced `dirname` "." and thus the invalid package pattern `//./...`, which failed the tier-1 `set(...)` rdeps query with "invalid package name '.'" (bazel exit 7). Route root-level BUILD/.bzl changes to the global-config fallback instead.

Also guard the per-package pattern: only add `//<dir>/...` when a query confirms it contains targets, so a `.bzl` in a non-package directory can't make the whole rdeps set() query fail.
