### PR TITLE
stats: add inline join support

### DIFF
--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -50,15 +50,6 @@ SymbolTable::Encoding::~Encoding() {
   ASSERT(mem_block_.capacity() == 0);
 }
 
-size_t SymbolTable::Encoding::encodingSizeBytes(uint64_t number) {
-  size_t num_bytes = 0;
-  do {
-    ++num_bytes;
-    number >>= 7;
-  } while (number != 0);
-  return num_bytes;
-}
-
 void SymbolTable::Encoding::appendEncoding(uint64_t number, MemBlockBuilder<uint8_t>& mem_block) {
   // UTF-8-like encoding where a value 127 or less gets written as a single
   // byte. For higher values we write the low-order 7 bits with a 1 in
@@ -681,13 +672,7 @@ SymbolTable::StoragePtr SymbolTable::join(absl::Span<const StatName> stat_names)
       num_bytes += stat_name.dataSize();
     }
   }
-  MemBlockBuilder<uint8_t> mem_block(Encoding::totalSizeBytes(num_bytes));
-  Encoding::appendEncoding(num_bytes, mem_block);
-  for (StatName stat_name : stat_names) {
-    stat_name.appendDataToMemBlock(mem_block);
-  }
-  ASSERT(mem_block.capacityRemaining() == 0);
-  return mem_block.release();
+  return heapJoin(stat_names, num_bytes);
 }
 
 void StatNameJoiner::join(absl::Span<const StatName> stat_names, const SymbolTable& symbol_table) {
@@ -707,10 +692,13 @@ void StatNameJoiner::join(absl::Span<const StatName> stat_names, const SymbolTab
   }
 
   if (needs_join) {
-    storage_ = symbol_table.join(stat_names);
-    stat_name_ = StatName(storage_.get());
+    // Assemble straight into storage_. Taking the returned-by-value form here would cost a copy:
+    // the bytes land at runtime-varying offsets, so the compiler can fold the result into an
+    // initialization but not into an assignment.
+    symbol_table.inlineJoin(stat_names, storage_);
+    stat_name_ = storage_.statName();
   } else {
-    storage_.reset();
+    storage_ = SymbolTable::InlineStorage{};
     stat_name_ = sole_name;
   }
 }

