### PR TITLE
signal: fix race condition and memory leak in registerFatalActions()

### DIFF
--- a/source/common/signal/fatal_error_handler.cc
+++ b/source/common/signal/fatal_error_handler.cc
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <list>
+#include <utility>
 
 #include "envoy/event/dispatcher.h"
 
@@ -153,9 +154,14 @@ void registerFatalActions(FatalAction::FatalActionPtrList safe_actions,
                           FatalAction::FatalActionPtrList unsafe_actions,
                           Thread::ThreadFactory& thread_factory) {
   // Create a FatalActionManager and store it.
-  if (!fatal_action_manager) {
-    fatal_action_manager.exchange(new FatalAction::FatalActionManager(
-        std::move(safe_actions), std::move(unsafe_actions), thread_factory));
+  if (!fatal_action_manager.load(std::memory_order_acquire)) {
+    auto* new_manager = new FatalAction::FatalActionManager(
+        std::move(safe_actions), std::move(unsafe_actions), thread_factory);
+    FatalAction::FatalActionManager* expected = nullptr;
+    if (!fatal_action_manager.compare_exchange_strong(expected, new_manager,
+                                                      std::memory_order_acq_rel)) {
+      delete new_manager;
+    }
   }
 }
 

--- a/test/common/signal/fatal_action_test.cc
+++ b/test/common/signal/fatal_action_test.cc
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <vector>
 
 #include "envoy/common/scope_tracker.h"
@@ -36,11 +37,16 @@ class TestFatalErrorHandler : public FatalErrorHandlerInterface {
 
 class TestFatalAction : public Server::Configuration::FatalAction {
 public:
-  TestFatalAction(bool is_safe, int* const counter) : is_safe_(is_safe), counter_(counter) {}
+  TestFatalAction(bool is_safe, int* const counter) : is_safe_(is_safe), counter_(counter) {
+    ++alive_count_;
+  }
+  ~TestFatalAction() override { --alive_count_; }
   void run(absl::Span<const ScopeTrackedObject* const> /*tracked_objects*/) override {
     ++(*counter_);
   }
   bool isAsyncSignalSafe() const override { return is_safe_; }
+
+  static inline std::atomic<int> alive_count_{0};
 
 private:
   const bool is_safe_;
@@ -58,6 +64,7 @@ protected:
     // Reset module state
     FatalErrorHandler::resetFatalActionStateForTest();
     FatalErrorHandler::removeFatalErrorHandler(*handler_);
+    EXPECT_EQ(TestFatalAction::alive_count_.load(), 0);
   }
 
   std::unique_ptr<TestFatalErrorHandler> handler_;
@@ -119,6 +126,74 @@ TEST_F(FatalActionTest, ShouldOnlyBeAbleToRunUnsafeActionsFromThreadThatRanSafeA
   run_unsafe_actions.Notify();
 
   fatal_action_thread->join();
+}
+
+TEST_F(FatalActionTest, DuplicateRegistrationIsIgnored) {
+  safe_actions_.emplace_back(std::make_unique<TestFatalAction>(true, &counter_));
+  unsafe_actions_.emplace_back(std::make_unique<TestFatalAction>(false, &counter_));
+  FatalErrorHandler::registerFatalActions(std::move(safe_actions_), std::move(unsafe_actions_),
+                                          Thread::threadFactoryForTest());
+
+  int second_counter = 0;
+  FatalAction::FatalActionPtrList second_safe;
+  FatalAction::FatalActionPtrList second_unsafe;
+  second_safe.emplace_back(std::make_unique<TestFatalAction>(true, &second_counter));
+  second_unsafe.emplace_back(std::make_unique<TestFatalAction>(false, &second_counter));
+  FatalErrorHandler::registerFatalActions(std::move(second_safe), std::move(second_unsafe),
+                                          Thread::threadFactoryForTest());
+
+  EXPECT_EQ(FatalErrorHandler::runSafeActions(), Status::Success);
+  EXPECT_EQ(counter_, 1);
+  EXPECT_EQ(second_counter, 0);
+
+  EXPECT_EQ(FatalErrorHandler::runUnsafeActions(), Status::Success);
+  EXPECT_EQ(counter_, 2);
+  EXPECT_EQ(second_counter, 0);
+}
+
+TEST_F(FatalActionTest, ConcurrentRegistration) {
+  constexpr int num_threads = 8;
+  constexpr int num_iterations = 20;
+
+  for (int iter = 0; iter < num_iterations; ++iter) {
+    std::vector<Thread::ThreadPtr> threads;
+    threads.reserve(num_threads);
+
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+
+    for (int i = 0; i < num_threads; ++i) {
+      threads.push_back(Thread::threadFactoryForTest().createThread([this, &ready, &go]() {
+        FatalAction::FatalActionPtrList safe_actions;
+        FatalAction::FatalActionPtrList unsafe_actions;
+        safe_actions.emplace_back(std::make_unique<TestFatalAction>(true, &counter_));
+        unsafe_actions.emplace_back(std::make_unique<TestFatalAction>(false, &counter_));
+
+        ready.fetch_add(1, std::memory_order_release);
+        while (!go.load(std::memory_order_acquire)) {
+        }
+
+        FatalErrorHandler::registerFatalActions(std::move(safe_actions), std::move(unsafe_actions),
+                                                Thread::threadFactoryForTest());
+      }));
+    }
+
+    while (ready.load(std::memory_order_acquire) < num_threads) {
+    }
+    go.store(true, std::memory_order_release);
+
+    for (auto& thread : threads) {
+      thread->join();
+    }
+
+    FatalErrorHandler::resetFatalActionStateForTest();
+    if (TestFatalAction::alive_count_.load() != 0) {
+      break;
+    }
+  }
+
+  EXPECT_EQ(TestFatalAction::alive_count_.load(), 0)
+      << "Memory leak detected: orphaned FatalActionManager leaked actions";
 }
 
 } // namespace FatalAction


### PR DESCRIPTION
When creating multiple Envoy::Platform::Engine instances concurrently in the same process, multiple threads could invoke
`FatalErrorHandler::registerFatalActions()` simultaneously when fatal_action_manager is uninitialized. The previous `exchange()` call unconditionally replaced the atomic pointer, leaking any `FatalActionManager` instance allocated and stored by a concurrent thread.

Use `compare_exchange_strong` with acquire-release ordering to atomically install the newly allocated manager only if fatal_action_manager is still nullptr, and delete the newly allocated manager if another thread already installed one. Also add tests for concurrent and duplicate registration.

I used AI to generate this PR. I have read and fully understand this PR.