### PR TITLE
Raise more annotations in CI

### DIFF
--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -41,6 +41,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: true
       request: ${{ inputs.request }}
       catch-errors: ${{ matrix.catch-errors || false }}

--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       rbe: true
       request: ${{ inputs.request }}

--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -41,7 +41,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_build.yml
+++ b/.github/workflows/_check_build.yml
@@ -40,7 +40,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_build_openssl.yml
+++ b/.github/workflows/_check_build_openssl.yml
@@ -41,6 +41,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: true
       request: ${{ inputs.request }}
       catch-errors: ${{ matrix.catch-errors || false }}

--- a/.github/workflows/_check_build_openssl.yml
+++ b/.github/workflows/_check_build_openssl.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_build_openssl.yml
+++ b/.github/workflows/_check_build_openssl.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       rbe: true
       request: ${{ inputs.request }}

--- a/.github/workflows/_check_build_openssl.yml
+++ b/.github/workflows/_check_build_openssl.yml
@@ -41,7 +41,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_build_openssl.yml
+++ b/.github/workflows/_check_build_openssl.yml
@@ -40,7 +40,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -44,7 +44,7 @@ jobs:
         Error:
         lower than limit
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -43,7 +43,7 @@ jobs:
         error:
         Error:
         lower than limit
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -44,6 +44,9 @@ jobs:
         Error:
         lower than limit
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: true
       request: ${{ inputs.request }}
       runs-on: ${{ fromJSON(inputs.request).config.ci.agent-ubuntu }}

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -44,7 +44,6 @@ jobs:
         Error:
         lower than limit
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_check_coverage.yml
+++ b/.github/workflows/_check_coverage.yml
@@ -44,7 +44,6 @@ jobs:
         Error:
         lower than limit
         FAILED
-        not meeting coverage
         FAIL:
       rbe: true
       request: ${{ inputs.request }}

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -41,7 +41,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       request: ${{ inputs.request }}

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       request: ${{ inputs.request }}
       target: ${{ matrix.target }}

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       request: ${{ inputs.request }}

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -41,6 +41,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       request: ${{ inputs.request }}
       target: ${{ matrix.target }}
       timeout-minutes: 180

--- a/.github/workflows/_check_runtime.yml
+++ b/.github/workflows/_check_runtime.yml
@@ -40,7 +40,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       request: ${{ inputs.request }}

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: ${{ matrix.rbe }}

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -40,7 +40,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: ${{ matrix.rbe }}

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -41,7 +41,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       rbe: ${{ matrix.rbe }}
       target: ${{ matrix.target }}

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -41,7 +41,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: ${{ matrix.rbe }}

--- a/.github/workflows/_check_san.yml
+++ b/.github/workflows/_check_san.yml
@@ -41,6 +41,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: ${{ matrix.rbe }}
       target: ${{ matrix.target }}
       timeout-minutes: 180

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -77,6 +77,9 @@ on:
           error:
           Error:
           FAILED in
+          FAILED.*\(\d+ ms\)
+          not meeting coverage
+          FAIL:
       notice-match:
         type: string
         default: |

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -77,7 +77,6 @@ on:
           error:
           Error:
           FAILED in
-          FAILED.*\\(\\d+ ms\\)
           not meeting coverage
           FAIL:
       notice-match:

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -77,7 +77,7 @@ on:
           error:
           Error:
           FAILED in
-          FAILED.*\(\d+ ms\)
+          FAILED.*\\(\\d+ ms\\)
           not meeting coverage
           FAIL:
       notice-match:

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -77,7 +77,6 @@ on:
           error:
           Error:
           FAILED
-          not meeting coverage
           FAIL:
       notice-match:
         type: string

--- a/.github/workflows/_mobile_container_ci.yml
+++ b/.github/workflows/_mobile_container_ci.yml
@@ -76,7 +76,7 @@ on:
           ERROR
           error:
           Error:
-          FAILED in
+          FAILED
           not meeting coverage
           FAIL:
       notice-match:

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -44,7 +44,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -45,7 +45,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       rbe: true
       target: ${{ matrix.target }}

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -45,6 +45,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: true
       target: ${{ matrix.target }}
       trusted: ${{ inputs.trusted }}

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -45,7 +45,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_deps.yml
+++ b/.github/workflows/_precheck_deps.yml
@@ -45,7 +45,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -42,6 +42,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: true
       target: ${{ matrix.target }}
       timeout-minutes: 30

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -41,7 +41,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -42,7 +42,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       rbe: true
       target: ${{ matrix.target }}

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -42,7 +42,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_external.yml
+++ b/.github/workflows/_precheck_external.yml
@@ -42,7 +42,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -44,7 +44,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -44,7 +44,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -43,7 +43,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       rbe: true

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -44,7 +44,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       rbe: true
       target: ${{ matrix.target }}

