### PR TITLE
formatter: optimize the ssl connection info formatter

### DIFF
--- a/source/common/formatter/stream_info_formatter.cc
+++ b/source/common/formatter/stream_info_formatter.cc
@@ -1284,131 +1284,117 @@ private:
   const std::optional<int> mask_prefix_len_;
 };
 
-// Ssl::ConnectionInfo std::string field extractor.
-class StreamInfoSslConnectionInfoFormatterProvider : public StreamInfoFormatterProvider {
+// Ssl::ConnectionInfo field extractor. The `StringType` is either `std::string` for the fields
+// that must be built on the fly, or `absl::string_view` for the fields that are backed by the
+// connection info itself and needn't be copied. The `ConnectionInfoGetter` provides the SSL
+// connection info (downstream or upstream) of the stream.
+template <class StringType, class ConnectionInfoGetter>
+class StreamInfoSslConnectionInfoFormatterProviderBase : public StreamInfoFormatterProvider {
 public:
-  // TODO(wbpcode): Most of attributes of SSL connection info need to create a new string.
-  using FieldExtractor =
-      std::function<std::optional<std::string>(const Ssl::ConnectionInfo& connection_info)>;
+  // NOTE: if the `StringType` is `absl::string_view`, the returned view must be backed by the
+  // connection info itself. Use the `std::string` variant for any command that builds its value
+  // on the fly.
+  using FieldExtractor = std::function<std::optional<StringType>(const Ssl::ConnectionInfo&)>;
 
-  StreamInfoSslConnectionInfoFormatterProvider(FieldExtractor f) : field_extractor_(f) {}
+  StreamInfoSslConnectionInfoFormatterProviderBase(FieldExtractor f)
+      : field_extractor_(std::move(f)) {}
 
   // StreamInfoFormatterProvider
   std::optional<std::string> format(const Context&,
                                     const StreamInfo::StreamInfo& stream_info) const override {
-    if (stream_info.downstreamAddressProvider().sslConnection() == nullptr) {
+    // Keep the connection info alive until the extracted value is consumed because the value
+    // may only be a view of the connection info.
+    const auto connection_info = ConnectionInfoGetter::get(stream_info);
+    if (connection_info == nullptr) {
       return std::nullopt;
     }
 
-    const auto value = field_extractor_(*stream_info.downstreamAddressProvider().sslConnection());
-    if (value && value->empty()) {
+    auto value = field_extractor_(*connection_info);
+    if (!value.has_value() || value->empty()) {
       return std::nullopt;
     }
 
-    return value;
+    return std::string(std::move(*value));
+  }
+
+  bool formatTo(std::string& sink, const Context&,
+                const StreamInfo::StreamInfo& stream_info) const override {
+    const auto connection_info = ConnectionInfoGetter::get(stream_info);
+    if (connection_info == nullptr) {
+      return false;
+    }
+
+    const auto value = field_extractor_(*connection_info);
+    if (!value.has_value() || value->empty()) {
+      return false;
+    }
+
+    sink.append(*value);
+    return true;
   }
 
   Protobuf::Value formatValue(const Context&,
                               const StreamInfo::StreamInfo& stream_info) const override {
-    if (stream_info.downstreamAddressProvider().sslConnection() == nullptr) {
+    const auto connection_info = ConnectionInfoGetter::get(stream_info);
+    if (connection_info == nullptr) {
       return SubstitutionFormatUtils::unspecifiedValue();
     }
 
-    const auto value = field_extractor_(*stream_info.downstreamAddressProvider().sslConnection());
-    if (value && value->empty()) {
+    const auto value = field_extractor_(*connection_info);
+    if (!value.has_value() || value->empty()) {
       return SubstitutionFormatUtils::unspecifiedValue();
     }
 
-    return ValueUtil::optionalStringValue(value);
+    return ValueUtil::stringValue(*value);
   }
-  bool formatTo(std::string& sink, const Context& context,
-                const StreamInfo::StreamInfo& stream_info) const override {
-    const auto value = format(context, stream_info);
-    if (!value.has_value()) {
-      return false;
-    }
-    sink.append(*value);
-    return true;
-  }
-  void formatValueTo(ValueSink& sink, const Context& context,
+
+  void formatValueTo(ValueSink& sink, const Context&,
                      const StreamInfo::StreamInfo& stream_info) const override {
-    const auto value = formatValue(context, stream_info);
-    if (value.kind_case() == Protobuf::Value::kNullValue ||
-        value.kind_case() == Protobuf::Value::KIND_NOT_SET) {
+    const auto connection_info = ConnectionInfoGetter::get(stream_info);
+    if (connection_info == nullptr) {
       // Keep the sink unmodified if no value is extracted and the caller can decide how to
       // handle the missing value.
       return;
     }
-    sink.addValue(value);
+
+    const auto value = field_extractor_(*connection_info);
+    if (!value.has_value() || value->empty()) {
+      return;
+    }
+
+    sink.addString(*value);
   }
 
 private:
   FieldExtractor field_extractor_;
 };
 
-class StreamInfoUpstreamSslConnectionInfoFormatterProvider : public StreamInfoFormatterProvider {
-public:
-  using FieldExtractor =
-      std::function<std::optional<std::string>(const Ssl::ConnectionInfo& connection_info)>;
-
-  StreamInfoUpstreamSslConnectionInfoFormatterProvider(FieldExtractor f) : field_extractor_(f) {}
-
-  // StreamInfoFormatterProvider
-  std::optional<std::string> format(const Context&,
-                                    const StreamInfo::StreamInfo& stream_info) const override {
-    if (!stream_info.upstreamInfo() ||
-        stream_info.upstreamInfo()->upstreamSslConnection() == nullptr) {
-      return std::nullopt;
-    }
-
-    const auto value = field_extractor_(*(stream_info.upstreamInfo()->upstreamSslConnection()));
-    if (value && value->empty()) {
-      return std::nullopt;
-    }
-
-    return value;
+struct DownstreamSslConnectionInfoGetter {
+  static Ssl::ConnectionInfoConstSharedPtr get(const StreamInfo::StreamInfo& stream_info) {
+    return stream_info.downstreamAddressProvider().sslConnection();
   }
-
-  Protobuf::Value formatValue(const Context&,
-                              const StreamInfo::StreamInfo& stream_info) const override {
-    if (!stream_info.upstreamInfo() ||
-        stream_info.upstreamInfo()->upstreamSslConnection() == nullptr) {
-      return SubstitutionFormatUtils::unspecifiedValue();
-    }
-
-    const auto value = field_extractor_(*(stream_info.upstreamInfo()->upstreamSslConnection()));
-    if (value && value->empty()) {
-      return SubstitutionFormatUtils::unspecifiedValue();
-    }
-
-    return ValueUtil::optionalStringValue(value);
-  }
-
-  bool formatTo(std::string& sink, const Context& context,
-                const StreamInfo::StreamInfo& stream_info) const override {
-    const auto value = format(context, stream_info);
-    if (!value.has_value()) {
-      return false;
-    }
-    sink.append(*value);
-    return true;
-  }
-
-  void formatValueTo(ValueSink& sink, const Context& context,
-                     const StreamInfo::StreamInfo& stream_info) const override {
-    const auto value = formatValue(context, stream_info);
-    if (value.kind_case() == Protobuf::Value::kNullValue ||
-        value.kind_case() == Protobuf::Value::KIND_NOT_SET) {
-      // Keep the sink unmodified if no value is extracted and the caller can decide how to
-      // handle the missing value.
-      return;
-    }
-    sink.addValue(value);
-  }
-
-private:
-  FieldExtractor field_extractor_;
 };
+
+struct UpstreamSslConnectionInfoGetter {
+  static Ssl::ConnectionInfoConstSharedPtr get(const StreamInfo::StreamInfo& stream_info) {
+    if (!stream_info.upstreamInfo()) {
+      return nullptr;
+    }
+    return stream_info.upstreamInfo()->upstreamSslConnection();
+  }
+};
+
+using StreamInfoSslConnectionInfoFormatterProvider =
+    StreamInfoSslConnectionInfoFormatterProviderBase<std::string,
+                                                     DownstreamSslConnectionInfoGetter>;
+using StreamInfoSslConnectionInfoViewFormatterProvider =
+    StreamInfoSslConnectionInfoFormatterProviderBase<absl::string_view,
+                                                     DownstreamSslConnectionInfoGetter>;
+using StreamInfoUpstreamSslConnectionInfoFormatterProvider =
+    StreamInfoSslConnectionInfoFormatterProviderBase<std::string, UpstreamSslConnectionInfoGetter>;
+using StreamInfoUpstreamSslConnectionInfoViewFormatterProvider =
+    StreamInfoSslConnectionInfoFormatterProviderBase<absl::string_view,
+                                                     UpstreamSslConnectionInfoGetter>;
 
 using StreamInfoFormatterProviderLookupTable =
     absl::flat_hash_map<absl::string_view, std::pair<CommandSyntaxChecker::CommandSyntaxFlags,
@@ -2081,38 +2067,36 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return std::make_optional<std::string>(
-                                           connection_info.ciphersuiteString());
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.ciphersuiteString();
                                      });
                                }}},
                              {"UPSTREAM_TLS_GROUP",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return std::make_optional<std::string>(
-                                           connection_info.tlsGroupString());
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.tlsGroupString();
                                      });
                                }}},
                              {"UPSTREAM_TLS_VERSION",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.tlsVersion();
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.tlsVersion();
                                      });
                                }}},
                              {"UPSTREAM_TLS_SESSION_ID",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.sessionId();
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.sessionId();
                                      });
                                }}},
                              {"UPSTREAM_SERVER_NAME",
@@ -2139,27 +2123,27 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.issuerPeerCertificate();
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.issuerPeerCertificate();
                                      });
                                }}},
                              {"UPSTREAM_PEER_CERT",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.urlEncodedPemEncodedPeerCertificate();
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.urlEncodedPemEncodedPeerCertificate();
                                      });
                                }}},
                              {"UPSTREAM_PEER_SUBJECT",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoUpstreamSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.subjectPeerCertificate();
+                                     StreamInfoUpstreamSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.subjectPeerCertificate();
                                      });
                                }}},
                              {"DOWNSTREAM_LOCAL_ADDRESS",
@@ -2527,83 +2511,81 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.subjectPeerCertificate();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.subjectPeerCertificate();
                                      });
                                }}},
                              {"DOWNSTREAM_LOCAL_SUBJECT",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.subjectLocalCertificate();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.subjectLocalCertificate();
                                      });
                                }}},
                              {"DOWNSTREAM_TLS_SESSION_ID",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.sessionId();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.sessionId();
                                      });
                                }}},
                              {"DOWNSTREAM_TLS_CIPHER",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return std::make_optional<std::string>(
-                                           connection_info.ciphersuiteString());
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.ciphersuiteString();
                                      });
                                }}},
                              {"DOWNSTREAM_TLS_GROUP",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return std::make_optional<std::string>(
-                                           connection_info.tlsGroupString());
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.tlsGroupString();
                                      });
                                }}},
                              {"DOWNSTREAM_TLS_VERSION",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.tlsVersion();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.tlsVersion();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_FINGERPRINT_256",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.sha256PeerCertificateDigest();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.sha256PeerCertificateDigest();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_FINGERPRINT_1",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.sha1PeerCertificateDigest();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.sha1PeerCertificateDigest();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_SERIAL",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.serialNumberPeerCertificate();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.serialNumberPeerCertificate();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_CHAIN_FINGERPRINTS_256",
@@ -2641,36 +2623,36 @@ const StreamInfoFormatterProviderLookupTable& getKnownStreamInfoFormatterProvide
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.issuerPeerCertificate();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.issuerPeerCertificate();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_ISSUER_FINGERPRINT_256",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.sha256PeerCertificateIssuerDigest();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.sha256PeerCertificateIssuerDigest();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_ISSUER_SERIAL",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.serialNumberPeerCertificateIssuer();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.serialNumberPeerCertificateIssuer();
                                      });
                                }}},
                              {"DOWNSTREAM_PEER_CERT",
                               {CommandSyntaxChecker::COMMAND_ONLY,
                                [](absl::string_view, std::optional<size_t>) {
                                  return std::make_unique<
-                                     StreamInfoSslConnectionInfoFormatterProvider>(
-                                     [](const Ssl::ConnectionInfo& connection_info) {
-                                       return connection_info.urlEncodedPemEncodedPeerCertificate();
+                                     StreamInfoSslConnectionInfoViewFormatterProvider>(
+                                     [](const Ssl::ConnectionInfo& info) -> absl::string_view {
+                                       return info.urlEncodedPemEncodedPeerCertificate();
                                      });
                                }}},
                              {"DOWNSTREAM_TRANSPORT_FAILURE_REASON",


### PR DESCRIPTION
Commit Message: formatter: optimize the ssl connection info formatter
Additional Description:

For most ssl connection info related formatter commands, it's unnecessary to create the string copy.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.