### PR TITLE
runtime: removed use_migration_in_quiche flag and legacy code paths

### DIFF
--- a/changelogs/current/removed_config_or_runtime/quic__use-migration-in-quiche.rst
+++ b/changelogs/current/removed_config_or_runtime/quic__use-migration-in-quiche.rst
@@ -1,0 +1,1 @@
+Removed runtime flag ``envoy.reloadable_features.use_migration_in_quiche`` and legacy code paths.

--- a/source/common/quic/client_connection_factory_impl.cc
+++ b/source/common/quic/client_connection_factory_impl.cc
@@ -117,20 +117,12 @@ std::unique_ptr<Network::ClientConnection> createQuicNetworkConnection(
   QuicClientPacketWriterFactory::CreationResult creation_result =
       info_impl->writer_factory_->createSocketAndQuicPacketWriter(server_addr, current_network,
                                                                   local_addr, options);
-  const bool use_migration_in_quiche =
-      Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_migration_in_quiche");
-  quic::QuicForceBlockablePacketWriter* wrapper = nullptr;
-  if (use_migration_in_quiche) {
-    wrapper = new quic::QuicForceBlockablePacketWriter();
-    // Owns the inner writer.
-    wrapper->set_writer(creation_result.writer_.release());
-  }
+  auto* wrapper = new quic::QuicForceBlockablePacketWriter();
+  // Owns the inner writer.
+  wrapper->set_writer(creation_result.writer_.release());
   auto connection = std::make_unique<EnvoyQuicClientConnection>(
       quic::QuicUtils::CreateRandomConnectionId(), info_impl->conn_helper_,
-      info_impl->alarm_factory_,
-      (use_migration_in_quiche
-           ? wrapper
-           : static_cast<quic::QuicPacketWriter*>(creation_result.writer_.release())),
+      info_impl->alarm_factory_, wrapper,
       /*owns_writer=*/true, quic_versions, dispatcher, std::move(creation_result.socket_),
       generator);
   // Override the max packet length of the QUIC connection if the option value is not 0.
@@ -138,19 +130,11 @@ std::unique_ptr<Network::ClientConnection> createQuicNetworkConnection(
     connection->SetMaxPacketLength(info_impl->max_packet_length_);
   }
 
-  EnvoyQuicClientConnection::EnvoyQuicMigrationHelper* migration_helper = nullptr;
-  quic::QuicConnectionMigrationConfig migration_config = info_impl->migration_config_;
-  if (use_migration_in_quiche) {
-    migration_helper = &connection->getOrCreateMigrationHelper(
-        *info_impl->writer_factory_, current_network,
-        makeOptRefFromPtr<EnvoyQuicNetworkObserverRegistry>(network_observer_registry));
-  } else {
-    // The connection needs to be aware of the writer factory so it can create migration probing
-    // sockets.
-    connection->setWriterFactory(*info_impl->writer_factory_);
-    // Disable all kinds of migration in QUICHE as the session won't be setup to handle it.
-    migration_config = quicConnectionMigrationDisableAllConfig();
-  }
+  const quic::QuicConnectionMigrationConfig migration_config = info_impl->migration_config_;
+  EnvoyQuicClientConnection::EnvoyQuicMigrationHelper* migration_helper =
+      &connection->getOrCreateMigrationHelper(
+          *info_impl->writer_factory_, current_network,
+          makeOptRefFromPtr<EnvoyQuicNetworkObserverRegistry>(network_observer_registry));
   // TODO (danzh) move this temporary config and initial RTT configuration to h3 pool.
   quic::QuicConfig config = info_impl->quic_config_;
   // Update config with latest srtt, if available.

--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -178,7 +178,6 @@ RUNTIME_GUARD(envoy_reloadable_features_use_canonical_suffix_for_quic_brokenness
 // from the connection-level drain notification (Network::Connection::onDrain()) instead of by
 // polling the listener DrainDecision. Latched per connection when the network filter is created.
 RUNTIME_GUARD(envoy_reloadable_features_use_connection_event_drain);
-RUNTIME_GUARD(envoy_reloadable_features_use_migration_in_quiche);
 RUNTIME_GUARD(envoy_reloadable_features_use_response_decoder_handle);
 RUNTIME_GUARD(envoy_reloadable_features_validate_upstream_headers);
 RUNTIME_GUARD(envoy_reloadable_features_websocket_allow_4xx_5xx_through_filter_chain);

--- a/test/common/quic/client_connection_factory_impl_test.cc
+++ b/test/common/quic/client_connection_factory_impl_test.cc
@@ -164,23 +164,15 @@ TEST_P(QuicNetworkConnectionTest, QuicheHandlesMigrationOfIdleSessions) {
   client_connection->connect();
   EXPECT_TRUE(client_connection->connecting());
   ASSERT(session != nullptr);
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_migration_in_quiche")) {
-    // Session should have a handle to the writer if quiche handles migration.
-    EXPECT_NE(session->writer(), nullptr);
-    // Port migration should be configured.
-    EXPECT_TRUE(session->GetConnectionMigrationConfig().allow_port_migration);
-    EXPECT_TRUE(session->GetConnectionMigrationConfig().migrate_session_on_network_change);
-    EXPECT_EQ(quic::QuicTime::Delta::FromSeconds(10),
-              session->GetConnectionMigrationConfig().idle_migration_period);
-    EXPECT_EQ(quic::QuicTime::Delta::FromSeconds(90),
-              session->GetConnectionMigrationConfig().max_time_on_non_default_network);
-  } else {
-    EXPECT_EQ(session->writer(), nullptr);
-    // QUICHE migration config should have all kinds of migration disabled.
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().allow_server_preferred_address);
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().allow_port_migration);
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().migrate_session_on_network_change);
-  }
+  // Session should have a handle to the writer as quiche handles migration.
+  EXPECT_NE(session->writer(), nullptr);
+  // Port migration should be configured.
+  EXPECT_TRUE(session->GetConnectionMigrationConfig().allow_port_migration);
+  EXPECT_TRUE(session->GetConnectionMigrationConfig().migrate_session_on_network_change);
+  EXPECT_EQ(quic::QuicTime::Delta::FromSeconds(10),
+            session->GetConnectionMigrationConfig().idle_migration_period);
+  EXPECT_EQ(quic::QuicTime::Delta::FromSeconds(90),
+            session->GetConnectionMigrationConfig().max_time_on_non_default_network);
   client_connection->close(Network::ConnectionCloseType::NoFlush);
 }
 
