### PR TITLE
dynamic_modules: bulk healthy-host getter for module clusters

### DIFF
--- a/source/extensions/clusters/dynamic_modules/abi_impl.cc
+++ b/source/extensions/clusters/dynamic_modules/abi_impl.cc
@@ -312,6 +312,37 @@ envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
   return const_cast<Envoy::Upstream::Host*>(healthy_hosts[index].get());
 }
 
+bool envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    envoy_dynamic_module_type_cluster_host_envoy_ptr* hosts_out, size_t hosts_capacity,
+    size_t* hosts_size_out) {
+  if (hosts_size_out == nullptr) {
+    return false;
+  }
+  *hosts_size_out = 0;
+  if (lb_envoy_ptr == nullptr) {
+    return false;
+  }
+  const auto& host_sets = getLb(lb_envoy_ptr)->prioritySet().hostSetsPerPriority();
+  if (priority >= host_sets.size()) {
+    return false;
+  }
+  const auto& healthy_hosts = host_sets[priority]->healthyHosts();
+  *hosts_size_out = healthy_hosts.size();
+  // Write nothing when the buffer is too small so a caller cannot act on a partial healthy set.
+  if (healthy_hosts.size() > hosts_capacity) {
+    return false;
+  }
+  // The fill loop writes through hosts_out, so reject a null buffer that claims nonzero capacity.
+  if (hosts_out == nullptr && !healthy_hosts.empty()) {
+    return false;
+  }
+  for (size_t i = 0; i < healthy_hosts.size(); i++) {
+    hosts_out[i] = const_cast<Envoy::Upstream::Host*>(healthy_hosts[i].get());
+  }
+  return true;
+}
+
 // =============================================================================
 // Cluster LB Host Information Callbacks
 // =============================================================================

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -10067,6 +10067,30 @@ envoy_dynamic_module_type_cluster_host_envoy_ptr
 envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority, size_t index);
 
+/**
+ * envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts writes every healthy host pointer at
+ * the given priority level into a module-owned array, in the same order
+ * envoy_dynamic_module_callback_cluster_lb_get_healthy_host reports. It reads the whole partition
+ * in one ABI crossing instead of one crossing per host.
+ *
+ * Nothing is written unless every healthy host fits, so a caller whose buffer is too small sizes
+ * the retry from hosts_size_out rather than acting on a partial partition.
+ *
+ * @param lb_envoy_ptr is the pointer to the Envoy load balancer.
+ * @param priority is the priority level.
+ * @param hosts_out is the array to fill, owned by the module. May be null only when hosts_capacity
+ * is zero.
+ * @param hosts_capacity is the number of elements hosts_out can hold.
+ * @param hosts_size_out is set to the number of healthy hosts at this priority level, whether or
+ * not they fit. Set to zero when the priority level does not exist. Must not be null.
+ * @return true when every healthy host was written, false when the priority level does not exist or
+ * hosts_capacity is smaller than hosts_size_out.
+ */
+bool envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr lb_envoy_ptr, uint32_t priority,
+    envoy_dynamic_module_type_cluster_host_envoy_ptr* hosts_out, size_t hosts_capacity,
+    size_t* hosts_size_out);
+
 // =============================================================================
 // Cluster LB Host Information Callbacks
 // =============================================================================

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -557,6 +557,14 @@ envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
   return nullptr;
 }
 
