### PR TITLE
dynamic_modules: per-selection async host selection cancellation

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -1458,24 +1458,35 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
   // The module may invoke this callback on any thread and race the load balancer destructor.
   // Validate the raw pointer against the live registry and snapshot the state we need under the
   // registry lock.
-  std::shared_ptr<std::atomic<bool>> cancelled;
+  Envoy::Extensions::Clusters::DynamicModules::DynamicModuleAsyncHostSelectionRegistrySharedPtr
+      selections;
   Envoy::Event::Dispatcher* dispatcher = nullptr;
   DynamicModuleClusterHandleSharedPtr handle;
   const bool found = DynamicModuleLoadBalancer::withActiveInstance(
       lb_raw, [&](const DynamicModuleLoadBalancer& lb) {
-        cancelled = lb.activeAsyncCancelled();
-        dispatcher = lb.activeAsyncDispatcher();
+        selections = lb.asyncSelections();
+        dispatcher = lb.workerDispatcher();
         handle = lb.handle();
       });
   if (!found) {
     return;
   }
 
+  // Look the completing selection up by its own context. A load balancer serves many concurrent
+  // selections, so reading a single shared flag here would let a cancellation on one selection drop
+  // the completion of another. An absent entry means this selection was already completed or
+  // cancelled and its `cancelable` destroyed, so the context must not be touched.
+  std::shared_ptr<std::atomic<bool>> cancelled = selections->find(context_envoy_ptr);
+  if (cancelled == nullptr) {
+    return;
+  }
+
   if (dispatcher != nullptr) {
-    // Post to the worker thread. The handle keeps the cluster alive until the callback runs.
+    // Post to the worker thread. The handle keeps the cluster alive until the callback runs. The
+    // flag is re-read inside the post because the router may cancel between the post and the run.
     dispatcher->post([context_envoy_ptr, host, details_str = std::move(details_str),
                       cancelled = std::move(cancelled), handle = std::move(handle)]() {
-      if (cancelled != nullptr && cancelled->load(std::memory_order_acquire)) {
+      if (cancelled->load(std::memory_order_acquire)) {
         return;
       }
       auto* context = getContext(context_envoy_ptr);
@@ -1485,15 +1496,19 @@ void envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       }
       context->onAsyncHostSelection(std::move(host_shared), std::string(details_str));
     });
-  } else {
-    // No worker dispatcher. Complete inline on the calling thread.
-    auto* context = getContext(context_envoy_ptr);
-    Envoy::Upstream::HostConstSharedPtr host_shared;
-    if (host != nullptr) {
-      host_shared = handle->cluster()->findHost(host);
-    }
-    context->onAsyncHostSelection(std::move(host_shared), std::move(details_str));
+    return;
   }
+
+  // No worker dispatcher. Complete inline on the calling thread.
+  if (cancelled->load(std::memory_order_acquire)) {
+    return;
+  }
+  auto* context = getContext(context_envoy_ptr);
+  Envoy::Upstream::HostConstSharedPtr host_shared;
+  if (host != nullptr) {
+    host_shared = handle->cluster()->findHost(host);
+  }
+  context->onAsyncHostSelection(std::move(host_shared), std::move(details_str));
 }
 
 // =============================================================================

--- a/source/extensions/clusters/dynamic_modules/cluster.cc
+++ b/source/extensions/clusters/dynamic_modules/cluster.cc
@@ -801,18 +801,22 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
     return {nullptr};
   }
 
-  // Pre-capture the worker dispatcher and prepare the cancellation flag before calling into the
-  // module. The module's choose_host may spawn a background thread that calls
-  // async_host_selection_complete, which reads these fields. Setting them beforehand establishes
-  // a happens-before relationship via the thread::spawn synchronization in the module.
+  // Pre-capture the worker dispatcher and register the per-selection cancellation flag before
+  // calling into the module. The module's choose_host may spawn a background thread that calls
+  // async_host_selection_complete, which reads both. Publishing them beforehand establishes a
+  // happens-before relationship via the thread::spawn synchronization in the module.
+  //
+  // The flag and the registry entry are keyed by `context`, not held in a single slot on this load
+  // balancer, because a worker serves many concurrent async selections. A single slot would let a
+  // cancellation on one selection suppress the completion of an unrelated one.
   const auto* connection = context != nullptr ? context->downstreamConnection() : nullptr;
