### PR TITLE
dynamic_modules: fix HTTP scalar attribute accessors

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__http-scalar-attributes.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__http-scalar-attributes.rst
@@ -1,0 +1,2 @@
+dynamic modules: fixed request and response size and gRPC status scalar attributes in HTTP-aware
+contexts.

--- a/envoy/formatter/http_formatter_context.h
+++ b/envoy/formatter/http_formatter_context.h
@@ -56,6 +56,15 @@ public:
   }
 
   /**
+   * Set or overwrite the request trailers.
+   * @param request_trailers supplies the request trailers.
+   */
+  Context& setRequestTrailers(const Http::RequestTrailerMap& request_trailers) {
+    request_trailers_ = request_trailers;
+    return *this;
+  }
+
+  /**
    * Set or overwrite the response headers.
    * @param response_headers supplies the response headers.
    */
@@ -95,6 +104,11 @@ public:
    * @return OptRef<const Http::RequestHeaderMap> the request headers.
    */
   OptRef<const Http::RequestHeaderMap> requestHeaders() const { return request_headers_; }
+
+  /**
+   * @return OptRef<const Http::RequestTrailerMap> the request trailers.
+   */
+  OptRef<const Http::RequestTrailerMap> requestTrailers() const { return request_trailers_; }
 
   /**
    * @return OptRef<const Http::ResponseHeaderMap> the response headers.
@@ -156,6 +170,7 @@ public:
 private:
   absl::string_view local_reply_body_;
   OptRef<const Http::RequestHeaderMap> request_headers_;
+  OptRef<const Http::RequestTrailerMap> request_trailers_;
   OptRef<const Http::ResponseHeaderMap> response_headers_;
   OptRef<const Http::ResponseTrailerMap> response_trailers_;
   OptRef<const Extension> extension_;

--- a/source/common/http/conn_manager_impl.cc
+++ b/source/common/http/conn_manager_impl.cc
@@ -1045,9 +1045,12 @@ ConnectionManagerImpl::ActiveStream::ActiveStream(ConnectionManagerImpl& connect
 }
 
 void ConnectionManagerImpl::ActiveStream::log(AccessLog::AccessLogType type) {
-  const Formatter::Context log_context{
+  Formatter::Context log_context{
       request_headers_.get(), response_headers_.get(), response_trailers_.get(), {}, type,
       active_span_.get()};
+  if (request_trailers_ != nullptr) {
+    log_context.setRequestTrailers(*request_trailers_);
+  }
 
   filter_manager_.log(log_context);
 
@@ -2255,9 +2258,12 @@ void ConnectionManagerImpl::ActiveStream::modifySpan(Tracing::Span& span,
   ASSERT(connection_manager_tracing_config_.has_value());
 
   const Tracing::HttpTraceContext trace_context(*request_headers_);
-  const Formatter::Context formatter_context{
+  Formatter::Context formatter_context{
       request_headers_.get(), response_headers_.get(), response_trailers_.get(), {}, {},
       active_span_.get()};
+  if (request_trailers_ != nullptr) {
+    formatter_context.setRequestTrailers(*request_trailers_);
+  }
   const Tracing::CustomTagContext ctx{trace_context, filter_manager_.streamInfo(),
                                       formatter_context};
 

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -268,11 +268,14 @@ void UpstreamRequest::cleanUp() {
 }
 
 void UpstreamRequest::upstreamLog(AccessLog::AccessLogType access_log_type) {
-  const Formatter::Context log_context{parent_.downstreamHeaders(),
-                                       upstream_headers_.get(),
-                                       upstream_trailers_.get(),
-                                       {},
-                                       access_log_type};
+  Formatter::Context log_context{parent_.downstreamHeaders(),
+                                 upstream_headers_.get(),
+                                 upstream_trailers_.get(),
+                                 {},
+                                 access_log_type};
+  if (parent_.downstreamTrailers() != nullptr) {
+    log_context.setRequestTrailers(*parent_.downstreamTrailers());
+  }
 
   for (const auto& upstream_log : parent_.config().upstream_logs_) {
     upstream_log->log(log_context, stream_info_);

--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -897,7 +897,8 @@ bool envoy_dynamic_module_callback_access_logger_get_attribute_int(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result) {
   auto* logger = static_cast<ThreadLocalLogger*>(logger_envoy_ptr);
-  return ContextAccessor::getAttributeInt(*logger->stream_info_, attribute_id, result);
+  return ContextAccessor::getAttributeInt(*logger->stream_info_, *logger->log_context_,
+                                          attribute_id, result);
 }
 
 bool envoy_dynamic_module_callback_access_logger_get_attribute_bool(

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -60,6 +60,8 @@ envoy_cc_library(
         "//envoy/stream_info:stream_info_interface",
         "//source/common/common:minimal_logger_lib",
         "//source/common/config:metadata_lib",
+        "//source/common/grpc:common_lib",
+        "//source/common/http:header_map_lib",
         "//source/common/http:utility_lib",
         "//source/common/protobuf",
         "//source/common/router:string_accessor_lib",

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -15,7 +15,6 @@
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/string_accessor_impl.h"
 
-#include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 
 namespace Envoy {
@@ -82,6 +81,8 @@ ContextAccessor::headerMapByType(const Formatter::Context& context,
   switch (type) {
   case envoy_dynamic_module_type_http_header_type_RequestHeader:
     return context.requestHeaders();
+  case envoy_dynamic_module_type_http_header_type_RequestTrailer:
+    return context.requestTrailers();
   case envoy_dynamic_module_type_http_header_type_ResponseHeader:
     return context.responseHeaders();
   case envoy_dynamic_module_type_http_header_type_ResponseTrailer:
@@ -414,17 +415,7 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
     if (http_context == nullptr) {
       break;
     }
-    if (http_context->request_headers != nullptr &&
-        http_context->request_headers->ContentLength() != nullptr) {
-      uint64_t content_length;
-      if (!absl::SimpleAtoi(http_context->request_headers->getContentLengthValue(),
-                            &content_length)) {
-        break;
-      }
-      *result = content_length;
-    } else {
-      *result = stream_info.bytesReceived();
-    }
+    *result = stream_info.bytesReceived();
     ok = true;
     break;
   }
@@ -434,7 +425,9 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
     }
     *result =
         stream_info.bytesReceived() +
-        (http_context->request_headers != nullptr ? http_context->request_headers->byteSize() : 0);
+        (http_context->request_headers != nullptr ? http_context->request_headers->byteSize() : 0) +
+        (http_context->request_trailers != nullptr ? http_context->request_trailers->byteSize()
+                                                   : 0);
     ok = true;
     break;
   }
@@ -542,9 +535,9 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
   if (!stream_info.protocol().has_value()) {
     return getAttributeInt(stream_info, attribute_id, result);
   }
-  const HttpAttributeContext http_context{context.requestHeaders().ptr(),
-                                          context.responseHeaders().ptr(),
-                                          context.responseTrailers().ptr()};
+  const HttpAttributeContext http_context{
+      context.requestHeaders().ptr(), context.responseHeaders().ptr(),
+      context.responseTrailers().ptr(), context.requestTrailers().ptr()};
   return getAttributeInt(stream_info, attribute_id, result, &http_context);
 }
 

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -9,10 +9,13 @@
 
 #include "source/common/common/logger.h"
 #include "source/common/config/metadata.h"
+#include "source/common/grpc/common.h"
+#include "source/common/http/header_map_impl.h"
 #include "source/common/http/utility.h"
 #include "source/common/protobuf/protobuf.h"
 #include "source/common/router/string_accessor_impl.h"
 
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_split.h"
 
 namespace Envoy {
@@ -404,9 +407,37 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
 
 bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
                                       envoy_dynamic_module_type_attribute_id attribute_id,
-                                      uint64_t* result) {
+                                      uint64_t* result, const HttpAttributeContext* http_context) {
   bool ok = false;
   switch (attribute_id) {
+  case envoy_dynamic_module_type_attribute_id_RequestSize: {
+    if (http_context == nullptr) {
+      break;
+    }
+    if (http_context->request_headers != nullptr &&
+        http_context->request_headers->ContentLength() != nullptr) {
+      uint64_t content_length;
+      if (!absl::SimpleAtoi(http_context->request_headers->getContentLengthValue(),
+                            &content_length)) {
+        break;
+      }
+      *result = content_length;
+    } else {
+      *result = stream_info.bytesReceived();
+    }
+    ok = true;
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_RequestTotalSize: {
+    if (http_context == nullptr) {
+      break;
+    }
+    *result =
+        stream_info.bytesReceived() +
+        (http_context->request_headers != nullptr ? http_context->request_headers->byteSize() : 0);
+    ok = true;
+    break;
+  }
   case envoy_dynamic_module_type_attribute_id_ResponseCode: {
     const auto code = stream_info.responseCode();
     if (code.has_value()) {
@@ -424,6 +455,37 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
   }
   case envoy_dynamic_module_type_attribute_id_ResponseSize: {
     *result = stream_info.bytesSent();
+    ok = true;
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus: {
+    if (http_context == nullptr) {
+      break;
+    }
+    const auto& response_headers = http_context->response_headers != nullptr
+                                       ? *http_context->response_headers
+                                       : *Http::StaticEmptyHeaders::get().response_headers;
+    const auto& response_trailers = http_context->response_trailers != nullptr
+                                        ? *http_context->response_trailers
+                                        : *Http::StaticEmptyHeaders::get().response_trailers;
+    const auto status =
+        Grpc::Common::getGrpcStatus(response_trailers, response_headers, stream_info);
+    if (status.has_value()) {
+      *result = static_cast<uint64_t>(status.value());
+      ok = true;
+    }
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_ResponseTotalSize: {
+    if (http_context == nullptr) {
+      break;
+    }
+    *result =
+        stream_info.bytesSent() +
+        (http_context->response_headers != nullptr ? http_context->response_headers->byteSize()
+                                                   : 0) +
+        (http_context->response_trailers != nullptr ? http_context->response_trailers->byteSize()
+                                                    : 0);
     ok = true;
     break;
   }
@@ -471,6 +533,19 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
     break;
   }
   return ok;
+}
+
+bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
+                                      const Formatter::Context& context,
+                                      envoy_dynamic_module_type_attribute_id attribute_id,
+                                      uint64_t* result) {
+  if (!stream_info.protocol().has_value()) {
+    return getAttributeInt(stream_info, attribute_id, result);
+  }
+  const HttpAttributeContext http_context{context.requestHeaders().ptr(),
+                                          context.responseHeaders().ptr(),
+                                          context.responseTrailers().ptr()};
+  return getAttributeInt(stream_info, attribute_id, result, &http_context);
 }
 
 bool ContextAccessor::getAttributeBool(const StreamInfo::StreamInfo& stream_info,

--- a/source/extensions/dynamic_modules/abi_context_accessors.h
+++ b/source/extensions/dynamic_modules/abi_context_accessors.h
@@ -26,6 +26,12 @@ using HeadersMapOptConstRef = OptRef<const Http::HeaderMap>;
  */
 class ContextAccessor {
 public:
+  struct HttpAttributeContext {
+    const Http::RequestHeaderMap* request_headers{};
+    const Http::ResponseHeaderMap* response_headers{};
+    const Http::ResponseTrailerMap* response_trailers{};
+  };
+
   // Resolve the header map for the given type from the formatting context. Supported types are
   // RequestHeader, ResponseHeader, and ResponseTrailer.
   static HeadersMapOptConstRef headerMapByType(const Formatter::Context& context,
@@ -51,6 +57,13 @@ public:
   // Get an integer attribute from the stream info. Returns false when the attribute is unavailable
   // or not an integer.
   static bool getAttributeInt(const StreamInfo::StreamInfo& stream_info,
+                              envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result,
+                              const HttpAttributeContext* http_context = nullptr);
+
+  // Get an integer attribute using the formatting context for HTTP header state. HTTP-only
+  // attributes are unavailable for non-HTTP streams.
+  static bool getAttributeInt(const StreamInfo::StreamInfo& stream_info,
+                              const Formatter::Context& context,
                               envoy_dynamic_module_type_attribute_id attribute_id,
                               uint64_t* result);
 

--- a/source/extensions/dynamic_modules/abi_context_accessors.h
+++ b/source/extensions/dynamic_modules/abi_context_accessors.h
@@ -30,10 +30,11 @@ public:
     const Http::RequestHeaderMap* request_headers{};
     const Http::ResponseHeaderMap* response_headers{};
     const Http::ResponseTrailerMap* response_trailers{};
+    const Http::RequestTrailerMap* request_trailers{};
   };
 
   // Resolve the header map for the given type from the formatting context. Supported types are
-  // RequestHeader, ResponseHeader, and ResponseTrailer.
+  // RequestHeader, RequestTrailer, ResponseHeader, and ResponseTrailer.
   static HeadersMapOptConstRef headerMapByType(const Formatter::Context& context,
                                                envoy_dynamic_module_type_http_header_type type);
 

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -2065,7 +2065,10 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
     // Fall back to the shared context accessor for stream-info-based attributes that are not
     // served from the live request state above.
     if (const auto stream_info = filter->streamInfo(); stream_info != nullptr) {
-      ok = ContextAccessor::getAttributeInt(*stream_info, attribute_id, result);
+      const ContextAccessor::HttpAttributeContext context{filter->requestHeaders().ptr(),
+                                                          filter->responseHeaders().ptr(),
+                                                          filter->responseTrailers().ptr()};
+      ok = ContextAccessor::getAttributeInt(*stream_info, attribute_id, result, &context);
     }
     break;
   }

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -2065,9 +2065,9 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
     // Fall back to the shared context accessor for stream-info-based attributes that are not
     // served from the live request state above.
     if (const auto stream_info = filter->streamInfo(); stream_info != nullptr) {
-      const ContextAccessor::HttpAttributeContext context{filter->requestHeaders().ptr(),
-                                                          filter->responseHeaders().ptr(),
-                                                          filter->responseTrailers().ptr()};
+      const ContextAccessor::HttpAttributeContext context{
+          filter->requestHeaders().ptr(), filter->responseHeaders().ptr(),
+          filter->responseTrailers().ptr(), filter->requestTrailers().ptr()};
       ok = ContextAccessor::getAttributeInt(*stream_info, attribute_id, result, &context);
     }
     break;

