### PR TITLE
dynamic_modules: add upstream server name attribute

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__upstream-server-name-attribute.rst
+++ b/changelogs/current/new_features/dynamic_modules__upstream-server-name-attribute.rst
@@ -1,0 +1,2 @@
+dynamic modules: added the upstream requested server name attribute to the dynamic module ABI and
+C++, Go, and Rust SDKs.

--- a/source/extensions/dynamic_modules/BUILD
+++ b/source/extensions/dynamic_modules/BUILD
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 load(
     "//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
@@ -98,6 +98,12 @@ go_library(
     cgo = True,
     importpath = "github.com/envoyproxy/envoy/source/extensions/dynamic_modules/sdk/go/shared",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_sdk_shared_test",
+    srcs = ["sdk/go/shared/types_test.go"],
+    embed = [":go_sdk_shared"],
 )
 
 go_library(

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -386,6 +386,8 @@ typedef enum envoy_dynamic_module_type_attribute_id {
   envoy_dynamic_module_type_attribute_id_XdsFilterChainName,
   // health_check
   envoy_dynamic_module_type_attribute_id_HealthCheck,
+  // upstream.server_name
+  envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName,
 } envoy_dynamic_module_type_attribute_id;
 
 /**

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -257,6 +257,13 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
     }
     break;
   }
+  case envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName:
+    return getUpstreamSslAttribute(
+        stream_info,
+        [](const Ssl::ConnectionInfoConstSharedPtr ssl) -> OptRef<const std::string> {
+          return ssl->sni();
+        },
+        result);
   case envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion:
     return getDownstreamSslAttribute(
         stream_info,

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -246,7 +246,8 @@ enum class AttributeID : uint32_t {
   XdsVirtualHostMetadata,
   XdsUpstreamHostMetadata,
   XdsFilterChainName,
-  HealthCheck
+  HealthCheck,
+  UpstreamRequestedServerName
 };
 
 enum class LogLevel : uint32_t { Trace, Debug, Info, Warn, Error, Critical, Off };

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -15,12 +15,6 @@
 namespace Envoy {
 namespace DynamicModules {
 
-static_assert(static_cast<uint32_t>(AttributeID::HealthCheck) ==
-              static_cast<uint32_t>(envoy_dynamic_module_type_attribute_id_HealthCheck));
-static_assert(
-    static_cast<uint32_t>(AttributeID::UpstreamRequestedServerName) ==
-    static_cast<uint32_t>(envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName));
-
 // BodyBuffer implementation
 template <envoy_dynamic_module_type_http_body_type Type> class BodyBufferImpl : public BodyBuffer {
 public:

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk_internal.cc
@@ -15,6 +15,12 @@
 namespace Envoy {
 namespace DynamicModules {
 
+static_assert(static_cast<uint32_t>(AttributeID::HealthCheck) ==
+              static_cast<uint32_t>(envoy_dynamic_module_type_attribute_id_HealthCheck));
+static_assert(
+    static_cast<uint32_t>(AttributeID::UpstreamRequestedServerName) ==
+    static_cast<uint32_t>(envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName));
+
 // BodyBuffer implementation
 template <envoy_dynamic_module_type_http_body_type Type> class BodyBufferImpl : public BodyBuffer {
 public:

--- a/source/extensions/dynamic_modules/sdk/go/shared/types.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/types.go
@@ -197,6 +197,8 @@ const (
 	AttributeIDXdsFilterChainName
 	// health_check
 	AttributeIDHealthCheck
+	// upstream.server_name
+	AttributeIDUpstreamRequestedServerName
 )
 
 // LogLevel is the log level for messages logged via the host environment's logging mechanism.

--- a/source/extensions/dynamic_modules/sdk/go/shared/types_test.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/types_test.go
@@ -1,0 +1,20 @@
+package shared
+
+import "testing"
+
+func TestAttributeIDOrdering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		id   AttributeID
+		want AttributeID
+	}{
+		{AttributeIDHealthCheck, 67},
+		{AttributeIDUpstreamRequestedServerName, 68},
+	}
+	for _, test := range tests {
+		if test.id != test.want {
+			t.Errorf("attribute ID = %d, want %d", test.id, test.want)
+		}
+	}
+}

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -9739,6 +9739,18 @@ fn test_cluster_specifier_context_reads_request_state() {
 }
 
 #[test]
+fn test_attribute_id_ordering() {
+  assert_eq!(
+    67,
+    abi::envoy_dynamic_module_type_attribute_id::HealthCheck as u32
+  );
+  assert_eq!(
+    68,
+    abi::envoy_dynamic_module_type_attribute_id::UpstreamRequestedServerName as u32
+  );
+}
+
+#[test]
 fn test_cluster_specifier_context_records_selection() {
   use cluster_specifier::ResourcePriority;
 

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -2876,6 +2876,41 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringDownstreamSslMissing) {
       env_ptr, envoy_dynamic_module_type_attribute_id_ConnectionUriSanPeerCertificate, &result));
 }
 
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeUpstreamRequestedServerName) {
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName, &string_result));
+
+  auto ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  std::string sni;
+  ON_CALL(*ssl_info, sni()).WillByDefault(testing::ReturnRef(sni));
+  stream_info_.upstream_info_->setUpstreamSslConnection(ssl_info);
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName, &string_result));
+
+  sni = "upstream.example.com";
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName, &string_result));
+  EXPECT_EQ("upstream.example.com", absl::string_view(string_result.ptr, string_result.length));
+  bool bool_result = false;
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_bool(
+      env_ptr, envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName, &bool_result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeUpstreamRequestedServerNameWithoutUpstreamInfo) {
+  stream_info_.upstream_info_.reset();
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName, &string_result));
+}
+
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeIntDestinationPort) {
   auto local_addr = Network::Address::InstanceConstSharedPtr{
       new Network::Address::Ipv4Instance("127.0.0.1", 8443)};

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2758,6 +2758,28 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, ConfigStatsOperate) {
                 config, invalid_id, 1));
 }
 
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeUpstreamRequestedServerName) {
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName,
+      &string_result));
+
+  auto ssl_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();
+  std::string sni = "network-upstream.example.com";
+  ON_CALL(*ssl_info, sni()).WillByDefault(testing::ReturnRef(sni));
+  connection_.stream_info_.upstream_info_->setUpstreamSslConnection(ssl_info);
+
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName,
+      &string_result));
+  EXPECT_EQ("network-upstream.example.com",
+            absl::string_view(string_result.ptr, string_result.length));
+  bool bool_result = false;
+  EXPECT_FALSE(envoy_dynamic_module_callback_network_filter_get_attribute_bool(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName,
+      &bool_result));
+}
+
 TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeInt) {
   const uint64_t response_flags = (1ULL << 1) | (1ULL << 26);
   EXPECT_CALL(connection_.stream_info_, legacyResponseFlags())


### PR DESCRIPTION
## Description

Adds an append-only dynamic module attribute ID for the upstream requested server name, with matching C++, Go, and Rust SDK exposure.

The attribute returns the SNI from the upstream TLS connection. It is unavailable when there is no upstream TLS connection or the SNI is empty.

---

**Commit Message:** dynamic_modules: add upstream server name attribute
**Risk Level:** Low
**Testing:** Added ABI, SDK ordering, access logger, and network filter coverage
**Docs Changes:** N/A (existing attribute documentation already defines upstream.server_name)
**Release Notes:** Added

AI assistance was used; I reviewed and understand the changes.