--- a/source/common/stats/symbol_table.cc
+++ b/source/common/stats/symbol_table.cc
@@ -676,6 +676,11 @@ SymbolTable::StoragePtr SymbolTable::join(absl::Span<const StatName> stat_names)
 }
 
 void StatNameJoiner::join(absl::Span<const StatName> stat_names, const SymbolTable& symbol_table) {
+  // The elided path below drops storage_ without copying anything out of it, so it needs the same
+  // aliasing check that SymbolTable::inlineJoin() makes for the assembling path.
+  ASSERT(!storage_.checkStatNameOverlaps(stat_names),
+         "stat_names should not contain name overlapping with the storage");
+
   // A join with at most one non-empty name produces bytes identical to that name, so the
   // allocation can be skipped and the name referenced directly.
   StatName sole_name;

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <stack>
 #include <string>
@@ -15,6 +16,7 @@
 #include "source/common/common/utility.h"
 #include "source/common/stats/recent_lookups.h"
 
+#include "absl/base/attributes.h"
 #include "absl/container/fixed_array.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/inlined_vector.h"
@@ -97,6 +99,35 @@ public:
   using StoragePtr = std::unique_ptr<Storage>;
 
   /**
+   * Storage for a stat-name assembled on the fly, e.g. by inlineJoin(). The bytes are held
+   * inline unless they don't fit, in which case they spill onto the heap, so the common case
+   * of a short name costs no allocation.
+   *
+   * WARNING: The bytes live in this object, so statName() must not outlive it, and a StatName
+   * fetched before a move does not refer to the moved-to object's bytes; call statName() again
+   * after a move.
+   */
+  struct InlineStorage {
+    /**
+     * @return the assembled name, or an empty name if nothing has been assembled yet.
+     */
+    inline StatName statName() const;
+
+  private:
+    // The bytes are assembled only by the SymbolTable, e.g. by inlineJoin(); everyone else
+    // reads the result through statName().
+    friend class SymbolTable;
+
+    // Names longer than this spill into a heap allocation. This covers the names Envoy
+    // assembles on hot paths, whose tokens are typically one byte each, while keeping the
+    // object small enough to be a cheap stack temporary.
+    static constexpr size_t InlineCapacity = 24;
+
+    uint8_t inline_[InlineCapacity] = {0};
+    StoragePtr heap_ = nullptr;
+  };
+
+  /**
    * Intermediate representation for a stat-name. This helps store multiple
    * names in a single packed allocation. First we encode each desired name,
    * then sum their sizes for the single packed allocation. This is used to
@@ -159,7 +190,14 @@ public:
      * @param number A number to encode in a variable length byte-array.
      * @return The number of bytes it would take to encode the number.
      */
-    static size_t encodingSizeBytes(uint64_t number);
+    ABSL_ATTRIBUTE_ALWAYS_INLINE static size_t encodingSizeBytes(uint64_t number) {
+      size_t num_bytes = 0;
+      do {
+        ++num_bytes;
+        number >>= 7;
+      } while (number != 0);
+      return num_bytes;
+    }
 
     /**
      * @param num_data_bytes The number of bytes in a data-block.
@@ -212,6 +250,25 @@ public:
         number |= (uc & Low7Bits) << shift;
       }
       return std::make_pair(number, encoding - start);
+    }
+
+    /**
+     * As above, but writes into a raw buffer, which must have room for
+     * encodingSizeBytes(number) bytes.
+     *
+     * Defined inline in the header so that callers assembling a name in place write the bytes
+     * straight into their destination, rather than through a temporary.
+     *
+     * @param number the number to write.
+     * @param p the buffer to write into.
+     * @return the first byte past the encoding.
+     */
+    static uint8_t* appendEncoding(uint64_t number, uint8_t* p) {
+      do {
+        *p++ = (number < (1 << 7)) ? number : ((number & Low7Bits) | SpilloverMask);
+        number >>= 7;
+      } while (number != 0);
+      return p;
     }
 
     // Masks used for variable-length encoding of arbitrary-sized integers into a
@@ -305,6 +362,46 @@ public:
    * @return Storage allocated for the joined name.
    */
   StoragePtr join(absl::Span<const StatName> stat_names) const;
+
+  /**
+   * Joins two or more StatNames into a buffer held by the returned object, which is normally
+   * inline, so that no heap allocation is needed for the common case of a short joined name.
+   * The joined bytes are identical to those produced by join().
+   *
+   * This is for joins whose result is consumed locally -- looking up or creating a stat in a
+   * scope, say -- where the storage never needs to be stored or handed to anyone else:
+   *
+   *   scope.counterFromStatName(symbol_table.inlineJoin({prefix, name}).statName()).inc();
+   *
+   * The returned name points into the returned storage, so see the warning on InlineStorage
+   * before doing anything with it other than consuming it in the same expression. Use
+   * StatNameJoiner when the joined bytes must outlive the joining expression, or join() when
+   * their ownership must be transferred.
+   *
+   * As with join(), this does not bump reference counts on the referenced Symbols, so the
+   * result is only valid for the lifetime of the joined StatNames.
+   *
+   * @param stat_names the names to join.
+   * @return storage holding the joined name.
+   */
+  ABSL_ATTRIBUTE_ALWAYS_INLINE inline InlineStorage
+  inlineJoin(absl::Span<const StatName> stat_names) const;
+
+  /**
+   * As above, but assembles the joined name into caller-provided storage, replacing whatever it
+   * held. This is for a destination that outlives the call and is joined into repeatedly, where
+   * returning by value would cost a copy: the bytes land at runtime-varying offsets, so the
+   * compiler cannot fold the returned object into an assignment the way it folds it into an
+   * initialization.
+   *
+   * WARNING: stat_names must not alias storage, i.e., it must not contain the name storage
+   * currently holds.
+   *
+   * @param stat_names the names to join.
+   * @param storage the destination to assemble into.
+   */
+  ABSL_ATTRIBUTE_ALWAYS_INLINE inline void inlineJoin(absl::Span<const StatName> stat_names,
+                                                      InlineStorage& storage) const;
 
   /**
    * Populates a StatNameList from a list of encodings. This is not done at
@@ -412,6 +509,14 @@ public:
   }
 
 private:
+  /**
+   * Builds the joined name of stat_names, whose data occupies num_bytes, on the heap. Shared by
+   * join() and by inlineJoin()'s spill path, which has already measured the names and would
+   * otherwise have to measure them again.
+   */
+  ABSL_ATTRIBUTE_ALWAYS_INLINE inline StoragePtr heapJoin(absl::Span<const StatName> stat_names,
+                                                          size_t num_bytes) const;
+
   friend class StatName;
   friend class StatNameTest;
   friend class StatNameDeathTest;
@@ -742,6 +847,67 @@ private:
   const uint8_t* size_and_data_;
 };
 
