### PR TITLE
formatter: only tuncate string for metadata formatter

### DIFF
--- a/changelogs/current/minor_behavior_changes/access_log__metadata-formatter-truncate-string-only.rst
+++ b/changelogs/current/minor_behavior_changes/access_log__metadata-formatter-truncate-string-only.rst
@@ -1,0 +1,12 @@
+The length limit ``Z`` of the metadata command operators (:ref:`%DYNAMIC_METADATA()%
+<config_access_log_format_dynamic_metadata>`, :ref:`%CLUSTER_METADATA()%
+<config_access_log_format_cluster_metadata>`, :ref:`%UPSTREAM_METADATA()%
+<config_access_log_format_upstream_host_metadata>` and the :ref:`%METADATA()%
+<envoy_v3_api_msg_extensions.formatter.metadata.v3.Metadata>` formatter extension) now only
+truncates string values in typed output such as JSON access logs. Previously any non-structured
+value was rendered as JSON and, when the limit applied, emitted as a truncated string, so a
+numeric value of ``1234`` with a limit of 2 was logged as the string ``"12"``. Numbers and
+booleans now keep their type and are logged in full, matching structs and lists, which were
+already never truncated. Text access logs are unchanged: the rendered value is still truncated to
+``Z`` characters. This behavioral change can be reverted by setting the runtime guard
+``envoy.reloadable_features.metadata_formatter_only_truncate_string`` to ``false``.

--- a/docs/root/configuration/advanced/substitution_formatter.rst
+++ b/docs/root/configuration/advanced/substitution_formatter.rst
@@ -1006,7 +1006,9 @@ Current supported substitution commands include:
     :ref:`Dynamic Metadata <envoy_v3_api_msg_config.core.v3.Metadata>` info,
     where ``NAMESPACE`` is the filter namespace used when setting the metadata, ``KEY`` is an optional
     lookup key in the namespace with the option of specifying nested keys separated by ':', and ``Z`` is an
-    optional parameter denoting string (and other non-structured value) truncation up to ``Z`` characters long.
+    optional parameter denoting truncation of the rendered value up to ``Z`` characters long. In typed
+    output (for example JSON access logs), only string values are truncated; values of any other type
+    (numbers, booleans, structs and lists) keep their type and are logged in full.
     Dynamic Metadata can be set by filters using the :repo:`StreamInfo <envoy/stream_info/stream_info.h>` API:
     *setDynamicMetadata*. The data will be logged as a JSON string. For example, for the following dynamic metadata:
 

--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -88,7 +88,9 @@ MetadataFormatter::MetadataFormatter(absl::string_view filter_namespace,
                                      std::optional<size_t> max_length,
                                      MetadataFormatter::GetMetadataFunction get_func)
     : filter_namespace_(filter_namespace), path_(path.begin(), path.end()), max_length_(max_length),
