### PR TITLE
changelogs: document removal of no_extension_lookup_by_name in v1.39.0

### DIFF
--- a/changelogs/1.39.0.yaml
+++ b/changelogs/1.39.0.yaml
@@ -601,6 +601,13 @@ minor_behavior_changes:
     by setting runtime guard ``envoy.reloadable_features.upstream_wasm_filter_uses_root_scope`` to
     ``false``.
 
+removed_config_or_runtime:
+- area: config
+  change: |
+    Removed the runtime guard ``envoy.reloadable_features.no_extension_lookup_by_name`` and the
+    ability to look up extensions by name. Extensions are now always looked up by their typed
+    :ref:`type URL <envoy_v3_api_field_config.core.v3.TypedExtensionConfig.typed_config>`.
+
 new_features:
 - area: access_log
   change: |


### PR DESCRIPTION
Commit Message:
Document the removal of the runtime feature
envoy.reloadable_features.no_extension_lookup_by_name in 2a5ad79ca5b45f4633dcfb8f0978559afdaf9796 that was part of the v1.39.0 release.

Additional Description:
This was missed in https://github.com/envoyproxy/envoy/pull/45325.
Risk Level: none
Testing: CI
Docs Changes: removed guard in v1.39.0
Release Notes: none
Platform Specific Features: none