### PR TITLE
oauth2: chunk large token cookies to avoid browsers dropping them

### DIFF
--- a/changelogs/current/minor_behavior_changes/oauth2__chunk-large-token-cookies.rst
+++ b/changelogs/current/minor_behavior_changes/oauth2__chunk-large-token-cookies.rst
@@ -1,0 +1,18 @@
+OAuth2 token cookies larger than 4096 bytes are now split across multiple cookies and rejoined when
+the request comes back. Browsers reject a cookie that large, so an access, ID or refresh token above
+that size was silently dropped by the client and the filter redirected the user to the authorization
+server on every request. A token that still fits in one cookie is written exactly as before.
+
+A token is split into at most 15 cookies, as ``<name>_0`` .. ``<name>_N-1`` alongside a
+``<name>_chunks`` cookie holding the count. One too large for that is written as a single cookie, as
+it was before, and increments ``oauth_token_cookie_oversized``. A session that splits all three
+tokens may need ``max_request_headers_kb`` raised. Because a large ID token now survives where it
+was previously dropped, a configured ``end_session_endpoint`` receives a correspondingly large
+``id_token_hint``, which some providers may reject.
+
+This behavior can be reverted by setting
+``envoy.reloadable_features.oauth2_chunk_large_token_cookies`` to ``false``. That is worth doing
+during a rolling upgrade if a client may reach an instance that predates this change, since such an
+instance cannot rejoin the cookies and would restart the authorization flow. Rejoining and deleting
+chunked cookies is always active regardless of the flag, so it can be turned back off without
+stranding clients that already hold chunked cookies.

--- a/docs/root/configuration/http/http_filters/oauth2_filter.rst
+++ b/docs/root/configuration/http/http_filters/oauth2_filter.rst
@@ -425,3 +425,7 @@ The OAuth2 filter outputs statistics in the ``<stat_prefix>.`` namespace.
   oauth_unauthorization_rq, Counter, Total unauthorized requests.
   oauth_refreshtoken_success, Counter, Total successful requests for update access token using by refresh token
   oauth_refreshtoken_failure, Counter, Total failed requests for update access token using by refresh token
+  oauth_token_cookie_chunked, Counter, Total token cookies that were split across multiple cookies
+  oauth_token_cookie_reassembled, Counter, Total token cookies rebuilt from a chunked cookie set
+  oauth_token_cookie_malformed_chunks, Counter, Total chunked cookie sets discarded as malformed
+  oauth_token_cookie_oversized, Counter, Total token cookies emitted above the browser size limit

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -110,6 +110,12 @@ RUNTIME_GUARD(envoy_reloadable_features_mobile_use_network_observer_registry);
 // drain sequence and notifies the connections of the covered listeners that a drain has begun,
 // instead of only stopping the listeners, and accepts `skip_exit` to drain without stopping them.
 RUNTIME_GUARD(envoy_reloadable_features_non_graceful_drain_notifies_connections);
+// When true, OAuth2 token cookies too large for a browser to store are split into several cookies.
+// A cookie that already fits is written exactly as before, so only sessions that were already
+// broken behave differently. Set this to false during a rolling upgrade if a client may reach an
+// instance that predates this change and so cannot rejoin the cookies. Rejoining and deleting
+// chunked cookies is always enabled, so the flag can be turned back off safely.
+RUNTIME_GUARD(envoy_reloadable_features_oauth2_chunk_large_token_cookies);
 RUNTIME_GUARD(envoy_reloadable_features_oauth2_client_retries_respect_user_retry_on);
 // OAuth2 filter cookie decryption: when true (the default), decrypt() accepts legacy CBC
 // ciphertexts via the legacy AES-256-CBC fallback. When false, only "gcm."-prefixed ciphertexts

--- a/source/extensions/filters/http/oauth2/filter.cc
+++ b/source/extensions/filters/http/oauth2/filter.cc
@@ -90,6 +90,59 @@ constexpr absl::string_view CookieSuffixDelimiter = ".";
 constexpr int DEFAULT_CSRF_TOKEN_EXPIRES_IN = 600;
 constexpr int DEFAULT_CODE_VERIFIER_TOKEN_EXPIRES_IN = 600;
 
+// A token cookie too large for MaxCookieSize is split into ``<name>_0`` .. ``<name>_N-1``, with
+// ``<name>_chunks`` holding N. Token cookies never take a flow id suffix, so this delimiter cannot
+// collide with CookieSuffixDelimiter.
+constexpr absl::string_view TokenCookieChunkCountSuffix = "_chunks";
+constexpr absl::string_view TokenCookieChunkDelimiter = "_";
+// Browsers reject a cookie larger than this. The limit covers the name and attributes, not just
+// the value.
+constexpr size_t MaxCookieSize = 4096;
+// Limits how many cookies one token can become. This bounds the work done on untrusted request
+// cookies. A session that chunks all three tokens may need max_request_headers_kb raised.
+constexpr uint32_t MaxChunksPerToken = 15;
+
+std::string tokenCookieChunkName(absl::string_view base_name, uint32_t index) {
+  return absl::StrCat(base_name, TokenCookieChunkDelimiter, index);
+}
+
+std::string tokenCookieChunkCountName(absl::string_view base_name) {
+  return absl::StrCat(base_name, TokenCookieChunkCountSuffix);
+}
+
+// Request cookies are untrusted, so a count outside the supported range is rejected, not clamped.
+std::optional<uint32_t> parseChunkCount(absl::string_view value) {
+  uint32_t count = 0;
+  if (!absl::SimpleAtoi(value, &count) || count < 1 || count > MaxChunksPerToken) {
+    return std::nullopt;
+  }
+  return count;
+}
+
+// Gates only the writing of chunked cookies. Rejoining and deleting them stays enabled, so the
+// flag can be turned back off without stranding clients.
+bool chunkLargeTokenCookiesEnabled() {
+  return Runtime::runtimeFeatureEnabled(
+      "envoy.reloadable_features.oauth2_chunk_large_token_cookies");
+}
+
+// Erases every chunk cookie for the token names, including the count cookie, and reports whether
+// anything was erased. Used wherever chunk cookies must not be read later or sent upstream. This
+// does not need a count cookie, so it also clears chunks left behind without one.
+bool eraseChunkCookies(absl::flat_hash_map<std::string, std::string>& cookies,
+                       const CookieNames& cookie_names) {
+  bool erased = false;
+  for (const absl::string_view base_name :
+       {absl::string_view(cookie_names.bearer_token_), absl::string_view(cookie_names.id_token_),
+        absl::string_view(cookie_names.refresh_token_)}) {
+    erased |= cookies.erase(tokenCookieChunkCountName(base_name)) > 0;
+    for (uint32_t i = 0; i < MaxChunksPerToken; ++i) {
+      erased |= cookies.erase(tokenCookieChunkName(base_name, i)) > 0;
+    }
+  }
+  return erased;
+}
+
 template <class T>
 std::vector<Http::HeaderUtility::HeaderDataPtr>
 headerMatchers(const T& matcher_protos, Server::Configuration::CommonFactoryContext& context) {
@@ -938,6 +991,10 @@ Http::FilterHeadersStatus OAuth2Filter::decodeHeaders(Http::RequestHeaderMap& he
     return Http::FilterHeadersStatus::StopIteration;
   }
 
+  // Rejoin chunked token cookies. This must run before decryption because the chunks hold
+  // ciphertext.
+  reassembleChunkedTokenCookies(headers);
+
   // Decrypt the OAuth tokens and update the corresponding cookies in the request headers
   // before forwarding the request upstream. This step must occur early to ensure that
   // other parts of the filter can access the decrypted tokens—for example, to calculate
@@ -1168,6 +1225,85 @@ bool OAuth2Filter::canSkipOAuth(Http::RequestHeaderMap& headers) const {
   ENVOY_TAGGED_STREAM_LOG(debug, oauthLogTags(*decoder_callbacks_), *decoder_callbacks_,
                           "can not skip oauth flow");
   return false;
+}
+
+// Rejoins chunked token cookies into one cookie per token, under the base name. This must run
+// before decryptAndUpdateOAuthTokenCookies() because the chunks hold ciphertext, and because that
+// function returns early when token encryption is disabled.
+void OAuth2Filter::reassembleChunkedTokenCookies(Http::RequestHeaderMap& headers) {
+  // This runs on every request, so check the raw header before paying for a full cookie parse.
+  const auto cookie_headers = headers.get(Http::Headers::get().Cookie);
+  bool maybe_chunked = false;
+  for (size_t i = 0; i < cookie_headers.size(); ++i) {
+    if (absl::StrContains(cookie_headers[i]->value().getStringView(),
+                          TokenCookieChunkCountSuffix)) {
+      maybe_chunked = true;
+      break;
+    }
+  }
+  if (!maybe_chunked) {
+    return;
+  }
+
+  absl::flat_hash_map<std::string, std::string> cookies = Http::Utility::parseCookies(headers);
+  if (cookies.empty()) {
+    return;
+  }
+
+  const CookieNames& cookie_names = config_->cookieNames();
+  bool modified = false;
+
+  for (const absl::string_view base_name :
+       {absl::string_view(cookie_names.bearer_token_), absl::string_view(cookie_names.id_token_),
+        absl::string_view(cookie_names.refresh_token_)}) {
+    const std::string count_name = tokenCookieChunkCountName(base_name);
+    const auto count_it = cookies.find(count_name);
+    if (count_it == cookies.end()) {
+      continue;
+    }
+
+    const std::optional<uint32_t> count = parseChunkCount(count_it->second);
+    // Record the chunks so the response can delete them. Assume the cap when the count is
+    // unusable, because the real number is unknown.
+    chunked_token_cookies_seen_[std::string(base_name)] = count.value_or(MaxChunksPerToken);
+
+    std::string reassembled;
+    bool complete = count.has_value();
+    if (complete) {
+      for (uint32_t i = 0; i < count.value(); ++i) {
+        const auto chunk_it = cookies.find(tokenCookieChunkName(base_name, i));
+        if (chunk_it == cookies.end()) {
+          // A missing chunk means the value cannot be rebuilt. Joining what is present would give
+          // a truncated token to the HMAC check.
+          complete = false;
+          break;
+        }
+        absl::StrAppend(&reassembled, chunk_it->second);
+      }
+    }
+
+    modified = true;
+
+    if (complete) {
+      cookies.insert_or_assign(std::string(base_name), std::move(reassembled));
+      config_->stats().oauth_token_cookie_reassembled_.inc();
+    } else {
+      // An unchunked cookie of the same name stays as a fallback. If there is none, the HMAC
+      // check restarts the authorization flow.
+      config_->stats().oauth_token_cookie_malformed_chunks_.inc();
+      ENVOY_LOG_EVERY_POW_2(warn, "oauth2: discarding malformed chunked cookie set for {}",
+                            base_name);
+    }
+  }
+
+  // Drop every chunk cookie, whatever the outcome above. A partial set must never be read later or
+  // sent upstream.
+  modified |= eraseChunkCookies(cookies, cookie_names);
+
+  if (modified) {
+    const std::string new_cookies(absl::StrJoin(cookies, "; ", absl::PairFormatter("=")));
+    headers.setReferenceKey(Http::Headers::get().Cookie, new_cookies);
+  }
 }
 
 // Decrypt the OAuth tokens and updates the OAuth tokens in the request cookies before forwarding
@@ -1403,6 +1539,28 @@ Http::FilterHeadersStatus OAuth2Filter::signOutUser(const Http::RequestHeaderMap
     }
   }
 