-      get_func_(get_func) {}
+      get_func_(get_func),
+      only_truncate_string_(Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.metadata_formatter_only_truncate_string")) {}
 
 std::optional<std::string>
 MetadataFormatter::formatMetadata(const envoy::config::core::v3::Metadata& metadata) const {
@@ -125,18 +127,27 @@ MetadataFormatter::formatMetadataValue(const envoy::config::core::v3::Metadata& 
     return SubstitutionFormatUtils::unspecifiedValue();
   }
 
-  if (max_length_.has_value() && val.kind_case() != Protobuf::Value::kStructValue &&
-      val.kind_case() != Protobuf::Value::kListValue) {
-    std::string str;
-    if (val.kind_case() == Protobuf::Value::kStringValue) {
-      str = val.string_value();
-    } else {
-      Json::Utility::appendValueToString(val, str);
-    }
-    if (SubstitutionFormatUtils::truncate(str, max_length_)) {
-      Protobuf::Value output;
-      output.set_string_value(str);
-      return output;
+  if (max_length_.has_value()) {
+    // Only string values are truncated. Structs and lists keep their structure, and non-string
+    // scalars (numbers, booleans) keep their type because truncating their rendered form would
+    // only produce a string that no longer represents the original value.
+    const bool truncatable = only_truncate_string_
+                                 ? val.kind_case() == Protobuf::Value::kStringValue
+                                 : (val.kind_case() != Protobuf::Value::kStructValue &&
+                                    val.kind_case() != Protobuf::Value::kListValue);
+
+    if (truncatable) {
+      std::string str;
+      if (val.kind_case() == Protobuf::Value::kStringValue) {
+        str = val.string_value();
+      } else {
+        Json::Utility::appendValueToString(val, str);
+      }
+      if (SubstitutionFormatUtils::truncate(str, max_length_)) {
+        Protobuf::Value output;
+        output.set_string_value(str);
+        return output;
+      }
     }
   }
 

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -65,6 +65,8 @@ private:
   std::vector<std::string> path_;
   std::optional<size_t> max_length_;
   GetMetadataFunction get_func_;
+  // Latched at construction to keep the runtime lookup off the formatting path.
+  const bool only_truncate_string_;
 };
 
 /**

--- a/source/common/formatter/stream_info_formatter.h
+++ b/source/common/formatter/stream_info_formatter.h
@@ -66,7 +66,7 @@ private:
   std::optional<size_t> max_length_;
   GetMetadataFunction get_func_;
   // Latched at construction to keep the runtime lookup off the formatting path.
-  const bool only_truncate_string_;
+  const bool only_truncate_string_ = false;
 };
 
 /**

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -105,6 +105,7 @@ RUNTIME_GUARD(envoy_reloadable_features_local_ratelimit_shadow_mode_no_short_cir
 RUNTIME_GUARD(envoy_reloadable_features_map_http_stream_reset_to_tcp_rst);
 RUNTIME_GUARD(envoy_reloadable_features_match_headers_individually);
 RUNTIME_GUARD(envoy_reloadable_features_mcp_filter_use_new_metadata_namespace);
+RUNTIME_GUARD(envoy_reloadable_features_metadata_formatter_only_truncate_string);
 RUNTIME_GUARD(envoy_reloadable_features_mobile_use_network_observer_registry);
 // When enabled, a non-graceful admin drain (/drain_listeners without `graceful`) also starts a
 // drain sequence and notifies the connections of the covered listeners that a drain has begun,

--- a/test/common/formatter/substitution_formatter_test.cc
+++ b/test/common/formatter/substitution_formatter_test.cc
@@ -4466,7 +4466,8 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
     EXPECT_THAT(formatValueForTest(formatter, stream_info), ProtoEq(expected_val));
   }
 
-  // A non-string scalar is rendered as JSON and, once truncated, becomes a string.
+  // A non-string scalar keeps its type regardless of the length limit; only its rendered form is
+  // truncated.
   {
     Protobuf::Struct& struct_obj = (*metadata.mutable_filter_metadata())["com.test"];
     (*struct_obj.mutable_fields())["test_num"] = ValueUtil::numberValue(1234);
@@ -4487,11 +4488,12 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
                   ProtoEq(ValueUtil::numberValue(1234)));
     }
     {
-      // A limit that bites turns the value into a truncated string.
+      // A limit that bites leaves the value typed too...
       DynamicMetadataFormatter formatter("com.test", {"test_num"}, std::optional<size_t>(2));
-      EXPECT_EQ("12", formatForTest(formatter, stream_info));
       EXPECT_THAT(formatValueForTest(formatter, stream_info),
-                  ProtoEq(ValueUtil::stringValue("12")));
+                  ProtoEq(ValueUtil::numberValue(1234)));
+      // ...but its rendered form is truncated.
+      EXPECT_EQ("12", formatForTest(formatter, stream_info));
     }
     {
       DynamicMetadataFormatter formatter("com.test", {"test_bool"}, std::optional<size_t>());
@@ -4500,8 +4502,22 @@ TEST(SubstitutionFormatterTest, DynamicMetadataFieldExtractor) {
     }
     {
       DynamicMetadataFormatter formatter("com.test", {"test_bool"}, std::optional<size_t>(2));
+      EXPECT_THAT(formatValueForTest(formatter, stream_info), ProtoEq(ValueUtil::boolValue(true)));
       EXPECT_EQ("tr", formatForTest(formatter, stream_info));
-      EXPECT_THAT(formatValueForTest(formatter, stream_info),
+    }
+
+    // With the runtime guard disabled, a non-string scalar whose rendered form is truncated
+    // becomes a string.
+    {
+      TestScopedRuntime scoped_runtime;
+      scoped_runtime.mergeValues(
+          {{"envoy.reloadable_features.metadata_formatter_only_truncate_string", "false"}});
+
+      DynamicMetadataFormatter num_formatter("com.test", {"test_num"}, std::optional<size_t>(2));
+      EXPECT_THAT(formatValueForTest(num_formatter, stream_info),
+                  ProtoEq(ValueUtil::stringValue("12")));
+      DynamicMetadataFormatter bool_formatter("com.test", {"test_bool"}, std::optional<size_t>(2));
+      EXPECT_THAT(formatValueForTest(bool_formatter, stream_info),
                   ProtoEq(ValueUtil::stringValue("tr")));
     }
 


### PR DESCRIPTION
Commit Message: formatter: only truncate string for metadata formatter

Additional Description:
The length limit `Z` of the metadata command operators (`%DYNAMIC_METADATA()%`,
`%CLUSTER_METADATA()%`, `%UPSTREAM_METADATA()%` and the `%METADATA()%` formatter extension)
was applied to every non-structured value. In typed output, such as JSON access logs, a value
that was not a string was first rendered as JSON and then, if the limit bit, emitted as a
truncated string: a numeric value of `1234` with a limit of `2` was logged as the string `"12"`.

With this change only string values are truncated in typed output. Numbers and booleans keep
their type and are logged in full, which is the behavior structs and lists already had. Text
access logs are unaffected: the rendered value is still truncated to `Z` characters.

The runtime lookup is latched in the formatter constructor so it stays off the formatting path.

Generative AI was used to assist with this change. I have reviewed all the changes.

Risk Level: Low
Testing: Updated the existing unit test coverage in `substitution_formatter_test.cc` for both
the new behavior and the guarded old behavior.
Docs Changes: Updated the description of `Z` in the substitution formatter docs.
Release Notes: Added.
Platform Specific Features: N/A
Runtime guard: `envoy.reloadable_features.metadata_formatter_only_truncate_string`