### PR TITLE
runtime: removed uri_template_match_on_asterisk flag and legacy code paths

### DIFF
--- a/changelogs/current/removed_config_or_runtime/uri_template__match-on-asterisk.rst
+++ b/changelogs/current/removed_config_or_runtime/uri_template__match-on-asterisk.rst
@@ -1,0 +1,2 @@
+Removed runtime flag ``envoy.reloadable_features.uri_template_match_on_asterisk`` and legacy code
+paths.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -171,7 +171,6 @@ RUNTIME_GUARD(envoy_reloadable_features_uhv_allow_malformed_url_encoding);
 RUNTIME_GUARD(envoy_reloadable_features_upstream_bind_config_fix_port_exhaustion);
 RUNTIME_GUARD(envoy_reloadable_features_upstream_http_filters_correct_stats_prefix);
 RUNTIME_GUARD(envoy_reloadable_features_upstream_wasm_filter_uses_root_scope);
-RUNTIME_GUARD(envoy_reloadable_features_uri_template_match_on_asterisk);
 RUNTIME_GUARD(envoy_reloadable_features_uri_template_mixed_variable_literals);
 RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_brokenness);
 // Decide connection drain-close (HCM, TCP proxy, and the Mongo, Redis, Thrift and generic proxies)

--- a/source/extensions/path/uri_template_lib/uri_template_internal.cc
+++ b/source/extensions/path/uri_template_lib/uri_template_internal.cc
@@ -45,17 +45,7 @@ constexpr absl::string_view kLiteral = "a-zA-Z0-9-._~" // Unreserved
                                        "%"             // pct-encoded
                                        "!$&'()+,;"     // sub-delims excluding *=
                                        ":@"
-                                       "="; // user included "=" allowed
-
-// Additional literal that allows "*" in the pattern.
-// This should replace "kLiteral" after removal of
-// "reloadable_features.uri_template_match_on_asterisk" runtime guard.
-// Valid pchar from https://datatracker.ietf.org/doc/html/rfc3986#appendix-A
-constexpr absl::string_view kLiteralWithAsterisk = "a-zA-Z0-9-._~" // Unreserved
-                                                   "%"             // pct-encoded
-                                                   "!$&'()+,;"     // sub-delims excluding *=
-                                                   ":@"
-                                                   "=*"; // reserved characters
+                                       "=*"; // user included "=" and "*" allowed
 
 // Default operator used for the variable when none specified.
 constexpr Operator kDefaultVariableOperator = Operator::PathGlob;
