### PR TITLE
dynamic_modules: fix connection attribute accessors

### DIFF
--- a/changelogs/current/behavior_changes/dynamic_modules__connection-attribute-accessors.rst
+++ b/changelogs/current/behavior_changes/dynamic_modules__connection-attribute-accessors.rst
@@ -1,0 +1,2 @@
+dynamic modules: aligned IP source and destination address attributes with CEL by including their
+ports, preserved non-IP address strings, and made missing connection IDs and addresses unavailable.

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -187,9 +187,9 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
   }
   case envoy_dynamic_module_type_attribute_id_SourceAddress: {
     const auto& addr_provider = stream_info.downstreamAddressProvider();
-    if (addr_provider.remoteAddress() &&
-        addr_provider.remoteAddress()->type() == Network::Address::Type::Ip) {
-      const auto& addr_str = addr_provider.remoteAddress()->ip()->addressAsString();
+    const auto& address = addr_provider.remoteAddress();
+    if (address) {
+      const auto addr_str = address->asStringView();
       *result = {const_cast<char*>(addr_str.data()), addr_str.size()};
       ok = true;
     }
@@ -197,9 +197,9 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
   }
   case envoy_dynamic_module_type_attribute_id_DestinationAddress: {
     const auto& addr_provider = stream_info.downstreamAddressProvider();
-    if (addr_provider.localAddress() &&
-        addr_provider.localAddress()->type() == Network::Address::Type::Ip) {
-      const auto& addr_str = addr_provider.localAddress()->ip()->addressAsString();
+    const auto& address = addr_provider.localAddress();
+    if (address) {
+      const auto addr_str = address->asStringView();
       *result = {const_cast<char*>(addr_str.data()), addr_str.size()};
       ok = true;
     }
@@ -428,8 +428,11 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
     break;
   }
   case envoy_dynamic_module_type_attribute_id_ConnectionId: {
-    *result = stream_info.downstreamAddressProvider().connectionID().value_or(0);
-    ok = true;
+    const auto connection_id = stream_info.downstreamAddressProvider().connectionID();
+    if (connection_id.has_value()) {
+      *result = connection_id.value();
+      ok = true;
+    }
     break;
   }
   case envoy_dynamic_module_type_attribute_id_SourcePort: {

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1808,20 +1808,24 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
   case envoy_dynamic_module_type_attribute_id_SourceAddress: {
     const auto stream_info = filter->streamInfo();
     if (stream_info) {
-      const auto addressProvider =
-          stream_info->downstreamAddressProvider().remoteAddress()->asStringView();
-      *result = {addressProvider.data(), addressProvider.size()};
-      ok = true;
+      const auto& address = stream_info->downstreamAddressProvider().remoteAddress();
+      if (address != nullptr) {
+        const auto address_string = address->asStringView();
+        *result = {address_string.data(), address_string.size()};
+        ok = true;
+      }
     }
     break;
   }
   case envoy_dynamic_module_type_attribute_id_DestinationAddress: {
     const auto stream_info = filter->streamInfo();
     if (stream_info) {
-      const auto addressProvider =
-          stream_info->downstreamAddressProvider().localAddress()->asStringView();
-      *result = {addressProvider.data(), addressProvider.size()};
-      ok = true;
+      const auto& address = stream_info->downstreamAddressProvider().localAddress();
+      if (address != nullptr) {
+        const auto address_string = address->asStringView();
+        *result = {address_string.data(), address_string.size()};
+        ok = true;
+      }
     }
     break;
   }
@@ -2034,9 +2038,9 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
   case envoy_dynamic_module_type_attribute_id_SourcePort: {
     const auto stream_info = filter->streamInfo();
     if (stream_info) {
-      const auto ip = stream_info->downstreamAddressProvider().remoteAddress()->ip();
-      if (ip) {
-        *result = ip->port();
+      const auto& address = stream_info->downstreamAddressProvider().remoteAddress();
+      if (address != nullptr && address->type() == Network::Address::Type::Ip) {
+        *result = address->ip()->port();
         ok = true;
       }
     }
@@ -2045,9 +2049,9 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_int(
   case envoy_dynamic_module_type_attribute_id_DestinationPort: {
     const auto stream_info = filter->streamInfo();
     if (stream_info) {
-      const auto ip = stream_info->downstreamAddressProvider().localAddress()->ip();
-      if (ip) {
-        *result = ip->port();
+      const auto& address = stream_info->downstreamAddressProvider().localAddress();
+      if (address != nullptr && address->type() == Network::Address::Type::Ip) {
+        *result = address->ip()->port();
         ok = true;
       }
     }

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -2446,7 +2446,53 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringDestinationAddress) {
   envoy_dynamic_module_type_envoy_buffer result{};
   EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
       env_ptr, envoy_dynamic_module_type_attribute_id_DestinationAddress, &result));
-  EXPECT_EQ("127.0.0.1", absl::string_view(result.ptr, result.length));
+  EXPECT_EQ("127.0.0.1:8080", absl::string_view(result.ptr, result.length));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeMissingConnectionValues) {
+  stream_info_.downstream_connection_info_provider_->setRemoteAddress(nullptr);
+  stream_info_.downstream_connection_info_provider_->setLocalAddress(nullptr);
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  uint64_t int_result = 0;
+
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourceAddress,
+                        envoy_dynamic_module_type_attribute_id_DestinationAddress}) {
+    EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(env_ptr, id,
+                                                                                  &string_result));
+  }
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourcePort,
+                        envoy_dynamic_module_type_attribute_id_DestinationPort,
+                        envoy_dynamic_module_type_attribute_id_ConnectionId}) {
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_access_logger_get_attribute_int(env_ptr, id, &int_result));
+  }
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeNonIpConnectionValues) {
+  auto pipe_or_error = Network::Address::PipeInstance::create("dynamic-module-attribute-test");
+  ASSERT_TRUE(pipe_or_error.ok());
+  Network::Address::InstanceConstSharedPtr pipe_address(std::move(pipe_or_error).value());
+  stream_info_.downstream_connection_info_provider_->setRemoteAddress(pipe_address);
+  stream_info_.downstream_connection_info_provider_->setLocalAddress(pipe_address);
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  uint64_t int_result = 0;
+
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourceAddress,
+                        envoy_dynamic_module_type_attribute_id_DestinationAddress}) {
+    EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(env_ptr, id,
+                                                                                 &string_result));
+    EXPECT_EQ("dynamic-module-attribute-test",
+              absl::string_view(string_result.ptr, string_result.length));
+  }
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourcePort,
+                        envoy_dynamic_module_type_attribute_id_DestinationPort}) {
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_access_logger_get_attribute_int(env_ptr, id, &int_result));
+  }
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringUpstreamAddress) {

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -120,6 +120,7 @@ envoy_cc_test(
     rbe_pool = "linux_x64_small",
     deps = [
         "//envoy/registry",
+        "//source/common/network:address_lib",
         "//source/common/router:string_accessor_lib",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:abi_impl",

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -9,6 +9,7 @@
 #include "envoy/extensions/transport_sockets/tls/v3/secret.pb.h"
 #include "envoy/registry/registry.h"
 
+#include "source/common/network/address_impl.h"
 #include "source/common/router/string_accessor_impl.h"
 #include "source/extensions/filters/http/dynamic_modules/filter.h"
 #include "source/extensions/filters/http/dynamic_modules/filter_config.h"
@@ -2690,6 +2691,50 @@ TEST(ABIImpl, GetAttributes) {
   EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_int(
       &filter, envoy_dynamic_module_type_attribute_id_UpstreamRequestAttemptCount, &result_number));
   EXPECT_EQ(result_number, 3);
+}
+
+TEST(ABIImpl, GetAttributesMissingAndNonIpAddresses) {
+  Stats::SymbolTableImpl symbol_table;
+  DynamicModuleHttpFilter filter{nullptr, symbol_table, 0};
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info;
+  EXPECT_CALL(callbacks, streamInfo()).WillRepeatedly(testing::ReturnRef(stream_info));
+  EXPECT_CALL(callbacks, connection()).WillRepeatedly(testing::Return(std::nullopt));
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  uint64_t int_result = 0;
+  stream_info.downstream_connection_info_provider_->setRemoteAddress(nullptr);
+  stream_info.downstream_connection_info_provider_->setLocalAddress(nullptr);
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourceAddress,
+                        envoy_dynamic_module_type_attribute_id_DestinationAddress}) {
+    EXPECT_FALSE(envoy_dynamic_module_callback_http_filter_get_attribute_string(&filter, id,
+                                                                                &string_result));
+  }
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourcePort,
+                        envoy_dynamic_module_type_attribute_id_DestinationPort,
+                        envoy_dynamic_module_type_attribute_id_ConnectionId}) {
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_http_filter_get_attribute_int(&filter, id, &int_result));
+  }
+
+  auto pipe_or_error = Network::Address::PipeInstance::create("dynamic-module-attribute-test");
+  ASSERT_TRUE(pipe_or_error.ok());
+  Network::Address::InstanceConstSharedPtr pipe_address(std::move(pipe_or_error).value());
+  stream_info.downstream_connection_info_provider_->setRemoteAddress(pipe_address);
+  stream_info.downstream_connection_info_provider_->setLocalAddress(pipe_address);
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourceAddress,
+                        envoy_dynamic_module_type_attribute_id_DestinationAddress}) {
+    EXPECT_TRUE(envoy_dynamic_module_callback_http_filter_get_attribute_string(&filter, id,
+                                                                               &string_result));
+    EXPECT_EQ("dynamic-module-attribute-test",
+              absl::string_view(string_result.ptr, string_result.length));
+  }
+  for (const auto id : {envoy_dynamic_module_type_attribute_id_SourcePort,
+                        envoy_dynamic_module_type_attribute_id_DestinationPort}) {
+    EXPECT_FALSE(
+        envoy_dynamic_module_callback_http_filter_get_attribute_int(&filter, id, &int_result));
+  }
 }
 
 // When the request header map is present but a typed header is absent, the attribute must be


### PR DESCRIPTION
## Description

Makes source and destination address attributes consistent across dynamic module contexts.

IP addresses include their ports, matching CEL semantics and existing HTTP behavior. Non-IP address strings remain supported. Missing addresses, missing connection IDs, and ports for non-IP addresses are reported as unavailable.

---

**Commit Message:** dynamic_modules: fix connection attribute accessors
**Risk Level:** Low
**Testing:** Added access logger and HTTP ABI coverage for missing and non-IP addresses and absent connection IDs
**Docs Changes:** N/A (existing attribute documentation already defines these values)
**Release Notes:** Added

AI assistance was used; I reviewed and understand the changes.