### PR TITLE
server: match cgroup CPU controllers exactly

### DIFF
--- a/changelogs/current/bug_fixes/server__match-cgroup-cpu-controller-exactly.rst
+++ b/changelogs/current/bug_fixes/server__match-cgroup-cpu-controller-exactly.rst
@@ -1,0 +1,2 @@
+Fixed cgroup v1 CPU controller detection to match ``cpu`` as an exact controller name instead of
+matching controller names such as ``cpuset`` or ``cpuacct``.

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -9,7 +9,6 @@
 
 #include "source/common/common/logger.h"
 
-#include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
@@ -23,6 +22,15 @@ void setReason(CgroupDetectionDiagnostic* diag, absl::string_view message, bool 
     diag->message = std::string(message);
     diag->is_error = is_error;
   }
+}
+
+bool containsToken(absl::string_view value, absl::string_view token) {
+  for (absl::string_view item : absl::StrSplit(value, ',')) {
+    if (item == token) {
+      return true;
+    }
+  }
+  return false;
 }
 } // namespace
 
@@ -179,7 +187,7 @@ std::optional<CgroupPathInfo> CgroupCpuUtil::getCurrentCgroupPath(Filesystem::In
     }
 
     // Priority handling: If v1 hierarchy + containsCPU(): Return immediately (v1 wins)
-    if (absl::StrContains(controllers, "cpu")) {
+    if (containsToken(controllers, "cpu")) {
       // Found cgroup v1 with CPU controller - return immediately (highest priority)
       return CgroupPathInfo{std::string(path), "v1"};
     }
@@ -516,7 +524,7 @@ std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instan
     absl::string_view super_options = line;
 
     // v1 hierarchy - check for CPU controller
-    if (absl::StrContains(super_options, "cpu")) {
+    if (containsToken(super_options, "cpu")) {
       // Found a v1 CPU controller. This must be the only one, so we're done
       return mount_point; // Return immediately - v1 CPU wins
     }

--- a/test/server/cgroup_cpu_util_test.cc
+++ b/test/server/cgroup_cpu_util_test.cc
@@ -144,6 +144,17 @@ TEST_F(CgroupCpuUtilTest, GetCurrentCgroupPath_OnlyNonCpuV1) {
   EXPECT_FALSE(result.has_value()); // No v2 and no v1 CPU = nullopt
 }
 
+TEST_F(CgroupCpuUtilTest, GetCurrentCgroupPath_ControllerNameContainingCpu) {
+  fs_.setFileContents("/proc/self/cgroup", "2:cpuset:/foo\n"
+                                           "3:cpuacct:/bar\n"
+                                           "0::/v2\n");
+
+  auto result = CgroupCpuUtil::TestUtil::getCurrentCgroupPath(fs_);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().relative_path, "/v2");
+  EXPECT_EQ(result.value().version, "v2");
+}
+
 // =============================================================================
 // Test: unescapePath
 // =============================================================================
@@ -317,6 +328,17 @@ TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_V2) {
   auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
   ASSERT_TRUE(mount_opt.has_value());
   EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup"); // Should return v2 mount point
+}
+
+TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_ControllerNameContainingCpu) {
+  std::string mountinfo = "25 21 0:22 / /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n"
+                          "59 22 0:43 / /sys/fs/cgroup/cpuset rw - cgroup cgroup rw,cpuset\n"
+                          "60 22 0:44 / /sys/fs/cgroup/cpuacct rw - cgroup cgroup rw,cpuacct\n";
+  fs_.setFileContents("/proc/self/mountinfo", mountinfo);
+
+  auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
+  ASSERT_TRUE(mount_opt.has_value());
+  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup");
 }
 
 TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_Mixed_V1Wins) {


### PR DESCRIPTION


The cgroup v1 CPU controller detection currently uses substring matching when parsing /proc/self/cgroup and /proc/self/mountinfo. This incorrectly treats controllers such as cpuset and cpuacct as the cpu controller.

Match comma-separated controller names exactly so that only the cpu controller selects a cgroup v1 CPU hierarchy.

Additional Description:

Added regression coverage for cpuset and cpuacct controller names in both /proc/self/cgroup and /proc/self/mountinfo. In hybrid cgroup environments, these names no longer incorrectly take precedence over the cgroup v2 hierarchy.

AI assistance(CodeX) was used to tests and to prepare this patch. The submitted changes have been reviewed and understood by the author.

Risk Level:
Low

Testing:
- Added unit test coverage for cpuset and cpuacct false positives.
- Passed git diff --check.
- Passed clang-format --dry-run --Werror.
- The Bazel target //test/server:cgroup_cpu_util_test could not be run in
  this environment because bazel/bazelisk is not installed.

Docs Changes:
N/A

Release Notes:

Added changelogs/current/bug_fixes/server__match-cgroup-cpu-controller-exactly.rst

Platform Specific Features:

This fixes the existing Linux cgroup CPU detection implementation. No new platform-specific feature is introduced, and non-Linux behavior is unchanged.

[Optional Runtime guard:]
N/A; this corrects false-positive controller detection and does not introduce a separately selectable behavior.