@@ -138,30 +128,19 @@ std::string ParsedPathPattern::debugString() const {
 }
 
 bool isValidLiteral(absl::string_view literal) {
-  static const std::string* kValidLiteralRegexAsterisk =
-      new std::string(absl::StrCat("^[", kLiteralWithAsterisk, "]+$"));
   static const std::string* kValidLiteralRegex =
       new std::string(absl::StrCat("^[", kLiteral, "]+$"));
-  static const LazyRE2 literal_regex_asterisk = {kValidLiteralRegexAsterisk->data()};
   static const LazyRE2 literal_regex = {kValidLiteralRegex->data()};
 
-  return Runtime::runtimeFeatureEnabled("envoy.reloadable_features.uri_template_match_on_asterisk")
-             ? RE2::FullMatch(literal, *literal_regex_asterisk)
-             : RE2::FullMatch(literal, *literal_regex);
+  return RE2::FullMatch(literal, *literal_regex);
 }
 
 bool isValidRewriteLiteral(absl::string_view literal) {
   static const std::string* kValidLiteralRegex =
       new std::string(absl::StrCat("^[", kLiteral, "/]+$"));
-  static const std::string* kValidLiteralRegexAsterisk =
-      new std::string(absl::StrCat("^[", kLiteralWithAsterisk, "/]+$"));
-
   static const LazyRE2 literal_regex = {kValidLiteralRegex->data()};
-  static const LazyRE2 literal_regex_asterisk = {kValidLiteralRegexAsterisk->data()};
 
-  return Runtime::runtimeFeatureEnabled("envoy.reloadable_features.uri_template_match_on_asterisk")
-             ? RE2::FullMatch(literal, *literal_regex_asterisk)
-             : RE2::FullMatch(literal, *literal_regex);
+  return RE2::FullMatch(literal, *literal_regex);
 }
 
 bool isValidVariableName(absl::string_view variable) {
@@ -455,25 +434,11 @@ std::string toRegexPattern(Operator pattern) {
   static const std::string* kPathGlobRegex = new std::string(absl::StrCat("[", kLiteral, "]+"));
   static const std::string* kTextGlobRegex = new std::string(absl::StrCat("[", kLiteral, "/]*"));
 
-  static const std::string* kPathGlobRegexAsterisk =
-      new std::string(absl::StrCat("[", kLiteralWithAsterisk, "]+"));
-  static const std::string* kTextGlobRegexAsterisk =
-      new std::string(absl::StrCat("[", kLiteralWithAsterisk, "/]*"));
-
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.uri_template_match_on_asterisk")) {
-    switch (pattern) {
-    case Operator::PathGlob: // "*"
-      return *kPathGlobRegexAsterisk;
-    case Operator::TextGlob: // "**"
-      return *kTextGlobRegexAsterisk;
-    }
-  } else {
-    switch (pattern) {
-    case Operator::PathGlob: // "*"
-      return *kPathGlobRegex;
-    case Operator::TextGlob: // "**"
-      return *kTextGlobRegex;
-    }
+  switch (pattern) {
+  case Operator::PathGlob: // "*"
+    return *kPathGlobRegex;
+  case Operator::TextGlob: // "**"
+    return *kTextGlobRegex;
   }
   return "";
 }

--- a/test/extensions/path/uri_template_lib/uri_template_internal_test.cc
+++ b/test/extensions/path/uri_template_lib/uri_template_internal_test.cc
@@ -54,15 +54,6 @@ TEST(InternalParsing, ParsedPathDebugString) {
   EXPECT_EQ(patt2.debugString(), "/{var}");
 }
 
-TEST(InternalParsing, IsValidLiteralAsteriskDisabled) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.uri_template_match_on_asterisk", "false"}});
-
-  EXPECT_FALSE(isValidLiteral("ab*c"));
-  EXPECT_FALSE(isValidLiteral("a**c"));
-}
-
 TEST(InternalParsing, IsValidLiteralWorks) {
   EXPECT_TRUE(isValidLiteral("123abcABC"));
   EXPECT_TRUE(isValidLiteral("._~-"));
@@ -77,14 +68,6 @@ TEST(InternalParsing, IsValidLiteralWorks) {
   EXPECT_FALSE(isValidLiteral("{abc"));
   EXPECT_FALSE(isValidLiteral("abc}"));
   EXPECT_FALSE(isValidLiteral("{abc}"));
-}
-
-TEST(InternalParsing, IsValidRewriteAsteriskDisabled) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.uri_template_match_on_asterisk", "false"}});
-
-  EXPECT_FALSE(isValidRewriteLiteral("a*c"));
 }
 
 TEST(InternalParsing, IsValidRewriteLiteralWorks) {
@@ -344,15 +327,6 @@ TEST(InternalRegexGen, RegexLikePatternIsMatchedLiterally) {
 TEST(InternalRegexGen, DollarSignMatchesItself) {
   EXPECT_TRUE(RE2::FullMatch("abc$", toRegexPattern("abc$")));
   EXPECT_FALSE(RE2::FullMatch("abc", toRegexPattern("abc$")));
-}
-
-TEST(InternalRegexGen, OperatorRegexPatternAsteriskDisabled) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.uri_template_match_on_asterisk", "false"}});
-
-  EXPECT_EQ(toRegexPattern(Operator::PathGlob), "[a-zA-Z0-9-._~%!$&'()+,;:@=]+");
-  EXPECT_EQ(toRegexPattern(Operator::TextGlob), "[a-zA-Z0-9-._~%!$&'()+,;:@=/]*");
 }
 
 TEST(InternalRegexGen, OperatorRegexPattern) {
@@ -618,10 +592,6 @@ TEST(InternalMixedVariableLiteralParsing, MixedVariableDebugString) {
 }
 
 TEST(InternalMixedVariableLiteralParsing, MixedVariableRegexPattern) {
-  TestScopedRuntime scoped_runtime;
-  scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.uri_template_match_on_asterisk", "true"}});
-
   Variable var = Variable("version", {}, "api", ".json");
   std::string regex = toRegexPattern(var);
   EXPECT_EQ(regex, "api(?P<version>[a-zA-Z0-9-._~%!$&'()+,;:@=*]+)\\.json");
@@ -657,8 +627,7 @@ TEST(InternalMixedVariableLiteralParsing, PathPatternWithMixedVariables) {
 TEST(InternalMixedVariableLiteralParsing, PathPatternWithMixedVariablesDisabled) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues(
-      {{"envoy.reloadable_features.uri_template_match_on_asterisk", "true"},
-       {"envoy.reloadable_features.uri_template_mixed_variable_literals", "false"}});
+      {{"envoy.reloadable_features.uri_template_mixed_variable_literals", "false"}});
 
   // When the feature flag is disabled, mixed variables should not be supported and parsing should
   // fail


### PR DESCRIPTION
Commit Message: runtime: removed uri_template_match_on_asterisk flag and legacy code paths
Additional Description: To close #42982
Risk Level: Low
Testing: Existing tests.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A
