### PR TITLE
ext_authz: Add config knob to suppress egress client spans while preserving trace context- #47132

### DIFF
--- a/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
+++ b/api/envoy/extensions/filters/http/ext_authz/v3/ext_authz.proto
@@ -30,7 +30,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // External Authorization :ref:`configuration overview <config_http_filters_ext_authz>`.
 // [#extension: envoy.filters.http.ext_authz]
 
-// [#next-free-field: 33]
+// [#next-free-field: 34]
 message ExtAuthz {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v3.ExtAuthz";
@@ -397,6 +397,13 @@ message ExtAuthz {
   //
   // Defaults to ``false``.
   bool shadow_mode = 32;
+
+  // Whether to emit client-side spans for external authorization requests (e.g. gRPC or HTTP calls).
+  // When set to false, client-side egress spans will not be emitted/exported to trace collectors,
+  // but trace context (e.g. ``traceparent``) will still be propagated to the authorization server.
+  //
+  // If unset, defaults to ``true``.
+  google.protobuf.BoolValue emit_client_span = 33;
 }
 
 // Serialized form of the shadow-mode authorization decision written to FilterState
@@ -624,7 +631,7 @@ message ExtAuthzPerRoute {
 }
 
 // Extra settings for the check request.
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message CheckSettings {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.http.ext_authz.v2.CheckSettings";
@@ -673,4 +680,7 @@ message CheckSettings {
     // Override with an HTTP service configuration.
     HttpService http_service = 5;
   }
+
+  // Overrides the filter-level ``emit_client_span`` setting for this route.
+  google.protobuf.BoolValue emit_client_span = 6;
 }

--- a/changelogs/current/new_features/ext_authz__emit_client_span.rst
+++ b/changelogs/current/new_features/ext_authz__emit_client_span.rst
@@ -1,0 +1,1 @@
+ext_authz: added :ref:`emit_client_span <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.ExtAuthz.emit_client_span>` and per-route :ref:`emit_client_span <envoy_v3_api_field_extensions.filters.http.ext_authz.v3.CheckSettings.emit_client_span>` to allow suppressing client-side egress spans for external authorization calls while preserving trace context propagation.

--- a/source/extensions/filters/common/ext_authz/ext_authz.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz.h
@@ -177,6 +177,19 @@ public:
    * Returns streamInfo of the current request if possible. By default just return a nullptr.
    */
   virtual StreamInfo::StreamInfo const* streamInfo() const { return nullptr; }
+
+  /**
+   * Set whether to emit client span for check requests.
+   */
+  virtual void setEmitClientSpan(bool emit_client_span) { emit_client_span_ = emit_client_span; }
+
+  /**
+   * Returns whether to emit client span for check requests.
+   */
+  bool emitClientSpan() const { return emit_client_span_; }
+
+protected:
+  bool emit_client_span_{true};
 };
 
 using ClientPtr = std::unique_ptr<Client>;

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.cc
@@ -79,10 +79,13 @@ void copyOkResponseMutations(ResponsePtr& response,
 }
 
 GrpcClientImpl::GrpcClientImpl(const Grpc::RawAsyncClientSharedPtr& async_client,
-                               const std::optional<std::chrono::milliseconds>& timeout)
+                               const std::optional<std::chrono::milliseconds>& timeout,
+                               bool emit_client_span)
     : async_client_(async_client), timeout_(timeout),
       service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
-          "envoy.service.auth.v3.Authorization.Check")) {}
+          "envoy.service.auth.v3.Authorization.Check")) {
+  emit_client_span_ = emit_client_span;
+}
 
 GrpcClientImpl::~GrpcClientImpl() { ASSERT(!callbacks_); }
 