+  // Delete the chunk cookies. Reassembly already removed them from the request header, so use what
+  // it recorded. The names are owned here because cookies_to_delete only holds views.
+  std::vector<std::pair<std::string, absl::string_view>> chunk_cookies_to_delete;
+  const std::pair<absl::string_view, absl::string_view> token_cookie_paths[] = {
+      {cookie_names.bearer_token_, config_->bearerTokenCookieSettings().path_},
+      {cookie_names.id_token_, config_->idTokenCookieSettings().path_},
+      {cookie_names.refresh_token_, config_->refreshTokenCookieSettings().path_},
+  };
+  for (const auto& [base_name, cookie_path] : token_cookie_paths) {
+    const auto it = chunked_token_cookies_seen_.find(base_name);
+    if (it == chunked_token_cookies_seen_.end()) {
+      continue;
+    }
+    chunk_cookies_to_delete.emplace_back(tokenCookieChunkCountName(base_name), cookie_path);
+    for (uint32_t i = 0; i < it->second; ++i) {
+      chunk_cookies_to_delete.emplace_back(tokenCookieChunkName(base_name, i), cookie_path);
+    }
+  }
+  for (const auto& [cookie_name, cookie_path] : chunk_cookies_to_delete) {
+    cookies_to_delete.emplace_back(cookie_name, cookie_path);
+  }
+
   std::string cookie_domain;
   if (!config_->cookieDomain().empty()) {
     cookie_domain = fmt::format(CookieDomainFormatString, config_->cookieDomain());
@@ -1628,6 +1786,16 @@ void OAuth2Filter::finishRefreshAccessTokenFlow() {
   absl::flat_hash_map<std::string, std::string> cookies =
       Http::Utility::parseCookies(*request_headers_);
 
+  // Record which token cookies arrived unchunked. removeOAuthFlowCookies() below strips them, so
+  // the response path could not otherwise tell that the client still holds one.
+  for (const absl::string_view base_name :
+       {absl::string_view(cookie_names.bearer_token_), absl::string_view(cookie_names.id_token_),
+        absl::string_view(cookie_names.refresh_token_)}) {
+    if (cookies.contains(base_name)) {
+      unchunked_token_cookies_seen_.emplace(base_name);
+    }
+  }
+
   if (!access_token_.empty()) {
     cookies.insert_or_assign(cookie_names.bearer_token_, access_token_);
   }
@@ -1703,44 +1871,130 @@ void OAuth2Filter::setOAuthResponseCookies(Http::ResponseHeaderMap& headers,
     cookie_domain = fmt::format(CookieDomainFormatString, config_->cookieDomain());
   }
 
-  if (!access_token_.empty()) {
-    headers.addReferenceKey(
-        Http::Headers::get().SetCookie,
-        absl::StrCat(cookie_names.bearer_token_, "=", encryptToken(access_token_),
-                     buildCookieTail(config_->bearerTokenCookieSettings(), expires_in_)));
-  } else if (request_cookies.contains(cookie_names.bearer_token_)) {
-    headers.addReferenceKey(
-        Http::Headers::get().SetCookie,
-        absl::StrCat(fmt::format(CookieDeleteFormatString, config_->cookieNames().bearer_token_,
-                                 config_->bearerTokenCookieSettings().path_),
-                     cookie_domain));
-  }
+  // Sets a token cookie, then deletes any chunk cookies the request carried that this response did
+  // not overwrite. This runs whether or not chunking is enabled, so the flag can be turned back
+  // off without stranding clients.
+  auto set_token_cookie = [&](const std::string& name, const std::string& token,
+                              const std::string& cookie_tail, absl::string_view cookie_path) {
+    if (!token.empty()) {
+      const uint32_t chunks_written =
+          addTokenCookie(headers, name, encryptToken(token), cookie_tail);
+      addChunkDeletionHeaders(headers, name, chunks_written, cookie_path, cookie_domain);
+      // Delete the old single cookie, which the client would otherwise keep sending at full size.
+      // request_cookies needs both checks: reassembly puts the rejoined value back under the base
+      // name, and the refresh path strips the cookie before this runs.
+      const bool client_holds_single_cookie =
+          unchunked_token_cookies_seen_.contains(name) ||
+          (request_cookies.contains(name) && !chunked_token_cookies_seen_.contains(name));
+      if (chunks_written > 0 && client_holds_single_cookie) {
+        headers.addReferenceKey(
+            Http::Headers::get().SetCookie,
+            absl::StrCat(fmt::format(CookieDeleteFormatString, name, cookie_path), cookie_domain));
+      }
+      return;
+    }
+    // The token is gone, so delete its cookie. The second test covers a request that carried only
+    // chunks which failed to rejoin, leaving no base cookie to match.
+    if (request_cookies.contains(name) || chunked_token_cookies_seen_.contains(name)) {
+      headers.addReferenceKey(
+          Http::Headers::get().SetCookie,
+          absl::StrCat(fmt::format(CookieDeleteFormatString, name, cookie_path), cookie_domain));
+      addChunkDeletionHeaders(headers, name, 0, cookie_path, cookie_domain);
+    }
+  };
 
-  if (!id_token_.empty()) {
-    headers.addReferenceKey(
-        Http::Headers::get().SetCookie,
-        absl::StrCat(cookie_names.id_token_, "=", encryptToken(id_token_),
-                     buildCookieTail(config_->idTokenCookieSettings(), expires_id_token_in_)));
-  } else if (request_cookies.contains(cookie_names.id_token_)) {
-    headers.addReferenceKey(
-        Http::Headers::get().SetCookie,
-        absl::StrCat(fmt::format(CookieDeleteFormatString, config_->cookieNames().id_token_,
-                                 config_->idTokenCookieSettings().path_),
-                     cookie_domain));
-  }
+  set_token_cookie(cookie_names.bearer_token_, access_token_,
+                   buildCookieTail(config_->bearerTokenCookieSettings(), expires_in_),
+                   config_->bearerTokenCookieSettings().path_);
+  set_token_cookie(cookie_names.id_token_, id_token_,
+                   buildCookieTail(config_->idTokenCookieSettings(), expires_id_token_in_),
+                   config_->idTokenCookieSettings().path_);
+  set_token_cookie(
+      cookie_names.refresh_token_, refresh_token_,
+      buildCookieTail(config_->refreshTokenCookieSettings(), expires_refresh_token_in_),
+      config_->refreshTokenCookieSettings().path_);
+}
 
-  if (!refresh_token_.empty()) {
+uint32_t OAuth2Filter::addTokenCookie(Http::ResponseHeaderMap& headers, const std::string& name,
+                                      const std::string& value,
+                                      const std::string& cookie_tail) const {
+  // The limit covers the whole cookie, so count the name, the "=" and the attributes. Deciding on
+  // the exact size matters: anything that fits must be written exactly as it is today, whether or
+  // not chunking is enabled.
+  const size_t single_cookie_size = name.size() + 1 /* "=" */ + value.size() + cookie_tail.size();
+  const bool fits = single_cookie_size <= MaxCookieSize;
+
+  // A chunk name carries an index suffix on top of the base name, so chunks share a smaller budget
+  // than a single cookie gets. Reserve the widest suffix so every chunk uses one budget.
+  const size_t chunk_overhead = name.size() + TokenCookieChunkDelimiter.size() +
+                                absl::StrCat(MaxChunksPerToken).size() + 1 /* "=" */ +
+                                cookie_tail.size();
+  const size_t max_value_size = MaxCookieSize > chunk_overhead ? MaxCookieSize - chunk_overhead : 0;
+
+  if (fits || !chunkLargeTokenCookiesEnabled() || max_value_size == 0) {
+    if (!fits) {
+      // Write the oversized cookie anyway, which is what happens today. The counter tells an
+      // operator to enable chunking.
+      config_->stats().oauth_token_cookie_oversized_.inc();
+      ENVOY_LOG_EVERY_POW_2(
+          warn, "oauth2: token cookie {} is {} bytes and exceeds the {} bytes most browsers store",
+          name, value.size(), MaxCookieSize);
+    }
     headers.addReferenceKey(Http::Headers::get().SetCookie,
-                            absl::StrCat(cookie_names.refresh_token_, "=",
-                                         encryptToken(refresh_token_),
-                                         buildCookieTail(config_->refreshTokenCookieSettings(),
-                                                         expires_refresh_token_in_)));
-  } else if (request_cookies.contains(cookie_names.refresh_token_)) {
+                            absl::StrCat(name, "=", value, cookie_tail));
+    return 0;
+  }
+
+  const size_t required_chunks = (value.size() + max_value_size - 1) / max_value_size;
+  if (required_chunks > MaxChunksPerToken) {
+    // A truncated set would claim chunks that do not exist, so write one cookie instead.
+    config_->stats().oauth_token_cookie_oversized_.inc();
+    ENVOY_LOG_EVERY_POW_2(warn,
+                          "oauth2: token cookie {} needs {} chunks which exceeds the limit of {}",
+                          name, required_chunks, MaxChunksPerToken);
+    headers.addReferenceKey(Http::Headers::get().SetCookie,
+                            absl::StrCat(name, "=", value, cookie_tail));
+    return 0;
+  }
+
+  for (uint32_t i = 0; i < required_chunks; ++i) {
     headers.addReferenceKey(
         Http::Headers::get().SetCookie,
-        absl::StrCat(fmt::format(CookieDeleteFormatString, config_->cookieNames().refresh_token_,
-                                 config_->refreshTokenCookieSettings().path_),
-                     cookie_domain));
+        absl::StrCat(tokenCookieChunkName(name, i), "=",
+                     absl::string_view(value).substr(i * max_value_size, max_value_size),
+                     cookie_tail));
+  }
+  headers.addReferenceKey(
+      Http::Headers::get().SetCookie,
+      absl::StrCat(tokenCookieChunkCountName(name), "=", required_chunks, cookie_tail));
+
+  config_->stats().oauth_token_cookie_chunked_.inc();
+  return static_cast<uint32_t>(required_chunks);
+}
+
+void OAuth2Filter::addChunkDeletionHeaders(Http::ResponseHeaderMap& headers,
+                                           const std::string& name, uint32_t chunks_written,
+                                           absl::string_view cookie_path,
+                                           absl::string_view cookie_domain) const {
+  const auto it = chunked_token_cookies_seen_.find(name);
+  if (it == chunked_token_cookies_seen_.end()) {
+    return;
+  }
+
+  for (uint32_t i = chunks_written; i < it->second; ++i) {
+    headers.addReferenceKey(Http::Headers::get().SetCookie,
+                            absl::StrCat(fmt::format(CookieDeleteFormatString,
+                                                     tokenCookieChunkName(name, i), cookie_path),
+                                         cookie_domain));
+  }
+
+  // A response that chunked again overwrote the count cookie. One that did not must clear it, or
+  // the next request would look for chunks that are gone.
+  if (chunks_written == 0) {
+    headers.addReferenceKey(Http::Headers::get().SetCookie,
+                            absl::StrCat(fmt::format(CookieDeleteFormatString,
+                                                     tokenCookieChunkCountName(name), cookie_path),
+                                         cookie_domain));
   }
 }
 
