### PR TITLE
udp_proxy: apply cluster upstream socket options

### DIFF
--- a/changelogs/current/new_features/udp__upstream-socket-options.rst
+++ b/changelogs/current/new_features/udp__upstream-socket-options.rst
@@ -1,0 +1,7 @@
+Added support for applying :ref:`socket options
+<envoy_v3_api_field_config.core.v3.BindConfig.socket_options>` configured in a cluster's
+:ref:`upstream_bind_config <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_bind_config>` to
+UDP proxy upstream sockets. This supports use cases such as packet marking with Linux ``SO_MARK``.
+:ref:`use_original_src_ip
+<envoy_v3_api_field_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig.use_original_src_ip>` is
+compatible with cluster socket options, which are combined with the transparent socket options.

--- a/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
+++ b/docs/root/configuration/listeners/udp_filters/udp_proxy.rst
@@ -29,6 +29,13 @@ The UDP proxy listener filter also can operate as a *transparent* proxy if the
 :ref:`use_original_src_ip <envoy_v3_api_msg_extensions.filters.udp.udp_proxy.v3.UdpProxyConfig>`
 field is set to true. But please keep in mind that it does not forward the port to upstreams. It forwards only the IP address to upstreams.
 
+UDP proxy upstream sockets apply the :ref:`socket options
+<envoy_v3_api_field_config.core.v3.BindConfig.socket_options>` configured in the cluster's
+:ref:`upstream_bind_config <envoy_v3_api_field_config.cluster.v3.Cluster.upstream_bind_config>`.
+This supports use cases such as packet marking with Linux ``SO_MARK``. When
+``use_original_src_ip`` is enabled, the cluster socket options are combined with the options required
+to select the downstream source IP per datagram.
+
 Load balancing and unhealthy host handling
 ------------------------------------------
 

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.cc
@@ -483,6 +483,9 @@ bool UdpProxyFilter::ActiveSession::onNewSession() {
 
     active_read_filter->initialized_ = true;
     auto status = active_read_filter->read_filter_->onNewSession();
+    if (handleUpstreamCreationFailure()) {
+      return false;
+    }
     if (status == ReadFilterStatus::StopIteration) {
       return true;
     }
@@ -504,6 +507,10 @@ bool UdpProxyFilter::ActiveSession::onNewSession() {
 }
 
 void UdpProxyFilter::ActiveSession::onData(Network::UdpRecvData& data) {
+  if (handleUpstreamCreationFailure()) {
+    return;
+  }
+
   const uint64_t rx_buffer_length = data.buffer_->length();
   ENVOY_LOG(trace, "received {} byte datagram from downstream: downstream={} local={} upstream={}",
             rx_buffer_length, addresses_.peer_->asStringView(), addresses_.local_->asStringView(),
@@ -518,6 +525,9 @@ void UdpProxyFilter::ActiveSession::onData(Network::UdpRecvData& data) {
 
   for (auto& active_read_filter : read_filters_) {
     auto status = active_read_filter->read_filter_->onData(data);
+    if (handleUpstreamCreationFailure()) {
+      return;
+    }
     if (status == ReadFilterStatus::StopIteration) {
       return;
     }
@@ -583,6 +593,10 @@ void UdpProxyFilter::UdpActiveSession::writeUpstream(Network::UdpRecvData& data)
 bool UdpProxyFilter::ActiveSession::onContinueFilterChain(ActiveReadFilter* filter) {
   ASSERT(filter != nullptr);
 
+  if (handleUpstreamCreationFailure()) {
+    return false;
+  }
+
   std::list<ActiveReadFilterPtr>::iterator entry = std::next(filter->entry());
   for (; entry != read_filters_.end(); entry++) {
     if (!(*entry)->read_filter_ || (*entry)->initialized_) {
@@ -591,6 +605,9 @@ bool UdpProxyFilter::ActiveSession::onContinueFilterChain(ActiveReadFilter* filt
 
     (*entry)->initialized_ = true;
     auto status = (*entry)->read_filter_->onNewSession();
+    if (handleUpstreamCreationFailure()) {
+      return false;
+    }
     if (status == ReadFilterStatus::StopIteration) {
       return true;
     }
@@ -608,8 +625,40 @@ bool UdpProxyFilter::ActiveSession::onContinueFilterChain(ActiveReadFilter* filt
     }
   }
 
-  filter_.removeSession(this);
+  upstream_creation_failed_ = true;
+  handleUpstreamCreationFailure();
   return false;
+}
+
+bool UdpProxyFilter::ActiveSession::handleUpstreamCreationFailure() {
+  if (!upstream_creation_failed_) {
+    return false;
+  }
+
+  // A filter may reach this path from continueFilterChain() or injectDatagramToFilterChain().
+  // Defer removal so that the calling filter can unwind before the session and its filters are
+  // destroyed. During initial session creation the session has not been inserted, and the caller
+  // owns it until onNewSession() returns false.
+  const auto session = filter_.sessions_.find(this);
+  if (!upstream_failure_removal_scheduled_ && session != filter_.sessions_.end() &&
+      session->get() == this) {
+    if (cluster_ != nullptr) {
+      ASSERT(!cluster_->sessions_.contains(this));
+      cluster_->sessions_.emplace(this);
+    }
+    upstream_failure_removal_scheduled_ = true;
+    std::weak_ptr<ActiveSession> weak_session = *session;
+    filter_.read_callbacks_->udpListener().dispatcher().post([weak_session] {
+      if (auto session = weak_session.lock()) {
+        const auto stored_session = session->filter_.sessions_.find(session.get());
+        if (stored_session != session->filter_.sessions_.end() &&
+            stored_session->get() == session.get()) {
+          session->filter_.removeSession(session.get());
+        }
+      }
+    });
+  }
+  return true;
 }
 
 bool UdpProxyFilter::UdpActiveSession::shouldCreateUpstream() {
@@ -639,16 +688,33 @@ bool UdpProxyFilter::UdpActiveSession::createUpstream() {
   udp_session_info_.upstreamInfo()->addUpstreamHostAttempted(host_);
   udp_session_info_.upstreamInfo()->setUpstreamHost(host_);
   udp_session_info_.upstreamInfo()->setUpstreamRemoteAddress(host_->address());
+  if (!createUdpSocket(host_)) {
+    cluster_->cluster_stats_.sess_tx_errors_.inc();
+    // The host is not registered with ClusterInfo until socket setup succeeds. Clear it so that a
+    // deferred session can be removed without trying to unregister it.
+    host_.reset();
+    return false;
+  }
   cluster_->addSession(host_.get(), this);
-  createUdpSocket(host_);
   return true;
 }
 
-void UdpProxyFilter::UdpActiveSession::createUdpSocket(const Upstream::HostConstSharedPtr& host) {
+bool UdpProxyFilter::UdpActiveSession::createUdpSocket(const Upstream::HostConstSharedPtr& host) {
   ASSERT(cluster_);
-  // NOTE: The socket call can only fail due to memory/fd exhaustion. No local ephemeral port
-  //       is bound until the first packet is sent to the upstream host.
+  Network::ConnectionSocket::OptionsSharedPtr socket_options;
+  if (use_original_src_ip_) {
+    socket_options = Network::SocketOptionFactory::buildIpTransparentOptions();
+  }
+
+  const auto upstream_socket_options =
+      host->cluster()
+          .getUpstreamLocalAddressSelector()
+          ->getUpstreamLocalAddress(host->address(), socket_options,
+                                    /*transport_socket_options=*/{})
+          .socket_options_;
+
   udp_socket_ = filter_.createUdpSocket(host);
+
   udp_socket_->ioHandle().initializeFileEvent(
       filter_.read_callbacks_->udpListener().dispatcher(),
       [this](uint32_t) {
@@ -657,17 +723,18 @@ void UdpProxyFilter::UdpActiveSession::createUdpSocket(const Upstream::HostConst
       },
       Event::PlatformDefaultTriggerType, Event::FileReadyType::Read);
 
+  if (!Network::Socket::applyOptions(upstream_socket_options, *udp_socket_,
+                                     envoy::config::core::v3::SocketOption::STATE_PREBIND)) {
+    ENVOY_LOG(debug, "cannot apply options to UDP upstream socket");
+    udp_socket_.reset();
+    return false;
+  }
+
   ENVOY_LOG(debug, "creating new session: downstream={} local={} upstream={}",
             addresses_.peer_->asStringView(), addresses_.local_->asStringView(),
             host->address()->asStringView());
 
   if (use_original_src_ip_) {
-    const Network::Socket::OptionsSharedPtr socket_options =
-        Network::SocketOptionFactory::buildIpTransparentOptions();
-    const bool ok = Network::Socket::applyOptions(
-        socket_options, *udp_socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND);
-
-    RELEASE_ASSERT(ok, "Should never occur!");
     ENVOY_LOG(debug, "The original src is enabled for address {}.",
               addresses_.peer_->asStringView());
   }
@@ -677,11 +744,16 @@ void UdpProxyFilter::UdpActiveSession::createUdpSocket(const Upstream::HostConst
   // sockets. We need to figure out how to either refactor Socket into something that works better
   // for this use case or allow the socket option abstractions to work directly against an IO
   // handle.
+  return true;
 }
 
 void UdpProxyFilter::ActiveSession::onInjectReadDatagramToFilterChain(ActiveReadFilter* filter,
                                                                       Network::UdpRecvData& data) {
   ASSERT(filter != nullptr);
+
+  if (handleUpstreamCreationFailure()) {
+    return;
+  }
 
   std::list<ActiveReadFilterPtr>::iterator entry = std::next(filter->entry());
   for (; entry != read_filters_.end(); entry++) {
@@ -690,6 +762,9 @@ void UdpProxyFilter::ActiveSession::onInjectReadDatagramToFilterChain(ActiveRead
     }
 
     auto status = (*entry)->read_filter_->onData(data);
+    if (handleUpstreamCreationFailure()) {
+      return;
+    }
     if (status == ReadFilterStatus::StopIteration) {
       return;
     }

--- a/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
+++ b/source/extensions/filters/udp/udp_proxy/udp_proxy_filter.h
@@ -674,6 +674,7 @@ protected:
 
   private:
     std::shared_ptr<Network::ConnectionInfoSetterImpl> createDownstreamConnectionInfoProvider();
+    bool handleUpstreamCreationFailure();
     void onAccessLogFlushInterval();
     void rearmAccessLogFlushTimer();
     void disableAccessLogFlushTimer();
@@ -681,6 +682,8 @@ protected:
 
     bool cluster_connections_inc_{false};
     bool on_session_complete_called_{false};
+    bool upstream_creation_failed_{false};
+    bool upstream_failure_removal_scheduled_{false};
   };
 
   using ActiveSessionSharedPtr = std::shared_ptr<ActiveSession>;
@@ -725,7 +728,7 @@ protected:
 
   private:
     void onReadReady();
-    void createUdpSocket(const Upstream::HostConstSharedPtr& host);
+    bool createUdpSocket(const Upstream::HostConstSharedPtr& host);
 
     // The socket is used for writing packets to the selected upstream host as well as receiving
     // packets from the upstream host. Note that a a local ephemeral port is bound on the first

--- a/test/extensions/filters/udp/udp_proxy/BUILD
+++ b/test/extensions/filters/udp/udp_proxy/BUILD
@@ -36,6 +36,7 @@ envoy_extension_cc_test(
         ":mocks",
         "//source/common/common:hash_lib",
         "//source/common/formatter:formatter_extension_lib",
+        "//source/common/network:socket_option_lib",
         "//source/common/router:string_accessor_lib",
         "//source/common/stream_info:uint32_accessor_lib",
         "//source/extensions/access_loggers/file:config",

--- a/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_proxy_filter_test.cc
@@ -1,3 +1,5 @@
+#include <cerrno>
+
 #include "envoy/config/accesslog/v3/accesslog.pb.h"
 #include "envoy/extensions/access_loggers/file/v3/file.pb.h"
 #include "envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.pb.h"
@@ -104,6 +106,10 @@ Api::IoCallUint64Result makeNoError(uint64_t rc) {
 Api::IoCallUint64Result makeError(int sys_errno) {
   return {0, Network::IoSocketError::create(sys_errno)};
 }
+
+constexpr int TestSocketOptionLevel = 1;
+constexpr int TestSocketOptionName = 36;
+constexpr int TestSocketOptionValue = 4;
 
 class UdpProxyFilterBase : public testing::Test {
 public:
@@ -350,6 +356,28 @@ public:
     ON_CALL(*host, address()).WillByDefault(Return(host_address));
     ON_CALL(*host, coarseHealth()).WillByDefault(Return(Upstream::Host::Health::Healthy));
     return host;
+  }
+
+  void setUpstreamSocketOptions(const Network::Address::InstanceConstSharedPtr& local_address) {
+    auto socket_options = std::make_shared<Network::ConnectionSocket::Options>();
+    socket_options->push_back(std::make_shared<Network::SocketOptionImpl>(
+        envoy::config::core::v3::SocketOption::STATE_PREBIND,
+        Network::SocketOptionName(TestSocketOptionLevel, TestSocketOptionName,
+                                  "test upstream socket option"),
+        TestSocketOptionValue));
+    auto host =
+        factory_context_.server_factory_context_.cluster_manager_.thread_local_cluster_.lb_.host_;
+    ON_CALL(*host->cluster_.upstream_local_address_selector_, getUpstreamLocalAddressImpl(_, _))
+        .WillByDefault(Return(Upstream::UpstreamLocalAddress{local_address, socket_options}));
+  }
+
+  void expectUpstreamSocketOption(TestSession& session, Api::SysCallIntResult result) {
+    EXPECT_CALL(*session.socket_->io_handle_,
+                setOption(TestSocketOptionLevel, TestSocketOptionName, _, sizeof(int)))
+        .WillOnce(Invoke([result](int, int, const void* value, socklen_t) {
+          EXPECT_EQ(TestSocketOptionValue, *static_cast<const int*>(value));
+          return result;
+        }));
   }
 
   void checkTransferStats(uint64_t rx_bytes, uint64_t rx_datagrams, uint64_t tx_bytes,
@@ -1251,6 +1279,182 @@ TEST_F(UdpProxyFilterTest, SocketOptionForUseOriginalSrcIp) {
   InSequence s;
 
   ensureIpTransparentSocketOptions(upstream_address_, "10.0.0.2:80", 1, 0);
+}
+
+TEST_F(UdpProxyFilterTest, AppliesUpstreamSocketOptionsWithoutBindingConfiguredAddress) {
+  setup(readConfig(R"EOF(
+stat_prefix: foo
+matcher:
+  on_no_match:
+    action:
+      name: route
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+        cluster: fake_cluster
+  )EOF"));
+
+  const auto local_address =
+      Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.2:12345");
+  setUpstreamSocketOptions(local_address);
+  expectSessionCreate(upstream_address_);
+  expectUpstreamSocketOption(test_sessions_[0], {0, 0});
+  EXPECT_CALL(*test_sessions_[0].socket_, bind(_)).Times(0);
+  test_sessions_[0].expectWriteToUpstream("hello", 0, nullptr, true);
+
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+}
+
+TEST_F(UdpProxyFilterTest, UpstreamSocketOptionFailureRejectsSession) {
+  setup(readConfig(R"EOF(
+stat_prefix: foo
+matcher:
+  on_no_match:
+    action:
+      name: route
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+        cluster: fake_cluster
+  )EOF"));
+
+  const auto local_address =
+      Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.2:12345");
+  setUpstreamSocketOptions(local_address);
+  expectSessionCreate(upstream_address_);
+  expectUpstreamSocketOption(test_sessions_[0], {-1, EPERM});
+  EXPECT_CALL(*test_sessions_[0].socket_->io_handle_, connect(_)).Times(0);
+
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+  EXPECT_EQ(1, TestUtility::findCounter(factory_context_.server_factory_context_.cluster_manager_
+                                            .thread_local_cluster_.cluster_.info_->stats_store_,
+                                        "udp.sess_tx_errors")
+                   ->value());
+}
+
+TEST_F(UdpProxyFilterTest, UpstreamSocketOptionFailureDuringSynchronousContinueRejectsSession) {
+  setup(readConfig(R"EOF(
+stat_prefix: foo
+matcher:
+  on_no_match:
+    action:
+      name: route
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+        cluster: fake_cluster
+session_filters:
+- name: continue-on-new-session-1
+  typed_config:
+    '@type': type.googleapis.com/test.extensions.filters.udp.udp_proxy.session_filters.DrainerUdpSessionReadFilterConfig
+- name: continue-on-new-session-2
+  typed_config:
+    '@type': type.googleapis.com/test.extensions.filters.udp.udp_proxy.session_filters.DrainerUdpSessionReadFilterConfig
+  )EOF"));
+
+  const auto local_address =
+      Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.2:12345");
+  setUpstreamSocketOptions(local_address);
+  expectSessionCreate(upstream_address_);
+  expectUpstreamSocketOption(test_sessions_[0], {-1, EPERM});
+
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+  EXPECT_EQ(1, TestUtility::findCounter(factory_context_.server_factory_context_.cluster_manager_
+                                            .thread_local_cluster_.cluster_.info_->stats_store_,
+                                        "udp.sess_tx_errors")
+                   ->value());
+
+  // A new datagram with the same tuple can create a fresh session after the failed setup.
+  expectSessionCreate(upstream_address_);
+  expectUpstreamSocketOption(test_sessions_[1], {0, 0});
+  test_sessions_[1].expectWriteToUpstream("world", 0, nullptr, true);
+
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "world");
+
+  EXPECT_EQ(2, config_->stats().downstream_sess_total_.value());
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+}
+
+TEST_F(UdpProxyFilterTest, UpstreamSocketOptionFailureDuringOnDataContinueRejectsSession) {
+  setup(readConfig(R"EOF(
+stat_prefix: foo
+matcher:
+  on_no_match:
+    action:
+      name: route
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+        cluster: fake_cluster
+session_filters:
+- name: continue-on-data
+  typed_config:
+    '@type': type.googleapis.com/test.extensions.filters.udp.udp_proxy.session_filters.DrainerUdpSessionReadFilterConfig
+    stop_iteration_on_new_session: true
+    continue_filter_chain: true
+  )EOF"));
+
+  const auto local_address =
+      Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.2:12345");
+  setUpstreamSocketOptions(local_address);
+  expectSessionCreate(upstream_address_);
+  expectUpstreamSocketOption(test_sessions_[0], {-1, EPERM});
+  EXPECT_CALL(*test_sessions_[0].idle_timer_, enableTimer(config_->sessionTimeout(), nullptr));
+  Event::PostCb remove_session_cb;
+  EXPECT_CALL(callbacks_.udp_listener_.dispatcher_, post(_))
+      .Times(2)
+      .WillRepeatedly([&](Event::PostCb cb) { remove_session_cb = std::move(cb); });
+
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "hello");
+
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+  remove_session_cb();
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+
+  expectSessionCreate(upstream_address_);
+  expectUpstreamSocketOption(test_sessions_[1], {-1, EPERM});
+  EXPECT_CALL(*test_sessions_[1].idle_timer_, enableTimer(config_->sessionTimeout(), nullptr));
+  recvDataFromDownstream("10.0.0.1:1000", "10.0.0.2:80", "world");
+
+  EXPECT_EQ(1, config_->stats().downstream_sess_active_.value());
+  cluster_update_callbacks_->onClusterRemoval("fake_cluster");
+  EXPECT_EQ(0, config_->stats().downstream_sess_active_.value());
+  remove_session_cb();
+  EXPECT_EQ(2, TestUtility::findCounter(factory_context_.server_factory_context_.cluster_manager_
+                                            .thread_local_cluster_.cluster_.info_->stats_store_,
+                                        "udp.sess_tx_errors")
+                   ->value());
+}
+
+TEST_F(UdpProxyFilterTest, UpstreamSocketOptionsAreCompatibleWithUseOriginalSrcIp) {
+  if (!isTransparentSocketOptionsSupported()) {
+    GTEST_SKIP();
+  }
+  EXPECT_CALL(os_sys_calls_, supportsIpTransparent(_));
+
+  setup(readConfig(R"EOF(
+stat_prefix: foo
+matcher:
+  on_no_match:
+    action:
+      name: route
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.udp.udp_proxy.v3.Route
+        cluster: fake_cluster
+use_original_src_ip: true
+  )EOF"));
+
+  const auto configured_local_address =
+      Network::Utility::parseInternetAddressAndPortNoThrow("127.0.0.2:12345");
+  setUpstreamSocketOptions(configured_local_address);
+  expectSessionCreate(upstream_address_);
+  test_sessions_[0].expectSetIpTransparentSocketOption();
+  expectUpstreamSocketOption(test_sessions_[0], {0, 0});
+  test_sessions_[0].expectWriteToUpstream("hello", 0, peer_address_->ip());
+
+  recvDataFromDownstream(peer_address_->asString(), "10.0.0.2:80", "hello");
+  checkSocketOptions(test_sessions_[0], ENVOY_SOCKET_IP_TRANSPARENT, 1,
+                     ENVOY_SOCKET_IPV6_TRANSPARENT, 0);
 }
 
 TEST_F(UdpProxyFilterTest, MutualExcludePerPacketLoadBalancingAndSessionFilters) {


### PR DESCRIPTION
Apply cluster upstream_bind_config.socket_options to UDP proxy upstream sockets. The UDP proxy currently ignores these options.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