@@ -100,6 +103,7 @@ void GrpcClientImpl::check(RequestCallbacks& callbacks,
   Http::AsyncClient::RequestOptions options;
   options.setTimeout(timeout_);
   options.setParentContext(Http::AsyncClient::ParentContext{&stream_info});
+  options.setSampled(emit_client_span_ ? std::nullopt : std::make_optional(false));
 
   ENVOY_LOG(trace, "Sending CheckRequest: {}", request.DebugString());
   request_ = async_client_->send(service_method_, request, *this, parent_span, options);

--- a/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_grpc_impl.h
@@ -44,7 +44,8 @@ class GrpcClientImpl : public Client,
                        public Logger::Loggable<Logger::Id::ext_authz> {
 public:
   GrpcClientImpl(const Grpc::RawAsyncClientSharedPtr& async_client,
-                 const std::optional<std::chrono::milliseconds>& timeout);
+                 const std::optional<std::chrono::milliseconds>& timeout,
+                 bool emit_client_span = true);
   ~GrpcClientImpl() override;
 
   // ExtAuthz::Client

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.cc
@@ -171,14 +171,16 @@ ClientConfig::ClientConfig(const envoy::extensions::filters::http::ext_authz::v3
                         ? THROW_OR_RETURN_VALUE(
                               createRetryPolicy(config.http_service().retry_policy(), context),
                               Router::RetryPolicyConstSharedPtr)
-                        : nullptr) {
+                        : nullptr),
+      emit_client_span_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, emit_client_span, true)) {
   THROW_IF_NOT_OK(
       validateOnlyOneOfPathPrefixOrOverride(path_prefix, config.http_service().path_override()));
 }
 
 ClientConfig::ClientConfig(
     const envoy::extensions::filters::http::ext_authz::v3::HttpService& http_service,
-    bool encode_raw_headers, uint32_t timeout, Server::Configuration::CommonFactoryContext& context)
+    bool encode_raw_headers, uint32_t timeout, Server::Configuration::CommonFactoryContext& context,
+    bool emit_client_span)
     : client_header_matchers_(toClientMatchers(
           http_service.authorization_response().allowed_client_headers(), context)),
       client_header_on_success_matchers_(toClientMatchersOnSuccess(
@@ -205,7 +207,8 @@ ClientConfig::ClientConfig(
           http_service.has_retry_policy()
               ? THROW_OR_RETURN_VALUE(createRetryPolicy(http_service.retry_policy(), context),
                                       Router::RetryPolicyConstSharedPtr)
-              : nullptr) {
+              : nullptr),
+      emit_client_span_(emit_client_span) {
   THROW_IF_NOT_OK(validateOnlyOneOfPathPrefixOrOverride(http_service.path_prefix(),
                                                         http_service.path_override()));
 }
@@ -264,7 +267,9 @@ ClientConfig::toUpstreamMatchers(const envoy::type::matcher::v3::ListStringMatch
 }
 
 RawHttpClientImpl::RawHttpClientImpl(Upstream::ClusterManager& cm, ClientConfigSharedPtr config)
-    : cm_(cm), config_(config) {}
+    : cm_(cm), config_(config) {
+  emit_client_span_ = config_->emitClientSpan();
+}
 
 RawHttpClientImpl::~RawHttpClientImpl() { ASSERT(callbacks_ == nullptr); }
 
@@ -366,7 +371,7 @@ void RawHttpClientImpl::check(RequestCallbacks& callbacks,
                        .setTimeout(config_->timeout())
                        .setParentSpan(parent_span)
                        .setChildSpanName(config_->tracingName())
-                       .setSampled(std::nullopt);
+                       .setSampled(emit_client_span_ ? std::nullopt : std::make_optional(false));
 
     options.setSendXff(false);
 

--- a/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
+++ b/source/extensions/filters/common/ext_authz/ext_authz_http_impl.h
@@ -32,7 +32,7 @@ public:
   // Build config directly from HttpService without constructing a temporary ExtAuthz.
   ClientConfig(const envoy::extensions::filters::http::ext_authz::v3::HttpService& http_service,
                bool encode_raw_headers, uint32_t timeout,
-               Server::Configuration::CommonFactoryContext& context);
+               Server::Configuration::CommonFactoryContext& context, bool emit_client_span = true);
 
   /**
    * Returns the name of the authorization cluster.
@@ -108,6 +108,11 @@ public:
    */
   const Router::RetryPolicyConstSharedPtr& retryPolicy() const { return retry_policy_; }
 
+  /**
+   * Returns whether to emit client span.
+   */
+  bool emitClientSpan() const { return emit_client_span_; }
+
 private:
   static MatcherSharedPtr toClientMatchers(const envoy::type::matcher::v3::ListStringMatcher& list,
                                            Server::Configuration::CommonFactoryContext& context);
@@ -135,6 +140,7 @@ private:
   Router::HeaderParserPtr request_headers_parser_;
   const bool encode_raw_headers_;
   const Router::RetryPolicyConstSharedPtr retry_policy_;
+  const bool emit_client_span_;
 };
 
 using ClientConfigSharedPtr = std::shared_ptr<ClientConfig>;

--- a/source/extensions/filters/http/ext_authz/config.cc
+++ b/source/extensions/filters/http/ext_authz/config.cc
@@ -67,7 +67,7 @@ absl::StatusOr<Http::FilterFactoryCb> ExtAuthzFilterConfig::createHttpFilterFact
                                      config_with_hash_key, server_context.scope(), true);
       RELEASE_ASSERT(client_or_error.ok(), "failed to create ext_authz gRPC client");
       auto client = std::make_unique<Filters::Common::ExtAuthz::GrpcClientImpl>(
-          client_or_error.value(), timeout);
+          client_or_error.value(), timeout, filter_config->emitClientSpan());
       callbacks.addStreamFilter(
           std::make_shared<Filter>(filter_config, std::move(client), server_context));
     };