+__attribute__((weak)) bool envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(
+    envoy_dynamic_module_type_cluster_lb_envoy_ptr, uint32_t,
+    envoy_dynamic_module_type_cluster_host_envoy_ptr*, size_t, size_t*) {
+  IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts: "
+               "not implemented in this context");
+  return false;
+}
+
 __attribute__((weak)) void envoy_dynamic_module_callback_cluster_lb_get_cluster_name(
     envoy_dynamic_module_type_cluster_lb_envoy_ptr, envoy_dynamic_module_type_envoy_buffer*) {
   IS_ENVOY_BUG("envoy_dynamic_module_callback_cluster_lb_get_cluster_name: "

--- a/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/cluster.rs
@@ -607,6 +607,23 @@ pub trait EnvoyClusterLoadBalancer: Send {
     index: usize,
   ) -> Option<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>;
 
+  /// Get every healthy host at the given priority level in one ABI crossing.
+  ///
+  /// This reads the whole partition at once. [`EnvoyClusterLoadBalancer::get_healthy_host`] instead
+  /// costs one crossing per host, which a module rebuilding its own view pays on every membership
+  /// update.
+  ///
+  /// `hosts` is cleared first, then filled in the same order [`get_healthy_host`] reports. Returns
+  /// `false` and leaves `hosts` empty when the priority level does not exist, or when the partition
+  /// grows between the internal sizing and fill passes.
+  ///
+  /// [`get_healthy_host`]: EnvoyClusterLoadBalancer::get_healthy_host
+  fn get_healthy_hosts(
+    &self,
+    priority: u32,
+    hosts: &mut Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>,
+  ) -> bool;
+
   /// Get a host by index within all hosts at the given priority level, regardless of health status.
   ///
   /// Unlike [`EnvoyClusterLoadBalancer::get_healthy_host`] which only returns healthy hosts, this
@@ -1335,6 +1352,55 @@ impl EnvoyClusterLoadBalancer for EnvoyClusterLoadBalancerImpl {
     } else {
       Some(host)
     }
+  }
+
+  fn get_healthy_hosts(
+    &self,
+    priority: u32,
+    hosts: &mut Vec<abi::envoy_dynamic_module_type_cluster_host_envoy_ptr>,
+  ) -> bool {
+    hosts.clear();
+    let mut size: usize = 0;
+    // First call sizes the partition. An empty buffer is legal, so a priority with no healthy hosts
+    // succeeds here and needs no second call.
+    // SAFETY: `size` is a live local and the callback tolerates a null buffer when the capacity is
+    // zero.
+    let fitted = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(
+        self.raw,
+        priority,
+        std::ptr::null_mut(),
+        0,
+        &mut size,
+      )
+    };
+    if fitted {
+      return true;
+    }
+    if size == 0 {
+      // The priority level does not exist. `hosts` is already empty.
+      return false;
+    }
+    hosts.reserve(size);
+    // SAFETY: the spare capacity is at least `size` elements of the exact pointer type the callback
+    // writes, and the length is only committed once the callback reports it filled them all.
+    let filled = unsafe {
+      abi::envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(
+        self.raw,
+        priority,
+        hosts.as_mut_ptr(),
+        hosts.capacity(),
+        &mut size,
+      )
+    };
+    if !filled {
+      // A membership change between the two calls grew the partition. Leave `hosts` empty and let
+      // the caller decide, rather than reporting a partial healthy set.
+      return false;
+    }
+    // SAFETY: the callback wrote exactly `size` initialized elements, and `size <= capacity`.
+    unsafe { hosts.set_len(size) };
+    true
   }
 
   fn get_host(
@@ -2930,6 +2996,42 @@ pub unsafe extern "C" fn envoy_dynamic_module_on_cluster_http_callout_done(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  // The stub in `lib_test.rs` maps each priority to a scenario, so this drives the real wrapper's
+  // size-then-fill handshake rather than a mock.
+  #[test]
+  fn get_healthy_hosts_fills_the_whole_partition_in_one_pass() {
+    let lb = EnvoyClusterLoadBalancerImpl::new(std::ptr::null_mut());
+    let mut hosts = Vec::new();
+
+    // Priority 0 has two healthy hosts, filled in order through the size-then-fill handshake.
+    assert!(lb.get_healthy_hosts(0, &mut hosts));
+    assert_eq!(hosts.len(), 2);
+    assert_eq!(hosts[0] as usize, 0xAB);
+    assert_eq!(hosts[1] as usize, 0xCD);
+
+    // Priority 1 exists but is empty, so a single sizing pass succeeds and leaves the buffer empty.
+    hosts.push(std::ptr::null_mut());
+    assert!(lb.get_healthy_hosts(1, &mut hosts));
+    assert!(hosts.is_empty());
+
+    // Priority 2 never fits, modeling a partition that grows between the two calls, so the wrapper
+    // fails and leaves the buffer empty rather than reporting a partial set.
+    hosts.push(std::ptr::null_mut());
+    assert!(!lb.get_healthy_hosts(2, &mut hosts));
+    assert!(hosts.is_empty());
+
+    // A missing priority level reports failure and leaves the buffer empty, so a caller cannot
+    // mistake it for an empty healthy set.
+    assert!(!lb.get_healthy_hosts(7, &mut hosts));
+    assert!(hosts.is_empty());
+
+    // A reused buffer is cleared first, so a second call cannot append to a stale partition.
+    hosts.push(std::ptr::null_mut());
+    assert!(lb.get_healthy_hosts(0, &mut hosts));
+    assert_eq!(hosts.len(), 2);
+    assert!(hosts.iter().all(|host| !host.is_null()));
+  }
 
   #[test]
   fn add_hosts_with_hostnames_dispatches_and_validates_lengths() {

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -4732,6 +4732,49 @@ pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_host(
   std::ptr::null_mut()
 }
 
+/// Maps each priority to a scenario so the SDK wrapper's size-then-fill handshake is exercised end
+/// to end.
+#[no_mangle]
+pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(
+  _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,
+  priority: u32,
+  hosts_out: *mut abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+  hosts_capacity: usize,
+  hosts_size_out: *mut usize,
+) -> bool {
+  const HOSTS: [usize; 2] = [0xAB, 0xCD];
+  match priority {
+    // Two healthy hosts, filled once the buffer is large enough.
+    0 => {
+      unsafe { *hosts_size_out = HOSTS.len() };
+      if hosts_capacity < HOSTS.len() {
+        return false;
+      }
+      for (i, addr) in HOSTS.iter().enumerate() {
+        unsafe {
+          *hosts_out.add(i) = *addr as abi::envoy_dynamic_module_type_cluster_host_envoy_ptr
+        };
+      }
+      true
+    },
+    // Existing but empty partition. A zero buffer already holds it.
+    1 => {
+      unsafe { *hosts_size_out = 0 };
+      true
+    },
+    // A partition that never fits, so the fill call keeps failing.
+    2 => {
+      unsafe { *hosts_size_out = HOSTS.len() };
+      false
+    },
+    // No such priority level.
+    _ => {
+      unsafe { *hosts_size_out = 0 };
+      false
+    },
+  }
+}
+
 #[no_mangle]
 pub extern "C" fn envoy_dynamic_module_callback_cluster_lb_get_cluster_name(
   _lb_envoy_ptr: abi::envoy_dynamic_module_type_cluster_lb_envoy_ptr,

--- a/test/extensions/clusters/dynamic_modules/cluster_test.cc
+++ b/test/extensions/clusters/dynamic_modules/cluster_test.cc
@@ -824,6 +824,75 @@ TEST_F(DynamicModuleClusterTest, LbAbiCallbacks) {
   EXPECT_EQ(nullptr, envoy_dynamic_module_callback_cluster_lb_get_healthy_host(dm_lb, 0, 2));
   // Invalid priority.
   EXPECT_EQ(nullptr, envoy_dynamic_module_callback_cluster_lb_get_healthy_host(dm_lb, 99, 0));
+
+  // The bulk getter reports the size for a zero-capacity probe and writes nothing.
+  size_t healthy_size = 12345;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, nullptr, 0,
+                                                                          &healthy_size));
+  EXPECT_EQ(2, healthy_size);
+
+  // A buffer that is one short writes nothing, so a caller cannot act on a partial healthy set.
+  envoy_dynamic_module_type_cluster_host_envoy_ptr too_small[1] = {nullptr};
+  healthy_size = 0;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, too_small, 1,
+                                                                          &healthy_size));
+  EXPECT_EQ(2, healthy_size);
+  EXPECT_EQ(nullptr, too_small[0]);
+
+  // A large enough buffer is filled in the indexed accessor's order.
+  envoy_dynamic_module_type_cluster_host_envoy_ptr filled[4] = {nullptr, nullptr, nullptr, nullptr};
+  healthy_size = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, filled, 4,
+                                                                         &healthy_size));
+  EXPECT_EQ(2, healthy_size);
+  EXPECT_EQ(hosts[0].get(), filled[0]);
+  EXPECT_EQ(hosts[1].get(), filled[1]);
+  EXPECT_EQ(nullptr, filled[2]);
+
+  // A buffer sized exactly to the partition is filled completely.
+  envoy_dynamic_module_type_cluster_host_envoy_ptr exact[2] = {nullptr, nullptr};
+  healthy_size = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, exact, 2,
+                                                                         &healthy_size));
+  EXPECT_EQ(2, healthy_size);
+  EXPECT_EQ(hosts[0].get(), exact[0]);
+  EXPECT_EQ(hosts[1].get(), exact[1]);
+
+  // An unknown priority level reports zero and fails, distinguishing it from an empty partition.
+  healthy_size = 12345;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 99, filled, 4,
+                                                                          &healthy_size));
+  EXPECT_EQ(0, healthy_size);
+
+  // A null load balancer pointer is rejected rather than dereferenced.
+  healthy_size = 12345;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(nullptr, 0, filled, 4,
+                                                                          &healthy_size));
+  EXPECT_EQ(0, healthy_size);
+
+  // A null size output pointer is rejected rather than dereferenced.
+  EXPECT_FALSE(
+      envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, filled, 4, nullptr));
+
+  // A null buffer that claims capacity is rejected rather than written through.
+  healthy_size = 0;
+  EXPECT_FALSE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, nullptr, 4,
+                                                                          &healthy_size));
+  EXPECT_EQ(2, healthy_size);
+
+  // Draining every host leaves priority 0 in the set but empty, so the getter reports success with
+  // size zero, which a caller must not confuse with an unknown priority.
+  EXPECT_EQ(2, cluster->removeHosts(hosts));
+  healthy_size = 12345;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, filled, 4,
+                                                                         &healthy_size));
+  EXPECT_EQ(0, healthy_size);
+
+  // A zero-capacity probe on the same empty partition also succeeds and writes nothing.
+  healthy_size = 12345;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(dm_lb, 0, nullptr, 0,
+                                                                         &healthy_size));
+  EXPECT_EQ(0, healthy_size);
 }
 
 // Test the LB host information ABI callbacks.