@@ -2001,6 +2255,11 @@ void OAuth2Filter::removeOAuthFlowCookies(Http::RequestHeaderMap& headers) const
   eraseCookieWithSuffix(cookie_names.oauth_nonce_);
   eraseCookieWithSuffix(cookie_names.code_verifier_);
 
+  // The refresh token is stripped above, so its chunks must go too. Reassembly only removes them
+  // when the count cookie is present, so a request without a count would otherwise send token
+  // fragments upstream.
+  eraseChunkCookies(cookies, cookie_names);
+
   std::string new_cookies(absl::StrJoin(cookies, "; ", absl::PairFormatter("=")));
   headers.setReferenceKey(Http::Headers::get().Cookie, new_cookies);
 }
@@ -2022,6 +2281,10 @@ void OAuth2Filter::removeOAuthTokenCookies(Http::RequestHeaderMap& headers) cons
   cookies.erase(cookie_names.oauth_hmac_);
   cookies.erase(cookie_names.oauth_expires_);
   cookies.erase(cookie_names.refresh_token_);
+
+  // Reassembly only removes chunk cookies when the count cookie is present. Remove them here as
+  // well, so a request without a count cannot send token fragments upstream.
+  eraseChunkCookies(cookies, cookie_names);
 
   std::string new_cookies(absl::StrJoin(cookies, "; ", absl::PairFormatter("=")));
   headers.setReferenceKey(Http::Headers::get().Cookie, new_cookies);