+// Always inlined so that join() and inlineJoin()'s spill path each build the name directly
+// rather than paying a call to reach it.
+ABSL_ATTRIBUTE_ALWAYS_INLINE inline SymbolTable::StoragePtr
+SymbolTable::heapJoin(absl::Span<const StatName> stat_names, size_t num_bytes) const {
+  MemBlockBuilder<uint8_t> mem_block(Encoding::totalSizeBytes(num_bytes));
+  Encoding::appendEncoding(num_bytes, mem_block);
+  for (StatName stat_name : stat_names) {
+    stat_name.appendDataToMemBlock(mem_block);
+  }
+  ASSERT(mem_block.capacityRemaining() == 0);
+  return mem_block.release();
+}
+
+// Both overloads are always inlined: assembling the name straight into its destination is the
+// whole point, and left out-of-line the caller has to zero a temporary, call, and read the bytes
+// back out of it.
+ABSL_ATTRIBUTE_ALWAYS_INLINE inline void
+SymbolTable::inlineJoin(absl::Span<const StatName> stat_names, InlineStorage& storage) const {
+  size_t num_bytes = 0;
+  for (StatName stat_name : stat_names) {
+    num_bytes += stat_name.dataSize();
+  }
+  const size_t total_bytes = Encoding::totalSizeBytes(num_bytes);
+
+  if (total_bytes > InlineStorage::InlineCapacity) {
+    // Too long for the inline buffer, so spill onto the heap.
+    storage.inline_[0] = 0;
+    storage.heap_ = heapJoin(stat_names, num_bytes);
+    return;
+  }
+
+  storage.heap_ = nullptr;
+  uint8_t* p = Encoding::appendEncoding(num_bytes, storage.inline_);
+  for (StatName stat_name : stat_names) {
+    const size_t nbytes = stat_name.dataSize();
+    memcpy(p, stat_name.data(), nbytes); // NOLINT(safe-memcpy)
+    p += nbytes;
+  }
+  ASSERT(p == storage.inline_ + total_bytes);
+}
+
+ABSL_ATTRIBUTE_ALWAYS_INLINE inline SymbolTable::InlineStorage
+SymbolTable::inlineJoin(absl::Span<const StatName> stat_names) const {
+  InlineStorage storage;
+  inlineJoin(stat_names, storage);
+  return storage;
+}
+
+StatName SymbolTable::InlineStorage::statName() const {
+  // A zero first byte means a zero-length name, which is what unassembled storage holds and
+  // also what an assembled empty name encodes; StatName() has those same bytes, so the two
+  // cases need not be told apart.
+  if (heap_ != nullptr) {
+    return StatName(heap_.get());
+  }
+  if (inline_[0] != 0) {
+    return StatName(inline_);
+  }
+  return {};
+}
+
 StatName StatNameStorageBase::statName() const { return StatName(bytes_.get()); }
 
 /**
@@ -786,8 +952,9 @@ private:
  * storage is allocated and statName() references the caller's name directly. Callers must
  * therefore keep the joined names valid for the lifetime of this object.
  *
- * Movable but not copyable: the joined bytes live on the heap, so a move transfers ownership
- * without invalidating statName(). Copying would mean duplicating that storage.
+ * NOTE: neither copyable nor movable. statName() points at bytes held inside this object (see
+ * SymbolTable::InlineStorage), so relocating the joiner would dangle every StatName already taken
+ * from it. This is designed to assemble a temporary stat name and should be kept on the stack.
  */
 class StatNameJoiner {
 public:
@@ -795,31 +962,26 @@ public:
   StatNameJoiner(absl::Span<const StatName> stat_names, const SymbolTable& symbol_table) {
     join(stat_names, symbol_table);
   }
-  StatNameJoiner(StatNameJoiner&& other) noexcept
-      : storage_(std::move(other.storage_)), stat_name_(other.stat_name_) {
-    other.stat_name_ = StatName();
-  }
-  StatNameJoiner& operator=(StatNameJoiner&& other) noexcept {
-    if (this != &other) {
-      storage_ = std::move(other.storage_);
-      stat_name_ = other.stat_name_;
-      other.stat_name_ = StatName();
-    }
-    return *this;
-  }
+
+  // Not copyable or movable.
   StatNameJoiner(const StatNameJoiner&) = delete;
   StatNameJoiner& operator=(const StatNameJoiner&) = delete;
+  StatNameJoiner(StatNameJoiner&&) = delete;
+  StatNameJoiner& operator=(StatNameJoiner&&) = delete;
 
   /**
    * Joins stat_names, replacing any previously joined value. stat_names is consumed here and never
    * retained, so it is safe to pass a braced initializer list.
+   *
+   * WARNING: stat_names must not contain the name this StatNameJoiner currently holds to avoid
+   * a use-after-free or self-overlapping copy.
    */
   void join(absl::Span<const StatName> stat_names, const SymbolTable& symbol_table);
 
   StatName statName() const { return stat_name_; }
 
 private:
-  SymbolTable::StoragePtr storage_;
+  SymbolTable::InlineStorage storage_;
   StatName stat_name_;
 };
 