@@ -4112,6 +4181,15 @@ TEST_F(DynamicModuleClusterTest, LbGetHostIncludesUnhealthy) {
   EXPECT_EQ(1, envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(lb_ptr, 0));
   EXPECT_NE(nullptr, envoy_dynamic_module_callback_cluster_lb_get_healthy_host(lb_ptr, 0, 0));
   EXPECT_EQ(nullptr, envoy_dynamic_module_callback_cluster_lb_get_healthy_host(lb_ptr, 0, 1));
+
+  // The bulk getter reads the same healthy partition and returns only the healthy host.
+  envoy_dynamic_module_type_cluster_host_envoy_ptr healthy[2] = {nullptr, nullptr};
+  size_t healthy_size = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(lb_ptr, 0, healthy, 2,
+                                                                         &healthy_size));
+  EXPECT_EQ(1, healthy_size);
+  EXPECT_EQ(hosts[1].get(), healthy[0]);
+  EXPECT_EQ(nullptr, healthy[1]);
 }
 
 // Test that add_hosts supports adding hosts at a specific priority level.

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -252,6 +252,25 @@ TEST_P(DynamicModuleClusterIntegrationTest, MemberUpdatePackedAddress) {
   EXPECT_EQ("200", response->headers().getStatusValue());
 }
 