--- a/source/extensions/filters/http/oauth2/filter.h
+++ b/source/extensions/filters/http/oauth2/filter.h
@@ -122,7 +122,11 @@ private:
   COUNTER(oauth_refreshtoken_success)                                                              \
   COUNTER(oauth_refreshtoken_failure)                                                              \
   COUNTER(oauth_allow_failed_passthrough)                                                          \
-  COUNTER(oauth_legacy_cbc_decrypt)
+  COUNTER(oauth_legacy_cbc_decrypt)                                                                \
+  COUNTER(oauth_token_cookie_chunked)                                                              \
+  COUNTER(oauth_token_cookie_reassembled)                                                          \
+  COUNTER(oauth_token_cookie_malformed_chunks)                                                     \
+  COUNTER(oauth_token_cookie_oversized)
 
 /**
  * Wrapper struct filter stats. @see stats_macros.h
@@ -481,6 +485,12 @@ private:
   std::string flow_id_;
   Http::RequestHeaderMap* request_headers_{nullptr};
   bool was_refresh_token_flow_{false};
+  // Token names that arrived chunked, mapped to how many chunks to clean up. The response path
+  // uses this to delete stale chunks even when chunking is disabled.
+  absl::flat_hash_map<std::string, uint32_t> chunked_token_cookies_seen_;
+  // Token names that arrived as a single unchunked cookie. Only filled in on the refresh path,
+  // which strips those cookies from the request before the response is built.
+  absl::flat_hash_set<std::string> unchunked_token_cookies_seen_;
 
   std::shared_ptr<OAuth2Client> oauth_client_;
   FilterConfigSharedPtr default_config_;
@@ -517,7 +527,20 @@ private:
                                          const absl::string_view state) const;
   bool validateCsrfToken(const Http::RequestHeaderMap& headers, const std::string& csrf_token,
                          absl::string_view flow_id) const;
+  // Rejoins chunked token cookies into one cookie under the base name and removes the chunks from
+  // the Cookie header. Runs before decryption because the chunks hold ciphertext.
+  void reassembleChunkedTokenCookies(Http::RequestHeaderMap& headers);
   void decryptAndUpdateOAuthTokenCookies(Http::RequestHeaderMap& headers) const;
+  // Adds a token cookie, splitting it into ``<name>_0``.. plus a ``<name>_chunks`` count cookie
+  // when it is too large and chunking is enabled. Returns the number of chunks written, or 0 when
+  // it was written as one cookie.
+  uint32_t addTokenCookie(Http::ResponseHeaderMap& headers, const std::string& name,
+                          const std::string& value, const std::string& cookie_tail) const;
+  // Deletes chunk cookies the request carried beyond chunks_written, so a response that writes
+  // fewer chunks, or none, does not leave stale chunks in the client.
+  void addChunkDeletionHeaders(Http::ResponseHeaderMap& headers, const std::string& name,
+                               uint32_t chunks_written, absl::string_view cookie_path,
+                               absl::string_view cookie_domain) const;
   std::string encryptToken(const std::string& token) const;
   std::string decryptToken(const std::string& encrypted_token) const;
   void removeOAuthFlowCookies(Http::RequestHeaderMap& headers) const;

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -203,6 +203,30 @@ public:
     filter_->flow_id_ = "00000000075bcd15";
   }
 
+  // Same as init(), but uses the production OAuth2CookieValidator instead of the mock. Tests that
+  // write cookies and read them back need this, because the mock stubs out isValid().
+  void initWithRealValidator() { initWithRealValidator(getConfig()); }
+
+  void initWithRealValidator(FilterConfigSharedPtr config) {
+    oauth_client_ = std::make_shared<MockOAuth2Client>();
+
+    config_ = config;
+    ON_CALL(test_random_, random()).WillByDefault(Return(123456789));
+    filter_ = std::make_shared<OAuth2Filter>(
+        config_,
+        [this](const FilterConfig&) -> std::shared_ptr<OAuth2Client> { return oauth_client_; },
+        [](TimeSource& time_source,
+           const FilterConfig& active_config) -> std::shared_ptr<CookieValidator> {
+          return std::make_shared<OAuth2CookieValidator>(time_source, active_config.cookieNames(),
+                                                         active_config.cookieDomain());
+        },
+        test_time_, test_random_);
+    EXPECT_CALL(*oauth_client_, getState()).WillRepeatedly(Return(OAuth2Client::OAuthState::Idle));
+    filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+    filter_->setEncoderFilterCallbacks(encoder_callbacks_);
+    filter_->flow_id_ = "00000000075bcd15";
+  }
+
   // Set up proto fields with standard config.
   FilterConfigSharedPtr getConfig(
       bool forward_bearer_token = true, bool use_refresh_token = false,
@@ -484,6 +508,8 @@ public:
     primeActiveConfigForTest();
     return filter_->decryptToken(ct);
   }
+  // The refresh token the filter holds, so a test can check that a refresh preserved the old one.
+  const std::string& refreshTokenForTest() const { return filter_->refresh_token_; }
 
   // Validates the behavior of the cookie validator.
   void expectValidCookies(const CookieNames& cookie_names, const std::string& cookie_domain) {
@@ -7109,6 +7135,595 @@ TEST_F(OAuth2Test, PostMigrationConfigRejectsCbcCiphertext) {
   // Rejection path (no marker + compat off) must not tick the legacy CBC counter: nothing was
   // decrypted, just refused.
   EXPECT_EQ(0, config_->stats().oauth_legacy_cbc_decrypt_.value());
+}
+
+// Chunked token cookies.
+//
+// A token cookie too large for a browser is split into several cookies and rejoined on the way back
+// in. These tests use the real OAuth2CookieValidator because the HMAC covers the token values, so
+// only a full write then read round trip proves the split and the rejoin agree.
+class OAuth2ChunkedCookieTest : public OAuth2Test {
+public:
+  // Mirrors MaxCookieSize in filter.cc.
+  static constexpr size_t MaxCookieSizeForTest = 4096;
+
+  OAuth2ChunkedCookieTest() : OAuth2Test(false) {}
+
+  void enableChunking(bool enabled) {
+    scoped_runtime_.mergeValues({{"envoy.reloadable_features.oauth2_chunk_large_token_cookies",
+                                  enabled ? "true" : "false"}});
+  }
+
+  // Captures the Set-Cookie values from the next encodeHeaders() call.
+  void captureSetCookies(std::vector<std::string>& out) {
+    EXPECT_CALL(decoder_callbacks_, encodeHeaders_(testing::_, true))
+        .WillOnce(testing::Invoke([&out](Http::ResponseHeaderMap& headers, bool) {
+          headers.iterate([&out](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+            if (header.key().getStringView() == Http::Headers::get().SetCookie.get()) {
+              out.emplace_back(header.value().getStringView());
+            }
+            return Http::HeaderMap::Iterate::Continue;
+          });
+        }));
+  }
+
+  // Runs a token exchange and returns every Set-Cookie value. The /_signout request only sets
+  // host_ and request_headers_, as elsewhere in this file.
+  std::vector<std::string> runTokenExchange(const std::string& access_token,
+                                            const std::string& id_token,
+                                            const std::string& refresh_token,
+                                            const std::string& request_cookie = "") {
+    Http::TestRequestHeaderMapImpl request_headers{
+        {Http::Headers::get().Host.get(), "traffic.example.com"},
+        {Http::Headers::get().Path.get(), "/_signout"},
+        {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+    };
+    if (!request_cookie.empty()) {
+      request_headers.addCopy(Http::Headers::get().Cookie, request_cookie);
+    }
+    filter_->decodeHeaders(request_headers, false);
+
+    std::vector<std::string> set_cookies;
+    captureSetCookies(set_cookies);
+    filter_->onGetAccessTokenSuccess(access_token, id_token, refresh_token,
+                                     std::chrono::seconds(600));
+    // Drop the expectation before set_cookies goes out of scope, so a second exchange starts
+    // clean.
+    testing::Mock::VerifyAndClearExpectations(&decoder_callbacks_);
+    return set_cookies;
+  }
+
+  // Builds the Cookie header a browser would send next, skipping cookies the response deleted.
+  static std::string toCookieHeader(const std::vector<std::string>& set_cookies) {
+    std::string cookie_header;
+    for (const auto& set_cookie : set_cookies) {
+      const absl::string_view name_value =
+          absl::string_view(set_cookie).substr(0, set_cookie.find(';'));
+      if (absl::EndsWith(name_value, "=deleted")) {
+        continue;
+      }
+      if (!cookie_header.empty()) {
+        absl::StrAppend(&cookie_header, "; ");
+      }
+      absl::StrAppend(&cookie_header, name_value);
+    }
+    return cookie_header;
+  }
+
+  // Chunks a large access token out, sends the cookies back, and checks the filter accepted the
+  // session and forwarded the whole token. The HMAC covers the decrypted token, so this only
+  // passes if the split, the rejoin and the encryption in use all agree.
+  void expectChunkedRoundTripSucceeds(FilterConfigSharedPtr config) {
+    initWithRealValidator(config);
+    test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+    const std::string large_access_token(6000, 'a');
+    const std::vector<std::string> set_cookies =
+        runTokenExchange(large_access_token, "some-id-token", "some-refresh-token");
+    ASSERT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken_chunks"));
+
+    initWithRealValidator(config);
+    Http::TestRequestHeaderMapImpl replay{
+        {Http::Headers::get().Host.get(), "traffic.example.com"},
+        {Http::Headers::get().Path.get(), "/original_path"},
+        {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+        {Http::Headers::get().Cookie.get(), toCookieHeader(set_cookies)},
+    };
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(replay, false));
+    EXPECT_EQ(absl::StrCat("Bearer ", large_access_token),
+              replay.get_(Http::CustomHeaders::get().Authorization));
+  }
+
+  static std::vector<std::string> cookieNames(const std::vector<std::string>& set_cookies) {
+    std::vector<std::string> names;
+    names.reserve(set_cookies.size());
+    for (const auto& set_cookie : set_cookies) {
+      names.emplace_back(set_cookie.substr(0, set_cookie.find('=')));
+    }
+    return names;
+  }
+
+  static bool deletesCookie(const std::vector<std::string>& set_cookies, absl::string_view name) {
+    for (const auto& set_cookie : set_cookies) {
+      if (absl::StartsWith(set_cookie, absl::StrCat(name, "=deleted"))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  TestScopedRuntime scoped_runtime_;
+};
+
+// The cookie holds ciphertext while the HMAC covers the decrypted value, so chunks must be
+// rejoined before decryption. Rejoining later gives an HMAC over ciphertext that never matches.
+TEST_F(OAuth2ChunkedCookieTest, ChunkedCookiesRoundTripWithEncryptionEnabled) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::string large_access_token(6000, 'a');
+  const std::vector<std::string> set_cookies =
+      runTokenExchange(large_access_token, "some-id-token", "some-refresh-token");
+
+  // The access token was split, and the count cookie records how many parts there are.
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken_0"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken_1"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken_chunks"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Not(testing::Contains("BearerToken")));
+  EXPECT_EQ(1, config->stats().oauth_token_cookie_chunked_.value());
+
+  // Send the cookies back the way a browser would, on a fresh filter using the same config.
+  initWithRealValidator(config);
+  Http::TestRequestHeaderMapImpl replay{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(), toCookieHeader(set_cookies)},
+  };
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(replay, false));
+  EXPECT_EQ(1, config->stats().oauth_token_cookie_reassembled_.value());
+
+  // Upstream sees one plaintext cookie under the base name, and no chunk cookies at all.
+  const std::string forwarded(replay.get_(Http::Headers::get().Cookie));
+  EXPECT_THAT(forwarded, testing::HasSubstr(absl::StrCat("BearerToken=", large_access_token)));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("BearerToken_0")));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("BearerToken_chunks")));
+
+  // The whole token is forwarded, not just the first chunk.
+  EXPECT_EQ(absl::StrCat("Bearer ", large_access_token),
+            replay.get_(Http::CustomHeaders::get().Authorization));
+}
+
+// Turning the guard off must clean up. If the old chunk cookies stayed, the client would keep
+// sending a set that no longer matches what the filter writes, making the flag one way.
+TEST_F(OAuth2ChunkedCookieTest, StaleChunksDeletedWhenChunkingDisabled) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::vector<std::string> chunked =
+      runTokenExchange(std::string(6000, 'a'), "some-id-token", "some-refresh-token");
+  ASSERT_THAT(cookieNames(chunked), testing::Contains("BearerToken_chunks"));
+
+  // Now revert the guard and run another exchange, with the browser still holding the chunks.
+  enableChunking(false);
+  initWithRealValidator(config);
+  const std::vector<std::string> unchunked = runTokenExchange(
+      "access_code", "some-id-token", "some-refresh-token", toCookieHeader(chunked));
+
+  EXPECT_THAT(cookieNames(unchunked), testing::Contains("BearerToken"));
+  EXPECT_TRUE(deletesCookie(unchunked, "BearerToken_chunks"));
+  EXPECT_TRUE(deletesCookie(unchunked, "BearerToken_0"));
+}
+
+// A refresh that returns no new refresh token must keep the one the request carried. If that token
+// arrived chunked, a base name lookup finds nothing and the HMAC is rebuilt without it.
+TEST_F(OAuth2ChunkedCookieTest, ChunkedRefreshTokenPreservedAcrossRefresh) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::string large_refresh_token(6000, 'r');
+  const std::vector<std::string> set_cookies =
+      runTokenExchange("access_code", "some-id-token", large_refresh_token);
+  ASSERT_THAT(cookieNames(set_cookies), testing::Contains("RefreshToken_chunks"));
+
+  initWithRealValidator(config);
+  // Move past expiry so decodeHeaders() takes the refresh branch. The logged-in branch would strip
+  // the refresh token first.
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(2000)));
+  Http::TestRequestHeaderMapImpl replay{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(), toCookieHeader(set_cookies)},
+  };
+  // Reaching the refresh branch means the filter hands the rejoined refresh token to the client.
+  EXPECT_CALL(*oauth_client_,
+              asyncRefreshAccessToken(large_refresh_token, TEST_CLIENT_ID,
+                                      "asdf_client_secret_fdsa", AuthType::UrlEncodedBody));
+  filter_->decodeHeaders(replay, false);
+
+  // The IdP returns no new refresh token, so the old one has to survive the refresh.
+  filter_->onRefreshAccessTokenSuccess("new-access-token", "some-id-token", "",
+                                       std::chrono::seconds(600));
+  EXPECT_EQ(large_refresh_token, refreshTokenForTest());
+}
+
+// A token needing more chunks than the cap must not be written as a truncated set, because the
+// count would claim chunks that do not exist.
+TEST_F(OAuth2ChunkedCookieTest, TokenTooLargeToChunkFallsBackToSingleCookie) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  // 15 chunks of roughly 4 KB is the cap, so ask for well beyond it.
+  const std::vector<std::string> set_cookies =
+      runTokenExchange(std::string(80000, 'a'), "some-id-token", "some-refresh-token");
+
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Not(testing::Contains("BearerToken_chunks")));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Not(testing::Contains("BearerToken_0")));
+  EXPECT_EQ(1, config->stats().oauth_token_cookie_oversized_.value());
+}
+
+// With the guard off the filter behaves as before: one oversized cookie, plus a counter.
+TEST_F(OAuth2ChunkedCookieTest, LargeTokenIsNotChunkedWhenGuardIsOff) {
+  enableChunking(false);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::vector<std::string> set_cookies =
+      runTokenExchange(std::string(6000, 'a'), "some-id-token", "some-refresh-token");
+
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Not(testing::Contains("BearerToken_0")));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Not(testing::Contains("BearerToken_chunks")));
+  EXPECT_EQ(0, config->stats().oauth_token_cookie_chunked_.value());
+  EXPECT_EQ(1, config->stats().oauth_token_cookie_oversized_.value());
+}
+
+// Request cookies are untrusted. A count outside the supported range must be rejected, and the
+// chunks must still be stripped.
+TEST_F(OAuth2ChunkedCookieTest, MalformedChunkCountIsRejected) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+
+  for (const absl::string_view bad_count : {"0", "16", "abc", "-1", "99999999999999999999", ""}) {
+    initWithRealValidator(config);
+    test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+    Http::TestRequestHeaderMapImpl headers{
+        {Http::Headers::get().Host.get(), "traffic.example.com"},
+        {Http::Headers::get().Path.get(), "/original_path"},
+        {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+        {Http::Headers::get().Cookie.get(),
+         absl::StrCat("BearerToken_chunks=", bad_count, "; BearerToken_0=abc; BearerToken_1=def")},
+    };
+    filter_->decodeHeaders(headers, false);
+
+    const std::string forwarded(headers.get_(Http::Headers::get().Cookie));
+    EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("BearerToken_0"))) << bad_count;
+    EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("BearerToken_chunks"))) << bad_count;
+  }
+  EXPECT_LT(0, config->stats().oauth_token_cookie_malformed_chunks_.value());
+}
+
+// A gap in the set must discard the whole set, rather than give a truncated token to the HMAC
+// check.
+TEST_F(OAuth2ChunkedCookieTest, MissingChunkDiscardsTheWholeSet) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  // Announces three chunks but only supplies the first and the last.
+  Http::TestRequestHeaderMapImpl headers{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(),
+       "BearerToken_chunks=3; BearerToken_0=aaa; BearerToken_2=ccc"},
+  };
+  filter_->decodeHeaders(headers, false);
+
+  const std::string forwarded(headers.get_(Http::Headers::get().Cookie));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("aaa")));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("ccc")));
+  EXPECT_EQ(1, config->stats().oauth_token_cookie_malformed_chunks_.value());
+}
+
+// Signing out must clear the chunk cookies, or the client keeps sending token fragments.
+TEST_F(OAuth2ChunkedCookieTest, SignOutDeletesChunkCookies) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  std::vector<std::string> set_cookies;
+  captureSetCookies(set_cookies);
+
+  Http::TestRequestHeaderMapImpl headers{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/_signout"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(),
+       "BearerToken_chunks=2; BearerToken_0=aaa; BearerToken_1=bbb"},
+  };
+  filter_->decodeHeaders(headers, false);
+
+  EXPECT_TRUE(deletesCookie(set_cookies, "BearerToken"));
+  EXPECT_TRUE(deletesCookie(set_cookies, "BearerToken_chunks"));
+  EXPECT_TRUE(deletesCookie(set_cookies, "BearerToken_0"));
+  EXPECT_TRUE(deletesCookie(set_cookies, "BearerToken_1"));
+}
+
+// A token that grows past the limit switches from one cookie to a chunk set. The old single cookie
+// must be deleted, or the client keeps sending a full size dead copy alongside the chunks.
+TEST_F(OAuth2ChunkedCookieTest, SwitchingToChunkedDeletesTheOldSingleCookie) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  // The request still carries the previous, unchunked cookie.
+  const std::vector<std::string> set_cookies = runTokenExchange(
+      std::string(6000, 'a'), "some-id-token", "some-refresh-token", "BearerToken=small-old-value");
+
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken_chunks"));
+  EXPECT_TRUE(deletesCookie(set_cookies, "BearerToken"));
+}
+
+// The logged-in path strips the refresh token before forwarding, so it must strip refresh token
+// chunks that arrived without a count cookie as well. Reassembly does not see them, because it
+// only runs when a count cookie is present.
+TEST_F(OAuth2ChunkedCookieTest, OrphanChunksStrippedOnLoggedInPath) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::vector<std::string> set_cookies =
+      runTokenExchange("access_code", "some-id-token", "some-refresh-token");
+
+  // Replay a valid session with refresh token chunks alongside it, and no count cookie.
+  initWithRealValidator(config);
+  Http::TestRequestHeaderMapImpl replay{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(),
+       absl::StrCat(toCookieHeader(set_cookies), "; RefreshToken_0=leak0; RefreshToken_1=leak1")},
+  };
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(replay, false));
+
+  const std::string forwarded(replay.get_(Http::Headers::get().Cookie));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("leak0")));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("leak1")));
+}
+
+// On the refresh path removeOAuthFlowCookies() strips the token cookies from the request before
+// the response is built, so the response path cannot see that the client still holds a single
+// cookie. It must still delete that cookie when the new token is chunked.
+TEST_F(OAuth2ChunkedCookieTest, RefreshDeletesOldSingleCookieWhenNewTokenIsChunked) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  // A small refresh token, so it is written as a single cookie.
+  const std::vector<std::string> set_cookies =
+      runTokenExchange("access_code", "some-id-token", "small-refresh-token");
+  ASSERT_THAT(cookieNames(set_cookies), testing::Contains("RefreshToken"));
+
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(2000)));
+  Http::TestRequestHeaderMapImpl replay{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(), toCookieHeader(set_cookies)},
+  };
+  EXPECT_CALL(*oauth_client_, asyncRefreshAccessToken(_, _, _, _));
+  filter_->decodeHeaders(replay, false);
+
+  // The refresh returns a refresh token too large for one cookie.
+  filter_->onRefreshAccessTokenSuccess("new-access-token", "some-id-token", std::string(6000, 'r'),
+                                       std::chrono::seconds(600));
+
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  filter_->encodeHeaders(response_headers, false);
+
+  std::vector<std::string> response_cookies;
+  response_headers.iterate(
+      [&response_cookies](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+        if (header.key().getStringView() == Http::Headers::get().SetCookie.get()) {
+          response_cookies.emplace_back(header.value().getStringView());
+        }
+        return Http::HeaderMap::Iterate::Continue;
+      });
+
+  EXPECT_THAT(cookieNames(response_cookies), testing::Contains("RefreshToken_chunks"));
+  EXPECT_TRUE(deletesCookie(response_cookies, "RefreshToken"));
+}
+
+// The mirror of the test above. A request that arrived chunked has no single cookie, so the
+// response must not delete one. request_cookies cannot tell the difference on its own.
+TEST_F(OAuth2ChunkedCookieTest, ChunkedToChunkedDoesNotDeleteTheBaseCookie) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::vector<std::string> first =
+      runTokenExchange(std::string(6000, 'a'), "some-id-token", "some-refresh-token");
+  ASSERT_THAT(cookieNames(first), testing::Contains("BearerToken_chunks"));
+
+  initWithRealValidator(config);
+  const std::vector<std::string> second = runTokenExchange(
+      std::string(6000, 'b'), "some-id-token", "some-refresh-token", toCookieHeader(first));
+
+  EXPECT_THAT(cookieNames(second), testing::Contains("BearerToken_chunks"));
+  EXPECT_FALSE(deletesCookie(second, "BearerToken"));
+}
+
+// All three token cookies can be chunked at once. Each set is keyed by its own base name, so this
+// checks the sets do not interfere and the HMAC still covers all three rejoined values.
+TEST_F(OAuth2ChunkedCookieTest, AllThreeTokensChunkedAtOnce) {
+  enableChunking(true);
+  FilterConfigSharedPtr config = getConfig(true, true);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+
+  const std::string access_token(6000, 'a');
+  const std::string id_token(6000, 'i');
+  const std::string refresh_token(6000, 'r');
+  const std::vector<std::string> set_cookies =
+      runTokenExchange(access_token, id_token, refresh_token);
+
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("BearerToken_chunks"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("IdToken_chunks"));
+  EXPECT_THAT(cookieNames(set_cookies), testing::Contains("RefreshToken_chunks"));
+  EXPECT_EQ(3, config->stats().oauth_token_cookie_chunked_.value());
+
+  initWithRealValidator(config);
+  Http::TestRequestHeaderMapImpl replay{
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Path.get(), "/original_path"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Cookie.get(), toCookieHeader(set_cookies)},
+  };
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(replay, false));
+  EXPECT_EQ(3, config->stats().oauth_token_cookie_reassembled_.value());
+
+  // Each token was rejoined into its own cookie, with nothing carried across the sets. The refresh
+  // token is stripped before forwarding, so its rejoin is proven by the HMAC check above, which
+  // covers all three values.
+  const std::string forwarded(replay.get_(Http::Headers::get().Cookie));
+  EXPECT_THAT(forwarded, testing::HasSubstr(absl::StrCat("BearerToken=", access_token)));
+  EXPECT_THAT(forwarded, testing::HasSubstr(absl::StrCat("IdToken=", id_token)));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("RefreshToken")));
+}
+
+// The case for enabling this by default is that nothing changes for a cookie that already fits.
+// This pins the exact boundary: at the size limit the output must be byte identical either way,
+// and only one byte past it does chunking start. Encryption is off so the cookie value is the
+// token itself and the arithmetic is exact.
+TEST_F(OAuth2ChunkedCookieTest, OutputIsUnchangedForCookiesThatFit) {
+  constexpr auto DisabledSameSite = ::envoy::extensions::filters::http::oauth2::v3::
+      CookieConfig_SameSite::CookieConfig_SameSite_DISABLED;
+  FilterConfigSharedPtr config =
+      getConfig(true, true,
+                ::envoy::extensions::filters::http::oauth2::v3::OAuth2Config_AuthType::
+                    OAuth2Config_AuthType_URL_ENCODED_BODY,
+                0, false, false, false, false, false, DisabledSameSite, DisabledSameSite,
+                DisabledSameSite, DisabledSameSite, DisabledSameSite, DisabledSameSite,
+                DisabledSameSite, 0, 0, true /* disable_token_encryption */);
+
+  // Measure everything the cookie carries besides the value.
+  enableChunking(false);
+  initWithRealValidator(config);
+  test_time_.setSystemTime(SystemTime(std::chrono::seconds(1000)));
+  const std::vector<std::string> probe =
+      runTokenExchange("x", "some-id-token", "some-refresh-token");
+  size_t overhead = 0;
+  for (const auto& set_cookie : probe) {
+    if (absl::StartsWith(set_cookie, "BearerToken=")) {
+      overhead = set_cookie.size() - 1;
+    }
+  }
+  ASSERT_GT(overhead, 0);
+
+  // A token that fills the cookie exactly to the limit.
+  const std::string exact_fit(MaxCookieSizeForTest - overhead, 'a');
+  enableChunking(false);
+  initWithRealValidator(config);
+  const std::vector<std::string> without_guard =
+      runTokenExchange(exact_fit, "some-id-token", "some-refresh-token");
+  enableChunking(true);
+  initWithRealValidator(config);
+  const std::vector<std::string> with_guard =
+      runTokenExchange(exact_fit, "some-id-token", "some-refresh-token");
+
+  EXPECT_EQ(without_guard, with_guard);
+  EXPECT_THAT(cookieNames(with_guard), testing::Contains("BearerToken"));
+  EXPECT_THAT(cookieNames(with_guard), testing::Not(testing::Contains("BearerToken_chunks")));
+
+  // One byte past the limit is where chunking starts.
+  const std::string one_too_big(MaxCookieSizeForTest - overhead + 1, 'a');
+  enableChunking(true);
+  initWithRealValidator(config);
+  const std::vector<std::string> over =
+      runTokenExchange(one_too_big, "some-id-token", "some-refresh-token");
+  EXPECT_THAT(cookieNames(over), testing::Contains("BearerToken_chunks"));
+}
+
+// Token encryption can be turned off in config, and decryptAndUpdateOAuthTokenCookies() returns
+// early when it is. Rejoining runs as its own step so it still happens in that case.
+TEST_F(OAuth2ChunkedCookieTest, RoundTripWithTokenEncryptionDisabled) {
+  enableChunking(true);
+  constexpr auto DisabledSameSite = ::envoy::extensions::filters::http::oauth2::v3::
+      CookieConfig_SameSite::CookieConfig_SameSite_DISABLED;
+  expectChunkedRoundTripSucceeds(
+      getConfig(true /* forward_bearer_token */, true /* use_refresh_token */,
+                ::envoy::extensions::filters::http::oauth2::v3::OAuth2Config_AuthType::
+                    OAuth2Config_AuthType_URL_ENCODED_BODY,
+                0, false, false, false, false, false, DisabledSameSite, DisabledSameSite,
+                DisabledSameSite, DisabledSameSite, DisabledSameSite, DisabledSameSite,
+                DisabledSameSite, 0, 0, true /* disable_token_encryption */));
+}
+
+// GCM ciphertext carries a "gcm." marker that a chunk boundary can fall inside. Only the rejoined
+// value is ever decrypted, so the marker has to survive the split.
+TEST_F(OAuth2ChunkedCookieTest, RoundTripWithGcmEncryption) {
+  enableChunking(true);
+  scoped_runtime_.mergeValues({{"envoy.reloadable_features.oauth2_use_gcm_encryption", "true"}});
+  expectChunkedRoundTripSucceeds(getConfig(true, true));
+}
+
+// With cookie_domain set the HMAC is computed over that domain rather than the host, and the
+// chunk cookies carry a domain attribute.
+TEST_F(OAuth2ChunkedCookieTest, RoundTripWithCookieDomain) {
+  enableChunking(true);
+  expectChunkedRoundTripSucceeds(
+      getConfig(true /* forward_bearer_token */, true /* use_refresh_token */,
+                ::envoy::extensions::filters::http::oauth2::v3::OAuth2Config_AuthType::
+                    OAuth2Config_AuthType_URL_ENCODED_BODY,
+                0, false, false, true /* set_cookie_domain */));
+}
+
+// Reassembly only runs when the count cookie is present, so bare chunk cookies slip past it. The
+// allow_failed passthrough strips credentials, so it must remove them either way.
+TEST_F(OAuth2ChunkedCookieTest, ChunkCookiesStrippedOnAllowFailedWithoutCountCookie) {
+  enableChunking(true);
+  init(getConfig(true, true));
+
+  Http::TestRequestHeaderMapImpl request_headers{
+      {Http::Headers::get().Path.get(), "/allowfailed/api"},
+      {Http::Headers::get().Host.get(), "traffic.example.com"},
+      {Http::Headers::get().Method.get(), Http::Headers::get().MethodValues.Get},
+      {Http::Headers::get().Scheme.get(), "https"},
+      // Deliberately no BearerToken_chunks cookie.
+      {Http::Headers::get().Cookie.get(), "BearerToken_0=aaa; BearerToken_1=bbb; other=keep"},
+  };
+
+  EXPECT_CALL(*validator_, setParams(_, _));
+  EXPECT_CALL(*validator_, isValid()).WillOnce(Return(false));
+  // No usable refresh token, so the request takes the allow_failed passthrough.
+  EXPECT_CALL(*validator_, canUpdateTokenByRefreshToken()).WillOnce(Return(false));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+
+  const std::string forwarded(request_headers.get_(Http::Headers::get().Cookie));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("BearerToken_0")));
+  EXPECT_THAT(forwarded, testing::Not(testing::HasSubstr("BearerToken_1")));
+  EXPECT_THAT(forwarded, testing::HasSubstr("other=keep"));
 }
 
 } // namespace Oauth2

