### PR TITLE
Prune more duplicate integration tests

### DIFF
--- a/test/extensions/filters/http/api_key_auth/integration_test.cc
+++ b/test/extensions/filters/http/api_key_auth/integration_test.cc
@@ -68,7 +68,7 @@ public:
 
 INSTANTIATE_TEST_SUITE_P(
     Protocols, ApiKeyAuthIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // Request with valid credential.

--- a/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
+++ b/test/extensions/filters/http/basic_auth/basic_auth_integration_test.cc
@@ -81,16 +81,13 @@ public:
   }
 };
 
-// BasicAuth integration tests that should run with all protocols
-class BasicAuthIntegrationTestAllProtocols : public BasicAuthIntegrationTest {};
-
 INSTANTIATE_TEST_SUITE_P(
-    Protocols, BasicAuthIntegrationTestAllProtocols,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    Protocols, BasicAuthIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // Request with valid credential
-TEST_P(BasicAuthIntegrationTestAllProtocols, ValidCredential) {
+TEST_P(BasicAuthIntegrationTest, ValidCredential) {
   initializeFilter();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -115,7 +112,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, ValidCredential) {
 }
 
 // Request without credential
-TEST_P(BasicAuthIntegrationTestAllProtocols, NoCredential) {
+TEST_P(BasicAuthIntegrationTest, NoCredential) {
   initializeFilter();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -136,7 +133,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, NoCredential) {
 }
 
 // Request without wrong password
-TEST_P(BasicAuthIntegrationTestAllProtocols, WrongPasswrod) {
+TEST_P(BasicAuthIntegrationTest, WrongPasswrod) {
   initializeFilter();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -158,7 +155,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, WrongPasswrod) {
 }
 
 // Request with none-existed user
-TEST_P(BasicAuthIntegrationTestAllProtocols, NoneExistedUser) {
+TEST_P(BasicAuthIntegrationTest, NoneExistedUser) {
   initializeFilter();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -180,7 +177,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, NoneExistedUser) {
 }
 
 // Request with existing username header
-TEST_P(BasicAuthIntegrationTestAllProtocols, ExistingUsernameHeader) {
+TEST_P(BasicAuthIntegrationTest, ExistingUsernameHeader) {
   initializeFilter();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -205,7 +202,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, ExistingUsernameHeader) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
-TEST_P(BasicAuthIntegrationTestAllProtocols, BasicAuthPerRouteDisabled) {
+TEST_P(BasicAuthIntegrationTest, BasicAuthPerRouteDisabled) {
   disablePerRouteFilter();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -223,7 +220,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, BasicAuthPerRouteDisabled) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
-TEST_P(BasicAuthIntegrationTestAllProtocols, BasicAuthPerRouteEnabled) {
+TEST_P(BasicAuthIntegrationTest, BasicAuthPerRouteEnabled) {
   initializePerRouteFilter(AdminUsers);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -242,7 +239,7 @@ TEST_P(BasicAuthIntegrationTestAllProtocols, BasicAuthPerRouteEnabled) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
-TEST_P(BasicAuthIntegrationTestAllProtocols, BasicAuthPerRouteEnabledInvalidCredentials) {
+TEST_P(BasicAuthIntegrationTest, BasicAuthPerRouteEnabledInvalidCredentials) {
   initializePerRouteFilter(AdminUsers);
 
   codec_client_ = makeHttpConnection(lookupPort("http"));

--- a/test/extensions/filters/http/cdn_loop/filter_integration_test.cc
+++ b/test/extensions/filters/http/cdn_loop/filter_integration_test.cc
@@ -176,13 +176,10 @@ TEST_P(CdnLoopFilterIntegrationTest, CdnLoop2Allowed3Seen) {
   EXPECT_EQ("502", response->headers().getStatusValue());
 }
 
-INSTANTIATE_TEST_SUITE_P(Protocols, CdnLoopFilterIntegrationTest,
-                         testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParams(
-                             {Http::CodecType::HTTP1, Http::CodecType::HTTP2},
-                             // Upstream doesn't matter, so by testing only 1,
-                             // the test is twice as fast.
-                             {Http::CodecType::HTTP1})),
-                         HttpProtocolIntegrationTest::protocolTestParamsToString);
+INSTANTIATE_TEST_SUITE_P(
+    Protocols, CdnLoopFilterIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
+    HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 } // namespace
 } // namespace CdnLoop

--- a/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
+++ b/test/extensions/filters/http/csrf/csrf_filter_integration_test.cc
@@ -74,10 +74,9 @@ protected:
   }
 };
 
-// TODO(#26236): Fix test suite for HTTP/3.
 INSTANTIATE_TEST_SUITE_P(
     Protocols, CsrfFilterIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(CsrfFilterIntegrationTest, TestCsrfSuccess) {

--- a/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
+++ b/test/extensions/filters/http/custom_response/custom_response_integration_test.cc
@@ -1046,10 +1046,9 @@ TEST_P(CustomResponseIntegrationTest, LocalReplyMatcherIgnoresUpstreamResponse) 
   EXPECT_TRUE(response->headers().get(::Envoy::Http::LowerCaseString("x-local-reply")).empty());
 }
 
-// TODO(#26236): Fix test suite for HTTP/3.
 INSTANTIATE_TEST_SUITE_P(
     Protocols, CustomResponseIntegrationTest,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 } // namespace CustomResponse
 } // namespace HttpFilters

--- a/test/extensions/filters/http/file_server/integration_test.cc
+++ b/test/extensions/filters/http/file_server/integration_test.cc
@@ -99,7 +99,7 @@ typed_config:
 // to run combinatorial iterations of each test, we can just run one.
 INSTANTIATE_TEST_SUITE_P(
     Protocols, FileServerIntegrationTest,
-    testing::ValuesIn({HttpProtocolIntegrationTest::getProtocolTestParams()[0]}),
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(FileServerIntegrationTest, ReadsConfiguredIndexFileOnRequestForDirectory) {

--- a/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
+++ b/test/extensions/filters/http/kill_request/kill_request_filter_integration_test.cc
@@ -26,17 +26,13 @@ typed_config:
 )EOF";
 };
 
-// Tests should run with all protocols.
-class KillRequestFilterIntegrationTestAllProtocols : public KillRequestFilterIntegrationTest {};
-
-// TODO(#26236): Fix test suite for HTTP/3.
 INSTANTIATE_TEST_SUITE_P(
-    Protocols, KillRequestFilterIntegrationTestAllProtocols,
-    testing::ValuesIn(HttpProtocolIntegrationTest::getProtocolTestParamsWithoutHTTP3()),
+    Protocols, KillRequestFilterIntegrationTest,
+    testing::ValuesIn(HttpProtocolIntegrationTest::getHttp1OnlyProtocolTestParams()),
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 // Request crash Envoy controlled via header configuration.
-TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoy) {
+TEST_P(KillRequestFilterIntegrationTest, KillRequestCrashEnvoy) {
   initializeFilter(filter_config_);
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
@@ -54,7 +50,7 @@ TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoy) {
 // KillRequestCrashEnvoyOnResponse is flaky on Windows
 #ifndef WIN32
 // Request crash Envoy controlled via response.
-TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyOnResponse) {
+TEST_P(KillRequestFilterIntegrationTest, KillRequestCrashEnvoyOnResponse) {
   const std::string filter_config_response =
       R"EOF(
       name: envoy.filters.http.kill_request
@@ -82,7 +78,7 @@ TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyOnResp
 }
 #endif
 
-TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestCrashEnvoyWithCustomKillHeader) {
+TEST_P(KillRequestFilterIntegrationTest, KillRequestCrashEnvoyWithCustomKillHeader) {
   const std::string filter_config_with_custom_kill_header =
       R"EOF(
 name: envoy.filters.http.kill_request
@@ -106,14 +102,14 @@ typed_config:
 }
 #endif
 
-TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestDisabledWhenHeaderIsMissing) {
+TEST_P(KillRequestFilterIntegrationTest, KillRequestDisabledWhenHeaderIsMissing) {
   initializeFilter(filter_config_);
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto response =
       sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 1024);
 }
 
-TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestDisabledWhenHeaderValueIsInvalid) {
+TEST_P(KillRequestFilterIntegrationTest, KillRequestDisabledWhenHeaderValueIsInvalid) {
   initializeFilter(filter_config_);
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
@@ -126,7 +122,7 @@ TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestDisabledWhenHead
       sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 1024);
 }
 
-TEST_P(KillRequestFilterIntegrationTestAllProtocols, KillRequestDisabledByZeroProbability) {
+TEST_P(KillRequestFilterIntegrationTest, KillRequestDisabledByZeroProbability) {
   const std::string zero_probability_filter_config =
       R"EOF(
 name: envoy.filters.http.kill_request


### PR DESCRIPTION
Commit Message: Prune more duplicate integration tests
Additional Description: Following from #47057, this adjusts the most obviously simple http filters to no longer run 15+ copies of every test case (also simplifies `file_server` which already only ran one, to use the shared "only run one" set).

Change is AI assisted by Codex Luna.

Suggested as also likely suitable for subsequent pruning are:
`header_mutation`, `transform`, `match_delegate` - these use a different structure so the change would be different, but they're all suitably not-codec-or-ip-version-dependent for pruning.
`adaptive_concurrency`, `admission_control`, `local_ratelimit` - these involve timing, which *could* be impacted by using different protocols, but not in a way that would make a correctness difference to the filter.
`health_check` - the test currently has different branches for protocols, but the filter doesn't so it seems unnecessary.

Risk Level: test-only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