-  active_async_dispatcher_ = connection != nullptr ? &connection->dispatcher() : nullptr;
-  // Capture the worker dispatcher for worker timer creation. Sticky: keep any previously captured
-  // dispatcher when this call has no connection, since the worker dispatcher is stable.
-  if (active_async_dispatcher_ != nullptr) {
-    worker_dispatcher_ = active_async_dispatcher_;
+  // Sticky: keep any previously captured dispatcher when this call has no connection, since the
+  // worker dispatcher is stable for the worker's life.
+  if (connection != nullptr) {
+    worker_dispatcher_.store(&connection->dispatcher(), std::memory_order_release);
   }
-  active_async_cancelled_ = std::make_shared<std::atomic<bool>>(false);
+  auto cancelled = std::make_shared<std::atomic<bool>>(false);
+  async_selections_->add(context, cancelled);
 
   envoy_dynamic_module_type_cluster_host_envoy_ptr host_ptr = nullptr;
   envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle = nullptr;
@@ -820,16 +824,17 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
                                                           &async_handle);
 
   if (async_handle != nullptr) {
-    // Async pending: the module will call the completion callback later.
+    // Async pending: the module will call the completion callback later. The `cancelable` holds the
+    // registry so it can drop its entry even if it outlives this load balancer.
     auto cancelable = std::make_unique<DynamicModuleAsyncHostSelectionHandle>(
         async_handle, in_module_lb_,
-        handle_->cluster_->config()->on_cluster_lb_cancel_host_selection_, active_async_cancelled_);
+        handle_->cluster_->config()->on_cluster_lb_cancel_host_selection_, std::move(cancelled),
+        async_selections_, context);
     return Upstream::HostSelectionResponse{nullptr, std::move(cancelable)};
   }
 