--- a/source/extensions/filters/http/ext_authz/ext_authz.cc
+++ b/source/extensions/filters/http/ext_authz/ext_authz.cc
@@ -177,6 +177,7 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::ext_authz::v3
       include_tls_session_(config.include_tls_session()),
       charge_cluster_response_stats_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, charge_cluster_response_stats, true)),
+      emit_client_span_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, emit_client_span, true)),
       stats_(generateStats(stats_prefix, config.stat_prefix(), scope)),
       ext_authz_ok_(pool_.add(createPoolStatName(config.stat_prefix(), "ok"))),
       ext_authz_denied_(pool_.add(createPoolStatName(config.stat_prefix(), "denied"))),
@@ -231,6 +232,9 @@ void FilterConfigPerRoute::merge(const FilterConfigPerRoute& other) {
   for (auto it = begin_it; it != end_it; ++it) {
     context_extensions_[it->first] = it->second;
   }
+  if (other.emit_client_span_.has_value()) {
+    emit_client_span_ = other.emit_client_span_;
+  }
 }
 
 // Constructor used for merging configurations from different levels (vhost, route, etc.)
@@ -244,7 +248,10 @@ FilterConfigPerRoute::FilterConfigPerRoute(const FilterConfigPerRoute& less_spec
       grpc_service_(more_specific.grpc_service_.has_value() ? more_specific.grpc_service_
                                                             : std::nullopt),
       http_service_(more_specific.http_service_.has_value() ? more_specific.http_service_
-                                                            : std::nullopt) {
+                                                            : std::nullopt),
+      emit_client_span_(more_specific.emit_client_span_.has_value()
+                            ? more_specific.emit_client_span_
+                            : less_specific.emit_client_span_) {
   // Merge context extensions from more specific configuration, overriding less specific ones.
   for (const auto& extension : more_specific.context_extensions_) {
     context_extensions_[extension.first] = extension.second;
@@ -429,6 +436,13 @@ void Filter::initiateCall(const Http::RequestHeaderMap& headers) {
   ENVOY_STREAM_LOG(trace, "ext_authz filter calling authorization server.", *decoder_callbacks_);
   // Store start time of ext_authz filter call
   start_time_ = decoder_callbacks_->dispatcher().timeSource().monotonicTime();
+
+  bool emit_client_span = config_->emitClientSpan();
+  if (maybe_merged_per_route_config &&
+      maybe_merged_per_route_config->emitClientSpan().has_value()) {
+    emit_client_span = maybe_merged_per_route_config->emitClientSpan().value();
+  }
+  client_to_use->setEmitClientSpan(emit_client_span);
 
   state_ = State::Calling;
   filter_return_ = FilterReturn::StopDecoding; // Don't let the filter chain continue as we are

--- a/source/extensions/filters/http/ext_authz/ext_authz.h
+++ b/source/extensions/filters/http/ext_authz/ext_authz.h
@@ -289,6 +289,8 @@ public:
     return disallowed_headers_matcher_;
   }
 
+  bool emitClientSpan() const { return emit_client_span_; }
+
 private:
   static Http::Code toErrorCode(uint64_t status) {
     const auto code = static_cast<Http::Code>(status);
@@ -350,6 +352,7 @@ private:
   const bool include_peer_certificate_;
   const bool include_tls_session_;
   const bool charge_cluster_response_stats_;
+  const bool emit_client_span_;
 
   // The stats for the filter.
   ExtAuthzFilterStats stats_;
@@ -392,7 +395,11 @@ public:
                           : std::nullopt),
         http_service_(config.has_check_settings() && config.check_settings().has_http_service()
                           ? std::make_optional(config.check_settings().http_service())
-                          : std::nullopt) {
+                          : std::nullopt),
+        emit_client_span_(
+            config.has_check_settings() && config.check_settings().has_emit_client_span()
+                ? std::make_optional(config.check_settings().emit_client_span().value())
+                : std::nullopt) {
     if (config.has_check_settings() && config.check_settings().disable_request_body_buffering() &&
         config.check_settings().has_with_request_body()) {
       creation_status = absl::InvalidArgumentError(
@@ -438,6 +445,11 @@ public:
     return http_service_;
   }
 
+  /**
+   * @return The emit_client_span override for this route, if any.
+   */
+  const std::optional<bool>& emitClientSpan() const { return emit_client_span_; }
+
 private:
   // We save the context extensions as a protobuf map instead of a std::map as this allows us to
   // move it to the CheckRequest, thus avoiding a copy that would incur by converting it.
@@ -447,6 +459,7 @@ private:
   const std::optional<const envoy::config::core::v3::GrpcService> grpc_service_;
   const std::optional<const envoy::extensions::filters::http::ext_authz::v3::HttpService>
       http_service_;
+  std::optional<bool> emit_client_span_;
 };
 
 /**

--- a/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_grpc_impl_test.cc
@@ -691,6 +691,73 @@ TEST_F(ExtAuthzGrpcClientTest, TestGrpcClientResetOnComplete) {
   client_->onSuccess(std::make_unique<envoy::service::auth::v3::CheckResponse>(), span_);
 }
 
+TEST_F(ExtAuthzGrpcClientTest, EmitClientSpanDefault) {
+  initialize();
+  EXPECT_TRUE(client_->emitClientSpan());
+
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(*async_client_,
+              sendRaw(_, _, Grpc::ProtoBufferEq(request), Ref(*(client_.get())), _, _))
+      .WillOnce(
+          Invoke([this](absl::string_view, absl::string_view, Buffer::InstancePtr&&,
+                        Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                        const Http::AsyncClient::RequestOptions& options) -> Grpc::AsyncRequest* {
+            EXPECT_EQ(std::nullopt, options.sampled_);
+            return &async_request_;
+          }));
+
+  client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
+  EXPECT_CALL(request_callbacks_, onComplete_(_));
+  client_->onSuccess(CheckResponsePtr(std::make_unique<envoy::service::auth::v3::CheckResponse>()),
+                     Tracing::NullSpan::instance());
+}
+
+TEST_F(ExtAuthzGrpcClientTest, EmitClientSpanDisabled) {
+  client_ = std::make_unique<GrpcClientImpl>(Grpc::RawAsyncClientPtr{async_client_}, timeout_,
+                                             /*emit_client_span=*/false);
+  EXPECT_FALSE(client_->emitClientSpan());
+
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(*async_client_,
+              sendRaw(_, _, Grpc::ProtoBufferEq(request), Ref(*(client_.get())), _, _))
+      .WillOnce(
+          Invoke([this](absl::string_view, absl::string_view, Buffer::InstancePtr&&,
+                        Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                        const Http::AsyncClient::RequestOptions& options) -> Grpc::AsyncRequest* {
+            EXPECT_EQ(std::make_optional(false), options.sampled_);
+            return &async_request_;
+          }));
+
+  client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
+  EXPECT_CALL(request_callbacks_, onComplete_(_));
+  client_->onSuccess(CheckResponsePtr(std::make_unique<envoy::service::auth::v3::CheckResponse>()),
+                     Tracing::NullSpan::instance());
+}
+
+TEST_F(ExtAuthzGrpcClientTest, SetEmitClientSpan) {
+  initialize();
+  EXPECT_TRUE(client_->emitClientSpan());
+
+  client_->setEmitClientSpan(false);
+  EXPECT_FALSE(client_->emitClientSpan());
+
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(*async_client_,
+              sendRaw(_, _, Grpc::ProtoBufferEq(request), Ref(*(client_.get())), _, _))
+      .WillOnce(
+          Invoke([this](absl::string_view, absl::string_view, Buffer::InstancePtr&&,
+                        Grpc::RawAsyncRequestCallbacks&, Tracing::Span&,
+                        const Http::AsyncClient::RequestOptions& options) -> Grpc::AsyncRequest* {
+            EXPECT_EQ(std::make_optional(false), options.sampled_);
+            return &async_request_;
+          }));
+
+  client_->check(request_callbacks_, request, Tracing::NullSpan::instance(), stream_info_);
+  EXPECT_CALL(request_callbacks_, onComplete_(_));
+  client_->onSuccess(CheckResponsePtr(std::make_unique<envoy::service::auth::v3::CheckResponse>()),
+                     Tracing::NullSpan::instance());
+}
+
 } // namespace ExtAuthz
 } // namespace Common
 } // namespace Filters