--- a/source/extensions/formatter/dynamic_modules/abi_impl.cc
+++ b/source/extensions/formatter/dynamic_modules/abi_impl.cc
@@ -60,7 +60,7 @@ bool envoy_dynamic_module_callback_formatter_get_attribute_int(
     envoy_dynamic_module_type_formatter_context_envoy_ptr formatter_context_envoy_ptr,
     envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result) {
   auto* ctx = static_cast<FormatterContext*>(formatter_context_envoy_ptr);
-  return ContextAccessor::getAttributeInt(*ctx->stream_info, attribute_id, result);
+  return ContextAccessor::getAttributeInt(*ctx->stream_info, *ctx->context, attribute_id, result);
 }
 
 bool envoy_dynamic_module_callback_formatter_get_attribute_bool(

--- a/source/extensions/router/cluster_specifiers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/router/cluster_specifiers/dynamic_modules/abi_impl.cc
@@ -98,7 +98,9 @@ bool envoy_dynamic_module_callback_cluster_specifier_get_attribute_int(
     envoy_dynamic_module_type_cluster_specifier_context_envoy_ptr context_envoy_ptr,
     envoy_dynamic_module_type_attribute_id attribute_id, uint64_t* result) {
   auto* context = clusterSpecifierContext(context_envoy_ptr);
-  return ContextAccessor::getAttributeInt(context->stream_info, attribute_id, result);
+  const ContextAccessor::HttpAttributeContext http_context{&context->headers, nullptr, nullptr};
+  return ContextAccessor::getAttributeInt(context->stream_info, attribute_id, result,
+                                          &http_context);
 }
 
 bool envoy_dynamic_module_callback_cluster_specifier_get_attribute_bool(

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -2965,6 +2965,7 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogOnNewRequest) {
             // First call to log() is made when a new HTTP request has been received
             // On the first call it is expected that there is no response code.
             EXPECT_EQ(AccessLog::AccessLogType::DownstreamStart, log_context.accessLogType());
+            EXPECT_FALSE(log_context.requestTrailers().has_value());
             EXPECT_FALSE(stream_info.responseCode());
           }))
       .WillOnce(Invoke(
@@ -2978,6 +2979,11 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogOnNewRequest) {
             EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().remoteAddress());
             EXPECT_NE(nullptr, stream_info.downstreamAddressProvider().directRemoteAddress());
             EXPECT_NE(nullptr, stream_info.routeSharedPtr());
+            ASSERT_TRUE(log_context.requestTrailers().has_value());
+            const auto trailers =
+                log_context.requestTrailers()->get(Http::LowerCaseString("x-request-trailer"));
+            ASSERT_EQ(1, trailers.size());
+            EXPECT_EQ("value", trailers[0]->value().getStringView());
           }));
 
   EXPECT_CALL(*codec_, dispatch(_))