-  // Synchronous result or no host. Clear the async state.
-  active_async_dispatcher_ = nullptr;
-  active_async_cancelled_ = nullptr;
+  // Synchronous result or no host. Nothing will complete for this context, so drop its entry.
+  async_selections_->remove(context);
 
   if (host_ptr == nullptr) {
     return {nullptr};
@@ -841,6 +846,11 @@ DynamicModuleLoadBalancer::chooseHost(Upstream::LoadBalancerContext* context) {
 }
 
 DynamicModuleAsyncHostSelectionHandle::~DynamicModuleAsyncHostSelectionHandle() {
+  // Drop the registry entry first. Once it is gone the completion callback drops the event instead
+  // of touching a LoadBalancerContext the router is about to reclaim.
+  if (registry_ != nullptr) {
+    registry_->remove(context_);
+  }
   // Free the module-side async handle. The cancel function takes ownership of the handle and
   // drops it, so this works for both cancellation and normal completion paths.
   if (async_handle_ != nullptr && cancel_fn_ != nullptr) {

--- a/source/extensions/clusters/dynamic_modules/cluster.h
+++ b/source/extensions/clusters/dynamic_modules/cluster.h
@@ -551,6 +551,63 @@ private:
 };
 
 /**
+ * Registry of the async host selections that are in flight for one load balancer, keyed by the
+ * LoadBalancerContext pointer that the module echoes back on completion.
+ *
+ * A load balancer serves many concurrent async selections, so the cancellation state cannot live
+ * in a single slot on the load balancer. It is keyed per selection here instead.
+ *
+ * The registry is shared between the load balancer and every `cancelable` it hands to the router,
+ * because the router may destroy one after the load balancer is gone. It is mutex guarded because a
+ * module may complete a selection from any thread while the owning worker thread starts new ones.
+ */
+class DynamicModuleAsyncHostSelectionRegistry {
+public:
+  /**
+   * Records a new in-flight selection. The caller keeps a copy of `cancelled` in the `cancelable`
+   * it returns to the router, so cancellation state outlives this entry.
+   */
+  void add(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context,
+           const std::shared_ptr<std::atomic<bool>>& cancelled) {
+    absl::MutexLock lock(&mutex_);
+    entries_[context] = cancelled;
+  }
+
+  /** Drops the entry for `context`. Safe to call for a context that was never added. */
+  void remove(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) {
+    absl::MutexLock lock(&mutex_);
+    entries_.erase(context);
+  }
+
+  /**
+   * Returns the cancellation flag for `context`, or nullptr when no selection is in flight for it.
+   * A nullptr result means the selection was already completed or cancelled, so the caller must
+   * drop the event rather than touch the context.
+   */
+  std::shared_ptr<std::atomic<bool>>
+  find(envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context) const {
+    absl::MutexLock lock(&mutex_);
+    auto it = entries_.find(context);
+    return it == entries_.end() ? nullptr : it->second;
+  }
+
+  /** Number of in-flight selections. */
+  size_t sizeForTest() const {
+    absl::MutexLock lock(&mutex_);
+    return entries_.size();
+  }
+
+private:
+  mutable absl::Mutex mutex_;
+  absl::flat_hash_map<envoy_dynamic_module_type_cluster_lb_context_envoy_ptr,
+                      std::shared_ptr<std::atomic<bool>>>
+      entries_ ABSL_GUARDED_BY(mutex_);
+};
+
+using DynamicModuleAsyncHostSelectionRegistrySharedPtr =
+    std::shared_ptr<DynamicModuleAsyncHostSelectionRegistry>;
+
+/**
  * Async host selection handle that bridges the dynamic module's async host selection to Envoy's
  * LoadBalancerContext::onAsyncHostSelection. This is created when the module returns an async
  * pending result from choose_host, and destroyed after the module delivers the result or the
@@ -558,12 +615,16 @@ private:
  */
 class DynamicModuleAsyncHostSelectionHandle : public Upstream::AsyncHostSelectionHandle {
 public:
+  // `registry` and `context` drop this selection's entry on destruction. Both may be null or unset
+  // in unit tests that exercise cancellation without a registry.
   DynamicModuleAsyncHostSelectionHandle(
       envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle,
       envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb,
-      OnClusterLbCancelHostSelectionType cancel_fn, std::shared_ptr<std::atomic<bool>> cancelled)
+      OnClusterLbCancelHostSelectionType cancel_fn, std::shared_ptr<std::atomic<bool>> cancelled,
+      DynamicModuleAsyncHostSelectionRegistrySharedPtr registry = nullptr,
+      envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context = nullptr)
       : async_handle_(async_handle), in_module_lb_(in_module_lb), cancel_fn_(cancel_fn),
-        cancelled_(std::move(cancelled)) {}
+        cancelled_(std::move(cancelled)), registry_(std::move(registry)), context_(context) {}
 
   ~DynamicModuleAsyncHostSelectionHandle() override;
 
@@ -573,7 +634,13 @@ private:
   envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_{nullptr};
   OnClusterLbCancelHostSelectionType cancel_fn_;
+  // Per-selection cancellation flag. The completion path reads the same object through the
+  // registry, so setting it here is observed there. The router may destroy this handle right after
+  // cancel(), which is why the flag is shared rather than owned.
   std::shared_ptr<std::atomic<bool>> cancelled_;
+  // Shared so a handle outliving its load balancer can still drop its entry.
+  DynamicModuleAsyncHostSelectionRegistrySharedPtr registry_;
+  envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_{nullptr};
 };
 
 /**
@@ -609,27 +676,24 @@ public:
   const DynamicModuleClusterHandleSharedPtr& handle() const { return handle_; }
 
   /**
-   * Returns the shared cancellation flag for the current async host selection. When the router
-   * cancels the selection (e.g., stream timeout), the flag is set so the posted completion
-   * callback becomes a no-op. Returns nullptr when there is no active async selection.
+   * Returns the registry of in-flight async host selections. The async completion callback in
+   * abi_impl.cc looks the completing selection up by its LoadBalancerContext pointer, so a
+   * cancellation on one selection cannot suppress the completion of another.
    */
-  std::shared_ptr<std::atomic<bool>> activeAsyncCancelled() const {
-    return active_async_cancelled_;
+  const DynamicModuleAsyncHostSelectionRegistrySharedPtr& asyncSelections() const {
+    return async_selections_;
   }
 
   /**
-   * Returns the worker thread's dispatcher captured during chooseHost. Used by the async
-   * completion callback in abi_impl.cc to post to the correct worker thread without accessing
-   * the LoadBalancerContext from a background thread.
-   */
-  Event::Dispatcher* activeAsyncDispatcher() const { return active_async_dispatcher_; }
-
-  /**
    * Returns the worker thread's dispatcher captured during chooseHost, or nullptr if no chooseHost
-   * has run on this worker yet. Used by the worker timer ABI callbacks to create timers on the
-   * correct worker dispatcher. The captured dispatcher is stable for the worker's lifetime.
+   * has run on this worker yet. Used by the async completion callback to post to the owning worker
+   * without touching the LoadBalancerContext from a background thread, and by the worker timer ABI
+   * callbacks to create timers on the correct dispatcher. Sticky and atomic, since the completion
+   * may read it from any thread while the worker writes it.
    */
-  Event::Dispatcher* workerDispatcher() const { return worker_dispatcher_; }
+  Event::Dispatcher* workerDispatcher() const {
+    return worker_dispatcher_.load(std::memory_order_acquire);
+  }
 
   // The cluster config holding the resolved module function pointers.
   const DynamicModuleClusterConfigSharedPtr& config() const { return handle_->cluster()->config(); }
@@ -664,16 +728,15 @@ private:
   const Upstream::PrioritySet& priority_set_;
   envoy_dynamic_module_type_cluster_lb_module_ptr in_module_lb_;
 
-  // Shared cancellation flag for the active async host selection. Set in chooseHost when the
-  // module returns AsyncPending, and read by the posted completion callback in abi_impl.cc.
-  std::shared_ptr<std::atomic<bool>> active_async_cancelled_;
+  // In-flight async host selections keyed by LoadBalancerContext pointer. Shared with every
+  // `cancelable` handed to the router so one outliving this load balancer stays safe.
+  const DynamicModuleAsyncHostSelectionRegistrySharedPtr async_selections_{
+      std::make_shared<DynamicModuleAsyncHostSelectionRegistry>()};
 
-  // Worker thread dispatcher captured during chooseHost for async completion posting.
-  Event::Dispatcher* active_async_dispatcher_{nullptr};
-
-  // Worker thread dispatcher captured during chooseHost, used to create worker timers. Sticky:
-  // once captured it is never cleared, since the worker dispatcher is stable for the worker's life.
-  Event::Dispatcher* worker_dispatcher_{nullptr};
+  // Worker thread dispatcher captured during chooseHost, used for async completion posting and to
+  // create worker timers. Sticky: once captured it is never cleared, since the worker dispatcher is
+  // stable for the worker's life. Atomic because a module completion may read it from any thread.
+  std::atomic<Event::Dispatcher*> worker_dispatcher_{nullptr};
 
   // Per-host data storage keyed by (priority, index). This is per-LB-instance (per-worker).
   absl::flat_hash_map<std::pair<uint32_t, size_t>, uintptr_t> per_host_data_;

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -12,6 +12,7 @@ envoy_cc_dyn_module_test(
     name = "cluster_test",
     srcs = ["cluster_test.cc"],
     data = [
+        "//test/extensions/dynamic_modules/test_data/c:cluster_async_host_selection",
         "//test/extensions/dynamic_modules/test_data/c:cluster_config_new_fail",
         "//test/extensions/dynamic_modules/test_data/c:cluster_new_fail",
         "//test/extensions/dynamic_modules/test_data/c:cluster_no_op",

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -3094,6 +3094,10 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteWithHost) {
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
 
+  // chooseHost registers the selection on the async path. Register it directly here so the
+  // completion has the in-flight entry it looks itself up by.
+  lb_instance->asyncSelections()->add(context_ptr, std::make_shared<std::atomic<bool>>(false));
+
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       lb_envoy_ptr, context_ptr, raw_host_ptr, {"resolved", 8});
 }
@@ -3117,6 +3121,7 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteNullHost) {
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
+  lb_instance->asyncSelections()->add(context_ptr, std::make_shared<std::atomic<bool>>(false));
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
       lb_envoy_ptr, context_ptr, nullptr, {"dns_failure", 11});
@@ -3141,9 +3146,158 @@ TEST_F(DynamicModuleClusterTest, AsyncHostSelectionCompleteEmptyDetails) {
 
   auto* lb_envoy_ptr = static_cast<void*>(lb_instance.get());
   auto* context_ptr = static_cast<void*>(&context);
+  lb_instance->asyncSelections()->add(context_ptr, std::make_shared<std::atomic<bool>>(false));
 
   envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(lb_envoy_ptr, context_ptr,
                                                                          nullptr, {nullptr, 0});
+}
+
+// Two concurrent async host selections on one load balancer must not share cancellation state. A
+// downstream connection is set so the completion posts to the worker dispatcher, the path a real
+// request takes. With the old single cancellation slot the second chooseHost overwrote the first
+// selection's flag, so the first selection's completion read a cancelled flag and was dropped while
+// its stream waited for the route deadline.
+TEST_F(DynamicModuleClusterTest, ConcurrentAsyncSelectionsDoNotShareCancellation) {
+  auto result = createCluster(makeYamlConfig("cluster_async_host_selection"));
+  ASSERT_OK(result);
+  auto& [cluster, lb] = result.value();
+
+  auto& module_cluster = dynamic_cast<DynamicModuleCluster&>(*cluster);
+  std::vector<Upstream::HostSharedPtr> result_hosts;
+  ASSERT_TRUE(addSimpleHosts(module_cluster, {"127.0.0.1:8080"}, {1}, result_hosts));
+  ASSERT_EQ(result_hosts.size(), 1);
+  auto* raw_host_ptr = const_cast<Upstream::Host*>(result_hosts[0].get());
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  // A downstream connection makes chooseHost capture the worker dispatcher, so the completion takes
+  // the posted path. The mock dispatcher runs posted callbacks inline to keep the test
+  // deterministic.
+  NiceMock<Network::MockConnection> connection;
+  NiceMock<Upstream::MockLoadBalancerContext> first;
+  NiceMock<Upstream::MockLoadBalancerContext> second;
+  ON_CALL(first, downstreamConnection()).WillByDefault(Return(&connection));
+  ON_CALL(second, downstreamConnection()).WillByDefault(Return(&connection));
+
+  // Both selections park, so both get a `cancelable` and both stay in flight.
+  auto first_response = lb_instance->chooseHost(&first);
+  auto second_response = lb_instance->chooseHost(&second);
+  ASSERT_NE(first_response.cancelable, nullptr);
+  ASSERT_NE(second_response.cancelable, nullptr);
+  EXPECT_EQ(2, lb_instance->asyncSelections()->sizeForTest());
+
+  // The router cancels the second selection, for example on a stream timeout.
+  second_response.cancelable->cancel();
+
+  // The first selection resolves. It must still complete.
+  bool first_completed = false;
+  EXPECT_CALL(first, onAsyncHostSelection(_, _))
+      .WillOnce([&](Upstream::HostConstSharedPtr&& host, std::string&&) {
+        EXPECT_EQ(host.get(), raw_host_ptr);
+        first_completed = true;
+      });
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&first), raw_host_ptr,
+      {"resolved", 8});
+  EXPECT_TRUE(first_completed);
+
+  // The cancelled selection must not complete.
+  EXPECT_CALL(second, onAsyncHostSelection(_, _)).Times(0);
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&second), raw_host_ptr,
+      {"resolved", 8});
+}
+
+// Without a downstream connection no worker dispatcher is captured, so the completion runs inline
+// on the calling thread. A cancelled selection must still be dropped there.
+TEST_F(DynamicModuleClusterTest, InlineAsyncSelectionCompletionHonorsCancel) {
+  auto result = createCluster(makeYamlConfig("cluster_async_host_selection"));
+  ASSERT_OK(result);
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto response = lb_instance->chooseHost(&context);
+  ASSERT_NE(response.cancelable, nullptr);
+
+  response.cancelable->cancel();
+
+  EXPECT_CALL(context, onAsyncHostSelection(_, _)).Times(0);
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&context), nullptr,
+      {"resolved", 8});
+}
+
+// Destroying a `cancelable` drops its selection, so a late completion for that context is dropped
+// instead of reaching a LoadBalancerContext the router has reclaimed.
+TEST_F(DynamicModuleClusterTest, AsyncSelectionCompleteAfterCancelableDestroyedDropsEvent) {
+  auto result = createCluster(makeYamlConfig("cluster_async_host_selection"));
+  ASSERT_OK(result);
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto response = lb_instance->chooseHost(&context);
+  ASSERT_NE(response.cancelable, nullptr);
+  EXPECT_EQ(1, lb_instance->asyncSelections()->sizeForTest());
+
+  response.cancelable.reset();
+  EXPECT_EQ(0, lb_instance->asyncSelections()->sizeForTest());
+
+  EXPECT_CALL(context, onAsyncHostSelection(_, _)).Times(0);
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&context), nullptr, {"late", 4});
+}
+
+// A `cancelable` may outlive its load balancer. Its destructor must still be able to drop its
+// entry, which is why the registry is shared rather than owned by the load balancer.
+TEST_F(DynamicModuleClusterTest, AsyncSelectionCancelableOutlivesLoadBalancer) {
+  auto result = createCluster(makeYamlConfig("cluster_async_host_selection"));
+  ASSERT_OK(result);
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto response = lb_instance->chooseHost(&context);
+  ASSERT_NE(response.cancelable, nullptr);
+
+  lb_instance.reset();
+  // Cancelling and destroying after the load balancer is gone must not touch freed memory.
+  response.cancelable->cancel();
+  response.cancelable.reset();
+}
+
+// A synchronous chooseHost result leaves nothing in flight, so a module that later completes that
+// context is ignored rather than driving a context Envoy already finished with.
+TEST_F(DynamicModuleClusterTest, SynchronousChooseHostLeavesNoInFlightSelection) {
+  auto result = createCluster(makeYamlConfig("cluster_no_op"));
+  ASSERT_OK(result);
+  auto& [cluster, lb] = result.value();
+
+  auto handle = std::make_shared<DynamicModuleClusterHandle>(
+      std::dynamic_pointer_cast<DynamicModuleCluster>(cluster));
+  auto lb_instance = std::make_unique<DynamicModuleLoadBalancer>(handle, cluster->prioritySet());
+
+  NiceMock<Upstream::MockLoadBalancerContext> context;
+  auto response = lb_instance->chooseHost(&context);
+  EXPECT_EQ(response.cancelable, nullptr);
+  EXPECT_EQ(0, lb_instance->asyncSelections()->sizeForTest());
+
+  EXPECT_CALL(context, onAsyncHostSelection(_, _)).Times(0);
+  envoy_dynamic_module_callback_cluster_lb_async_host_selection_complete(
+      static_cast<void*>(lb_instance.get()), static_cast<void*>(&context), nullptr,
+      {"unsolicited", 11});
 }
 
 // Covers that `async_host_selection_complete` drops the event when the owning load balancer has

