### PR TITLE
odcds: evict terminal subscription to allow retry

### DIFF
--- a/changelogs/current/bug_fixes/upstream__odcds-ads-retry-after-terminal-status.rst
+++ b/changelogs/current/bug_fixes/upstream__odcds-ads-retry-after-terminal-status.rst
@@ -1,0 +1,3 @@
+Fixed an ODCDS-over-ADS regression that prevented retries after on-demand cluster discovery
+timeouts or missing resources. This change can be reverted by setting the runtime guard
+``envoy.reloadable_features.odcds_evict_subscription_on_terminal_status`` to ``false``.

--- a/envoy/upstream/cluster_manager.h
+++ b/envoy/upstream/cluster_manager.h
@@ -217,6 +217,10 @@ public:
   // Subscribe to a cluster with a given name. It's meant to eventually send a discovery request
   // with the cluster name to the management server.
   virtual void updateOnDemand(std::string cluster_name) PURE;
+
+  // Notifies ODCDS of a terminal on-demand discovery status.
+  virtual void onDiscoveryTerminated(absl::string_view /*resource_name*/,
+                                     ClusterDiscoveryStatus /*status*/) {}
 };
 
 using OdCdsApiSharedPtr = std::shared_ptr<OdCdsApi>;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -120,6 +120,7 @@ RUNTIME_GUARD(envoy_reloadable_features_oauth2_client_retries_respect_user_retry
 // false once their cookie TTL has elapsed and no legacy cookies remain in circulation.
 // TODO: flip the default to false and remove the flag once the migration window has elapsed.
 RUNTIME_GUARD(envoy_reloadable_features_oauth2_legacy_cbc_decrypt_compat);
+RUNTIME_GUARD(envoy_reloadable_features_odcds_evict_subscription_on_terminal_status);
 RUNTIME_GUARD(envoy_reloadable_features_odcds_over_ads_fix);
 RUNTIME_GUARD(envoy_reloadable_features_on_demand_cluster_no_recreate_stream);
 RUNTIME_GUARD(envoy_reloadable_features_orca_weight_manager_use_named_metrics_first);

--- a/source/common/upstream/cluster_manager_impl.cc
+++ b/source/common/upstream/cluster_manager_impl.cc
@@ -1796,6 +1796,16 @@ void ClusterManagerImpl::notifyClusterDiscoveryStatus(absl::string_view name,
     // notifies the cluster manager about it.
     return;
   }
+  // Defer eviction because a missing resource can be reported from a subscription callback;
+  // erasing it synchronously would destroy the subscription while it is active.
+  if (Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.odcds_evict_subscription_on_terminal_status")) {
+    if (auto& odcds = map_node_handle.mapped().odcds_; odcds != nullptr) {
+      dispatcher_.post([odcds, name = std::string(name), status]() {
+        odcds->onDiscoveryTerminated(name, status);
+      });
+    }
+  }
   // Let all the worker threads know that the discovery timed out.
   tls_.runOnAllThreads(
       [name = std::string(name), status](OptRef<ThreadLocalClusterManagerImpl> cluster_manager) {

--- a/source/common/upstream/od_cds_api_impl.cc
+++ b/source/common/upstream/od_cds_api_impl.cc
@@ -170,6 +170,14 @@ public:
     notifier_.notifyMissingCluster(resource_name);
   }
 
+  // Evicts the singleton subscription so a later on-demand request can retry.
+  void removeSubscription(absl::string_view resource_name) {
+    auto erased = subscriptions_.erase(resource_name);
+    if (erased > 0) {
+      ENVOY_LOG(debug, "ODCDS-manager: evicting subscription for resource {}", resource_name);
+    }
+  }
+
   void addSubscription(absl::string_view resource_name, bool old_ads) {
     if (subscriptions_.contains(resource_name)) {
       ENVOY_LOG(debug, "ODCDS-manager: resource {} is already subscribed to, skipping",
@@ -353,6 +361,13 @@ XdstpOdCdsApiImpl::subscriptionsManager(Server::Configuration::ServerFactoryCont
 
 void XdstpOdCdsApiImpl::updateOnDemand(std::string cluster_name) {
   subscriptions_manager_->addSubscription(cluster_name, old_ads_);
+}
+
+void XdstpOdCdsApiImpl::onDiscoveryTerminated(absl::string_view resource_name,
+                                              ClusterDiscoveryStatus status) {
+  if (status == ClusterDiscoveryStatus::Timeout || status == ClusterDiscoveryStatus::Missing) {
+    subscriptions_manager_->removeSubscription(resource_name);
+  }
 }
 } // namespace Upstream
 } // namespace Envoy

--- a/source/common/upstream/od_cds_api_impl.h
+++ b/source/common/upstream/od_cds_api_impl.h
@@ -86,6 +86,8 @@ public:
 
   // Upstream::OdCdsApi
   void updateOnDemand(std::string cluster_name) override;
+  void onDiscoveryTerminated(absl::string_view resource_name,
+                             ClusterDiscoveryStatus status) override;
 
 private:
   class XdstpOdcdsSubscriptionsManager;

--- a/test/common/upstream/xdstp_od_cds_api_impl_test.cc
+++ b/test/common/upstream/xdstp_od_cds_api_impl_test.cc
@@ -308,6 +308,54 @@ TEST_F(XdstpOdCdsApiImplTest, MultipleSubscriptions) {
   callbacks2->onConfigUpdateFailed(Envoy::Config::ConfigUpdateFailureReason::UpdateRejected, &e);
 }
 
+TEST_F(XdstpOdCdsApiImplTest, OnDiscoveryTerminatedTimeoutEvictsAndAllowsResubscribe) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  EXPECT_CALL(xds_manager_, subscribeToSingletonResource(_, _, _, _, _, _, _)).Times(0);
+  odcds_->updateOnDemand(cluster_name);
+
+  odcds_->onDiscoveryTerminated(cluster_name, ClusterDiscoveryStatus::Timeout);
+
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+}
+
+TEST_F(XdstpOdCdsApiImplTest, OnDiscoveryTerminatedMissingEvictsAndAllowsResubscribe) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  odcds_->onDiscoveryTerminated(cluster_name, ClusterDiscoveryStatus::Missing);
+
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+}
+
+TEST_F(XdstpOdCdsApiImplTest, OnDiscoveryTerminatedAvailableDoesNotEvict) {
+  InSequence s;
+
+  const std::string cluster_name = "fake_cluster";
+  expectSingletonSubscription(cluster_name);
+  odcds_->updateOnDemand(cluster_name);
+
+  odcds_->onDiscoveryTerminated(cluster_name, ClusterDiscoveryStatus::Available);
+
+  EXPECT_CALL(xds_manager_, subscribeToSingletonResource(_, _, _, _, _, _, _)).Times(0);
+  odcds_->updateOnDemand(cluster_name);
+}
+
+TEST_F(XdstpOdCdsApiImplTest, OnDiscoveryTerminatedUnknownResourceIsNoOp) {
+  odcds_->onDiscoveryTerminated("unknown_cluster", ClusterDiscoveryStatus::Timeout);
+  expectSingletonSubscription("fake_cluster");
+  odcds_->updateOnDemand("fake_cluster");
+}
+
 // Tests cluster removal via a delta update.
 TEST_F(XdstpOdCdsApiImplTest, ClusterRemovalViaDeltaUpdate) {
   InSequence s;

--- a/test/extensions/filters/http/on_demand/odcds_integration_test.cc
+++ b/test/extensions/filters/http/on_demand/odcds_integration_test.cc
@@ -965,6 +965,44 @@ TEST_P(OdCdsAdsIntegrationTest, OnDemandClusterDiscoveryTimesOut) {
   cleanupUpstreamAndDownstream();
 }
 
+TEST_P(OdCdsAdsIntegrationTest, OnDemandClusterDiscoveryTimesOutThenRetrySucceeds) {
+  if (!odcdsOverAdsFixEnabled()) {
+    GTEST_SKIP() << "This test only exercises the XdstpOdCdsApiImpl singleton-subscription path";
+  }
+
+  initialize();
+  doInitialCommunications();
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost.first"},
+                                                 {"Pick-This-Cluster", "new_cluster"}};
+
+  IntegrationStreamDecoderPtr response1 = codec_client_->makeHeaderOnlyRequest(request_headers);
+  EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {"new_cluster"}, {}));
+  ASSERT_TRUE(response1->waitForEndStream());
+  verifyResponse(std::move(response1), "503", {}, {});
+
+  // Timeout eviction tears down the singleton subscription.
+  EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {}, {"new_cluster"}));
+
+  IntegrationStreamDecoderPtr response2 = codec_client_->makeHeaderOnlyRequest(request_headers);
+  EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {"new_cluster"}, {}));
+
+  sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
+      Config::TestTypeUrl::get().Cluster, {new_cluster_}, {}, "3");
+  EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {}, {}));
+
+  waitForNextUpstreamRequest(new_cluster_upstream_idx_);
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+
+  ASSERT_TRUE(response2->waitForEndStream());
+  verifyResponse(std::move(response2), "200", {}, {});
+
+  cleanupUpstreamAndDownstream();
+}
+
 // tests a scenario when:
 //  - making a request to an unknown cluster
 //  - odcds initiates a connection with a request for the cluster