@@ -2989,7 +2995,10 @@ TEST_F(HttpConnectionManagerImplTest, TestAccessLogOnNewRequest) {
                                          {":authority", "host"},
                                          {":path", "/"},
                                          {"x-request-id", "125a4afb-6f55-a4ba-ad80-413f09f48a28"}}};
-        decoder_->decodeHeaders(std::move(headers), true);
+        decoder_->decodeHeaders(std::move(headers), false);
+        RequestTrailerMapPtr trailers{
+            new TestRequestTrailerMapImpl{{"x-request-trailer", "value"}}};
+        decoder_->decodeTrailers(std::move(trailers));
 
         filter->callbacks_->streamInfo().setResponseCodeDetails("");
         ResponseHeaderMapPtr response_headers{new TestResponseHeaderMapImpl{{":status", "200"}}};

--- a/test/common/router/router_upstream_log_test.cc
+++ b/test/common/router/router_upstream_log_test.cc
@@ -154,11 +154,12 @@ public:
     EXPECT_CALL(*per_try_timeout_, disableTimer());
   }
 
-  void
-  run(uint64_t response_code,
-      const std::initializer_list<std::pair<std::string, std::string>>& request_headers_init,
-      const std::initializer_list<std::pair<std::string, std::string>>& response_headers_init,
-      const std::initializer_list<std::pair<std::string, std::string>>& response_trailers_init) {
+  void run(uint64_t response_code,
+           const std::initializer_list<std::pair<std::string, std::string>>& request_headers_init,
+           const std::initializer_list<std::pair<std::string, std::string>>& response_headers_init,
+           const std::initializer_list<std::pair<std::string, std::string>>& response_trailers_init,
+           const std::initializer_list<std::pair<std::string, std::string>>& request_trailers_init =
+               {}) {
     NiceMock<Http::MockRequestEncoder> encoder;
     Http::ResponseDecoder* response_decoder = nullptr;
 
@@ -180,8 +181,12 @@ public:
     expectResponseTimerCreate();
 
     Http::TestRequestHeaderMapImpl headers(request_headers_init);
+    Http::TestRequestTrailerMapImpl request_trailers(request_trailers_init);
     HttpTestUtility::addDefaultHeaders(headers);
-    router_->decodeHeaders(headers, true);
+    router_->decodeHeaders(headers, request_trailers_init.size() == 0);
+    if (request_trailers_init.size() != 0) {
+      router_->decodeTrailers(request_trailers);
+    }
 
     EXPECT_CALL(*router_->retry_state_, shouldRetryHeaders(_, _, _))
         .WillOnce(Return(RetryStatus::No));
@@ -342,6 +347,20 @@ TEST_F(RouterUpstreamLogTest, LogHeaders) {
   EXPECT_EQ(output_.size(), 1U);
   EXPECT_EQ(output_.front(),
             "GET /foo HTTP/1.0 200 - 0 0 0 0 host 10.0.0.5:9211 10.0.0.5:10211 abcdef value\n");
+}
+
+TEST_F(RouterUpstreamLogTest, LogRequestTrailers) {
+  init(std::nullopt);
+  EXPECT_CALL(*mock_upstream_log_, log(_, _))
+      .WillOnce(Invoke([](const Formatter::Context& log_context, const StreamInfo::StreamInfo&) {
+        ASSERT_TRUE(log_context.requestTrailers().has_value());
+        const auto trailers =
+            log_context.requestTrailers()->get(Http::LowerCaseString("x-request-trailer"));
+        ASSERT_EQ(1, trailers.size());
+        EXPECT_EQ("value", trailers[0]->value().getStringView());
+      }));
+
+  run(200, {}, {}, {}, {{"x-request-trailer", "value"}});
 }
 
 // Test timestamps and durations are emitted.

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -67,6 +67,16 @@ TEST_F(DynamicModuleAccessLogAbiTest, HeadersSizeResponseHeaders) {
                    env_ptr, envoy_dynamic_module_type_http_header_type_ResponseHeader));
 }
 