--- a/test/extensions/dynamic_modules/test_data/c/BUILD
+++ b/test/extensions/dynamic_modules/test_data/c/BUILD
@@ -177,6 +177,8 @@ test_program(name = "cluster_specifier_missing_select")
 
 test_program(name = "cluster_specifier_config_new_fail")
 
+test_program(name = "cluster_async_host_selection")
+
 test_program(name = "cluster_no_op")
 
 test_program(name = "cluster_run_on_all_workers")

--- a/test/extensions/dynamic_modules/test_data/c/cluster_async_host_selection.c
+++ b/test/extensions/dynamic_modules/test_data/c/cluster_async_host_selection.c
@@ -1,0 +1,78 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "source/extensions/dynamic_modules/abi/abi.h"
+
+// A cluster module whose choose_host always parks, so a test can hold several async host
+// selections in flight on one load balancer at the same time.
+
+envoy_dynamic_module_type_abi_version_module_ptr envoy_dynamic_module_on_program_init(void) {
+  return envoy_dynamic_modules_abi_version;
+}
+
+envoy_dynamic_module_type_cluster_config_module_ptr envoy_dynamic_module_on_cluster_config_new(
+    envoy_dynamic_module_type_cluster_config_envoy_ptr config_envoy_ptr,
+    envoy_dynamic_module_type_envoy_buffer name, envoy_dynamic_module_type_envoy_buffer config) {
+  (void)config_envoy_ptr;
+  (void)name;
+  (void)config;
+  return (envoy_dynamic_module_type_cluster_config_module_ptr)0x1;
+}
+
+void envoy_dynamic_module_on_cluster_config_destroy(
+    envoy_dynamic_module_type_cluster_config_module_ptr config_module_ptr) {
+  (void)config_module_ptr;
+}
+
+envoy_dynamic_module_type_cluster_module_ptr envoy_dynamic_module_on_cluster_new(
+    envoy_dynamic_module_type_cluster_config_module_ptr config_module_ptr,
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr) {
+  (void)config_module_ptr;
+  (void)cluster_envoy_ptr;
+  return (envoy_dynamic_module_type_cluster_module_ptr)0x2;
+}
+
+void envoy_dynamic_module_on_cluster_init(
+    envoy_dynamic_module_type_cluster_envoy_ptr cluster_envoy_ptr,
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr) {
+  (void)cluster_envoy_ptr;
+  (void)cluster_module_ptr;
+}
+
+void envoy_dynamic_module_on_cluster_destroy(
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr) {
+  (void)cluster_module_ptr;
+}
+
+envoy_dynamic_module_type_cluster_lb_module_ptr envoy_dynamic_module_on_cluster_lb_new(
+    envoy_dynamic_module_type_cluster_module_ptr cluster_module_ptr,
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr) {
+  (void)cluster_module_ptr;
+  (void)lb_envoy_ptr;
+  return (envoy_dynamic_module_type_cluster_lb_module_ptr)0x3;
+}
+
+void envoy_dynamic_module_on_cluster_lb_destroy(
+    envoy_dynamic_module_type_cluster_lb_module_ptr lb_module_ptr) {
+  (void)lb_module_ptr;
+}
+
+// Always parks. The async handle is the context pointer so each selection gets a distinct
+// non-null handle, which is what makes Envoy return a cancelable.
+void envoy_dynamic_module_on_cluster_lb_choose_host(
+    envoy_dynamic_module_type_cluster_lb_module_ptr lb_module_ptr,
+    envoy_dynamic_module_type_cluster_lb_context_envoy_ptr context_envoy_ptr,
+    envoy_dynamic_module_type_cluster_host_envoy_ptr* host_out,
+    envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr* async_handle_out) {
+  (void)lb_module_ptr;
+  *host_out = NULL;
+  *async_handle_out =
+      (envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr)context_envoy_ptr;
+}
+
+void envoy_dynamic_module_on_cluster_lb_cancel_host_selection(
+    envoy_dynamic_module_type_cluster_lb_module_ptr lb_module_ptr,
+    envoy_dynamic_module_type_cluster_lb_async_handle_module_ptr async_handle_module_ptr) {
+  (void)lb_module_ptr;
+  (void)async_handle_module_ptr;
+}


### PR DESCRIPTION
## Description

Today the dynamic module cluster keeps one cancellation slot on the load balancer, so a second `chooseHost` overrides the first selection's flag. The completion callback then read the wrong flag, a request whose host had resolved was silently dropped whenever an unrelated, more recent selection on the same worker had been cancelled, and the stream sat until its route deadline.

In this PR, we are making the cancellation state per-selection, keyed by the `LoadBalancerContext` the module echoes back on completion. A completion for a selection that is no longer in flight would get dropped instead of driving a context the router already reclaimed, and the `cancelable` would drop its own entry on destruction. The registry is shared so a `cancelable` outliving its load balancer should stays safe.

---

**Commit Message**: dynamic_modules: per-selection async host selection cancellation
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes**: Added