@@ -984,7 +1022,12 @@ TEST_P(OdCdsAdsIntegrationTest, OnDemandClusterDiscoveryAsksForNonexistentCluste
   EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {"new_cluster"}, {}));
   sendDeltaDiscoveryResponse<envoy::config::cluster::v3::Cluster>(
       Config::TestTypeUrl::get().Cluster, {}, {"new_cluster"}, "3");
+  // ACK of the response from Envoy.
   EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {}, {}));
+  if (odcdsOverAdsFixEnabled()) {
+    // Missing-resource eviction tears down the singleton subscription.
+    EXPECT_TRUE(compareRequest(Config::TestTypeUrl::get().Cluster, {}, {"new_cluster"}));
+  }
 
   ASSERT_TRUE(response->waitForEndStream());
   verifyResponse(std::move(response), "503", {}, {});
@@ -1952,10 +1995,14 @@ TEST_P(OdCdsXdstpIntegrationTest, OnDemandClusterDiscoveryAsksForNonexistentClus
   sendDiscoveryResponse<envoy::config::cluster::v3::Cluster>(Config::TestTypeUrl::get().Cluster, {},
                                                              {}, {cluster_name}, "1", {},
                                                              authority1_xds_stream_.get());
-  // Expect a CDS ACK from authority1.
+  // ACK of the response from Envoy on the authority1 stream.
   EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "1", {cluster_name}, {},
                                       {}, false, Grpc::Status::WellKnownGrpcStatus::Ok, "",
                                       authority1_xds_stream_.get()));