--- a/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
+++ b/test/extensions/filters/common/ext_authz/ext_authz_http_impl_test.cc
@@ -1197,6 +1197,77 @@ TEST_F(ExtAuthzHttpClientTest, TestHttpClientResetOnComplete) {
   client_->onSuccess(async_request_, std::move(check_response));
 }
 
+TEST_F(ExtAuthzHttpClientTest, EmitClientSpanDefault) {
+  EXPECT_TRUE(config_->emitClientSpan());
+  EXPECT_TRUE(client_->emitClientSpan());
+
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(async_client_, send_(_, _, _))
+      .WillOnce(Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks&,
+                           const Http::AsyncClient::RequestOptions& options) {
+        EXPECT_EQ(std::nullopt, options.sampled_);
+        return &async_request_;
+      }));
+
+  client_->check(request_callbacks_, request, parent_span_, stream_info_);
+  EXPECT_CALL(request_callbacks_, onComplete_(_));
+  client_->onSuccess(async_request_, std::make_unique<Http::ResponseMessageImpl>(
+                                         Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
+                                             {{Http::LowerCaseString(":status"), "200"}})));
+}
+
+TEST_F(ExtAuthzHttpClientTest, EmitClientSpanDisabled) {
+  const std::string yaml = R"EOF(
+    http_service:
+      server_uri:
+        uri: "ext_authz:9000"
+        cluster: "ext_authz"
+        timeout: 0.25s
+    emit_client_span: false
+  )EOF";
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthz proto_config{};
+  TestUtility::loadFromYaml(yaml, proto_config);
+  auto config = std::make_shared<ClientConfig>(proto_config, 250, "/bar", factory_context_);
+  EXPECT_FALSE(config->emitClientSpan());
+
+  auto client = std::make_unique<RawHttpClientImpl>(cm_, config);
+  EXPECT_FALSE(client->emitClientSpan());
+
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(async_client_, send_(_, _, _))
+      .WillOnce(Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks&,
+                           const Http::AsyncClient::RequestOptions& options) {
+        EXPECT_EQ(std::make_optional(false), options.sampled_);
+        return &async_request_;
+      }));
+
+  client->check(request_callbacks_, request, parent_span_, stream_info_);
+  EXPECT_CALL(request_callbacks_, onComplete_(_));
+  client->onSuccess(async_request_, std::make_unique<Http::ResponseMessageImpl>(
+                                        Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
+                                            {{Http::LowerCaseString(":status"), "200"}})));
+}
+
+TEST_F(ExtAuthzHttpClientTest, SetEmitClientSpan) {
+  EXPECT_TRUE(client_->emitClientSpan());
+  client_->setEmitClientSpan(false);
+  EXPECT_FALSE(client_->emitClientSpan());
+
+  envoy::service::auth::v3::CheckRequest request;
+  EXPECT_CALL(async_client_, send_(_, _, _))
+      .WillOnce(Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks&,
+                           const Http::AsyncClient::RequestOptions& options) {
+        EXPECT_EQ(std::make_optional(false), options.sampled_);
+        return &async_request_;
+      }));
+
+  client_->check(request_callbacks_, request, parent_span_, stream_info_);
+  EXPECT_CALL(request_callbacks_, onComplete_(_));
+  client_->onSuccess(async_request_, std::make_unique<Http::ResponseMessageImpl>(
+                                         Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
+                                             {{Http::LowerCaseString(":status"), "200"}})));
+}
+
 } // namespace
 } // namespace ExtAuthz
 } // namespace Common

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -742,6 +742,57 @@ TEST_F(ExtAuthzFilterHttpTest, HttpClientFactoryPerRouteHttpServiceOverride) {
   decoder_filter->onDestroy();
 }
 
