### PR TITLE
Add CI annotation for 'FAILED in'

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -40,6 +40,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       rbe: true
       request: ${{ inputs.request }}
       catch-errors: ${{ matrix.catch-errors || false }}

--- a/.github/workflows/_check_build_openssl.yml
+++ b/.github/workflows/_check_build_openssl.yml
@@ -40,6 +40,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       rbe: true
       request: ${{ inputs.request }}
       catch-errors: ${{ matrix.catch-errors || false }}

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -43,6 +43,7 @@ jobs:
         error:
         Error:
         lower than limit
+        FAILED in
       rbe: true
       request: ${{ inputs.request }}
       runs-on: ${{ fromJSON(inputs.request).config.ci.agent-ubuntu }}

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -40,6 +40,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       request: ${{ inputs.request }}
       target: ${{ matrix.target }}
       timeout-minutes: 180

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -40,6 +40,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       rbe: ${{ matrix.rbe }}
       target: ${{ matrix.target }}
       timeout-minutes: 180

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -76,6 +76,7 @@ on:
           ERROR
           error:
           Error:
+          FAILED in
       notice-match:
         type: string
         default: |

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -44,6 +44,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       rbe: true
       target: ${{ matrix.target }}
       trusted: ${{ inputs.trusted }}

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -41,6 +41,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       rbe: true
       target: ${{ matrix.target }}
       timeout-minutes: 30

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -43,6 +43,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       rbe: true
       target: ${{ matrix.target }}
       trusted: ${{ inputs.trusted }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -48,6 +48,7 @@ jobs:
         ERROR
         error:
         Error:
+        FAILED in
       skip: ${{ matrix.skip != false && true || false }}
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -93,6 +93,7 @@ on:
           ERROR
           error:
           Error:
+          FAILED in
       fail-match:
         type: string
       import-gpg:


### PR DESCRIPTION
Commit Message: Add CI annotation for 'FAILED in'
Additional Description: Recently, CI has become even less navigable to the relevant logs than it was before, thanks to github changes. I've found log-searching for `FAILED in` is one of the most effective routes to navigate to the useful section of log. Making it an 'error' annotation should bubble it up to the top layer and make it a two-clicks solution to get there rather than three clicks and typing `FAILED in` and needing to have that knowledge.
Risk Level: No production change
Testing: No production change
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