+TEST_F(DynamicModuleAccessLogAbiTest, HeadersSizeRequestTrailers) {
+  Http::TestRequestTrailerMapImpl request_trailers{{"x-trailer", "trailer-value"}};
+  Formatter::Context log_context(&request_headers_, &response_headers_, &response_trailers_);
+  log_context.setRequestTrailers(request_trailers);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  EXPECT_EQ(1, envoy_dynamic_module_callback_access_logger_get_headers_size(
+                   env_ptr, envoy_dynamic_module_type_http_header_type_RequestTrailer));
+}
+
 TEST_F(DynamicModuleAccessLogAbiTest, HeadersSizeResponseTrailers) {
   Formatter::Context log_context(&request_headers_, &response_headers_, &response_trailers_);
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
@@ -2931,17 +2941,19 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntRequestSizes) {
   stream_info_.protocol_ = Http::Protocol::Http11;
   stream_info_.bytes_received_ = 17;
   Http::TestRequestHeaderMapImpl request_headers{{"content-length", "0"}, {"x-test", "value"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"x-trailer", "value"}};
   Formatter::Context log_context(&request_headers, nullptr, nullptr);
+  log_context.setRequestTrailers(request_trailers);
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   uint64_t result = 1;
   EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
       env_ptr, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
-  EXPECT_EQ(0, result);
+  EXPECT_EQ(17, result);
 
   EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
       env_ptr, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
-  EXPECT_EQ(17 + request_headers.byteSize(), result);
+  EXPECT_EQ(17 + request_headers.byteSize() + request_trailers.byteSize(), result);
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntSizeFallbacks) {
@@ -2970,15 +2982,17 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntSizeFallbacks) {
   EXPECT_EQ(29, result);
 }
 
-TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntRequestSizeInvalidContentLength) {
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntRequestSizeIgnoresInvalidContentLength) {
   stream_info_.protocol_ = Http::Protocol::Http11;
+  stream_info_.bytes_received_ = 23;
   Http::TestRequestHeaderMapImpl request_headers{{"content-length", "invalid"}};
   Formatter::Context log_context(&request_headers, nullptr, nullptr);
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   uint64_t result = 0;
-  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
       env_ptr, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(23, result);
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntResponseTotalSize) {

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -2927,6 +2927,125 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntResponseCodeNotSet) {
       env_ptr, envoy_dynamic_module_type_attribute_id_ResponseCode, &result));
 }
 
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntRequestSizes) {
+  stream_info_.protocol_ = Http::Protocol::Http11;
+  stream_info_.bytes_received_ = 17;
+  Http::TestRequestHeaderMapImpl request_headers{{"content-length", "0"}, {"x-test", "value"}};
+  Formatter::Context log_context(&request_headers, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 1;
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(0, result);
+
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
+  EXPECT_EQ(17 + request_headers.byteSize(), result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntSizeFallbacks) {
+  stream_info_.protocol_ = Http::Protocol::Http11;
+  stream_info_.bytes_received_ = 23;
+  stream_info_.bytes_sent_ = 29;
+  Http::TestRequestHeaderMapImpl request_headers{{"x-test", "value"}};
+  Formatter::Context log_context(&request_headers, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(23, result);
+
+  Formatter::Context no_headers(nullptr, nullptr, nullptr);
+  env_ptr = createThreadLocalLogger(no_headers, stream_info_);
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(23, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
+  EXPECT_EQ(23, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
+  EXPECT_EQ(29, result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntRequestSizeInvalidContentLength) {
+  stream_info_.protocol_ = Http::Protocol::Http11;
+  Http::TestRequestHeaderMapImpl request_headers{{"content-length", "invalid"}};
+  Formatter::Context log_context(&request_headers, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 0;
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntResponseTotalSize) {
+  stream_info_.protocol_ = Http::Protocol::Http11;
+  stream_info_.bytes_sent_ = 29;
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"x-test", "value"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"x-trailer", "value"}};
+  Formatter::Context log_context(nullptr, &response_headers, &response_trailers);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
+  EXPECT_EQ(29 + response_headers.byteSize() + response_trailers.byteSize(), result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntGrpcStatusPrecedence) {
+  stream_info_.protocol_ = Http::Protocol::Http11;
+  Http::TestResponseHeaderMapImpl response_headers{{"grpc-status", "3"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "7"}};
+  Formatter::Context log_context(nullptr, &response_headers, &response_trailers);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
+  EXPECT_EQ(7, result);
+
+  Formatter::Context headers_only(nullptr, &response_headers, nullptr);
+  env_ptr = createThreadLocalLogger(headers_only, stream_info_);
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
+  EXPECT_EQ(3, result);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntGrpcStatusFallbacks) {
+  stream_info_.protocol_ = Http::Protocol::Http11;
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
+  EXPECT_EQ(2, result);
+
+  stream_info_.response_code_ = std::nullopt;
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeHttpIntsWithoutProtocol) {
+  stream_info_.protocol_ = std::nullopt;
+  Http::TestRequestHeaderMapImpl request_headers{{"content-length", "17"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  Formatter::Context log_context(&request_headers, &response_headers, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  uint64_t result = 0;
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_RequestSize,
+                        envoy_dynamic_module_type_attribute_id_RequestTotalSize,
+                        envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus,
+                        envoy_dynamic_module_type_attribute_id_ResponseTotalSize}) {
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_access_logger_get_attribute_int(env_ptr, id, &result));
+  }
+}
+
 } // namespace
 } // namespace DynamicModules
 } // namespace AccessLoggers

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2726,6 +2726,65 @@ TEST(ABIImpl, GetAttributesAbsentTypedHeaders) {
       &filter, envoy_dynamic_module_type_attribute_id_RequestReferer, &result_buffer));
 }
 
+TEST(ABIImpl, GetHttpSizeAndGrpcStatusAttributes) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> decoder_callbacks;
+  NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  filter.setDecoderFilterCallbacks(decoder_callbacks);
+  filter.setEncoderFilterCallbacks(encoder_callbacks);
+  EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+
+  Http::TestRequestHeaderMapImpl request_headers{{"content-length", "41"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
+  EXPECT_CALL(decoder_callbacks, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  EXPECT_CALL(encoder_callbacks, responseHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
+  EXPECT_CALL(encoder_callbacks, responseTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<ResponseTrailerMap>(response_trailers)));
+  stream_info.bytes_received_ = 37;
+  stream_info.bytes_sent_ = 43;
+
+  uint64_t result = 1;
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(41, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
+  EXPECT_EQ(37 + request_headers.byteSize(), result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
+  EXPECT_EQ(43 + response_headers.byteSize() + response_trailers.byteSize(), result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
+  EXPECT_EQ(0, result);
+}
+
+TEST(ABIImpl, GetHttpSizeAttributesWithoutHeaderMaps) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  filter.setDecoderFilterCallbacks(callbacks);
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  stream_info.bytes_received_ = 37;
+  stream_info.bytes_sent_ = 43;
+
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(37, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
+  EXPECT_EQ(37, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
+      &filter, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
+  EXPECT_EQ(43, result);
+}
+
 TEST(ABIImpl, HttpCallout) {
   Stats::SymbolTableImpl symbol_table;
   DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -2737,10 +2737,13 @@ TEST(ABIImpl, GetHttpSizeAndGrpcStatusAttributes) {
   EXPECT_CALL(decoder_callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
 
   Http::TestRequestHeaderMapImpl request_headers{{"content-length", "41"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"x-request-trailer", "value"}};
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
   EXPECT_CALL(decoder_callbacks, requestHeaders())
       .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  EXPECT_CALL(decoder_callbacks, requestTrailers())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestTrailerMap>(request_trailers)));
   EXPECT_CALL(encoder_callbacks, responseHeaders())
       .WillRepeatedly(testing::Return(makeOptRef<ResponseHeaderMap>(response_headers)));
   EXPECT_CALL(encoder_callbacks, responseTrailers())
@@ -2751,10 +2754,10 @@ TEST(ABIImpl, GetHttpSizeAndGrpcStatusAttributes) {
   uint64_t result = 1;
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
-  EXPECT_EQ(41, result);
+  EXPECT_EQ(37, result);
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
-  EXPECT_EQ(37 + request_headers.byteSize(), result);
+  EXPECT_EQ(37 + request_headers.byteSize() + request_trailers.byteSize(), result);
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
   EXPECT_EQ(43 + response_headers.byteSize() + response_trailers.byteSize(), result);

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -3082,7 +3082,7 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeInt) {
 
   // A request attribute that is not backed by stream info returns false.
   EXPECT_FALSE(envoy_dynamic_module_callback_listener_filter_get_attribute_int(
-      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestPath, &result));
+      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestSize, &result));
 }
 
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeBool) {

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2774,7 +2774,7 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeInt) {
 
   // A request attribute that is not backed by stream info returns false.
   EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_get_attribute_int(
-      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestPath, &result));
+      filterPtr(), envoy_dynamic_module_type_attribute_id_RequestSize, &result));
 }
 
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeBool) {

--- a/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/cluster_specifier_integration_test.rs
@@ -126,6 +126,12 @@ fn read_echoed_value(ctx: &ClusterSpecifierContext, name: &[u8]) -> String {
     b"attribute-int" => ctx
       .get_attribute_int(AttributeId::UpstreamRequestAttemptCount)
       .map_or_else(|| ABSENT.to_owned(), |value| value.to_string()),
+    b"attribute-request-size" => ctx
+      .get_attribute_int(AttributeId::RequestSize)
+      .map_or_else(|| ABSENT.to_owned(), |value| value.to_string()),
+    b"attribute-request-total-size" => ctx
+      .get_attribute_int(AttributeId::RequestTotalSize)
+      .map_or_else(|| ABSENT.to_owned(), |value| value.to_string()),
     b"attribute-bool" => ctx
       .get_attribute_bool(AttributeId::HealthCheck)
       .map_or_else(|| ABSENT.to_owned(), |value| value.to_string()),

--- a/test/extensions/formatter/dynamic_modules/BUILD
+++ b/test/extensions/formatter/dynamic_modules/BUILD
@@ -1,12 +1,23 @@
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_dyn_module_test",
+    "envoy_cc_test",
     "envoy_package",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_package()
+
+envoy_cc_test(
+    name = "abi_impl_test",
+    srcs = ["abi_impl_test.cc"],
+    deps = [
+        "//source/extensions/formatter/dynamic_modules:formatter_lib",
+        "//test/mocks/stream_info:stream_info_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
 
 envoy_cc_dyn_module_test(
     name = "config_test",

--- a/test/extensions/formatter/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/formatter/dynamic_modules/abi_impl_test.cc
@@ -12,24 +12,43 @@ namespace Formatter {
 namespace DynamicModules {
 namespace {
 
+TEST(DynamicModuleFormatterAbiTest, RequestTrailersUseFormattingContext) {
+  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Http::TestRequestTrailerMapImpl request_trailers{{"x-request-trailer", "value"}};
+  ::Envoy::Formatter::Context context;
+  context.setRequestTrailers(request_trailers);
+  FormatterContext formatter_context{&context, &stream_info};
+
+  EXPECT_EQ(1, envoy_dynamic_module_callback_formatter_get_headers_size(
+                   &formatter_context, envoy_dynamic_module_type_http_header_type_RequestTrailer));
+
+  envoy_dynamic_module_type_envoy_buffer result{nullptr, 0};
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_header_value(
+      &formatter_context, envoy_dynamic_module_type_http_header_type_RequestTrailer,
+      {"x-request-trailer", 17}, &result, 0, nullptr));
+  EXPECT_EQ("value", absl::string_view(result.ptr, result.length));
+}
+
 TEST(DynamicModuleFormatterAbiTest, HttpIntegerAttributesUseFormattingContext) {
   testing::NiceMock<StreamInfo::MockStreamInfo> stream_info;
   stream_info.protocol_ = Http::Protocol::Http11;
   stream_info.bytes_received_ = 11;
   stream_info.bytes_sent_ = 13;
   Http::TestRequestHeaderMapImpl request_headers{{"content-length", "17"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"x-request-trailer", "value"}};
   Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
   ::Envoy::Formatter::Context context(&request_headers, &response_headers, &response_trailers);
+  context.setRequestTrailers(request_trailers);
   FormatterContext formatter_context{&context, &stream_info};
 
   uint64_t result = 1;
   EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
       &formatter_context, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
-  EXPECT_EQ(17, result);
+  EXPECT_EQ(11, result);
   EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
       &formatter_context, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
-  EXPECT_EQ(11 + request_headers.byteSize(), result);
+  EXPECT_EQ(11 + request_headers.byteSize() + request_trailers.byteSize(), result);
   EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
       &formatter_context, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
   EXPECT_EQ(13 + response_headers.byteSize() + response_trailers.byteSize(), result);

--- a/test/extensions/formatter/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/formatter/dynamic_modules/abi_impl_test.cc
@@ -1,0 +1,79 @@
+#include "source/extensions/dynamic_modules/abi/abi.h"
+#include "source/extensions/formatter/dynamic_modules/formatter.h"
+
+#include "test/mocks/stream_info/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Formatter {
+namespace DynamicModules {
+namespace {
+
+TEST(DynamicModuleFormatterAbiTest, HttpIntegerAttributesUseFormattingContext) {
+  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  stream_info.protocol_ = Http::Protocol::Http11;
+  stream_info.bytes_received_ = 11;
+  stream_info.bytes_sent_ = 13;
+  Http::TestRequestHeaderMapImpl request_headers{{"content-length", "17"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"grpc-status", "0"}};
+  ::Envoy::Formatter::Context context(&request_headers, &response_headers, &response_trailers);
+  FormatterContext formatter_context{&context, &stream_info};
+
+  uint64_t result = 1;
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
+      &formatter_context, envoy_dynamic_module_type_attribute_id_RequestSize, &result));
+  EXPECT_EQ(17, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
+      &formatter_context, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
+  EXPECT_EQ(11 + request_headers.byteSize(), result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
+      &formatter_context, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
+  EXPECT_EQ(13 + response_headers.byteSize() + response_trailers.byteSize(), result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
+      &formatter_context, envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus, &result));
+  EXPECT_EQ(0, result);
+}
+
+TEST(DynamicModuleFormatterAbiTest, HttpTotalSizeAttributesWithoutHeaderMaps) {
+  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  stream_info.protocol_ = Http::Protocol::Http11;
+  stream_info.bytes_received_ = 11;
+  stream_info.bytes_sent_ = 13;
+  ::Envoy::Formatter::Context context(nullptr, nullptr, nullptr);
+  FormatterContext formatter_context{&context, &stream_info};
+
+  uint64_t result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
+      &formatter_context, envoy_dynamic_module_type_attribute_id_RequestTotalSize, &result));
+  EXPECT_EQ(11, result);
+  EXPECT_TRUE(envoy_dynamic_module_callback_formatter_get_attribute_int(
+      &formatter_context, envoy_dynamic_module_type_attribute_id_ResponseTotalSize, &result));
+  EXPECT_EQ(13, result);
+}
+
+TEST(DynamicModuleFormatterAbiTest, HttpIntegerAttributesRequireHttpProtocol) {
+  testing::NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  Http::TestRequestHeaderMapImpl request_headers{{"content-length", "17"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+  ::Envoy::Formatter::Context context(&request_headers, &response_headers, nullptr);
+  FormatterContext formatter_context{&context, &stream_info};
+
+  uint64_t result = 0;
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_RequestSize,
+                        envoy_dynamic_module_type_attribute_id_RequestTotalSize,
+                        envoy_dynamic_module_type_attribute_id_ResponseGrpcStatus,
+                        envoy_dynamic_module_type_attribute_id_ResponseTotalSize}) {
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_formatter_get_attribute_int(&formatter_context, id, &result));
+  }
+}
+
+} // namespace
+} // namespace DynamicModules
+} // namespace Formatter
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
@@ -671,7 +671,7 @@ TEST_F(DynamicModuleClusterSpecifierReadTest, RequestSizeAttributesReadable) {
   setUpPlugin();
   stream_info_.bytes_received_ = 11;
   Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"env", "prod"}, {"content-length", "17"}};
-  EXPECT_EQ("17", echoedValue(headers, "attribute-request-size"));
+  EXPECT_EQ("11", echoedValue(headers, "attribute-request-size"));
   headers.setCopy(Http::LowerCaseString("x-echo"), "attribute-request-total-size");
   const uint64_t expected_total_size = 11 + headers.byteSize();
   EXPECT_EQ(absl::StrCat(expected_total_size), resolveRouteEntry(headers)->clusterName());

--- a/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
+++ b/test/extensions/router/cluster_specifiers/dynamic_modules/cluster_specifier_test.cc
@@ -667,6 +667,16 @@ TEST_F(DynamicModuleClusterSpecifierReadTest, StreamInfoAttributesReadable) {
   EXPECT_EQ("absent", echoedValue(headers, "attribute-string-unset"));
 }
 
+TEST_F(DynamicModuleClusterSpecifierReadTest, RequestSizeAttributesReadable) {
+  setUpPlugin();
+  stream_info_.bytes_received_ = 11;
+  Http::TestRequestHeaderMapImpl headers{{":path", "/"}, {"env", "prod"}, {"content-length", "17"}};
+  EXPECT_EQ("17", echoedValue(headers, "attribute-request-size"));
+  headers.setCopy(Http::LowerCaseString("x-echo"), "attribute-request-total-size");
+  const uint64_t expected_total_size = 11 + headers.byteSize();
+  EXPECT_EQ(absl::StrCat(expected_total_size), resolveRouteEntry(headers)->clusterName());
+}
+
 TEST_F(DynamicModuleClusterSpecifierReadTest, DynamicMetadataReadable) {
   setUpPlugin();
   Protobuf::Struct metadata;


### PR DESCRIPTION
## Description

Implements the missing integer accessors for request size, request total size, response total size, and gRPC status in HTTP-aware dynamic module contexts.

The values follow Envoy’s CEL semantics, including Content-Length handling, header sizes, and gRPC status precedence.

---

**Commit Message:** dynamic_modules: fix HTTP scalar attribute accessors
**Risk Level:** Low
**Testing:** Added and updated ABI tests for HTTP filters, access loggers, formatters, listener filters, network filters, and cluster specifiers
**Docs Changes:** N/A (existing attribute documentation already defines these semantics)
**Release Notes:** Added

AI assistance was used; I reviewed and understand the changes.