### PR TITLE
runtime: removed quic_signal_headers_only_to_http1_backend flag and legacy code paths

### DIFF
--- a/changelogs/current/removed_config_or_runtime/quic__signal-headers-only-to-http1-backend.rst
+++ b/changelogs/current/removed_config_or_runtime/quic__signal-headers-only-to-http1-backend.rst
@@ -1,0 +1,2 @@
+Removed runtime flag ``envoy.reloadable_features.quic_signal_headers_only_to_http1_backend`` and
+legacy code paths.

--- a/source/common/quic/envoy_quic_server_stream.cc
+++ b/source/common/quic/envoy_quic_server_stream.cc
@@ -185,10 +185,7 @@ void EnvoyQuicServerStream::OnInitialHeadersComplete(bool fin, size_t frame_len,
 
   ENVOY_STREAM_LOG(debug, "Received headers: {}.", *this, header_list.DebugString());
   const bool headers_only = fin_received() && highest_received_byte_offset() == NumBytesConsumed();
-  const bool end_stream =
-      fin ||
-      (headers_only && Runtime::runtimeFeatureEnabled("envoy.reloadable_features.quic_signal_"
-                                                      "headers_only_to_http1_backend"));
+  const bool end_stream = fin || headers_only;
   ENVOY_STREAM_LOG(debug, "Headers_only: {}, end_stream: {}.", *this, headers_only, end_stream);
   if (end_stream) {
     end_stream_decoded_ = true;

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -137,7 +137,6 @@ RUNTIME_GUARD(envoy_reloadable_features_quic_mtls_server_enabled);
 // Ignore the automated "remove this flag" issue: we should keep this for 1 year. Confirm with
 // @danzh2010 or @RyanTheOptimist before removing.
 RUNTIME_GUARD(envoy_reloadable_features_quic_send_server_preferred_address_to_all_clients);
-RUNTIME_GUARD(envoy_reloadable_features_quic_signal_headers_only_to_http1_backend);
 RUNTIME_GUARD(envoy_reloadable_features_quic_support_additional_ecdsa_curves);
 RUNTIME_GUARD(envoy_reloadable_features_quic_upstream_client_certificates);
 RUNTIME_GUARD(envoy_reloadable_features_quic_upstream_reads_fixed_number_packets);


### PR DESCRIPTION
Commit Message: runtime: removed quic_signal_headers_only_to_http1_backend flag and legacy code paths
Additional Description: To close #42980
Risk Level: Low
Testing: Existing tests.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A
