### PR TITLE
dynamic_modules: fix xDS scalar attribute accessors

### DIFF
--- a/changelogs/current/bug_fixes/dynamic_modules__xds-attribute-accessors.rst
+++ b/changelogs/current/bug_fixes/dynamic_modules__xds-attribute-accessors.rst
@@ -1,0 +1,2 @@
+dynamic modules: fixed missing scalar accessors for xDS cluster names, listener directions, and
+filter chain names, and preserved empty route names as available values.

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -161,8 +161,9 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
     break;
   }
   case envoy_dynamic_module_type_attribute_id_XdsRouteName: {
-    const auto& name = stream_info.getRouteName();
-    if (!name.empty()) {
+    const auto route = stream_info.route();
+    if (route.has_value()) {
+      const auto& name = route->routeName();
       *result = {const_cast<char*>(name.data()), name.size()};
       ok = true;
     }
@@ -174,6 +175,23 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
       *result = {const_cast<char*>(name->data()), name->size()};
       ok = true;
     }
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_XdsClusterName: {
+    const auto cluster_info = stream_info.upstreamClusterInfo();
+    if (cluster_info) {
+      const auto& name = cluster_info->name();
+      *result = {const_cast<char*>(name.data()), name.size()};
+      ok = true;
+    }
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_XdsFilterChainName: {
+    const auto filter_chain_info = stream_info.downstreamAddressProvider().filterChainInfo();
+    const absl::string_view name =
+        filter_chain_info.has_value() ? filter_chain_info->name() : absl::string_view{};
+    *result = {const_cast<char*>(name.data()), name.size()};
+    ok = true;
     break;
   }
   case envoy_dynamic_module_type_attribute_id_RequestId: {
@@ -463,6 +481,14 @@ bool ContextAccessor::getAttributeInt(const StreamInfo::StreamInfo& stream_info,
   case envoy_dynamic_module_type_attribute_id_UpstreamRequestAttemptCount: {
     *result = stream_info.attemptCount().value_or(0);
     ok = true;
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_XdsListenerDirection: {
+    const auto listener_info = stream_info.downstreamAddressProvider().listenerInfo();
+    if (listener_info.has_value()) {
+      *result = static_cast<uint64_t>(listener_info->direction());
+      ok = true;
+    }
     break;
   }
   default:

--- a/source/extensions/filters/http/dynamic_modules/abi_impl.cc
+++ b/source/extensions/filters/http/dynamic_modules/abi_impl.cc
@@ -1911,15 +1911,6 @@ bool envoy_dynamic_module_callback_http_filter_get_attribute_string(
     }
     break;
   }
-  case envoy_dynamic_module_type_attribute_id_XdsRouteName: {
-    const auto stream_info = filter->streamInfo();
-    if (stream_info) {
-      const auto& route_name = stream_info->getRouteName();
-      *result = {route_name.data(), route_name.size()};
-      ok = true;
-    }
-    break;
-  }
   case envoy_dynamic_module_type_attribute_id_ConnectionTlsVersion:
     return getSslInfo(
         filter->connection(),

--- a/test/extensions/access_loggers/dynamic_modules/BUILD
+++ b/test/extensions/access_loggers/dynamic_modules/BUILD
@@ -60,6 +60,7 @@ envoy_cc_test(
         "//test/extensions/dynamic_modules:util",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
+        "//test/mocks/router:router_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/stream_info:stream_info_mocks",
         "//test/mocks/upstream:cluster_info_mocks",

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -4,6 +4,7 @@
 
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/router/mocks.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
 #include "test/mocks/upstream/cluster_info.h"
@@ -301,8 +302,9 @@ TEST_F(DynamicModuleAccessLogAbiTest, IsNotHealthCheck) {
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetRouteName) {
-  ON_CALL(stream_info_, getRouteName())
-      .WillByDefault(testing::ReturnRefOfCopy(std::string("test_route")));
+  auto route = std::make_shared<NiceMock<Router::MockRoute>>();
+  route->route_name_ = "test_route";
+  stream_info_.route_ = route;
   Formatter::Context log_context(nullptr, nullptr, nullptr);
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
@@ -312,12 +314,15 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetRouteName) {
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetRouteNameEmpty) {
-  ON_CALL(stream_info_, getRouteName()).WillByDefault(testing::ReturnRefOfCopy(std::string("")));
+  auto route = std::make_shared<NiceMock<Router::MockRoute>>();
+  route->route_name_.clear();
+  stream_info_.route_ = route;
   Formatter::Context log_context(nullptr, nullptr, nullptr);
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   envoy_dynamic_module_type_envoy_buffer result;
-  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_route_name(env_ptr, &result));
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_route_name(env_ptr, &result));
+  EXPECT_EQ(0, result.length);
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterName) {
@@ -2151,8 +2156,9 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringResponseCodeDetails) {
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringRouteName) {
   Formatter::Context log_context(nullptr, nullptr, nullptr);
-  ON_CALL(stream_info_, getRouteName())
-      .WillByDefault(testing::ReturnRefOfCopy(std::string("test_route")));
+  auto route = std::make_shared<NiceMock<Router::MockRoute>>();
+  route->route_name_ = "test_route";
+  stream_info_.route_ = route;
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   envoy_dynamic_module_type_envoy_buffer result{};
@@ -2163,13 +2169,66 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringRouteName) {
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringRouteNameEmpty) {
   Formatter::Context log_context(nullptr, nullptr, nullptr);
-  const std::string empty_route;
-  ON_CALL(stream_info_, getRouteName()).WillByDefault(testing::ReturnRef(empty_route));
+  auto route = std::make_shared<NiceMock<Router::MockRoute>>();
+  route->route_name_.clear();
+  stream_info_.route_ = route;
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_envoy_buffer result{};
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsRouteName, &result));
+  EXPECT_EQ(0, result.length);
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringRouteNameNotSet) {
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  stream_info_.route_.reset();
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   envoy_dynamic_module_type_envoy_buffer result{};
   EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
       env_ptr, envoy_dynamic_module_type_attribute_id_XdsRouteName, &result));
+}
+
+TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeXdsScalars) {
+  auto cluster_info = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+  const std::string cluster_name = "service_cluster";
+  ON_CALL(*cluster_info, name()).WillByDefault(testing::ReturnRef(cluster_name));
+  stream_info_.upstream_cluster_info_ = cluster_info;
+
+  auto listener_info = std::make_shared<NiceMock<Network::MockListenerInfo>>();
+  ON_CALL(*listener_info, direction())
+      .WillByDefault(testing::Return(envoy::config::core::v3::OUTBOUND));
+  stream_info_.downstream_connection_info_provider_->setListenerInfo(listener_info);
+
+  auto filter_chain_info = std::make_shared<NiceMock<Network::MockFilterChainInfo>>();
+  filter_chain_info->filter_chain_name_ = "service_filter_chain";
+  stream_info_.downstream_connection_info_provider_->setFilterChainInfo(filter_chain_info);
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  uint64_t int_result = 0;
+
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsClusterName, &string_result));
+  EXPECT_EQ("service_cluster", absl::string_view(string_result.ptr, string_result.length));
+  stream_info_.upstream_cluster_info_.reset();
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsClusterName, &string_result));
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsFilterChainName, &string_result));
+  EXPECT_EQ("service_filter_chain", absl::string_view(string_result.ptr, string_result.length));
+  stream_info_.downstream_connection_info_provider_->setFilterChainInfo(nullptr);
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsFilterChainName, &string_result));
+  EXPECT_EQ(0, string_result.length);
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsListenerDirection, &int_result));
+  EXPECT_EQ(static_cast<uint64_t>(envoy::config::core::v3::OUTBOUND), int_result);
+  stream_info_.downstream_connection_info_provider_->setListenerInfo(nullptr);
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsListenerDirection, &int_result));
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringRequestId) {

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -129,6 +129,7 @@ envoy_cc_test(
         "//test/mocks/event:event_mocks",
         "//test/mocks/http:http_mocks",
         "//test/mocks/network:network_mocks",
+        "//test/mocks/router:router_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/ssl:ssl_mocks",
         "//test/mocks/tracing:tracing_mocks",

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -18,6 +18,7 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/router/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
@@ -2425,8 +2426,9 @@ TEST(ABIImpl, GetAttributes) {
   StreamInfo::StreamIdProviderImpl id_provider("ffffffff-0012-0110-00ff-0c00400600ff");
   EXPECT_CALL(stream_info, getStreamIdProvider())
       .WillRepeatedly(testing::Return(makeOptRef<const StreamInfo::StreamIdProvider>(id_provider)));
-  const std::string route_name{"test_route"};
-  EXPECT_CALL(stream_info, getRouteName()).WillRepeatedly(testing::ReturnRef(route_name));
+  auto route = std::make_shared<NiceMock<Router::MockRoute>>();
+  route->route_name_ = "test_route";
+  stream_info.route_ = route;
 
   NiceMock<StreamInfo::MockStreamInfo> info;
   EXPECT_CALL(stream_info, downstreamAddressProvider())

--- a/test/extensions/dynamic_modules/listener/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/listener/abi_impl_test.cc
@@ -3111,6 +3111,30 @@ TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeString) {
       filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseFlags, &result));
 }
 
+TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeXdsListenerValues) {
+  auto listener_info = std::make_shared<NiceMock<Network::MockListenerInfo>>();
+  ON_CALL(*listener_info, direction())
+      .WillByDefault(testing::Return(envoy::config::core::v3::INBOUND));
+  callbacks_.stream_info_.downstream_connection_info_provider_->setListenerInfo(listener_info);
+  auto filter_chain_info = std::make_shared<NiceMock<Network::MockFilterChainInfo>>();
+  filter_chain_info->filter_chain_name_ = "listener_filter_chain";
+  callbacks_.stream_info_.downstream_connection_info_provider_->setFilterChainInfo(
+      filter_chain_info);
+
+  uint64_t int_result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_XdsListenerDirection, &int_result));
+  EXPECT_EQ(static_cast<uint64_t>(envoy::config::core::v3::INBOUND), int_result);
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_XdsFilterChainName, &string_result));
+  EXPECT_EQ("listener_filter_chain", absl::string_view(string_result.ptr, string_result.length));
+  callbacks_.stream_info_.downstream_connection_info_provider_->setFilterChainInfo(nullptr);
+  EXPECT_TRUE(envoy_dynamic_module_callback_listener_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_XdsFilterChainName, &string_result));
+  EXPECT_EQ(0, string_result.length);
+}
+
 TEST_F(DynamicModuleListenerFilterAbiCallbackTest, GetAttributeNullCallbacks) {
   auto filter = std::make_shared<DynamicModuleListenerFilter>(filter_config_);
   filter->onAccept(callbacks_);

--- a/test/extensions/dynamic_modules/network/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/network/abi_impl_test.cc
@@ -2803,6 +2803,30 @@ TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeString) {
       filterPtr(), envoy_dynamic_module_type_attribute_id_ResponseFlags, &result));
 }
 