+// Drives the bulk healthy-host getter end to end. Each worker load balancer rebuilds its routable
+// set from get_healthy_hosts, confirms it agrees with get_healthy_host_count, and routes a request
+// through a host pointer the bulk getter returned.
+TEST_P(DynamicModuleClusterIntegrationTest, HealthyHostsBulkRebuild) {
+  concurrency_ = 2;
+  initializeWithDecCluster("healthy_hosts_rebuild");
+
+  // Each worker increments the counter once its bulk read agrees with the per-host count.
+  test_server_->waitForCounter("dynamicmodulescustom.healthy_hosts_rebuilt_total", testing::Ge(2));
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  auto response =
+      sendRequestAndWaitForResponse(default_request_headers_, 0, default_response_headers_, 0);
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
 // Verifies that the cluster lifecycle callbacks fire correctly during cluster
 // initialization.
 TEST_P(DynamicModuleClusterIntegrationTest, LifecycleCallbacks) {

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -404,6 +404,9 @@ WEAK_STUB(ClusterLbGetHealthyHostCount,
           envoy_dynamic_module_callback_cluster_lb_get_healthy_host_count(nullptr, 0))
 WEAK_STUB(ClusterLbGetHealthyHost,
           envoy_dynamic_module_callback_cluster_lb_get_healthy_host(nullptr, 0, 0))
+WEAK_STUB(ClusterLbGetHealthyHosts,
+          envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts(nullptr, 0, nullptr, 0,
+                                                                     nullptr))
 WEAK_STUB(ClusterLbContextComputeHashKey,
           envoy_dynamic_module_callback_cluster_lb_context_compute_hash_key(nullptr, nullptr))
 WEAK_STUB(ClusterLbContextGetDownstreamHeadersSize,

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -75,6 +75,16 @@ fn new_cluster_config(
         metrics: envoy_cluster_metrics,
       }))
     },
