### PR TITLE
dynamic_modules: define worker_index_ on the network and UDP filters

### DIFF
--- a/source/extensions/access_loggers/dynamic_modules/access_log.cc
+++ b/source/extensions/access_loggers/dynamic_modules/access_log.cc
@@ -3,6 +3,7 @@
 #include "envoy/common/exception.h"
 
 #include "source/extensions/dynamic_modules/abi_context_accessors.h"
+#include "source/extensions/dynamic_modules/worker_index.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -36,12 +37,8 @@ DynamicModuleAccessLog::DynamicModuleAccessLog(AccessLog::FilterPtr&& filter,
       auto concurrency = context->options().concurrency();
       worker_index = concurrency; // Set main/test thread on free index.
     } else {
-      const std::string& worker_name = dispatcher.name();
-      auto pos = worker_name.find_first_of('_');
-      ENVOY_BUG(pos != std::string::npos, "worker name is not in expected format worker_{index}");
-      if (!absl::SimpleAtoi(worker_name.substr(pos + 1), &worker_index)) {
-        IS_ENVOY_BUG("failed to parse worker index from name");
-      }
+      worker_index =
+          Extensions::DynamicModules::parseWorkerIndexFromDispatcherName(dispatcher.name());
     }
     // Create a thread-local logger wrapper first, then pass it to the module.
     auto tl_logger = std::make_shared<ThreadLocalLogger>(nullptr, config, worker_index);

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     srcs = [
         "background_fetch_manager.cc",
         "dynamic_module_stats.cc",
+        "worker_index.cc",
     ] + select({
         "//bazel:windows_x86_64": ["win32/dynamic_modules.cc"],
         "//conditions:default": ["posix/dynamic_modules.cc"],
@@ -22,6 +23,7 @@ envoy_cc_library(
         "background_fetch_manager.h",
         "dynamic_module_stats.h",
         "dynamic_modules.h",
+        "worker_index.h",
     ],
     external_deps = ["ssl"],
     deps = [
@@ -31,6 +33,7 @@ envoy_cc_library(
         "//envoy/server:factory_context_interface",
         "//envoy/singleton:manager_interface",
         "//envoy/stats:stats_interface",
+        "//source/common/common:assert_lib",
         "//source/common/common:hex_lib",
         "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",

--- a/source/extensions/dynamic_modules/worker_index.cc
+++ b/source/extensions/dynamic_modules/worker_index.cc
@@ -1,0 +1,29 @@
+#include "source/extensions/dynamic_modules/worker_index.h"
+
+#include "source/common/common/assert.h"
+
+#include "absl/strings/numbers.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace DynamicModules {
+
+uint32_t parseWorkerIndexFromDispatcherName(absl::string_view dispatcher_name) {
+  // `SimpleAtoi` leaves its output unspecified on failure, so fall back to zero on a malformed
+  // name.
+  const auto separator = dispatcher_name.find_first_of('_');
+  if (separator == absl::string_view::npos) {
+    IS_ENVOY_BUG("worker name is not in expected format worker_{index}");
+    return 0;
+  }
+  uint32_t worker_index = 0;
+  if (!absl::SimpleAtoi(dispatcher_name.substr(separator + 1), &worker_index)) {
+    IS_ENVOY_BUG("failed to parse worker index from name");
+    return 0;
+  }
+  return worker_index;
+}
+
+} // namespace DynamicModules
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/dynamic_modules/worker_index.h
+++ b/source/extensions/dynamic_modules/worker_index.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace DynamicModules {
+
+// Returns the worker index encoded in a `worker_{index}` dispatcher name, or zero when the name is
+// malformed.
+uint32_t parseWorkerIndexFromDispatcherName(absl::string_view dispatcher_name);
+
+} // namespace DynamicModules
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/http/dynamic_modules/factory.cc
+++ b/source/extensions/filters/http/dynamic_modules/factory.cc
@@ -4,6 +4,7 @@
 #include "source/common/runtime/runtime_features.h"
 #include "source/extensions/dynamic_modules/dynamic_module_stats.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
+#include "source/extensions/dynamic_modules/worker_index.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"
 
@@ -61,13 +62,8 @@ buildFilterFactoryCallback(Extensions::DynamicModules::DynamicModulePtr dynamic_
   }
 
   return [config = filter_config.value()](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    const std::string& worker_name = callbacks.dispatcher().name();
-    auto pos = worker_name.find_first_of('_');
-    ENVOY_BUG(pos != std::string::npos, "worker name is not in expected format worker_{index}");
-    uint32_t worker_index;
-    if (!absl::SimpleAtoi(worker_name.substr(pos + 1), &worker_index)) {
-      IS_ENVOY_BUG("failed to parse worker index from name");
-    }
+    const uint32_t worker_index = Extensions::DynamicModules::parseWorkerIndexFromDispatcherName(
+        callbacks.dispatcher().name());
     auto filter =
         std::make_shared<Envoy::Extensions::DynamicModules::HttpFilters::DynamicModuleHttpFilter>(
             config, config->stats_scope_->symbolTable(), worker_index);

--- a/source/extensions/filters/http/dynamic_modules/filter.h
+++ b/source/extensions/filters/http/dynamic_modules/filter.h
@@ -294,7 +294,7 @@ private:
   const DynamicModuleHttpFilterConfigSharedPtr config_ = nullptr;
   envoy_dynamic_module_type_http_filter_module_ptr in_module_filter_ = nullptr;
   Stats::StatNameDynamicPool stat_name_pool_;
-  uint32_t worker_index_;
+  uint32_t worker_index_ = 0;
   // Tracks whether addDownstreamWatermarkCallbacks() has been invoked on decoder_callbacks_.
   // Also gates the paired remove in onDestroy(), because removeDownstreamWatermarkCallbacks()
   // asserts that the callback was previously added.

--- a/source/extensions/filters/listener/dynamic_modules/filter.cc
+++ b/source/extensions/filters/listener/dynamic_modules/filter.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/listener/dynamic_modules/filter.h"
 
+#include "source/extensions/dynamic_modules/worker_index.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
@@ -53,12 +55,7 @@ Network::FilterStatus DynamicModuleListenerFilter::onAccept(Network::ListenerFil
   // Publish the worker dispatcher for cross-thread `commit()`; see `dispatcher()`.
   cached_dispatcher_.store(&cb.dispatcher(), std::memory_order_release);
 
-  const std::string& worker_name = cb.dispatcher().name();
-  auto pos = worker_name.find_first_of('_');
-  ENVOY_BUG(pos != std::string::npos, "worker name is not in expected format worker_{index}");
-  if (!absl::SimpleAtoi(worker_name.substr(pos + 1), &worker_index_)) {
-    IS_ENVOY_BUG("failed to parse worker index from name");
-  }
+  worker_index_ = parseWorkerIndexFromDispatcherName(cb.dispatcher().name());
   // Delay the in-module filter initialization until callbacks are set
   // to allow accessing worker thread index during filter creation.
   initializeInModuleFilter();

--- a/source/extensions/filters/network/dynamic_modules/filter.cc
+++ b/source/extensions/filters/network/dynamic_modules/filter.cc
@@ -1,5 +1,7 @@
 #include "source/extensions/filters/network/dynamic_modules/filter.h"
 
+#include "source/extensions/dynamic_modules/worker_index.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace DynamicModules {
@@ -69,12 +71,7 @@ void DynamicModuleNetworkFilter::initializeReadFilterCallbacks(
   // Publish the worker dispatcher for cross-thread `commit()`; see `dispatcher()`.
   cached_dispatcher_.store(&callbacks.connection().dispatcher(), std::memory_order_release);
 
-  const std::string& worker_name = callbacks.connection().dispatcher().name();
-  auto pos = worker_name.find_first_of('_');
-  ENVOY_BUG(pos != std::string::npos, "worker name is not in expected format worker_{index}");
-  if (!absl::SimpleAtoi(worker_name.substr(pos + 1), &worker_index_)) {
-    IS_ENVOY_BUG("failed to parse worker index from name");
-  }
+  worker_index_ = parseWorkerIndexFromDispatcherName(callbacks.connection().dispatcher().name());
 
   // Delay the in-module filter initialization until read callbacks are set
   // to allow accessing worker index during filter creation.

--- a/source/extensions/filters/network/dynamic_modules/filter.h
+++ b/source/extensions/filters/network/dynamic_modules/filter.h
@@ -192,7 +192,7 @@ private:
   // Worker dispatcher published at callback-init, cleared on destroy. Read via `dispatcher()`.
   std::atomic<Event::Dispatcher*> cached_dispatcher_{nullptr};
 
-  uint32_t worker_index_;
+  uint32_t worker_index_ = 0;
 
   /**
    * This implementation of the AsyncClient::Callbacks is used to handle the response from the HTTP

--- a/source/extensions/filters/udp/dynamic_modules/BUILD
+++ b/source/extensions/filters/udp/dynamic_modules/BUILD
@@ -53,6 +53,7 @@ envoy_cc_extension(
         ":filter_config_lib",
         ":filter_lib",
         "//source/common/protobuf:utility_lib",
+        "//source/extensions/dynamic_modules:dynamic_modules_lib",
         "//source/extensions/filters/network/common:factory_base_lib",
     ],
 )

--- a/source/extensions/filters/udp/dynamic_modules/factory.cc
+++ b/source/extensions/filters/udp/dynamic_modules/factory.cc
@@ -1,6 +1,7 @@
 #include "source/extensions/filters/udp/dynamic_modules/factory.h"
 
 #include "source/common/runtime/runtime_features.h"
+#include "source/extensions/dynamic_modules/worker_index.h"
 #include "source/extensions/filters/udp/dynamic_modules/filter.h"
 
 namespace Envoy {
@@ -44,13 +45,8 @@ DynamicModuleUdpListenerFilterConfigFactory::createFilterFactoryFromProto(
 
   return [filter_config](Network::UdpListenerFilterManager& filter_manager,
                          Network::UdpReadFilterCallbacks& callbacks) -> void {
-    const std::string& worker_name = callbacks.udpListener().dispatcher().name();
-    auto pos = worker_name.find_first_of('_');
-    ENVOY_BUG(pos != std::string::npos, "worker name is not in expected format worker_{index}");
-    uint32_t worker_index;
-    if (!absl::SimpleAtoi(worker_name.substr(pos + 1), &worker_index)) {
-      IS_ENVOY_BUG("failed to parse worker index from name");
-    }
+    const uint32_t worker_index = Extensions::DynamicModules::parseWorkerIndexFromDispatcherName(
+        callbacks.udpListener().dispatcher().name());
     filter_manager.addReadFilter(
         std::make_unique<DynamicModuleUdpListenerFilter>(callbacks, filter_config, worker_index));
   };

--- a/source/extensions/filters/udp/dynamic_modules/filter.h
+++ b/source/extensions/filters/udp/dynamic_modules/filter.h
@@ -45,7 +45,7 @@ private:
   const DynamicModuleUdpListenerFilterConfigSharedPtr config_;
   envoy_dynamic_module_type_udp_listener_filter_module_ptr in_module_filter_{nullptr};
   Network::UdpRecvData* current_data_{nullptr};
-  uint32_t worker_index_;
+  uint32_t worker_index_ = 0;
 };
 
 using DynamicModuleUdpListenerFilterSharedPtr = std::shared_ptr<DynamicModuleUdpListenerFilter>;

--- a/test/extensions/dynamic_modules/dynamic_modules_test.cc
+++ b/test/extensions/dynamic_modules/dynamic_modules_test.cc
@@ -8,6 +8,7 @@
 #include "source/common/stats/isolated_store_impl.h"
 #include "source/extensions/dynamic_modules/dynamic_module_stats.h"
 #include "source/extensions/dynamic_modules/dynamic_modules.h"
+#include "source/extensions/dynamic_modules/worker_index.h"
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/mocks/init/mocks.h"
@@ -662,6 +663,31 @@ TEST(DynamicModuleStats, IncrementConfigLoadFailure) {
   // An absent context is a no-op (the context-less caller path).
   incrementLoadFailure(std::nullopt, "my-filter", ModuleLoadErrorStat);
   EXPECT_EQ(2U, failureCounter(scope, ModuleLoadErrorStat, "my-filter"));
+}
+
+// A well-formed `worker_{index}` dispatcher name yields its index.
+TEST(ParseWorkerIndexFromDispatcherName, WellFormedName) {
+  EXPECT_EQ(0U, parseWorkerIndexFromDispatcherName("worker_0"));
+  EXPECT_EQ(7U, parseWorkerIndexFromDispatcherName("worker_7"));
+  EXPECT_EQ(42U, parseWorkerIndexFromDispatcherName("worker_42"));
+}
+
+// A name whose index cannot be parsed falls back to zero.
+TEST(ParseWorkerIndexFromDispatcherName, UnparsableIndexFallsBackToZero) {
+  EXPECT_ENVOY_BUG(EXPECT_EQ(0U, parseWorkerIndexFromDispatcherName("worker_notanumber")),
+                   "failed to parse worker index from name");
+}
+
+// An index that overflows `uint32_t` falls back to zero.
+TEST(ParseWorkerIndexFromDispatcherName, OverflowingIndexFallsBackToZero) {
+  EXPECT_ENVOY_BUG(EXPECT_EQ(0U, parseWorkerIndexFromDispatcherName("worker_4294967296")),
+                   "failed to parse worker index from name");
+}
+
+// A name with no separator trips the format check and falls back to zero.
+TEST(ParseWorkerIndexFromDispatcherName, NameWithoutSeparatorFallsBackToZero) {
+  EXPECT_ENVOY_BUG(EXPECT_EQ(0U, parseWorkerIndexFromDispatcherName("noseparator")),
+                   "worker name is not in expected format");
 }
 
 } // namespace DynamicModules

--- a/test/extensions/dynamic_modules/network/filter_test.cc
+++ b/test/extensions/dynamic_modules/network/filter_test.cc
@@ -314,6 +314,24 @@ TEST(DynamicModuleNetworkFilterConfigTest, StopIterationStatus) {
 }
 
 // -----------------------------------------------------------------------------
+// Worker index tests
+// -----------------------------------------------------------------------------
+
+// The filter publishes the worker index parsed from its dispatcher name. Malformed names are
+// covered by the shared helper unit test.
+TEST_F(DynamicModuleNetworkFilterTest, WorkerIndexParsedFromDispatcherName) {
+  NiceMock<Event::MockDispatcher> worker_dispatcher{"worker_7"};
+  NiceMock<Network::MockReadFilterCallbacks> read_callbacks;
+  NiceMock<Network::MockConnection> connection;
+  ON_CALL(connection, dispatcher()).WillByDefault(testing::ReturnRef(worker_dispatcher));
+  ON_CALL(read_callbacks, connection()).WillByDefault(testing::ReturnRef(connection));
+
+  auto filter = std::make_shared<DynamicModuleNetworkFilter>(filter_config_);
+  filter->initializeReadFilterCallbacks(read_callbacks);
+  EXPECT_EQ(7U, filter->workerIndex());
+}
+
+// -----------------------------------------------------------------------------
 // Metrics Tests
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

This PR fixes the network and UDP filters leaving `worker_index_` uninitialized.

---

**Commit Message**: dynamic_modules: define worker_index_ on the network and UDP filters
**Risk Level:** Low
**Testing**: Added Tests
**Docs Changes:** N/A
**Release Notes**: N/A