+  // Missing-resource eviction tears down the singleton subscription.
+  EXPECT_TRUE(compareDiscoveryRequest(Config::TestTypeUrl::get().Cluster, "1", {}, {},
+                                      {cluster_name}, false, Grpc::Status::WellKnownGrpcStatus::Ok,
+                                      "", authority1_xds_stream_.get()));
 
   ASSERT_TRUE(response->waitForEndStream());
   verifyResponse(std::move(response), "503", {}, {});


### PR DESCRIPTION
Commit Message: evict a terminally-failed ODCDS-over-ADS subscription so the
next on-demand request retries discovery.

Additional Description:
On-demand CDS (ODCDS) keeps a singleton subscription per resource in the
subscriptions manager. When that subscription receives a terminal discovery
status over ADS (a timeout or a missing resource), the entry stays cached.
Because a later on-demand request finds the resource already subscribed, it
short-circuits and reuses the terminal subscription instead of restarting
discovery.

This is a 1.37 to 1.38 regression introduced by #41174 on configurations
using `odcds.source: { ads: {} }` (the ODCDS-over-ADS per-resource singleton
path). The legacy OdCdsApiImpl path (a single long-lived subscription) is
unaffected. Observed symptom: after the first on-demand attempt reaches a
terminal status (Timeout or Missing), the per-resource entry stays in the
singleton subscriptions_ map, addSubscription short-circuits with the log
`ODCDS-manager: resource <name> is already subscribed to, skipping`, no new
DiscoveryRequest is issued, and each retry burns the ~5s on-demand timeout
before returning 503 NC cluster_not_found.

At the xDS protocol level a subscription is a standing registration, so under
a healthy mux the server would push the resource once available and the 503
would be transient. The reason it is not transient here is the known delivery
bug in this path: issue #46561 and wbpcode's open PR #46216, where an update
to an already-started subscription is silently dropped. So "still subscribed"
does not guarantee delivery: the standing subscription never receives the
resource, and addSubscription short-circuits so no fresh request is sent
either, leaving the cluster unresolvable in this path until the process
restarts. This PR is a retry-path robustness fix that is complementary to,
not a replacement for, #46216, and it re-submits the stale-closed #44742.

The fix defers eviction of the failed subscription until after the
terminal-status callback completes. notifyClusterDiscoveryStatus posts to the
dispatcher so that ODCDS is notified via onDiscoveryTerminated once the
current callback has unwound, and the subscriptions manager then erases the
entry for Timeout and Missing statuses. Deferring the erase is required
because a missing resource can be reported from within a subscription
callback; erasing it synchronously would destroy the subscription while it is
still active on the stack. With the entry gone, the next on-demand request
creates a fresh subscription and retries discovery. Available is intentionally
retained.

The new behavior is gated by
envoy.reloadable_features.odcds_evict_subscription_on_terminal_status (default
true). Set the guard to false to restore the legacy behavior of keeping the
terminal subscription cached.

Risk Level: moderate, this is a guarded behavior change.
Testing: unit (xdstp_od_cds_api_impl_test), integration (odcds_integration_test).
Docs Changes: n/a
Release Notes: added (changelogs/current/bug_fixes)
Platform Specific Features: n/a