@@ -200,22 +192,14 @@ TEST_P(QuicNetworkConnectionTest, QuicheHandlesMigration) {
   client_connection->connect();
   EXPECT_TRUE(client_connection->connecting());
   ASSERT(session != nullptr);
-  if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.use_migration_in_quiche")) {
-    // Session should have a handle to the writer if quiche handles migration.
-    EXPECT_NE(session->writer(), nullptr);
-    // Port migration should be configured.
-    EXPECT_TRUE(session->GetConnectionMigrationConfig().allow_port_migration);
-    EXPECT_TRUE(session->GetConnectionMigrationConfig().migrate_session_on_network_change);
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().migrate_idle_session);
-    EXPECT_EQ(quic::QuicTime::Delta::FromSeconds(90),
-              session->GetConnectionMigrationConfig().max_time_on_non_default_network);
-  } else {
-    EXPECT_EQ(session->writer(), nullptr);
-    // QUICHE migration config should have all kinds of migration disabled.
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().allow_server_preferred_address);
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().allow_port_migration);
-    EXPECT_FALSE(session->GetConnectionMigrationConfig().migrate_session_on_network_change);
-  }
+  // Session should have a handle to the writer as quiche handles migration.
+  EXPECT_NE(session->writer(), nullptr);
+  // Port migration should be configured.
+  EXPECT_TRUE(session->GetConnectionMigrationConfig().allow_port_migration);
+  EXPECT_TRUE(session->GetConnectionMigrationConfig().migrate_session_on_network_change);
+  EXPECT_FALSE(session->GetConnectionMigrationConfig().migrate_idle_session);
+  EXPECT_EQ(quic::QuicTime::Delta::FromSeconds(90),
+            session->GetConnectionMigrationConfig().max_time_on_non_default_network);
   client_connection->close(Network::ConnectionCloseType::NoFlush);
 }
 


### PR DESCRIPTION
Commit Message: runtime: removed use_migration_in_quiche flag and legacy code paths
Additional Description: To close #46134
Risk Level: Low
Testing: Existing tests.
Docs Changes: N/A
Release Notes: Added.
Platform Specific Features: N/A
