### PR TITLE
[workflows] Make /retest work more reliably

### DIFF
--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -34,18 +34,19 @@ jobs:
       with:
         text: ${{ github.event.comment.body }}
         matching: >-
-          ^/(retest)
+          ^/(retest)([[:space:]]|$)
 
     # /retest
+    # The command parser may retain a carriage return in the command for CRLF comments.
     - uses: envoyproxy/toolshed/actions/appauth@4a6a2986abd53c8a2d1077de4165fae369c5bc41  # actions-v0.4.23
-      if: ${{ steps.command.outputs.command == 'retest' }}
+      if: ${{ startsWith(steps.command.outputs.command, 'retest') }}
       id: appauth-retest
       name: Appauth (retest)
       with:
         key: ${{ secrets.ENVOY_CI_APP_KEY }}
         app_id: ${{ secrets.ENVOY_CI_APP_ID }}
     - uses: envoyproxy/toolshed/actions/retest@4a6a2986abd53c8a2d1077de4165fae369c5bc41  # actions-v0.4.23
-      if: ${{ steps.command.outputs.command == 'retest' }}
+      if: ${{ startsWith(steps.command.outputs.command, 'retest') }}
       name: Retest
       with:
         token: ${{ steps.appauth-retest.outputs.token }}


### PR DESCRIPTION
Commit Message: [workflows] Make /retest work more reliably
Additional Description: Previously, only `/retest` as the whole message would work, because
```
/retest

Some explanation
```
when entered via the web UI, would parse as `/retest\r` which wouldn't match the equality operator in the script.

This makes it so the regex matcher requires whitespace after `/retest` so we don't unintentionally match e.g. `/retesting`, but then makes the later code tolerant of trailing mismatched whitespace characters by using `startsWith`.

AI assisted with Codex Luna, and reviewed manually.
Risk Level: No production changes
Testing: No production changes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