+    "healthy_hosts_rebuild" => {
+      let counter_id = envoy_cluster_metrics
+        .define_counter("healthy_hosts_rebuilt_total")
+        .ok();
+      Some(Box::new(HealthyHostsRebuildClusterConfig {
+        upstream_address: config_str.to_string(),
+        counter_id,
+        metrics: envoy_cluster_metrics,
+      }))
+    },
     "worker_timer" => {
       let armed_id = envoy_cluster_metrics
         .define_counter("timer_armed_total")
@@ -974,5 +984,109 @@ impl ClusterLb for NativeLbTestLb {
       let _ = self.metrics.increment_counter(counter_id, 1);
     }
     HostSelectionResult::Selected(hosts.0[idx])
+  }
+}
+
+// =============================================================================
+// Healthy-partition bulk rebuild.
+// =============================================================================
+//
+// Mirrors the worker-local-rebuild flow, but on_host_membership_update rebuilds the routable set
+// from get_healthy_hosts in one ABI crossing rather than applying the member-update delta. It
+// increments a counter once the bulk read agrees with get_healthy_host_count, so the test can wait
+// for every worker to converge before routing through a pointer the bulk getter returned.
+
+const HEALTHY_HOSTS_REBUILD_ADD_EVENT_ID: u64 = 400;
+
+struct HealthyHostsRebuildClusterConfig {
+  upstream_address: String,
+  counter_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl ClusterConfig for HealthyHostsRebuildClusterConfig {
+  fn new_cluster(&self, _envoy_cluster: &dyn EnvoyCluster) -> Box<dyn Cluster> {
+    Box::new(HealthyHostsRebuildCluster {
+      upstream_address: self.upstream_address.clone(),
+      counter_id: self.counter_id,
+      metrics: self.metrics.clone(),
+    })
+  }
+}
+
+struct HealthyHostsRebuildCluster {
+  upstream_address: String,
+  counter_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl Cluster for HealthyHostsRebuildCluster {
+  fn on_init(&mut self, envoy_cluster: &dyn EnvoyCluster) {
+    envoy_cluster.pre_init_complete();
+    let scheduler = envoy_cluster.new_scheduler();
+    scheduler.commit(HEALTHY_HOSTS_REBUILD_ADD_EVENT_ID);
+  }
+
+  fn new_load_balancer(
+    &self,
+    _envoy_lb: &dyn EnvoyClusterLoadBalancer,
+  ) -> Option<Box<dyn ClusterLb>> {
+    Some(Box::new(HealthyHostsRebuildLb {
+      hosts: Vec::new(),
+      index: 0,
+      counter_id: self.counter_id,
+      metrics: self.metrics.clone(),
+    }))
+  }
+
+  fn on_scheduled(&self, envoy_cluster: &dyn EnvoyCluster, event_id: u64) {
+    if event_id == HEALTHY_HOSTS_REBUILD_ADD_EVENT_ID {
+      envoy_cluster.add_hosts(&[self.upstream_address.clone()], &[1u32]);
+    }
+  }
+}
+
+struct HealthyHostsRebuildLb {
+  hosts: Vec<usize>,
+  index: usize,
+  counter_id: Option<EnvoyCounterId>,
+  metrics: Arc<dyn EnvoyClusterMetrics>,
+}
+
+impl ClusterLb for HealthyHostsRebuildLb {
+  fn choose_host(
+    &mut self,
+    _context: Option<&dyn ClusterLbContext>,
+    _async_completion: Box<dyn EnvoyAsyncHostSelectionComplete>,
+  ) -> HostSelectionResult {
+    if self.hosts.is_empty() {
+      return HostSelectionResult::NoHost;
+    }
+    let idx = self.index % self.hosts.len();
+    self.index += 1;
+    HostSelectionResult::Selected(
+      self.hosts[idx] as abi::envoy_dynamic_module_type_cluster_host_envoy_ptr,
+    )
+  }
+
+  fn on_host_membership_update(
+    &mut self,
+    envoy_lb: &dyn EnvoyClusterLoadBalancer,
+    _num_hosts_added: usize,
+    _num_hosts_removed: usize,
+  ) {
+    // Rebuild the routable set from the whole healthy partition in one crossing.
+    let mut healthy = Vec::new();
+    if !envoy_lb.get_healthy_hosts(0, &mut healthy) {
+      return;
+    }
+    self.hosts = healthy.iter().map(|&host| host as usize).collect();
+    // Increment once the bulk read is non-empty and agrees with the per-host count, so the test can
+    // wait for every worker to converge.
+    if !self.hosts.is_empty() && self.hosts.len() == envoy_lb.get_healthy_host_count(0) {
+      if let Some(counter_id) = self.counter_id {
+        let _ = self.metrics.increment_counter(counter_id, 1);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

A module cluster that keeps its own view of the healthy partition pays one ABI crossing per host through
`envoy_dynamic_module_callback_cluster_lb_get_healthy_host`. It pays that cost on every membership update, because Envoy reports a health only transition, an active health check flip, an outlier ejection, or an EDS health status change, as an update with no added and no removed hosts. The module cannot tell which host moved, so it has to re-read the whole partition.

This PR adds a new `envoy_dynamic_module_callback_cluster_lb_get_healthy_hosts` which enables reading it in one crossing.

---

**Commit Message:** dynamic_modules: bulk healthy-host getter for module clusters
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** N/A