### PR TITLE
runtime: removed raise_file_limits flag and legacy code paths

### DIFF
--- a/changelogs/current/removed_config_or_runtime/server__raise-file-limits.rst
+++ b/changelogs/current/removed_config_or_runtime/server__raise-file-limits.rst
@@ -1,0 +1,1 @@
+Removed runtime flag ``envoy.restart_features.raise_file_limits`` and legacy code paths.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -185,7 +185,6 @@ RUNTIME_GUARD(envoy_reloadable_features_websocket_allow_4xx_5xx_through_filter_c
 RUNTIME_GUARD(envoy_reloadable_features_websocket_enable_timeout_on_upgrade_response);
 RUNTIME_GUARD(envoy_reloadable_features_xds_failover_to_primary_enabled);
 RUNTIME_GUARD(envoy_reloadable_features_xds_legacy_delta_skip_subsequent_node);
-RUNTIME_GUARD(envoy_restart_features_raise_file_limits);
 RUNTIME_GUARD(envoy_restart_features_validate_http3_pseudo_headers);
 RUNTIME_GUARD(envoy_restart_features_worker_threads_watchdog_fix);
 // Begin false flags. Most of them should come with a TODO to flip true.

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -408,9 +408,6 @@ absl::Status InstanceUtil::loadBootstrapConfig(
 }
 
 void InstanceUtil::raiseFileLimits() {
-  if (!Runtime::runtimeFeatureEnabled("envoy.restart_features.raise_file_limits")) {
-    return;
-  }
   if (const auto result = Api::OsSysCallsSingleton::get().raiseFileLimits();
       result.return_value_ != 0) {
     ENVOY_LOG(warn, "Failed to raise file descriptor limit, error {}.",


### PR DESCRIPTION
Commit Message: runtime: removed raise_file_limits flag and legacy code paths
Additional Description: To close #42983
Risk Level: Low
Testing: Existing tests.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A
