### PR TITLE
formatter: make the COALESCE accept empty string

### DIFF
--- a/changelogs/current/minor_behavior_changes/access_log__coalesce-formatter-empty-values.rst
+++ b/changelogs/current/minor_behavior_changes/access_log__coalesce-formatter-empty-values.rst
@@ -1,0 +1,5 @@
+The ``%COALESCE()%`` access log operator now returns the first result that is present, including a
+result that is present but empty. Previously an operator producing an empty value was treated as if
+it had produced no value at all, and the next operator in the list was evaluated. This change can be
+reverted by setting the runtime guard
+``envoy.reloadable_features.coalesce_formatter_accept_empty_values`` to ``false``.

--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -1707,8 +1707,13 @@ Current supported substitution commands include:
 ``%COALESCE(JSON_CONFIG):Z%``
   HTTP
     A higher-order formatter operator that evaluates multiple formatter operators in sequence and
-    returns the first non-null, non-empty result. This is useful for implementing fallback behavior,
+    returns the first non-null result. This is useful for implementing fallback behavior,
     such as using SNI when available but falling back to the ``:authority`` header when SNI is not set.
+
+    An operator that produces a value which is present but empty is accepted as the result. Set the
+    runtime guard ``envoy.reloadable_features.coalesce_formatter_accept_empty_values`` to ``false``
+    to restore the legacy behavior, where an empty value is skipped and the next operator is
+    evaluated.
 
     The ``JSON_CONFIG`` parameter is a JSON object with an ``operators`` array. Each operator can be
     specified as either:

--- a/source/common/formatter/BUILD
+++ b/source/common/formatter/BUILD
@@ -99,6 +99,7 @@ envoy_cc_library(
         "//source/common/common:fmt_lib",
         "//source/common/common:statusor_lib",
         "//source/common/json:json_loader_lib",
+        "//source/common/runtime:runtime_features_lib",
     ],
 )
 

--- a/source/common/formatter/coalesce_formatter.cc
+++ b/source/common/formatter/coalesce_formatter.cc
@@ -3,6 +3,7 @@
 #include "source/common/common/fmt.h"
 #include "source/common/formatter/builtin_command_parser_factory_helper.h"
 #include "source/common/json/json_loader.h"
+#include "source/common/runtime/runtime_features.h"
 
 namespace Envoy {
 namespace Formatter {
@@ -51,7 +52,10 @@ absl::StatusOr<FormatterProviderPtr> CoalesceFormatter::create(absl::string_view
     formatters.push_back(std::move(formatter_or_error.value()));
   }
 
-  return std::make_unique<CoalesceFormatter>(std::move(formatters), max_length);
+  const bool accept_empty_values = Runtime::runtimeFeatureEnabled(
+      "envoy.reloadable_features.coalesce_formatter_accept_empty_values");
+  return std::make_unique<CoalesceFormatter>(std::move(formatters), max_length,
+                                             accept_empty_values);
 }
 
 absl::StatusOr<FormatterProviderPtr>
@@ -121,12 +125,17 @@ std::optional<std::string>
 CoalesceFormatter::format(const Context& context, const StreamInfo::StreamInfo& stream_info) const {
   for (const auto& formatter : formatters_) {
     auto result = formatter->format(context, stream_info);
-    if (result.has_value() && !result.value().empty()) {
-      if (max_length_.has_value()) {
-        SubstitutionFormatUtils::truncate(result.value(), max_length_.value());
-      }
-      return result;
+    if (!result.has_value()) {
+      continue;
     }
+    // An empty result is only accepted when the runtime guard is enabled.
+    if (result.value().empty() && !accept_empty_values_) {
+      continue;
+    }
+    if (max_length_.has_value()) {
+      SubstitutionFormatUtils::truncate(result.value(), max_length_.value());
+    }
+    return result;
   }
   return std::nullopt;
 }
@@ -135,21 +144,21 @@ Protobuf::Value CoalesceFormatter::formatValue(const Context& context,
                                                const StreamInfo::StreamInfo& stream_info) const {
   for (const auto& formatter : formatters_) {
     auto result = formatter->formatValue(context, stream_info);
-    // Check if this is a valid non-null value.
-    if (result.kind_case() != Protobuf::Value::KIND_NOT_SET &&
-        result.kind_case() != Protobuf::Value::kNullValue) {
-      // For string values, also check if empty.
-      if (result.kind_case() == Protobuf::Value::kStringValue) {
-        if (!result.string_value().empty()) {
-          if (max_length_.has_value() && result.string_value().size() > max_length_.value()) {
-            result.set_string_value(result.string_value().substr(0, max_length_.value()));
-          }
-          return result;
-        }
-      } else {
-        return result;
+    // Skip values that are not set or are explicitly null.
+    if (result.kind_case() == Protobuf::Value::KIND_NOT_SET ||
+        result.kind_case() == Protobuf::Value::kNullValue) {
+      continue;
+    }
+    if (result.kind_case() == Protobuf::Value::kStringValue) {
+      // An empty string is only accepted when the runtime guard is enabled.
+      if (result.string_value().empty() && !accept_empty_values_) {
+        continue;
+      }
+      if (max_length_.has_value() && result.string_value().size() > max_length_.value()) {
+        result.set_string_value(result.string_value().substr(0, max_length_.value()));
       }
     }
+    return result;
   }
   return SubstitutionFormatUtils::unspecifiedValue();
 }

--- a/source/common/formatter/coalesce_formatter.h
+++ b/source/common/formatter/coalesce_formatter.h
@@ -32,6 +32,11 @@ namespace Formatter {
  *   ]
  * }
  *
+ * By default an operator that produces a value which is present but empty is accepted as the
+ * result. Setting the runtime guard
+ * ``envoy.reloadable_features.coalesce_formatter_accept_empty_values`` to false restores the
+ * legacy behavior where an empty result is skipped and the next operator is evaluated.
+ *
  * Note that the JSON parameter cannot contain literal ')' characters as they would
  * interfere with the command parser regex.
  */
@@ -46,9 +51,18 @@ public:
   static absl::StatusOr<FormatterProviderPtr> create(absl::string_view json_config,
                                                      std::optional<size_t> max_length);
 
+  /**
+   * @param formatters the operator formatters to evaluate in order.
+   * @param max_length optional maximum length for the output.
+   * @param accept_empty_values whether a value that is present but empty is accepted as a result
+   *        rather than skipped. This is evaluated from the
+   *        ``envoy.reloadable_features.coalesce_formatter_accept_empty_values`` runtime guard when
+   *        the formatter is created.
+   */
   CoalesceFormatter(std::vector<FormatterProviderPtr>&& formatters,
-                    std::optional<size_t> max_length)
-      : formatters_(std::move(formatters)), max_length_(max_length) {}
+                    std::optional<size_t> max_length, bool accept_empty_values)
+      : formatters_(std::move(formatters)), max_length_(max_length),
+        accept_empty_values_(accept_empty_values) {}
 
   // FormatterProvider interface.
   std::optional<std::string> format(const Context& context,
@@ -81,6 +95,7 @@ private:
 
   std::vector<FormatterProviderPtr> formatters_;
   std::optional<size_t> max_length_;
+  const bool accept_empty_values_;
 };
 
 } // namespace Formatter

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -36,6 +36,7 @@
 // problem of the bugs being found after the old code path has been removed.
 RUNTIME_GUARD(envoy_reloadable_features_async_host_selection);
 RUNTIME_GUARD(envoy_reloadable_features_cel_message_serialize_text_format);
+RUNTIME_GUARD(envoy_reloadable_features_coalesce_formatter_accept_empty_values);
 RUNTIME_GUARD(envoy_reloadable_features_coalesce_lb_rebuilds_on_batch_update);
 RUNTIME_GUARD(envoy_reloadable_features_codec_client_enable_idle_timer_only_when_connected);
 RUNTIME_GUARD(envoy_reloadable_features_conn_pool_fix_reentrancy);

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -6698,6 +6698,54 @@ TEST(SubstitutionFormatterTest, CoalesceFormatterGridTest) {
   }
 }
 
