### PR TITLE
runtime: removed enable_cel_regex_precompilation flag and legacy code paths

### DIFF
--- a/changelogs/current/removed_config_or_runtime/rbac__cel-regex-precompilation.rst
+++ b/changelogs/current/removed_config_or_runtime/rbac__cel-regex-precompilation.rst
@@ -1,0 +1,2 @@
+Removed runtime flag ``envoy.reloadable_features.enable_cel_regex_precompilation`` and legacy code
+paths.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -54,7 +54,6 @@ RUNTIME_GUARD(envoy_reloadable_features_disallow_quic_client_udp_mmsg);
 // the factory is rebuilt before the batched update is posted and a worker cannot snapshot a stale
 // factory after a transient health-check flap.
 RUNTIME_GUARD(envoy_reloadable_features_enable_batch_aware_update);
-RUNTIME_GUARD(envoy_reloadable_features_enable_cel_regex_precompilation);
 RUNTIME_GUARD(envoy_reloadable_features_enable_cel_response_path_matching);
 RUNTIME_GUARD(envoy_reloadable_features_enable_compression_bomb_protection);
 RUNTIME_GUARD(envoy_reloadable_features_enable_new_dns_implementation);

--- a/source/extensions/filters/common/expr/evaluator.cc
+++ b/source/extensions/filters/common/expr/evaluator.cc
@@ -128,9 +128,7 @@ BuilderConstPtr createBuilder(OptRef<const envoy::config::core::v3::CelExpressio
   options.enable_list_concat = false;
 
   // Performance-oriented defaults.
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.enable_cel_regex_precompilation")) {
-    options.enable_regex_precompilation = true;
-  }
+  options.enable_regex_precompilation = true;
 
   // Enable constant folding with arena if provided for RBAC backward compatibility optimization.
   if (arena != nullptr) {


### PR DESCRIPTION
Commit Message: runtime: removed enable_cel_regex_precompilation flag and legacy code paths
Additional Description: To close #42976
Risk Level: Low
Testing: Existing tests.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A
