### PR TITLE
dynamic_modules: test async host selection and tls session reuse

### DIFF
--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -64,6 +64,8 @@ envoy_cc_dyn_module_test(
     rbe_pool = "linux_x64_small",
     deps = [
         "//source/common/router:string_accessor_lib",
+        "//source/common/tls:server_context_config_lib",
+        "//source/common/tls:server_ssl_socket_lib",
         "//source/extensions/clusters/dynamic_modules:cluster",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:factory_registration",
@@ -72,6 +74,7 @@ envoy_cc_dyn_module_test(
         "//test/extensions/dynamic_modules:util",
         "//test/integration:http_integration_lib",
         "//test/test_common:logging_lib",
+        "//test/test_common:simulated_time_system_lib",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/dynamic_modules/v3:pkg_cc_proto",

--- a/test/extensions/clusters/dynamic_modules/BUILD
+++ b/test/extensions/clusters/dynamic_modules/BUILD
@@ -63,6 +63,7 @@ envoy_cc_dyn_module_test(
     ],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//source/common/common:cleanup_lib",
         "//source/common/router:string_accessor_lib",
         "//source/common/tls:server_context_config_lib",
         "//source/common/tls:server_ssl_socket_lib",

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -7,10 +7,13 @@
 
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/string_accessor_impl.h"
+#include "source/common/tls/server_context_config_impl.h"
+#include "source/common/tls/server_ssl_socket.h"
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/integration/http_integration.h"
 #include "test/test_common/logging.h"
+#include "test/test_common/simulated_time_system.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -76,13 +79,14 @@ public:
   }
 
   void initializeWithDecCluster(const std::string& cluster_name,
-                                const std::string& cluster_config = "") {
+                                const std::string& cluster_config = "",
+                                const std::vector<std::string>& logical_hostnames = {}) {
     TestEnvironment::setEnvVar(
         "ENVOY_DYNAMIC_MODULES_SEARCH_PATH",
         TestEnvironment::runfilesPath("test/extensions/dynamic_modules/test_data/rust"), 1);
 
     // Replace the default cluster_0 with a DEC cluster that uses the Rust module.
-    config_helper_.addConfigModifier([this, cluster_name, cluster_config](
+    config_helper_.addConfigModifier([this, cluster_name, cluster_config, logical_hostnames](
                                          envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       auto* cluster = bootstrap.mutable_static_resources()->mutable_clusters(0);
 
@@ -101,7 +105,15 @@ public:
 
       // Pass the upstream address via the cluster config so the Rust module knows
       // where to add hosts.
-      const std::string config_value = cluster_config.empty() ? upstream_address : cluster_config;
+      std::string config_value = cluster_config.empty() ? upstream_address : cluster_config;
+      if (!logical_hostnames.empty()) {
+        RELEASE_ASSERT(logical_hostnames.size() == fake_upstreams_.size(), "");
+        config_value.clear();
+        for (size_t i = 0; i < logical_hostnames.size(); ++i) {
+          config_value +=
+              logical_hostnames[i] + "," + fake_upstreams_[i]->localAddress()->asString() + "\n";
+        }
+      }
       Protobuf::StringValue config_proto;
       config_proto.set_value(config_value);
       std::ignore = dec_config.mutable_cluster_config()->PackFrom(config_proto);
@@ -176,6 +188,108 @@ TEST_P(DynamicModuleClusterIntegrationTest, AsyncHostSelection) {
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// Exercise asynchronous selection and TLS together using one client context and distinct
+// runtime hosts. Both servers accept the same tickets so server-side key isolation cannot
+// conceal a client that incorrectly offers one hostname's session to another hostname.
+class DynamicModuleAsyncTlsIntegrationTest : public Event::TestUsingSimulatedTime,
+                                             public DynamicModuleClusterIntegrationTest {
+public:
+  void createUpstreams() override {
+    for (uint32_t i = 0; i < fake_upstreams_count_; ++i) {
+      envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+      auto* common = tls_context.mutable_common_tls_context();
+      common->mutable_tls_params()->set_tls_maximum_protocol_version(
+          envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
+      auto* cert = common->add_tls_certificates();
+      cert->mutable_certificate_chain()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/upstreamcert.pem"));
+      cert->mutable_private_key()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/upstreamkey.pem"));
+      tls_context.mutable_session_ticket_keys()->add_keys()->set_inline_bytes(std::string(80, 'a'));
+      auto config = *Extensions::TransportSockets::Tls::ServerContextConfigImpl::create(
+          tls_context, factory_context_, {}, false);
+      addFakeUpstream(
+          *Extensions::TransportSockets::Tls::ServerSslSocketFactory::create(
+              std::move(config), context_manager_, server_factory_context_.serverScope()),
+          Http::CodecType::HTTP1, false);
+    }
+  }
+
+  void initializeAsyncTls(const std::vector<std::string>& hostnames) {
+    setUpstreamCount(hostnames.size());
+    configureUpstreamTlsForLogicalHostname();
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* socket =
+          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls_context;
+      RELEASE_ASSERT(socket->typed_config().UnpackTo(&tls_context), "");
+      // TLS 1.2 delivers the ticket during the handshake, avoiding post-handshake ticket timing.
+      tls_context.mutable_common_tls_context()
+          ->mutable_tls_params()
+          ->set_tls_maximum_protocol_version(
+              envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_2);
+      tls_context.mutable_max_session_keys()->set_value(4);
+      std::ignore = socket->mutable_typed_config()->PackFrom(tls_context);
+    });
+    initializeWithDecCluster("async_logical_hostnames", "", hostnames);
+    codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  }
+
+  void verifySessionSequence(uint64_t first) {
+    const std::vector<std::string> hostnames{"a.lyft.com", "b.lyft.com"};
+    initializeAsyncTls(hostnames);
+    for (uint64_t i = 0; i < 4; ++i) {
+      const uint64_t upstream_index = (first + i) % 2;
+      SCOPED_TRACE(testing::Message() << "request " << i << ", host " << hostnames[upstream_index]);
+      Http::TestRequestHeaderMapImpl headers(default_request_headers_);
+      headers.setHost("downstream.example");
+      headers.addCopy("x-upstream-index", std::to_string(upstream_index));
+      auto response =
+          sendRequestAndWaitForResponse(headers, 0, default_response_headers_, 0, upstream_index);
+      ASSERT_TRUE(response->complete());
+      ASSERT_EQ("200", response->headers().getStatusValue());
+      ASSERT_NE(fake_upstream_connection_, nullptr);
+      ASSERT_NE(fake_upstream_connection_->connection().ssl(), nullptr);
+      EXPECT_EQ(hostnames[upstream_index], fake_upstream_connection_->connection().ssl()->sni());
+      test_server_->waitForCounter("cluster.cluster_0.ssl.handshake", testing::Eq(i + 1));
+      const auto reused = test_server_->counter("cluster.cluster_0.ssl.session_reused");
+      EXPECT_EQ(i < 2 ? 0 : i - 1, reused == nullptr ? 0 : reused->value());
+
+      // Await Envoy observing the close before the next request; otherwise the pool could reuse
+      // this connection and bypass the handshake that the next assertion is intended to exercise.
+      ASSERT_TRUE(fake_upstream_connection_->close());
+      ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+      test_server_->waitForCounter("cluster.cluster_0.upstream_cx_destroy", testing::Eq(i + 1));
+      upstream_request_.reset();
+      fake_upstream_connection_.reset();
+    }
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, DynamicModuleAsyncTlsIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+
+TEST_P(DynamicModuleAsyncTlsIntegrationTest, SessionReuseFollowsLogicalHostname) {
+  verifySessionSequence(0);
+}
+
+TEST_P(DynamicModuleAsyncTlsIntegrationTest, SessionReuseFollowsLogicalHostnameReverseOrder) {
+  verifySessionSequence(1);
+}
+
+TEST_P(DynamicModuleAsyncTlsIntegrationTest, RejectsMismatchedLogicalHostname) {
+  initializeAsyncTls({"outside-san.example"});
+  Http::TestRequestHeaderMapImpl headers(default_request_headers_);
+  headers.addCopy("x-upstream-index", "0");
+  auto response = codec_client_->makeHeaderOnlyRequest(headers);
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_EQ("503", response->headers().getStatusValue());
+  test_server_->waitForCounter("cluster.cluster_0.ssl.fail_verify_san", testing::Eq(1));
+  const auto requests = test_server_->counter("cluster.cluster_0.upstream_rq_total");
+  EXPECT_TRUE(requests == nullptr || requests->value() == 0);
 }
 
 // Verifies that a cluster can use the scheduler to add hosts after initialization.

--- a/test/extensions/clusters/dynamic_modules/integration_test.cc
+++ b/test/extensions/clusters/dynamic_modules/integration_test.cc
@@ -5,6 +5,7 @@
 #include "envoy/registry/registry.h"
 #include "envoy/stream_info/filter_state.h"
 
+#include "source/common/common/cleanup.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/common/tls/server_context_config_impl.h"
@@ -237,11 +238,16 @@ public:
     codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   }
 
-  void verifySessionSequence(uint64_t first) {
+  struct SessionExpectation {
+    uint64_t upstream_index;
+    uint64_t sessions_reused;
+  };
+
+  void verifySessionSequence(const std::vector<SessionExpectation>& sequence) {
     const std::vector<std::string> hostnames{"a.lyft.com", "b.lyft.com"};
     initializeAsyncTls(hostnames);
-    for (uint64_t i = 0; i < 4; ++i) {
-      const uint64_t upstream_index = (first + i) % 2;
+    for (size_t i = 0; i < sequence.size(); ++i) {
+      const auto& [upstream_index, sessions_reused] = sequence[i];
       SCOPED_TRACE(testing::Message() << "request " << i << ", host " << hostnames[upstream_index]);
       Http::TestRequestHeaderMapImpl headers(default_request_headers_);
       headers.setHost("downstream.example");
@@ -255,7 +261,7 @@ public:
       EXPECT_EQ(hostnames[upstream_index], fake_upstream_connection_->connection().ssl()->sni());
       test_server_->waitForCounter("cluster.cluster_0.ssl.handshake", testing::Eq(i + 1));
       const auto reused = test_server_->counter("cluster.cluster_0.ssl.session_reused");
-      EXPECT_EQ(i < 2 ? 0 : i - 1, reused == nullptr ? 0 : reused->value());
+      EXPECT_EQ(sessions_reused, reused == nullptr ? 0 : reused->value());
 
       // Await Envoy observing the close before the next request; otherwise the pool could reuse
       // this connection and bypass the handshake that the next assertion is intended to exercise.
@@ -273,11 +279,12 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, DynamicModuleAsyncTlsIntegrationTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(DynamicModuleAsyncTlsIntegrationTest, SessionReuseFollowsLogicalHostname) {
-  verifySessionSequence(0);
+  // A and B each need an initial handshake before their own sessions can be resumed.
+  verifySessionSequence({{0, 0}, {1, 0}, {0, 1}, {1, 2}});
 }
 
 TEST_P(DynamicModuleAsyncTlsIntegrationTest, SessionReuseFollowsLogicalHostnameReverseOrder) {
-  verifySessionSequence(1);
+  verifySessionSequence({{1, 0}, {0, 0}, {1, 1}, {0, 2}});
 }
 
 TEST_P(DynamicModuleAsyncTlsIntegrationTest, RejectsMismatchedLogicalHostname) {
@@ -285,11 +292,18 @@ TEST_P(DynamicModuleAsyncTlsIntegrationTest, RejectsMismatchedLogicalHostname) {
   Http::TestRequestHeaderMapImpl headers(default_request_headers_);
   headers.addCopy("x-upstream-index", "0");
   auto response = codec_client_->makeHeaderOnlyRequest(headers);
+  // Keep the decoder alive while closing any unfinished request after an assertion failure.
+  FakeRawConnectionPtr upstream_connection;
+  Cleanup cleanup([this]() { cleanupUpstreamAndDownstream(); });
+  // Consume the connection to enable reads so TLS can progress even when the handshake fails.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream_connection,
+                                                       TestUtility::DefaultTimeout, *dispatcher_));
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_EQ("503", response->headers().getStatusValue());
   test_server_->waitForCounter("cluster.cluster_0.ssl.fail_verify_san", testing::Eq(1));
   const auto requests = test_server_->counter("cluster.cluster_0.upstream_rq_total");
   EXPECT_TRUE(requests == nullptr || requests->value() == 0);
+  ASSERT_TRUE(upstream_connection->waitForDisconnect());
 }
 
 // Verifies that a cluster can use the scheduler to add hosts after initialization.

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -285,6 +285,8 @@ impl ClusterLb for AsyncHostSelectionLb {
       return HostSelectionResult::NoHost;
     }
     let index = if self.select_by_header {
+      // The test sets x-upstream-index to 0 or 1 to select A or B in a fixed order.
+      // The argument 0 reads the first header value; its contents select the upstream.
       let index = context
         .and_then(|context| context.get_downstream_header("x-upstream-index", 0))
         .and_then(|(value, _)| {

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -37,8 +37,23 @@ fn new_cluster_config(
       metrics: envoy_cluster_metrics,
     })),
     "async_host_selection" => Some(Box::new(AsyncHostSelectionClusterConfig {
-      upstream_address: config_str.to_string(),
+      upstream_addresses: vec![config_str.to_string()],
+      logical_hostnames: Vec::new(),
     })),
+    "async_logical_hostnames" => {
+      let hosts: Option<Vec<_>> = config_str
+        .lines()
+        .map(|line| line.split_once(','))
+        .collect();
+      let (logical_hostnames, upstream_addresses) = hosts?
+        .into_iter()
+        .map(|(hostname, address)| (hostname.to_string(), address.to_string()))
+        .unzip();
+      Some(Box::new(AsyncHostSelectionClusterConfig {
+        upstream_addresses,
+        logical_hostnames,
+      }))
+    },
     "scheduler_host_update" => Some(Box::new(SchedulerHostUpdateClusterConfig {
       upstream_address: config_str.to_string(),
     })),
@@ -187,28 +202,39 @@ impl ClusterLb for SyncHostSelectionLb {
 // =============================================================================
 
 struct AsyncHostSelectionClusterConfig {
-  upstream_address: String,
+  upstream_addresses: Vec<String>,
+  logical_hostnames: Vec<String>,
 }
 
 impl ClusterConfig for AsyncHostSelectionClusterConfig {
   fn new_cluster(&self, _envoy_cluster: &dyn EnvoyCluster) -> Box<dyn Cluster> {
     Box::new(AsyncHostSelectionCluster {
-      upstream_address: self.upstream_address.clone(),
+      upstream_addresses: self.upstream_addresses.clone(),
+      logical_hostnames: self.logical_hostnames.clone(),
       hosts: Arc::new(Mutex::new(HostList(Vec::new()))),
     })
   }
 }
 
 struct AsyncHostSelectionCluster {
-  upstream_address: String,
+  upstream_addresses: Vec<String>,
+  logical_hostnames: Vec<String>,
   hosts: SharedHostList,
 }
 
 impl Cluster for AsyncHostSelectionCluster {
   fn on_init(&mut self, envoy_cluster: &dyn EnvoyCluster) {
-    let addresses = vec![self.upstream_address.clone()];
-    let weights = vec![1u32];
-    if let Some(host_ptrs) = envoy_cluster.add_hosts(&addresses, &weights) {
+    let weights = vec![1u32; self.upstream_addresses.len()];
+    let host_ptrs = if self.logical_hostnames.is_empty() {
+      envoy_cluster.add_hosts(&self.upstream_addresses, &weights)
+    } else {
+      envoy_cluster.add_hosts_with_hostnames(
+        &self.upstream_addresses,
+        &self.logical_hostnames,
+        &weights,
+      )
+    };
+    if let Some(host_ptrs) = host_ptrs {
       self.hosts.lock().unwrap().0 = host_ptrs;
     }
     envoy_cluster.pre_init_complete();
@@ -220,6 +246,7 @@ impl Cluster for AsyncHostSelectionCluster {
   ) -> Option<Box<dyn ClusterLb>> {
     Some(Box::new(AsyncHostSelectionLb {
       hosts: self.hosts.clone(),
+      select_by_header: !self.logical_hostnames.is_empty(),
     }))
   }
 }
@@ -241,21 +268,38 @@ impl AsyncCompletionTask {
 
 struct AsyncHostSelectionLb {
   hosts: SharedHostList,
+  select_by_header: bool,
 }
 
 impl ClusterLb for AsyncHostSelectionLb {
   fn choose_host(
     &mut self,
-    _context: Option<&dyn ClusterLbContext>,
+    context: Option<&dyn ClusterLbContext>,
     async_completion: Box<dyn EnvoyAsyncHostSelectionComplete>,
   ) -> HostSelectionResult {
     let hosts = self.hosts.lock().unwrap();
     if hosts.0.is_empty() {
       return HostSelectionResult::NoHost;
     }
+    let index = if self.select_by_header {
+      let index = context
+        .and_then(|context| context.get_downstream_header("x-upstream-index", 0))
+        .and_then(|(value, _)| {
+          std::str::from_utf8(value.as_slice())
+            .ok()?
+            .parse::<usize>()
+            .ok()
+        });
+      match index {
+        Some(index) if index < hosts.0.len() => index,
+        _ => return HostSelectionResult::NoHost,
+      }
+    } else {
+      0
+    };
     let task = AsyncCompletionTask {
       completion: async_completion,
-      host: hosts.0[0],
+      host: hosts.0[index],
     };
     // Spawn a background thread to complete the host selection asynchronously.
     // The ABI implementation posts the completion to the correct worker thread.

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_integration_test.rs
@@ -41,6 +41,9 @@ fn new_cluster_config(
       logical_hostnames: Vec::new(),
     })),
     "async_logical_hostnames" => {
+      // Each line is "<logical hostname>,<connection address>", for example:
+      // "a.lyft.com,127.0.0.1:10001" or "b.lyft.com,[::1]:10002".
+      // Split on the comma to keep the TLS hostname separate from the socket address.
       let hosts: Option<Vec<_>> = config_str
         .lines()
         .map(|line| line.split_once(','))


### PR DESCRIPTION
Commit Message: Add integration coverage for asynchronous dynamic-module host selection with logical-hostname SNI, SAN validation, and TLS session reuse.

Additional Description:
The existing tests exercise async selection, logical-hostname TLS, and SNI-scoped session caching separately. This change exercises them together through the existing Rust test module and async completion path.

Two runtime hosts use distinct logical hostnames under one upstream TLS context. Both TLS servers share a certificate and ticket key so server-side ticket isolation cannot hide cross-hostname session reuse. The two cases select these hosts in A/B/A/B and B/A/B/A order through the asynchronous completion path. Each request explicitly selects a host using the test-only `x-upstream-index` header. The test verifies that the selected server receives the request and observes that host's logical hostname as SNI. The downstream authority stays at `downstream.example`, so the expected SNI must come from the selected host.

After each response, the test closes the upstream connection and waits for Envoy to observe its destruction before sending the next request. This forces every request to open a new connection and perform a TLS handshake. The cumulative handshake counter must therefore advance through 1/2/3/4, including resumed handshakes.

For A/B/A/B, the cumulative `ssl.session_reused` expectations are:

- First A: 0. A establishes its initial session.
- First B: 0. B must establish its own session without resuming A's session.
- Second A: 1. A resumes its previously established session after visiting B.
- Second B: 2. B resumes its own previously established session.

The reverse B/A/B/A case expects the same 0/0/1/2 counts, checking the behavior when B is visited first. Together, these assertions check both isolation between logical hostnames and successful resumption when returning to each hostname.

A separate case verifies rejection of a hostname outside the certificate SANs. It consumes the raw fake upstream connection to enable reads and uses scope cleanup to close any unfinished request before destroying its response decoder.

References #45962. The fixture uses TLS 1.2 for deterministic ticket delivery. This is test-only coverage; TLS 1.3 ticket timing, Go SDK additions, and multiple logical hosts sharing one address remain outside this PR.

Risk Level: Low

Testing:
- Full `//test/extensions/clusters/dynamic_modules:integration_test`

Docs Changes: N/A

Release Notes: N/A

AI assistance: Checked with AI assistance.
