### PR TITLE
runtime: removed ext_proc_stream_close_optimization flag and legacy code paths

### DIFF
--- a/changelogs/current/removed_config_or_runtime/ext_proc__stream-close-optimization.rst
+++ b/changelogs/current/removed_config_or_runtime/ext_proc__stream-close-optimization.rst
@@ -1,0 +1,2 @@
+Removed runtime flag ``envoy.reloadable_features.ext_proc_stream_close_optimization`` and legacy
+code paths.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -70,7 +70,6 @@ RUNTIME_GUARD(envoy_reloadable_features_ext_proc_fail_close_spurious_resp);
 RUNTIME_GUARD(envoy_reloadable_features_ext_proc_inject_data_with_state_update);
 RUNTIME_GUARD(envoy_reloadable_features_ext_proc_report_client_creation_error);
 RUNTIME_GUARD(envoy_reloadable_features_ext_proc_return_stop_iteration);
-RUNTIME_GUARD(envoy_reloadable_features_ext_proc_stream_close_optimization);
 // When a filter drains the current data frame into the filter-manager buffer via
 // addDecoded/EncodedData() and then returns Continue (e.g. a wasm filter resuming after buffering),
 // forward that buffered data down the chain instead of the now-empty frame, so the frame is not

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -1404,11 +1404,8 @@ FilterHeadersStatus Filter::encodeHeaders(ResponseHeaderMap& headers, bool end_s
   // If there is no external processing configured in the encoding path,
   // and no more external processing is needed in the decoding path,
   // closing the gRPC stream if it is still open.
-  if (Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.ext_proc_stream_close_optimization")) {
-    if (encoding_state_.noExternalProcess() && decoding_state_.noMoreExternalProcess()) {
-      closeStreamMaybeGraceful();
-    }
+  if (encoding_state_.noExternalProcess() && decoding_state_.noMoreExternalProcess()) {
+    closeStreamMaybeGraceful();
   }
 
   return status;
@@ -1803,8 +1800,7 @@ void Filter::closeGrpcStreamIfLastRespReceived(const ProcessingResponse& respons
                                                const bool eos_seen_in_body) {
   // Bail out if the gRPC stream has already been closed. This can happen in scenarios
   // like immediate responses or rejected header mutations.
-  if (stream_ == nullptr || !Runtime::runtimeFeatureEnabled(
-                                "envoy.reloadable_features.ext_proc_stream_close_optimization")) {
+  if (stream_ == nullptr) {
     return;
   }
 

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -633,11 +633,8 @@ TEST_P(ExtProcIntegrationTest, OnlyRequestHeadersServerHalfClosesFirst) {
         return true;
       });
 
-  if (Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.ext_proc_stream_close_optimization")) {
-    // Envoy closes the side stream in this case.
-    EXPECT_TRUE(processor_stream_->waitForReset());
-  }
+  // Envoy closes the side stream in this case.
+  EXPECT_TRUE(processor_stream_->waitForReset());
 
   // ext_proc server indicates that it is not expecting any more messages
   // from ext_proc filter and half-closes the stream.

--- a/test/extensions/filters/http/ext_proc/filter_test.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test.cc
@@ -129,8 +129,6 @@ protected:
   };
   void initialize(std::string&& yaml, bool is_upstream_filter = false) {
     scoped_runtime_.mergeValues(
-        {{"envoy.reloadable_features.ext_proc_stream_close_optimization", "true"}});
-    scoped_runtime_.mergeValues(
         {{"envoy.reloadable_features.ext_proc_inject_data_with_state_update", "true"}});
     scoped_runtime_.mergeValues(
         {{"envoy.reloadable_features.ext_proc_return_stop_iteration", "true"}});

--- a/test/extensions/filters/http/ext_proc/filter_test_common.cc
+++ b/test/extensions/filters/http/ext_proc/filter_test_common.cc
@@ -70,8 +70,6 @@ static constexpr uint32_t BufferSize = 100000;
 
 void HttpFilterTest::initialize(std::string&& yaml, bool is_upstream_filter) {
   scoped_runtime_.mergeValues(
-      {{"envoy.reloadable_features.ext_proc_stream_close_optimization", "true"}});
-  scoped_runtime_.mergeValues(
       {{"envoy.reloadable_features.ext_proc_inject_data_with_state_update", "true"}});
   scoped_runtime_.mergeValues(
       {{"envoy.reloadable_features.ext_proc_return_stop_iteration", "true"}});


### PR DESCRIPTION
Commit Message: runtime: removed ext_proc_stream_close_optimization flag and legacy code paths
Additional Description: To close #46127
Risk Level: Low
Testing: Existing tests.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A