--- a/source/common/stats/symbol_table.h
+++ b/source/common/stats/symbol_table.h
@@ -113,6 +113,17 @@ public:
      */
     inline StatName statName() const;
 
+    /**
+     * Determines whether any of stat_names is backed by the bytes this storage owns. Assembling
+     * into this storage overwrites its inline bytes as it goes, and replacing the storage
+     * releases its heap buffer, so such a name is a self-overlapping copy or a use-after-free,
+     * and the caller must assemble into a different destination.
+     *
+     * @param stat_names the names about to be joined into this storage.
+     * @return whether any of them aliases this storage.
+     */
+    inline bool checkStatNameOverlaps(absl::Span<const StatName> stat_names) const;
+
   private:
     // The bytes are assembled only by the SymbolTable, e.g. by inlineJoin(); everyone else
     // reads the result through statName().
@@ -865,6 +876,9 @@ SymbolTable::heapJoin(absl::Span<const StatName> stat_names, size_t num_bytes) c
 // back out of it.
 ABSL_ATTRIBUTE_ALWAYS_INLINE inline void
 SymbolTable::inlineJoin(absl::Span<const StatName> stat_names, InlineStorage& storage) const {
+  ASSERT(!storage.checkStatNameOverlaps(stat_names),
+         "stat_names should not contain name overlapping with the storage");
+
   size_t num_bytes = 0;
   for (StatName stat_name : stat_names) {
     num_bytes += stat_name.dataSize();
@@ -873,18 +887,18 @@ SymbolTable::inlineJoin(absl::Span<const StatName> stat_names, InlineStorage& st
 
   if (total_bytes > InlineStorage::InlineCapacity) {
     // Too long for the inline buffer, so spill onto the heap.
-    storage.inline_[0] = 0;
     storage.heap_ = heapJoin(stat_names, num_bytes);
+    storage.inline_[0] = 0;
     return;
   }
 
-  storage.heap_ = nullptr;
   uint8_t* p = Encoding::appendEncoding(num_bytes, storage.inline_);
   for (StatName stat_name : stat_names) {
     const size_t nbytes = stat_name.dataSize();
     memcpy(p, stat_name.data(), nbytes); // NOLINT(safe-memcpy)
     p += nbytes;
   }
+  storage.heap_ = nullptr;
   ASSERT(p == storage.inline_ + total_bytes);
 }
 
@@ -906,6 +920,17 @@ StatName SymbolTable::InlineStorage::statName() const {
     return StatName(inline_);
   }
   return {};
+}
+
+bool SymbolTable::InlineStorage::checkStatNameOverlaps(
+    absl::Span<const StatName> stat_names) const {
+  for (StatName stat_name : stat_names) {
+    const uint8_t* begin = stat_name.dataIncludingSize();
+    if (begin == inline_ || begin == heap_.get()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 StatName StatNameStorageBase::statName() const { return StatName(bytes_.get()); }

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -667,41 +667,6 @@ TEST_F(StatNameTest, JoinerRejoin) {
   EXPECT_EQ("g.h.i.j", table_.toString(joiner.statName()));
 }
 
-// Moving a joiner transfers ownership of the joined bytes; the moved-to statName() stays valid
-// because the storage lives on the heap, not inside the joiner.
-TEST_F(StatNameTest, JoinerMove) {
-  StatNameJoiner joiner({makeStat("a.b"), makeStat("c.d")}, table_);
-  const uint8_t* joined_bytes = joiner.statName().dataIncludingSize();
-
-  StatNameJoiner moved(std::move(joiner));
-  EXPECT_EQ("a.b.c.d", table_.toString(moved.statName()));
-  EXPECT_EQ(joined_bytes, moved.statName().dataIncludingSize());
-
-  StatNameJoiner assigned;
-  assigned = std::move(moved);
-  EXPECT_EQ("a.b.c.d", table_.toString(assigned.statName()));
-  EXPECT_EQ(joined_bytes, assigned.statName().dataIncludingSize());
-}
-
-// An elided joiner references a caller name; moving it must carry that reference over.
-TEST_F(StatNameTest, JoinerMoveElided) {
-  StatName name = makeStat("a.b");
-  StatNameJoiner joiner({StatName(), name}, table_);
-  StatNameJoiner moved(std::move(joiner));
-  EXPECT_EQ(name.dataIncludingSize(), moved.statName().dataIncludingSize());
-  EXPECT_EQ("a.b", table_.toString(moved.statName()));
-}
-
-// TagStatNameJoiner is stored in containers by callers, so it must remain movable.
-TEST_F(StatNameTest, TagStatNameJoinerMovable) {
-  static_assert(std::is_move_constructible_v<TagUtility::TagStatNameJoiner>);
-  std::vector<TagUtility::TagStatNameJoiner> joiners;
-  joiners.emplace_back(makeStat("prefix"), makeStat("name"), std::nullopt, table_);
-  joiners.emplace_back(StatName(), makeStat("name"), std::nullopt, table_);
-  EXPECT_EQ("prefix.name", table_.toString(joiners[0].nameWithTags()));
-  EXPECT_EQ("name", table_.toString(joiners[1].nameWithTags()));
-}
-
 // Validates that we don't get tsan or other errors when concurrently creating
 // a large number of stats.
 TEST_F(StatNameTest, RacingSymbolCreation) {
@@ -1126,6 +1091,43 @@ TEST(SymbolTableTest, Memory) {
   // symbol_table_mem_used:  1726056 (3.9x) -- does not seem to depend on STL sizes.
   EXPECT_MEMORY_LE(symbol_table_mem_used, string_mem_used / 3);
   EXPECT_MEMORY_EQ(symbol_table_mem_used, 1726056);
+}
+
+// A joiner holds the joined bytes in its own footprint, so relocating it would dangle any
+// StatName fetched from it. TagStatNameJoiner caches exactly such StatNames, so it must inherit
+// the restriction.
+TEST_F(StatNameTest, JoinerIsNotRelocatable) {
+  static_assert(!std::is_copy_constructible_v<StatNameJoiner>);
+  static_assert(!std::is_move_constructible_v<StatNameJoiner>);
+  static_assert(!std::is_move_assignable_v<StatNameJoiner>);
+  static_assert(!std::is_move_constructible_v<TagUtility::TagStatNameJoiner>);
+  static_assert(!std::is_move_assignable_v<TagUtility::TagStatNameJoiner>);
+}
+
+// inlineJoin() must produce exactly the bytes join() produces.
+TEST_F(StatNameTest, InlineJoinMatchesJoin) {
+  const std::vector<StatNameVec> cases = {
+      {makeStat("a.b"), makeStat("c.d")},
+      {makeStat(""), makeStat("c.d")},
+      {makeStat("a.b"), makeStat("")},
+      {makeStat(""), makeStat("")},
+      {makeStat("a.b"), makeStat("c.d"), makeStat("e.f")},
+      {makeStat(""), makeStat("c.d"), makeStat("")},
+      {makeStat(""), makeStat(""), makeStat("")},
+  };
+  for (const StatNameVec& names : cases) {
+    SymbolTable::StoragePtr joined = table_.join(names);
+    const SymbolTable::InlineStorage inline_joined = table_.inlineJoin(names);
+    EXPECT_EQ(table_.toString(StatName(joined.get())), table_.toString(inline_joined.statName()));
+    EXPECT_EQ(StatName(joined.get()), inline_joined.statName());
+  }
+}
+
+// Storage that has not been joined into holds an empty name rather than uninitialized bytes.
+TEST_F(StatNameTest, InlineJoinDefaultIsEmpty) {
+  const SymbolTable::InlineStorage storage{};
+  EXPECT_TRUE(storage.statName().empty());
+  EXPECT_EQ("", table_.toString(storage.statName()));
 }
 
 } // namespace Stats

--- a/test/common/stats/symbol_table_impl_test.cc
+++ b/test/common/stats/symbol_table_impl_test.cc
@@ -13,6 +13,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/hash/hash_testing.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "gtest/gtest.h"
@@ -39,6 +40,25 @@ protected:
   }
 
   StatName makeStat(absl::string_view name) { return pool_.add(name); }
+
+  // A name of num_tokens distinct tokens. Each token encodes to one byte while the table holds
+  // fewer than 128 symbols, so the encoded length tracks num_tokens closely enough to walk a
+  // join across the inline/heap boundary.
+  StatName makeMultiTokenStat(absl::string_view prefix, uint32_t num_tokens) {
+    std::vector<std::string> tokens;
+    tokens.reserve(num_tokens);
+    for (uint32_t i = 0; i < num_tokens; ++i) {
+      tokens.push_back(absl::StrCat(prefix, i));
+    }
+    return makeStat(absl::StrJoin(tokens, "."));
+  }
+
+  // Whether the assembled bytes sit in the storage's own footprint rather than in a heap spill.
+  static bool bytesAreInline(const SymbolTable::InlineStorage& storage) {
+    const uint8_t* bytes = storage.statName().dataIncludingSize();
+    const uint8_t* object = reinterpret_cast<const uint8_t*>(std::addressof(storage));
+    return bytes == object;
+  }
 
   std::vector<uint8_t> serializeDeserialize(uint64_t number) {
     return TestUtil::serializeDeserializeNumber(number);
@@ -1106,20 +1126,87 @@ TEST_F(StatNameTest, JoinerIsNotRelocatable) {
 
 // inlineJoin() must produce exactly the bytes join() produces.
 TEST_F(StatNameTest, InlineJoinMatchesJoin) {
+  const StatName spill = makeMultiTokenStat("spill", 40);
+  const StatName other_spill = makeMultiTokenStat("other", 40);
   const std::vector<StatNameVec> cases = {
       {makeStat("a.b"), makeStat("c.d")},
       {makeStat(""), makeStat("c.d")},
+      {spill, makeStat("tail")},
       {makeStat("a.b"), makeStat("")},
+      {makeStat(""), spill},
       {makeStat(""), makeStat("")},
+      {spill, makeStat(""), other_spill},
       {makeStat("a.b"), makeStat("c.d"), makeStat("e.f")},
+      {spill, other_spill},
       {makeStat(""), makeStat("c.d"), makeStat("")},
       {makeStat(""), makeStat(""), makeStat("")},
   };
+
+  // One storage for the whole loop, so every case also has to replace whatever the previous case
+  // left behind -- including a short join landing on top of a heap spill.
+  SymbolTable::InlineStorage reused;
   for (const StatNameVec& names : cases) {
     SymbolTable::StoragePtr joined = table_.join(names);
+    const StatName expected(joined.get());
+
     const SymbolTable::InlineStorage inline_joined = table_.inlineJoin(names);
-    EXPECT_EQ(table_.toString(StatName(joined.get())), table_.toString(inline_joined.statName()));
-    EXPECT_EQ(StatName(joined.get()), inline_joined.statName());
+    EXPECT_EQ(table_.toString(expected), table_.toString(inline_joined.statName()));
+    EXPECT_EQ(expected, inline_joined.statName());
+
+    table_.inlineJoin(names, reused);
+    EXPECT_EQ(table_.toString(expected), table_.toString(reused.statName()));
+    EXPECT_EQ(expected, reused.statName());
+
+    // Neither overload may decide the inline/heap question differently from the other.
+    EXPECT_EQ(bytesAreInline(inline_joined), bytesAreInline(reused))
+        << "for " << table_.toString(expected);
+  }
+}
+
+TEST_F(StatNameTest, InlineJoinMatchesJoinAcrossSpillBoundary) {
+  bool saw_inline = false;
+  bool saw_spill = false;
+  SymbolTable::InlineStorage reused;
+
+  for (uint32_t num_tokens = 1; num_tokens <= 40; ++num_tokens) {
+    const StatNameVec names{makeMultiTokenStat("token", num_tokens), makeStat("suffix")};
+    const SymbolTable::StoragePtr joined = table_.join(names);
+    const StatName expected(joined.get());
+
+    const SymbolTable::InlineStorage returned = table_.inlineJoin(names);
+    EXPECT_EQ(expected, returned.statName()) << "num_tokens=" << num_tokens;
+
+    table_.inlineJoin(names, reused);
+    EXPECT_EQ(expected, reused.statName()) << "num_tokens=" << num_tokens;
+    EXPECT_EQ(bytesAreInline(returned), bytesAreInline(reused)) << "num_tokens=" << num_tokens;
+
+    if (bytesAreInline(returned)) {
+      saw_inline = true;
+    } else {
+      saw_spill = true;
+    }
+  }
+
+  // The sweep proves nothing about the spill branch unless it reached it.
+  EXPECT_TRUE(saw_inline);
+  EXPECT_TRUE(saw_spill);
+}
+
+TEST_F(StatNameTest, InlineJoinStorageReuseAlternatesSpillAndInline) {
+  const StatNameVec long_names{makeMultiTokenStat("long", 40), makeStat("tail")};
+  const StatNameVec short_names{makeStat("a.b"), makeStat("c.d")};
+  const SymbolTable::StoragePtr long_joined = table_.join(long_names);
+  const SymbolTable::StoragePtr short_joined = table_.join(short_names);
+
+  SymbolTable::InlineStorage storage;
+  for (int iteration = 0; iteration < 3; ++iteration) {
+    table_.inlineJoin(long_names, storage);
+    EXPECT_EQ(StatName(long_joined.get()), storage.statName()) << "iteration=" << iteration;
+    EXPECT_FALSE(bytesAreInline(storage)) << "iteration=" << iteration;
+
+    table_.inlineJoin(short_names, storage);
+    EXPECT_EQ(StatName(short_joined.get()), storage.statName()) << "iteration=" << iteration;
+    EXPECT_TRUE(bytesAreInline(storage)) << "iteration=" << iteration;
   }
 }
 

--- a/test/common/stats/symbol_table_speed_test.cc
+++ b/test/common/stats/symbol_table_speed_test.cc
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <bit>
+#include <memory>
 
 #include "source/common/common/hash.h"
 #include "source/common/stats/isolated_store_impl.h"
@@ -15,6 +16,8 @@
 #include "test/test_common/thread_factory_for_test.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "benchmark/benchmark.h"
 
@@ -676,3 +679,116 @@ static void bmEncodingSizeBytes_ClzMixed(benchmark::State& state) {
   }
 }
 BENCHMARK(bmEncodingSizeBytes_ClzMixed);
+
+// Compares the three ways to assemble a temporary joined stat-name:
+//
+//   join()            -- the original: always a heap allocation, ownership returned.
+//   inlineJoin(names) -- returns InlineStorage by value; no allocation unless the joined bytes
+//                        overflow the inline buffer.
+//
+// plus StatNameJoiner, which is built on inlineJoin() and additionally elides a join whose inputs
+// hold at most one non-empty name.
+//
+// Each is measured over the shapes that tell them apart: a join that fits inline, one that
+// spills onto the heap anyway, and one that is a no-op. The "Dense" variants repeat the
+// fits-inline shape against a symbol table holding thousands of symbols, where symbol ids no
+// longer fit in a single encoded byte -- which is what a real Envoy looks like.
+namespace {
+
+using Envoy::Stats::StatName;
+using Envoy::Stats::StatNameJoiner;
+using Envoy::Stats::StatNamePool;
+using Envoy::Stats::SymbolTable;
+using Envoy::Stats::SymbolTableImpl;
+
+// Bench fixtures own the symbol table and the pool that keep the joined names alive.
+struct JoinFixture {
+  SymbolTableImpl symbol_table_;
+  StatNamePool pool_{symbol_table_};
+  std::vector<StatName> names_;
+
+  // Burns through `count` symbol ids so that the names added afterwards encode to multi-byte
+  // symbols, as they do in an Envoy with a non-trivial configuration.
+  void padSymbols(uint32_t count) {
+    for (uint32_t i = 0; i < count; ++i) {
+      pool_.add(absl::StrCat("pad", i));
+    }
+  }
+};
+
+// A join whose result fits in SymbolTable::InlineStorage: 3 tokens, a few bytes.
+std::unique_ptr<JoinFixture> shortFixture() {
+  auto fixture = std::make_unique<JoinFixture>();
+  fixture->names_ = {fixture->pool_.add("cluster.upstream_rq"), fixture->pool_.add("200")};
+  return fixture;
+}
+
+// The same shape, but against a symbol table large enough that each token costs two bytes.
+std::unique_ptr<JoinFixture> denseFixture() {
+  auto fixture = std::make_unique<JoinFixture>();
+  fixture->padSymbols(4096);
+  fixture->names_ = {fixture->pool_.add("cluster.some_service.upstream_rq"),
+                     fixture->pool_.add("200")};
+  return fixture;
+}
+
+// A join whose result does not fit inline, so inlineJoin() allocates as join() does.
+std::unique_ptr<JoinFixture> longFixture() {
+  auto fixture = std::make_unique<JoinFixture>();
+  std::vector<std::string> tokens;
+  for (uint32_t i = 0; i < 64; ++i) {
+    tokens.push_back(absl::StrCat("token", i));
+  }
+  fixture->names_ = {fixture->pool_.add(absl::StrJoin(tokens, ".")), fixture->pool_.add("200")};
+  return fixture;
+}
+
+// A join with one non-empty name: the bytes are identical to that name, which is what the
+// joiner's elision exploits and what inlineJoin() copies.
+std::unique_ptr<JoinFixture> noOpFixture() {
+  auto fixture = std::make_unique<JoinFixture>();
+  fixture->names_ = {StatName(), fixture->pool_.add("cluster.upstream_rq_200")};
+  return fixture;
+}
+
+} // namespace
+
+#define JOIN_BENCHMARKS(SUFFIX, FIXTURE)                                                           \
+  /* NOLINTNEXTLINE(readability-identifier-naming) */                                              \
+  static void bmJoin##SUFFIX(benchmark::State& state) {                                            \
+    const std::unique_ptr<JoinFixture> fixture = FIXTURE();                                        \
+    for (auto _ : state) {                                                                         \
+      UNREFERENCED_PARAMETER(_);                                                                   \
+      const SymbolTable::StoragePtr joined = fixture->symbol_table_.join(fixture->names_);         \
+      benchmark::DoNotOptimize(StatName(joined.get()).dataIncludingSize());                        \
+    }                                                                                              \
+  }                                                                                                \
+  BENCHMARK(bmJoin##SUFFIX);                                                                       \
+                                                                                                   \
+  /* NOLINTNEXTLINE(readability-identifier-naming) */                                              \
+  static void bmInlineJoin##SUFFIX(benchmark::State& state) {                                      \
+    const std::unique_ptr<JoinFixture> fixture = FIXTURE();                                        \
+    for (auto _ : state) {                                                                         \
+      UNREFERENCED_PARAMETER(_);                                                                   \
+      const SymbolTable::InlineStorage joined =                                                    \
+          fixture->symbol_table_.inlineJoin(fixture->names_);                                      \
+      benchmark::DoNotOptimize(joined.statName().dataIncludingSize());                             \
+    }                                                                                              \
+  }                                                                                                \
+  BENCHMARK(bmInlineJoin##SUFFIX);                                                                 \
+                                                                                                   \
+  /* NOLINTNEXTLINE(readability-identifier-naming) */                                              \
+  static void bmJoiner##SUFFIX(benchmark::State& state) {                                          \
+    const std::unique_ptr<JoinFixture> fixture = FIXTURE();                                        \
+    for (auto _ : state) {                                                                         \
+      UNREFERENCED_PARAMETER(_);                                                                   \
+      const StatNameJoiner joiner(fixture->names_, fixture->symbol_table_);                        \
+      benchmark::DoNotOptimize(joiner.statName().dataIncludingSize());                             \
+    }                                                                                              \
+  }                                                                                                \
+  BENCHMARK(bmJoiner##SUFFIX)
+
+JOIN_BENCHMARKS(Short, shortFixture);
+JOIN_BENCHMARKS(Dense, denseFixture);
+JOIN_BENCHMARKS(Long, longFixture);
+JOIN_BENCHMARKS(NoOp, noOpFixture);

--- a/test/extensions/access_loggers/stats/stats_speed_test.cc
+++ b/test/extensions/access_loggers/stats/stats_speed_test.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "source/common/stats/allocator_impl.h"
 #include "source/common/stats/symbol_table.h"
 #include "source/common/stats/tag_utility.h"
@@ -30,10 +32,13 @@ public:
       return;
     }
 
-    Stats::TagUtility::TagStatNameJoiner joiner(Stats::StatName(), stat_name,
-                                                Stats::Scope::toTagSpan(tags),
-                                                logger_->scope().symbolTable());
-    Stats::StatName joined_name = joiner.nameWithTags();
+    // The joiner holds the joined bytes in its own footprint and is not movable, so it is
+    // allocated here: joined_name points into it and is used as the map key, which requires the
+    // bytes to keep a stable address once the joiner is owned by the map.
+    auto joiner = std::make_unique<Stats::TagUtility::TagStatNameJoiner>(
+        Stats::StatName(), stat_name, Stats::Scope::toTagSpan(tags),
+        logger_->scope().symbolTable());
+    Stats::StatName joined_name = joiner->nameWithTags();
     auto it = inflight_gauges_.find(joined_name);
     if (it == inflight_gauges_.end()) {
       auto [new_it, inserted] = inflight_gauges_.try_emplace(
@@ -71,13 +76,14 @@ private:
   struct InflightGaugeNew {
     InflightGaugeNew(uint64_t value, Stats::Gauge::ImportMode import_mode,
                      std::vector<Stats::StatNameDynamicStorage> tags_storage,
-                     Stats::TagUtility::TagStatNameJoiner&& joiner)
+                     std::unique_ptr<Stats::TagUtility::TagStatNameJoiner> joiner)
         : value_(value), import_mode_(import_mode), tags_storage_(std::move(tags_storage)),
           joiner_(std::move(joiner)) {}
     uint64_t value_;
     Stats::Gauge::ImportMode import_mode_;
     std::vector<Stats::StatNameDynamicStorage> tags_storage_;
-    Stats::TagUtility::TagStatNameJoiner joiner_;
+    // Owns the bytes that this entry's map key points into; see addInflightGauge().
+    std::unique_ptr<Stats::TagUtility::TagStatNameJoiner> joiner_;
   };
   absl::node_hash_map<Stats::StatName, InflightGaugeNew> inflight_gauges_;
 };


### PR DESCRIPTION
Commit Message: stats: add inline join support
Additional Description:

1. add inline join support because in most cases, it is unnecessary to allocate memory from heap when generating temporary stat name.
2. make the StatNameJoiner be stack-only because we only use it at stack in practices.

With inline join support, the StatNameJoiner gets 2x improvement for 2 stat names joining.

| Implementation | Short | Dense | Long (spills to heap) |
|---|---:|---:|---:|
| `join()` — previous | 12.7 | 12.7 | 12.8 |
| `StatNameJoiner` — previous | 14.0 | 13.7 | 13.9 |
| `join()` — new | 12.5 | 12.8 | 12.9 |
| `inlineJoin()` — new | **3.63** | **3.92** | 13.2 |
| `StatNameJoiner` — new | **5.27** | **5.29** | 13.4 |


Related to https://github.com/envoyproxy/envoy/pull/46592.

Risk Level: low.
Testing: n/a.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