+TEST_F(DynamicModuleNetworkFilterAbiCallbackTest, GetAttributeXdsListenerValues) {
+  auto listener_info = std::make_shared<NiceMock<Network::MockListenerInfo>>();
+  ON_CALL(*listener_info, direction())
+      .WillByDefault(testing::Return(envoy::config::core::v3::INBOUND));
+  connection_.stream_info_.downstream_connection_info_provider_->setListenerInfo(listener_info);
+  auto filter_chain_info = std::make_shared<NiceMock<Network::MockFilterChainInfo>>();
+  filter_chain_info->filter_chain_name_ = "network_filter_chain";
+  connection_.stream_info_.downstream_connection_info_provider_->setFilterChainInfo(
+      filter_chain_info);
+
+  uint64_t int_result = 0;
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_int(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_XdsListenerDirection, &int_result));
+  EXPECT_EQ(static_cast<uint64_t>(envoy::config::core::v3::INBOUND), int_result);
+  envoy_dynamic_module_type_envoy_buffer string_result{};
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_XdsFilterChainName, &string_result));
+  EXPECT_EQ("network_filter_chain", absl::string_view(string_result.ptr, string_result.length));
+  connection_.stream_info_.downstream_connection_info_provider_->setFilterChainInfo(nullptr);
+  EXPECT_TRUE(envoy_dynamic_module_callback_network_filter_get_attribute_string(
+      filterPtr(), envoy_dynamic_module_type_attribute_id_XdsFilterChainName, &string_result));
+  EXPECT_EQ(0, string_result.length);
+}
+
 } // namespace NetworkFilters
 } // namespace DynamicModules
 } // namespace Extensions


### PR DESCRIPTION
## Description

Implements the missing scalar accessors for xDS cluster names, listener directions, and filter chain names.

Route names are read from the selected route, preserving the distinction between no selected route and a selected route with an empty name. The behavior matches Envoy’s CEL attribute implementation.

---

**Commit Message:** dynamic_modules: fix xDS scalar attribute accessors
**Risk Level:** Low
**Testing:** Added and updated access logger, HTTP, listener, and network ABI tests
**Docs Changes:** N/A (existing attribute documentation already defines these values)
**Release Notes:** Added

AI assistance was used; I reviewed and understand the changes.