### PR TITLE
Deflake multiplexed_integration_test

### DIFF
--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2631,12 +2631,16 @@ TEST_P(Http2FrameIntegrationTest, AdjustUpstreamSettingsMaxStreams) {
   FakeRawConnectionPtr fake_upstream_connection2;
   sendFrame(Http2Frame::makePostRequest(3, "host", "/path/to/long/url"));
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_upstream_connection2));
+  uint64_t bytes_read =
+      test_server_->counter("cluster.cluster_0.upstream_cx_rx_bytes_total")->value();
   ASSERT_TRUE(fake_upstream_connection2->write(std::string(settings_frame)));
+  test_server_->waitForCounter("cluster.cluster_0.upstream_cx_rx_bytes_total",
+                               Ge(bytes_read + settings_data.size()));
   test_server_->waitForGauge("cluster.cluster_0.upstream_rq_active", Eq(2));
   test_server_->waitForCounter("cluster.cluster_0.upstream_cx_total", Eq(2));
 
   // Adjust the max concurrent streams of one connection created above to 2.
-  auto bytes_read = test_server_->counter("cluster.cluster_0.upstream_cx_rx_bytes_total");
+  bytes_read = test_server_->counter("cluster.cluster_0.upstream_cx_rx_bytes_total")->value();
   const Http2Frame settings_frame2 = Http2Frame::makeSettingsFrame(
       Http2Frame::SettingsFlags::None, {{NGHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 3}});
   std::string settings_data2(settings_frame2);


### PR DESCRIPTION
Commit Message: Deflake multiplexed_integration_test
Additional Description: An `auto` mistakenly used a boolean for addition instead of the number it was intended to use. There was also a wait for "more data" that used "more than" an unresolved quantity due to a lack of wait on an earlier update. This fixes both of those.

```
[ RUN      ] IpVersions/Http2FrameIntegrationTest.AdjustUpstreamSettingsMaxStreams/IPv4_Oghttp2
  ./test/integration/server.h:497: Failure
  Value of: TestUtility::waitForCounter(statStore(), name, value_matcher, time_system_, timeout, dispatcher)
    Actual: false (timed out waiting for cluster.cluster_0.upstream_cx_total to is equal to 2: current value 3)
```

AI assisted by Codex Luna.
Risk Level: test-only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
