### PR TITLE
Deflake tcp_tunneling_integration_test

### DIFF
--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -2271,6 +2271,7 @@ envoy_cc_test(
         "//source/extensions/upstreams/http/tcp:config",
         "//test/integration/filters:add_header_filter_config_lib",
         "//test/integration/filters:add_header_filter_proto_cc_proto",
+        "//test/integration/filters:stop_in_headers_continue_in_data_filter_lib",
         "//test/integration/filters:stop_iteration_and_continue",
         "//test/test_common:logging_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",

--- a/test/integration/tcp_tunneling_integration_test.cc
+++ b/test/integration/tcp_tunneling_integration_test.cc
@@ -503,6 +503,14 @@ TEST_P(ConnectTerminationIntegrationTest, IgnoreH11HostField) {
 }
 
 TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataRejectedWithOverride) {
+  // Hold CONNECT headers before the router until the first data frame is decoded. In HTTP/3,
+  // encodeHeaders() and encodeData() can be delivered in separate QUIC packets even when the client
+  // flushes them together, allowing the upstream connection to complete before the data arrives.
+  config_helper_.addFilter(R"EOF(
+    name: stop-in-headers-continue-in-body-filter
+    typed_config:
+      "@type": type.googleapis.com/test.integration.filters.StopInHeadersContinueInBodyFilterConfig
+  )EOF");
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
              hcm) {
@@ -522,11 +530,11 @@ TEST_P(ConnectTerminationIntegrationTest, EarlyConnectDataRejectedWithOverride) 
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   // Send CONNECT request and immediately send some data without waiting for 200
-  // response from Envoy. Encode the CONNECT headers and the premature data into a single
-  // socket write so the data cannot race behind the synthesized 200 tunnel response.
+  // response from Envoy. The test filter releases the headers when it sees this data, ensuring the
+  // router processes both before the upstream connection can synthesize the 200 tunnel response.
   response_ = codec_client_->makeRequestWithBody(connect_headers_, "premature data", false);
 
-  // Envoy will try top open upstream connection before the premature CONNECT data is detected.
+  // Envoy will try to open an upstream connection before the premature CONNECT data is detected.
   ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(fake_raw_upstream_connection_));
 
   response_->waitForHeaders();


### PR DESCRIPTION
Commit Message: Deflake tcp_tunneling_integration_test
Additional Description: A race occurred in the test in question when using http/3. The test relied on the stream packet containing header and body together, but http/3 codec can split them across packets even when they're received together. This change forces envoy to wait for the body before sending the headers upstream in the test case, so upstream can't racily synthesize a "connection established" packet before the intentional-error-provoking body is handled.

This fixes
```
[ RUN      ] HttpAndIpVersions/ConnectTerminationIntegrationTest.EarlyConnectDataRejectedWithOverride/IPv4_Http3Downstream_HttpUpstreamNghttp2Legacy
  test/integration/tcp_tunneling_integration_test.cc:533: Failure
  Expected equality of these values:
    response_->headers().getStatusValue()
      Which is: "200"
    "400"
```

This was AI assisted with Codex Sol.
Risk Level: test-only
Testing: test-only
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
