### PR TITLE
Make assign-from bot less annoying

### DIFF
--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -238,7 +238,7 @@ def _assign_from(command, assignees):
         lines.append(
             "In future, please do this without the `@`, like `/assign-from " +
             " ".join(team_names_without_at) +
-            "`, so as to not subscribe the group to the PR",
+            "`, unless you wish to subscribe the group to the PR",
         )
     if lines:
         github.issue_create_comment("\n".join(lines))

--- a/ci/repokitteh/modules/ownerscheck.star
+++ b/ci/repokitteh/modules/ownerscheck.star
@@ -225,9 +225,21 @@ def _assign_from_team(team_name, assignees, exclude_users):
 
 def _assign_from(command, assignees):
     lines = []
+    team_names_without_at = []
+    used_team_mention = False
     for team_name in command.args:
         assigned = _assign_from_team(team_name, assignees, [])
         lines.append("%s assignee is @%s" % (team_name, assigned))
+        if team_name.startswith("@"):
+            used_team_mention = True
+            team_name = team_name[1:]
+        team_names_without_at.append(team_name)
+    if used_team_mention:
+        lines.append(
+            "In future, please do this without the `@`, like `/assign-from " +
+            " ".join(team_names_without_at) +
+            "`, so as to not subscribe the group to the PR",
+        )
     if lines:
         github.issue_create_comment("\n".join(lines))
 

--- a/source/docs/repokitteh.md
+++ b/source/docs/repokitteh.md
@@ -33,15 +33,17 @@ Adds `@someone` as an assignee to the issue or pull request that this comment is
 Removes `@someone` as an assignee.
 
 ```
-/assign-from @envoyproxy/some-team [@envoyproxy/another-team..]
+/assign-from envoyproxy/some-team [envoyproxy/another-team..]
 ```
-Assign a random member from `@envoyproxy/some-team` to an issue or pull request. Additional teams may be specified as
-extra args. Example teams include:
-- `@envoyproxy/senior-maintainers` (Senior maintainers)
-- `@envoyproxy/maintainers` (All maintainers)
-- `@envoyproxy/api-shepherds` (API shepherds)
-- `@envoyproxy/dependency-shepherds` (Dependency shepherds)
-- `@envoyproxy/first-pass-reviewers` (Contributors that provide first-pass
+Assign a random member from `envoyproxy/some-team` to an issue or pull request. Additional teams may be specified as
+extra args. Do not prefix team names with `@`, as doing so subscribes the entire team to the issue or pull request.
+Team names prefixed with `@` are still accepted for compatibility, but the bot will remind the user to omit it in
+future commands. Example teams include:
+- `envoyproxy/senior-maintainers` (Senior maintainers)
+- `envoyproxy/maintainers` (All maintainers)
+- `envoyproxy/api-shepherds` (API shepherds)
+- `envoyproxy/dependency-shepherds` (Dependency shepherds)
+- `envoyproxy/first-pass-reviewers` (Contributors that provide first-pass
   reviews, typically non-senior maintainers and maintainer applicants)
 
 Only organization members can assign or unassign other users, who must be organization members as well.


### PR DESCRIPTION
Commit Message: Make assign-from bot less annoying
Additional Description: I know several of us don't use `/assign-from`, and discourage others from using it, because the documented way to use it with e.g. `@envoyproxy/senior-maintainers` causes every senior maintainer to receive an email and be subscribed to the PR, which generally isn't what we want.

I experimented a little and found we can do this without the `@`, which makes it do the individual assignment without notifying the whole group. So this PR updates the documentation to recommend doing it without the `@`, and updates the bot so it still supports both ways, but asks you not to use the `@` in future if you use it, so the change is self-documenting.
Risk Level: No production change.
Testing: n/a
Docs Changes: Yes, to match.
Release Notes: n/a
Platform Specific Features: n/a
