### PR TITLE
ext_proc: clarify session affinity through intermediate proxies

### DIFF
--- a/docs/root/configuration/http/http_filters/ext_proc_filter.rst
+++ b/docs/root/configuration/http/http_filters/ext_proc_filter.rst
@@ -37,6 +37,13 @@ copy an affinity key from the downstream request, and configure the external pro
 with a matching
 :ref:`cluster-level hash policy <envoy_v3_api_field_extensions.upstreams.http.v3.HttpProtocolOptions.hash_policy>`.
 
+.. note::
+
+   Session affinity applies to the endpoint selected by the external processor cluster. If that
+   endpoint is an intermediate proxy that performs further load balancing, this configuration alone
+   does not ensure affinity to the final processor. Each such proxy must preserve the affinity key
+   and use an appropriate affinity policy when selecting its upstream endpoint.
+
 For example, the filter can copy a session header into the gRPC request:
 
 .. literalinclude:: /_configs/repo/ext-proc-session-affinity-header.yaml


### PR DESCRIPTION
Commit Message: Clarify that ext_proc session affinity applies to the endpoint selected by the external processor cluster. Intermediate proxies that perform further load balancing must preserve the affinity key and apply an appropriate affinity policy to maintain affinity to the final processor.

Additional Description: Follow-up to #46558 and the [question about intermediate proxies](https://github.com/envoyproxy/envoy/pull/46558#issuecomment-5272902090). Adds a note to the existing session-affinity documentation. Documentation only; no configuration or runtime behavior changes.

Risk Level: Low

Testing:
- The added note parsed successfully with docutils and passed a aspell check.

Docs Changes: Adds an intermediate-proxy scope note to the ext_proc session-affinity section.

Release Notes: N/A