--- a/test/extensions/filters/http/oauth2/oauth_integration_test.cc
+++ b/test/extensions/filters/http/oauth2/oauth_integration_test.cc
@@ -373,7 +373,7 @@ typed_config:
         false);
 
     envoy::extensions::http_filters::oauth2::OAuthResponse oauth_response;
-    oauth_response.mutable_access_token()->set_value("bar");
+    oauth_response.mutable_access_token()->set_value(access_token_value_);
     oauth_response.mutable_refresh_token()->set_value("foo");
     oauth_response.mutable_expires_in()->set_value(DateUtil::nowToSeconds(api_->timeSource()) + 10);
 
@@ -496,6 +496,10 @@ typed_config:
 
     cleanup();
   }
+
+  // The access token the fake authorization server returns. Tests override it to exceed the cookie
+  // size limit.
+  std::string access_token_value_{"bar"};
 
   const CookieNames default_cookie_names_{"BearerToken",  "OauthHMAC",  "OauthExpires", "IdToken",
                                           "RefreshToken", "OauthNonce", "CodeVerifier"};
@@ -999,6 +1003,116 @@ TEST_P(OauthIntegrationTest, LegacyCbcCodeVerifierAcceptedByDefault) {
   // Passing a CBC ciphertext here proves the default-on compat fallback succeeds end-to-end.
   doAuthenticationFlow("token_secret", "hmac_secret", TEST_STATE_CSRF_TOKEN, TEST_ENCODED_STATE,
                        TEST_ENCRYPTED_CODE_VERIFIER);
+}
+
+// With chunking enabled, a token too large for one cookie must be split on the way out and
+// rejoined on the way back in, with the HMAC still valid. This also covers real header size
+// limits.
+class OauthChunkedCookieIntegrationTest : public OauthIntegrationTest {
+public:
+  void initialize() override {
+    config_helper_.addRuntimeOverride("envoy.reloadable_features.oauth2_chunk_large_token_cookies",
+                                      "true");
+    OauthIntegrationTest::initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersionsAndGrpcTypes, OauthChunkedCookieIntegrationTest,
+                         GRPC_CLIENT_INTEGRATION_PARAMS_WITH_GCM_FLAG,
+                         OauthIntegrationTest::oauthIntegrationParamsToString);
+
+TEST_P(OauthChunkedCookieIntegrationTest, LargeAccessTokenIsChunkedAndRejoined) {
+  // Comfortably past the 4096 bytes a browser will store in one cookie.
+  access_token_value_ = std::string(6000, 'a');
+
+  on_server_init_function_ = [&]() {
+    createLdsStream();
+    sendLdsResponse({MessageUtil::getYamlStringFromMessage(listener_config_)}, "initial");
+  };
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestRequestHeaderMapImpl headers{
+      {":method", "GET"},
+      {":path", absl::StrCat("/callback?code=foo&state=", TEST_ENCODED_STATE)},
+      {":scheme", "http"},
+      {"x-forwarded-proto", "http"},
+      {":authority", "authority"},
+      {"authority", "Bearer token"},
+      {"cookie", absl::StrCat(default_cookie_names_.oauth_nonce_, ".", TEST_FLOW_ID, "=",
+                              TEST_STATE_CSRF_TOKEN)},
+      {"cookie", absl::StrCat(default_cookie_names_.code_verifier_, ".", TEST_FLOW_ID, "=",
+                              TEST_ENCRYPTED_CODE_VERIFIER)}};
+
+  auto encoder_decoder = codec_client_->startRequest(headers);
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  waitForOAuth2Response("token_secret");
+  response->waitForHeaders();
+  EXPECT_EQ("302", response->headers().getStatusValue());
+
+  // The access token came back as several cookies plus a count, not one oversized cookie.
+  const std::string chunk_count = Http::Utility::parseSetCookieValue(
+      response->headers(), absl::StrCat(default_cookie_names_.bearer_token_, "_chunks"));
+  ASSERT_FALSE(chunk_count.empty());
+  EXPECT_TRUE(
+      Http::Utility::parseSetCookieValue(response->headers(), default_cookie_names_.bearer_token_)
+          .empty());
+
+  std::vector<std::string> chunk_values;
+  for (uint32_t i = 0; i < 15; ++i) {
+    std::string value = Http::Utility::parseSetCookieValue(
+        response->headers(), absl::StrCat(default_cookie_names_.bearer_token_, "_", i));
+    if (value.empty()) {
+      break;
+    }
+    chunk_values.push_back(std::move(value));
+  }
+  EXPECT_GT(chunk_values.size(), 1);
+  EXPECT_EQ(absl::StrCat(chunk_values.size()), chunk_count);
+
+  const std::string hmac =
+      Http::Utility::parseSetCookieValue(response->headers(), default_cookie_names_.oauth_hmac_);
+  const std::string oauth_expires =
+      Http::Utility::parseSetCookieValue(response->headers(), default_cookie_names_.oauth_expires_);
+  const std::string refresh_token =
+      Http::Utility::parseSetCookieValue(response->headers(), default_cookie_names_.refresh_token_);
+
+  RELEASE_ASSERT(response->waitForEndStream(), "unexpected timeout");
+  cleanup();
+
+  // Send every chunk back. The HMAC covers the token value, so this only passes if the filter
+  // rejoined exactly what it signed.
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestRequestHeaderMapImpl replay{
+      {":method", "GET"},
+      {":path", absl::StrCat("/callback?code=foo&state=", TEST_ENCODED_STATE)},
+      {":scheme", "http"},
+      {"x-forwarded-proto", "http"},
+      {":authority", "authority"},
+      {"authority", "Bearer token"},
+      {"cookie", absl::StrCat(default_cookie_names_.oauth_hmac_, "=", hmac)},
+      {"cookie", absl::StrCat(default_cookie_names_.oauth_expires_, "=", oauth_expires)},
+      {"cookie", absl::StrCat(default_cookie_names_.oauth_nonce_, ".", TEST_FLOW_ID, "=",
+                              TEST_STATE_CSRF_TOKEN)},
+      {"cookie", absl::StrCat(default_cookie_names_.refresh_token_, "=", refresh_token)},
+      {"cookie", absl::StrCat(default_cookie_names_.bearer_token_, "_chunks=", chunk_count)},
+  };
+  for (uint32_t i = 0; i < chunk_values.size(); ++i) {
+    replay.addCopy(Http::LowerCaseString("cookie"),
+                   absl::StrCat(default_cookie_names_.bearer_token_, "_", i, "=", chunk_values[i]));
+  }
+
+  auto encoder_decoder2 = codec_client_->startRequest(replay, true);
+  auto response2 = std::move(encoder_decoder2.second);
+  response2->waitForHeaders();
+  // Redirecting to the original location means the session was accepted rather than restarted.
+  EXPECT_EQ("302", response2->headers().getStatusValue());
+  EXPECT_EQ("http://traffic.example.com/not/_oauth",
+            response2->headers().Location()->value().getStringView());
+  RELEASE_ASSERT(response2->waitForEndStream(), "unexpected timeout");
+  cleanup();
 }
 
 } // namespace