--- a/.github/workflows/_precheck_format.yml
+++ b/.github/workflows/_precheck_format.yml
@@ -44,6 +44,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       rbe: true
       target: ${{ matrix.target }}
       trusted: ${{ inputs.trusted }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -49,7 +49,6 @@ jobs:
         error:
         Error:
         FAILED
-        not meeting coverage
         FAIL:
       skip: ${{ matrix.skip != false && true || false }}
       steps-post: ${{ matrix.steps-post }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -49,6 +49,9 @@ jobs:
         error:
         Error:
         FAILED in
+        FAILED.*\(\d+ ms\)
+        not meeting coverage
+        FAIL:
       skip: ${{ matrix.skip != false && true || false }}
       steps-post: ${{ matrix.steps-post }}
       target: ${{ matrix.target }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -49,7 +49,7 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\(\d+ ms\)
+        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       skip: ${{ matrix.skip != false && true || false }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -49,7 +49,6 @@ jobs:
         error:
         Error:
         FAILED in
-        FAILED.*\\(\\d+ ms\\)
         not meeting coverage
         FAIL:
       skip: ${{ matrix.skip != false && true || false }}

--- a/.github/workflows/_precheck_publish.yml
+++ b/.github/workflows/_precheck_publish.yml
@@ -48,7 +48,7 @@ jobs:
         ERROR
         error:
         Error:
-        FAILED in
+        FAILED
         not meeting coverage
         FAIL:
       skip: ${{ matrix.skip != false && true || false }}

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -94,7 +94,7 @@ on:
           error:
           Error:
           FAILED in
-          FAILED.*\(\d+ ms\)
+          FAILED.*\\(\\d+ ms\\)
           not meeting coverage
           FAIL:
       fail-match:

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -93,7 +93,7 @@ on:
           ERROR
           error:
           Error:
-          FAILED in
+          FAILED
           not meeting coverage
           FAIL:
       fail-match:

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -94,7 +94,6 @@ on:
           error:
           Error:
           FAILED in
-          FAILED.*\\(\\d+ ms\\)
           not meeting coverage
           FAIL:
       fail-match:

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -94,7 +94,6 @@ on:
           error:
           Error:
           FAILED
-          not meeting coverage
           FAIL:
       fail-match:
         type: string

--- a/.github/workflows/_run.yml
+++ b/.github/workflows/_run.yml
@@ -94,6 +94,9 @@ on:
           error:
           Error:
           FAILED in
+          FAILED.*\(\d+ ms\)
+          not meeting coverage
+          FAIL:
       fail-match:
         type: string
       import-gpg:


### PR DESCRIPTION
Commit Message: Raise more annotations in CI
Additional Description: This adds more types of annotation, for three observed "would be nice if we could find this easier" log cases.
The log lines we're aiming to match with this are:
```
FAIL: //tools/code:check_test (Exit 1) (see /build/bazel_root/base/execroot/envoy/bazel-out/k8-fastbuild/testlogs/tools/code/check_test/test.log)
  ==================== Test output for //tools/code:check_test:
  CodeChecker ERROR [extensions_owners] Directory (source/extensions/http/early_header_mutation/exact_path_rewrite) has no owners in CODEOWNERS
  CodeChecker ERROR [extensions_owners] Check failed
  CodeChecker ERROR ERRORS Summary [extensions_owners]:
```
- choosing `FAIL:` because there is only one in the log, vs. 7 `CodeChecker ERROR` for the single failure. Not as useful without clicking through, but probably more useful than having to pick the right one of 7 because the other 6 are useless.

```
FAILED: Directories not meeting coverage thresholds:
```

specific test cases such as

```
  [  FAILED  ] AiProtocolManagerFilterTest.RaisedInlineStringThresholdKeepsLargeValuesInline (82 ms)
```

and the previously attempted to match with `FAILED in` that didn't work because there's escape codes in the middle

```
//test/extensions/filters/http/ai_protocol_manager:filter_test           FAILED in 4.2s
```

`FAILED` will unfortunately also match other less useful lines such as these:
```
  [  FAILED  ] 1 test, listed below:
  [  FAILED  ] AiProtocolManagerFilterTest.RaisedInlineStringThresholdKeepsLargeValuesInline
  
   1 FAILED TEST
 INFO: Build completed, 1 test FAILED, 33927 total actions
```

Risk Level: No production change
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