+TEST_F(ExtAuthzFilterHttpTest, PerRouteEmitClientSpanConfiguration) {
+  const std::string per_route_config_yaml = R"EOF(
+  check_settings:
+    emit_client_span: false
+  )EOF";
+
+  ExtAuthzFilterConfig factory;
+  ProtobufTypes::MessagePtr proto_config = factory.createEmptyRouteConfigProto();
+  TestUtility::loadFromYaml(per_route_config_yaml, *proto_config);
+
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  EXPECT_CALL(context, messageValidationVisitor());
+  auto route_config = factory.createRouteSpecificFilterConfig(*proto_config, context,
+                                                              context.messageValidationVisitor());
+  EXPECT_OK(route_config);
+
+  const auto& typed_config = dynamic_cast<const FilterConfigPerRoute&>(*route_config.value());
+  EXPECT_TRUE(typed_config.emitClientSpan().has_value());
+  EXPECT_FALSE(typed_config.emitClientSpan().value());
+}
+
+TEST_F(ExtAuthzFilterHttpTest, PerRouteEmitClientSpanMerge) {
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute vh_proto;
+  TestUtility::loadFromYaml(R"EOF(
+  check_settings:
+    emit_client_span: false
+  )EOF",
+                            vh_proto);
+  FilterConfigPerRoute vh_config = makePerRoute(vh_proto);
+
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute route_proto;
+  TestUtility::loadFromYaml(R"EOF(
+  check_settings:
+    emit_client_span: true
+  )EOF",
+                            route_proto);
+  FilterConfigPerRoute route_config = makePerRoute(route_proto);
+
+  // More specific overrides less specific.
+  FilterConfigPerRoute merged(vh_config, route_config);
+  EXPECT_TRUE(merged.emitClientSpan().has_value());
+  EXPECT_TRUE(merged.emitClientSpan().value());
+
+  // Empty more specific inherits from less specific.
+  envoy::extensions::filters::http::ext_authz::v3::ExtAuthzPerRoute empty_route_proto;
+  FilterConfigPerRoute empty_route_config = makePerRoute(empty_route_proto);
+  FilterConfigPerRoute merged_inherited(vh_config, empty_route_config);
+  EXPECT_TRUE(merged_inherited.emitClientSpan().has_value());
+  EXPECT_FALSE(merged_inherited.emitClientSpan().value());
+}
+
 class ExtAuthzFilterGrpcTest : public ExtAuthzFilterTest {
 public:
   void testFilterFactoryAndFilterWithGrpcClient(const std::string& ext_authz_config_yaml) {


### PR DESCRIPTION
Note this PR is part 2 of 2 related PRs. This PR makes the same change as #47132 but for ext_authz calls. This PR should be merged after that one is merged.

Adds a boolean emit_client_span configuration knob (defaulting to true to preserve backwards compatibility) to the ext_authz filter configuration protos and their per-route / virtual-host overrides.

When ext_authz filters initiate outbound HTTP or gRPC calls to external authorization or processing services, Envoy's underlying async client automatically creates and records a child egress client span under the active request span.

We would like the ability to control when this takes places since we have some side-streams that are customer-facing and others that are purely internal implementation details that should not have their traces emitted to customers.

Currently, there is no filter-level or route-level mechanism in ext_authz to suppress only the client span emission without breaking context propagation or globally altering tracer behavior.

Risk Level: low
Testing: Via unit testing
Fixes #46920

[Disclosed usage of generative AI: Yes, used to assist in code modifications.]