### PR DESCRIPTION
Commit Message: oauth2: chunk large token cookies to avoid browsers dropping them

Additional Description: token cookies can be larger than 4096 bytes, and most modern browsers reject a cookie that large. The cookie is silently dropped, so the HMAC no longer validates and the user is redirected to the authorization server on every request. Thus in this PR, we split such a token into `<name>_0` .. `<name>_N-1` cookies plus a `<name>_chunks` cookie holding the count, and recombine them during read.

The recombine happens before decryption, since the cookie holds ciphertext while the HMAC covers the decrypted value. Doing it any later gives an HMAC over ciphertext that can never match.

A token is split into at most 15 cookies. One too large for that is written as a single cookie, as it is today. A fully chunked session may need `max_request_headers_kb` raised, and a large id token now reaches a configured `end_session_endpoint` as a correspondingly large `id_token_hint`.

The guard defaults to true. A cookie that already fits is written exactly as before, byte for byte, so the only sessions that change are ones the client was already dropping. For those, a mixed fleet during a rolling upgrade is no worse than today: an instance that cannot recombine the cookies restarts the flow, which is what happens on every request now. The case to watch is a non-browser client that accepts cookies over 4096 bytes today, since it works now and would see the split during an upgrade; setting the guard to false restores the old behavior. Recombining and deleting chunked cookies is always enabled, so the guard can be turned back off safely.

Supersedes #28799. Overlaps #43135.

Risk Level: Low
Testing: unit and integration tests
Docs Changes: added the new counters to the oauth2 statistics table
Release Notes: changelogs/current/minor_behavior_changes/oauth2__chunk-large-token-cookies.rst
Platform Specific Features: n/a
Runtime guard: envoy.reloadable_features.oauth2_chunk_large_token_cookies
Fixes #27875