+TEST(SubstitutionFormatterTest, CoalesceFormatterEmptyValues) {
+  StreamInfo::MockStreamInfo stream_info;
+  // ":authority" is present but empty while "x-envoy-original-host" has a value.
+  Http::TestRequestHeaderMapImpl request_headers{{":authority", ""},
+                                                 {"x-envoy-original-host", "original.example.com"}};
+
+  const std::string format =
+      R"(%COALESCE({"operators": [{"command": "REQ", "param": ":authority"}, {"command": "REQ", "param": "x-envoy-original-host"}]})%)";
+
+  // By default a value that is present but empty is accepted as the result.
+  {
+    auto providers = *SubstitutionFormatParser::parse(format);
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("", formatForTest(*providers[0], {&request_headers}, stream_info));
+    EXPECT_THAT(formatValueForTest(*providers[0], {&request_headers}, stream_info),
+                ProtoEq(ValueUtil::stringValue("")));
+  }
+
+  // With the runtime guard disabled, the empty value is skipped and the next operator is used.
+  {
+    TestScopedRuntime scoped_runtime;
+    scoped_runtime.mergeValues(
+        {{"envoy.reloadable_features.coalesce_formatter_accept_empty_values", "false"}});
+
+    auto providers = *SubstitutionFormatParser::parse(format);
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_EQ("original.example.com",
+              formatForTest(*providers[0], {&request_headers}, stream_info));
+    EXPECT_THAT(formatValueForTest(*providers[0], {&request_headers}, stream_info),
+                ProtoEq(ValueUtil::stringValue("original.example.com")));
+  }
+
+  // With the runtime guard disabled and no non-empty operator, no value is produced.
+  {
+    TestScopedRuntime scoped_runtime;
+    scoped_runtime.mergeValues(
+        {{"envoy.reloadable_features.coalesce_formatter_accept_empty_values", "false"}});
+
+    Http::TestRequestHeaderMapImpl empty_headers{{":authority", ""}};
+    auto providers = *SubstitutionFormatParser::parse(
+        R"(%COALESCE({"operators": [{"command": "REQ", "param": ":authority"}]})%)");
+    ASSERT_EQ(providers.size(), 1);
+    EXPECT_FALSE(formatForTest(*providers[0], {&empty_headers}, stream_info).has_value());
+    EXPECT_THAT(formatValueForTest(*providers[0], {&empty_headers}, stream_info),
+                ProtoEq(ValueUtil::nullValue()));
+  }
+}
+
 TEST(SubstitutionFormatterTest, CoalesceFormatterErrorCases) {
   // Empty JSON config.
   {


### PR DESCRIPTION
Commit Message: formatter: make the COALESCE accept empty string
Additional Description:

For now, the COALESCE will always treat an empty string as null. But null and empty string may have different semantics. It's would be better to respect the underlying sub command's behavior. If it's has value, even it's empty string, we should accept it.
If we think we should treat the empty string as null, we should do it at the underlying sub command's implementation.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.
[Optional Runtime guard:] envoy.reloadable_features.coalesce_formatter_accept_empty_values