### PR TITLE
upstream tls: make the ca certs be shared across clusters

### DIFF
--- a/source/common/tls/cert_validator/default_validator.cc
+++ b/source/common/tls/cert_validator/default_validator.cc
@@ -47,6 +47,7 @@ namespace TransportSockets {
 namespace Tls {
 
 SINGLETON_MANAGER_REGISTRATION(crl_cache);
+SINGLETON_MANAGER_REGISTRATION(ca_cert_cache);
 
 absl::StatusOr<CrlListSharedPtr> CrlCache::getOrCreate(const std::string& crl_pem,
                                                        const std::string& crl_path) {
@@ -107,6 +108,75 @@ std::shared_ptr<CrlCache> getCrlCache(Singleton::Manager& singleton_manager) {
                                               [] { return std::make_shared<CrlCache>(); });
 }
 
+absl::StatusOr<CaCertListSharedPtr> CaCertCache::getOrCreate(const std::string& ca_pem,
+                                                             const std::string& ca_path) {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+
+  // Key by a SHA-256 digest of the CA blob rather than the blob itself, to avoid
+  // holding a second full copy of a potentially large trust bundle. SHA-256 is
+  // collision resistant, so distinct bundles never share a cache entry.
+  std::array<uint8_t, SHA256_DIGEST_LENGTH> key;
+  SHA256(reinterpret_cast<const uint8_t*>(ca_pem.data()), ca_pem.size(), key.data());
+
+  if (auto it = cache_.find(key); it != cache_.end()) {
+    if (CaCertListSharedPtr existing = it->second.lock(); existing != nullptr) {
+      return existing;
+    }
+  }
+
+  // Only reached when a new distinct CA blob is seen, which is uncommon. Release
+  // entries whose last referencing context has been torn down so the map does
+  // not grow without bound across xDS updates.
+  absl::erase_if(cache_, [](const auto& entry) { return entry.second.expired(); });
+
+  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(const_cast<char*>(ca_pem.data()), ca_pem.size()));
+  RELEASE_ASSERT(bio != nullptr, "");
+  // Based on BoringSSL's X509_load_cert_crl_file().
+  bssl::UniquePtr<STACK_OF(X509_INFO)> list(
+      PEM_X509_INFO_read_bio(bio.get(), nullptr, nullptr, nullptr));
+  if (list == nullptr) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Failed to load trusted CA certificates from ", ca_path));
+  }
+
+  auto ca_cert_list = std::make_shared<CaCertList>();
+  // Hold the cache alive for as long as this entry is referenced, so callers
+  // only need to keep the returned CaCertList.
+  ca_cert_list->cache = shared_from_this();
+  for (const X509_INFO* item : list.get()) {
+    if (item->x509) {
+      ca_cert_list->certs.push_back(bssl::UpRef(item->x509));
+    }
+    if (item->crl) {
+      ca_cert_list->crls.push_back(bssl::UpRef(item->crl));
+    }
+  }
+  // A blob that parses but carries no certificate is not a usable trust bundle.
+  if (ca_cert_list->certs.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Failed to load trusted CA certificates from ", ca_path));
+  }
+
+  cache_[key] = ca_cert_list;
+  return ca_cert_list;
+}
+
+size_t CaCertCache::size() const {
+  ASSERT_IS_MAIN_OR_TEST_THREAD();
+  size_t count = 0;
+  for (const auto& entry : cache_) {
+    if (!entry.second.expired()) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+std::shared_ptr<CaCertCache> getCaCertCache(Singleton::Manager& singleton_manager) {
+  return singleton_manager.getTyped<CaCertCache>(SINGLETON_MANAGER_REGISTERED_NAME(ca_cert_cache),
+                                                 [] { return std::make_shared<CaCertCache>(); });
+}
+
 DefaultCertValidator::DefaultCertValidator(
     const Envoy::Ssl::CertificateValidationContextConfig* config, SslStats& stats,
     Server::Configuration::CommonFactoryContext& context)
@@ -139,39 +209,33 @@ absl::StatusOr<int> DefaultCertValidator::initializeSslContexts(std::vector<SSL_
 
   if (config_ != nullptr && !config_->caCert().empty() && !provides_certificates) {
     ca_file_path_ = config_->caCertPath();
-    bssl::UniquePtr<BIO> bio(
-        BIO_new_mem_buf(const_cast<char*>(config_->caCert().data()), config_->caCert().size()));
-    RELEASE_ASSERT(bio != nullptr, "");
-    // Based on BoringSSL's X509_load_cert_crl_file().
-    bssl::UniquePtr<STACK_OF(X509_INFO)> list(
-        PEM_X509_INFO_read_bio(bio.get(), nullptr, nullptr, nullptr));
-    if (list == nullptr) {
-      return absl::InvalidArgumentError(
-          absl::StrCat("Failed to load trusted CA certificates from ", config_->caCertPath()));
-    }
+    // Parse the trusted CA blob through a process-wide cache so that identical CA
+    // content referenced from many TLS contexts is materialized in memory only
+    // once. The returned CaCertList keeps the cache alive, so no separate
+    // reference is needed.
+    std::shared_ptr<CaCertCache> ca_cert_cache = getCaCertCache(context_.singletonManager());
+    absl::StatusOr<CaCertListSharedPtr> ca_certs_or_error =
+        ca_cert_cache->getOrCreate(config_->caCert(), config_->caCertPath());
+    RETURN_IF_NOT_OK_REF(ca_certs_or_error.status());
+    shared_ca_certs_ = std::move(*ca_certs_or_error);
+
+    // The cache guarantees at least one certificate. Keep a reference to the
+    // first one for `getCaCertInformation()`.
+    ca_cert_ = bssl::UpRef(shared_ca_certs_->certs[0]);
 
     for (auto& ctx : contexts) {
       X509_STORE* store = SSL_CTX_get_cert_store(ctx);
       X509_STORE_set_flags(store, X509_V_FLAG_PARTIAL_CHAIN);
-      bool has_crl = false;
-      for (const X509_INFO* item : list.get()) {
-        if (item->x509) {
-          X509_STORE_add_cert(store, item->x509);
-          if (ca_cert_ == nullptr) {
-            X509_up_ref(item->x509);
-            ca_cert_.reset(item->x509);
-          }
-        }
-        if (item->crl) {
-          X509_STORE_add_crl(store, item->crl);
-          has_crl = true;
-        }
+      for (const auto& cert : shared_ca_certs_->certs) {
+        // X509_STORE_add_cert takes its own reference, so the shared certificate
+        // stays valid for the store's lifetime even after this cache entry is
+        // released.
+        X509_STORE_add_cert(store, cert.get());
       }
-      if (ca_cert_ == nullptr) {
-        return absl::InvalidArgumentError(
-            absl::StrCat("Failed to load trusted CA certificates from ", config_->caCertPath()));
+      for (const auto& crl : shared_ca_certs_->crls) {
+        X509_STORE_add_crl(store, crl.get());
       }
-      if (has_crl) {
+      if (!shared_ca_certs_->crls.empty()) {
         X509_STORE_set_flags(store, config_->onlyVerifyLeafCertificateCrl()
                                         ? X509_V_FLAG_CRL_CHECK
                                         : X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);

--- a/source/common/tls/cert_validator/default_validator.h
+++ b/source/common/tls/cert_validator/default_validator.h
@@ -90,6 +90,63 @@ private:
 // Returns the process-wide CRL cache, creating it on first use.
 std::shared_ptr<CrlCache> getCrlCache(Singleton::Manager& singleton_manager);
 
+class CaCertCache;
+
+// Holds the certificates - and any CRLs, since a trusted CA PEM blob is allowed
+// to carry both - parsed from a single trusted CA PEM blob. Instances are shared
+// (via shared_ptr) between every TLS context that references identical CA
+// content, so the parsed X509 structures, which for a large trust bundle
+// dominate a context's memory, are materialized in memory only once. A
+// shared_ptr to the owning cache is held so that holding a CaCertListSharedPtr
+// alone is enough to keep both the parsed certificates and the cache alive.
+struct CaCertList {
+  std::vector<bssl::UniquePtr<X509>> certs;
+  std::vector<bssl::UniquePtr<X509_CRL>> crls;
+  std::shared_ptr<CaCertCache> cache;
+};
+using CaCertListSharedPtr = std::shared_ptr<CaCertList>;
+
+// Process-wide cache that parses each distinct trusted CA blob once and shares
+// the parsed representation across all TLS contexts that reference it. Without
+// this, a trust bundle referenced from many `common_tls_context`s is parsed and
+// held in memory once per context. That is the common shape for upstream
+// clusters, which frequently share a single trust root, so the duplication grows
+// linearly with the number of clusters.
+//
+// Threading and lifetime model is identical to CrlCache above:
+//   - All methods must be called on the main (or test) thread. TLS context
+//     creation, the only caller, is confined to that thread.
+//   - Only a weak_ptr is stored, so an entry is released as soon as the last
+//     CaCertList referencing it is destroyed (for example after an xDS update).
+//     Each returned CaCertList holds a shared_ptr back to this cache, so the
+//     cache outlives every entry handed out from it.
+//   - The parsed X509s are reference counted by BoringSSL; each X509_STORE a
+//     certificate is added to holds its own reference, so it remains valid for
+//     that store's lifetime independent of this cache. Only the immutable parsed
+//     material is shared - each context keeps its own X509_STORE and therefore
+//     its own store flags.
+class CaCertCache : public Singleton::Instance, public std::enable_shared_from_this<CaCertCache> {
+public:
+  // Returns the shared parsed representation of `ca_pem`, parsing and caching it
+  // on first use. `ca_path` is only used to build the error message. Returns an
+  // error if `ca_pem` cannot be parsed or contains no certificate.
+  absl::StatusOr<CaCertListSharedPtr> getOrCreate(const std::string& ca_pem,
+                                                  const std::string& ca_path);
+
+  // Number of distinct CA blobs currently referenced by at least one context.
+  // Exposed for testing.
+  size_t size() const;
+
+private:
+  // Keyed by a SHA-256 digest of the CA PEM (rather than the PEM itself, to
+  // avoid holding a second full copy of potentially large trust bundles); stores
+  // a weak_ptr so entries do not outlive the contexts that use them.
+  absl::flat_hash_map<std::array<uint8_t, SHA256_DIGEST_LENGTH>, std::weak_ptr<CaCertList>> cache_;
+};
+
+// Returns the process-wide trusted CA cache, creating it on first use.
+std::shared_ptr<CaCertCache> getCaCertCache(Singleton::Manager& singleton_manager);
+
 class DefaultCertValidator : public CertValidator, Logger::Loggable<Logger::Id::connection> {
 public:
   DefaultCertValidator(const Envoy::Ssl::CertificateValidationContextConfig* config,
@@ -182,6 +239,10 @@ private:
   // The parsed CRLs shared with other TLS contexts that reference the same CRL.
   // This also keeps the CRL cache alive for as long as the validator uses it.
   CrlListSharedPtr shared_crl_;
+  // The parsed trusted CA certificates shared with other TLS contexts that
+  // reference the same CA blob. This also keeps the CA cache alive for as long
+  // as the validator uses it.
+  CaCertListSharedPtr shared_ca_certs_;
   bool allow_untrusted_certificate_{false};
   bool verify_trusted_ca_{false};
   const bool auto_sni_san_match_{false};

--- a/test/common/tls/cert_validator/default_validator_test.cc
+++ b/test/common/tls/cert_validator/default_validator_test.cc
@@ -1163,6 +1163,168 @@ TEST(DefaultCertValidatorTest, SharesCrlAcrossContexts) {
   EXPECT_EQ(getCrlCache(context.singletonManager())->size(), 2);
 }
 
+// The trusted CA cache returns one shared parsed representation for identical
+// content, so a trust bundle referenced from many contexts is materialized in
+// memory only once.
+TEST(CaCertCacheTest, SharesIdenticalCaContent) {
+  auto cache = std::make_shared<CaCertCache>();
+  const std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  absl::StatusOr<CaCertListSharedPtr> first = cache->getOrCreate(ca_cert, "ca_cert.pem");
+  ASSERT_OK(first);
+  absl::StatusOr<CaCertListSharedPtr> second = cache->getOrCreate(ca_cert, "ca_cert.pem");
+  ASSERT_OK(second);
+
+  // Both lookups return the same CaCertList and the same parsed X509.
+  EXPECT_EQ(first->get(), second->get());
+  ASSERT_FALSE((*first)->certs.empty());
+  EXPECT_EQ((*first)->certs[0].get(), (*second)->certs[0].get());
+  EXPECT_EQ(cache->size(), 1);
+}
+
+// Distinct CA content is cached separately.
+TEST(CaCertCacheTest, SeparatesDistinctCaContent) {
+  auto cache = std::make_shared<CaCertCache>();
+  const std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+  const std::string fake_ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/fake_ca_cert.pem"));
+
+  absl::StatusOr<CaCertListSharedPtr> first = cache->getOrCreate(ca_cert, "ca_cert.pem");
+  ASSERT_OK(first);
+  absl::StatusOr<CaCertListSharedPtr> second = cache->getOrCreate(fake_ca_cert, "fake_ca_cert.pem");
+  ASSERT_OK(second);
+
+  EXPECT_NE(first->get(), second->get());
+  EXPECT_EQ(cache->size(), 2);
+}
+
+// A trust bundle carrying several certificates is parsed into one entry holding
+// all of them.
+TEST(CaCertCacheTest, KeepsEveryCertificateInABundle) {
+  auto cache = std::make_shared<CaCertCache>();
+  const std::string bundle = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+      "{{ test_rundir }}/test/common/tls/test_data/ca_certificates.pem"));
+
+  absl::StatusOr<CaCertListSharedPtr> entry = cache->getOrCreate(bundle, "ca_certificates.pem");
+  ASSERT_OK(entry);
+  EXPECT_GT((*entry)->certs.size(), 1);
+}
+
+// A CA blob is allowed to carry CRLs alongside the certificates; both are kept
+// on the shared entry.
+TEST(CaCertCacheTest, KeepsCrlsCarriedInTheCaBlob) {
+  auto cache = std::make_shared<CaCertCache>();
+  const std::string ca_cert_with_crl =
+      TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
+          "{{ test_rundir }}/test/common/tls/test_data/ca_cert_with_crl.pem"));
+
+  absl::StatusOr<CaCertListSharedPtr> entry =
+      cache->getOrCreate(ca_cert_with_crl, "ca_cert_with_crl.pem");
+  ASSERT_OK(entry);
+  EXPECT_FALSE((*entry)->certs.empty());
+  EXPECT_FALSE((*entry)->crls.empty());
+}
+
+// An entry is released once the last reference to it is dropped, so the cache
+// does not grow without bound as certificates are rotated via xDS.
+TEST(CaCertCacheTest, ReleasesUnreferencedEntries) {
+  auto cache = std::make_shared<CaCertCache>();
+  const std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  {
+    absl::StatusOr<CaCertListSharedPtr> entry = cache->getOrCreate(ca_cert, "ca_cert.pem");
+    ASSERT_OK(entry);
+    EXPECT_EQ(cache->size(), 1);
+  }
+  // The only reference is gone, so the entry is released.
+  EXPECT_EQ(cache->size(), 0);
+
+  // Re-adding the same content succeeds and repopulates the cache.
+  absl::StatusOr<CaCertListSharedPtr> reloaded = cache->getOrCreate(ca_cert, "ca_cert.pem");
+  ASSERT_OK(reloaded);
+  EXPECT_EQ(cache->size(), 1);
+}
+
+// Content that carries no usable certificate returns an error and is not cached.
+TEST(CaCertCacheTest, ReturnsErrorForInvalidCaCert) {
+  auto cache = std::make_shared<CaCertCache>();
+  // Valid PEM envelope but garbage base64 inside, so nothing parses out of it.
+  const std::string invalid = "-----BEGIN CERTIFICATE-----\n"
+                              "not valid base64 content!!!\n"
+                              "-----END CERTIFICATE-----\n";
+
+  absl::StatusOr<CaCertListSharedPtr> result = cache->getOrCreate(invalid, "invalid_ca_cert.pem");
+  EXPECT_THAT(result, HasStatusMessage(testing::HasSubstr(
+                          "Failed to load trusted CA certificates from invalid_ca_cert.pem")));
+  EXPECT_EQ(cache->size(), 0);
+}
+
+// A returned CaCertList keeps the cache alive, so a caller only needs to hold
+// the CaCertList (this is what lets the validator store a single shared_ptr).
+TEST(CaCertCacheTest, CaCertListKeepsCacheAlive) {
+  std::weak_ptr<CaCertCache> weak_cache;
+  CaCertListSharedPtr ca_cert_list;
+  {
+    auto cache = std::make_shared<CaCertCache>();
+    weak_cache = cache;
+    const std::string ca_cert = TestEnvironment::readFileToStringForTest(
+        TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+    absl::StatusOr<CaCertListSharedPtr> result = cache->getOrCreate(ca_cert, "ca_cert.pem");
+    ASSERT_OK(result);
+    ca_cert_list = std::move(*result);
+  }
+  // The local cache reference is gone, but the CaCertList still holds it alive.
+  EXPECT_FALSE(weak_cache.expired());
+  EXPECT_EQ(ca_cert_list->cache.get(), weak_cache.lock().get());
+
+  // Dropping the CaCertList releases the cache.
+  ca_cert_list.reset();
+  EXPECT_TRUE(weak_cache.expired());
+}
+
+// Two validators created from the same factory context share a single parsed
+// trust bundle, which is the behavior that prevents a separate copy of the CA
+// certificates per TLS context.
+TEST(DefaultCertValidatorTest, SharesCaCertsAcrossContexts) {
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::TestUtil::TestStore store;
+  SslStats stats = generateSslStats(*store.rootScope());
+
+  const std::string ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/ca_cert.pem"));
+
+  auto config1 = makeSuppressConfig(ca_cert, false);
+  auto config2 = makeSuppressConfig(ca_cert, false);
+  DefaultCertValidator validator1(config1.get(), stats, context);
+  DefaultCertValidator validator2(config2.get(), stats, context);
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx1(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL_CTX> ssl_ctx2(SSL_CTX_new(TLS_method()));
+  std::vector<SSL_CTX*> contexts1 = {ssl_ctx1.get()};
+  std::vector<SSL_CTX*> contexts2 = {ssl_ctx2.get()};
+  ASSERT_OK(validator1.initializeSslContexts(contexts1, false, *store.rootScope()));
+  ASSERT_OK(validator2.initializeSslContexts(contexts2, false, *store.rootScope()));
+
+  // Both validators reference the same parsed CA certificates, cached exactly
+  // once, and each still reports the CA it was configured with.
+  EXPECT_EQ(getCaCertCache(context.singletonManager())->size(), 1);
+  EXPECT_NE(validator1.getCaCertInformation(), nullptr);
+  EXPECT_NE(validator2.getCaCertInformation(), nullptr);
+
+  // A validator using different CA content adds a second cache entry.
+  const std::string other_ca_cert = TestEnvironment::readFileToStringForTest(
+      TestEnvironment::substitute("{{ test_rundir }}/test/common/tls/test_data/fake_ca_cert.pem"));
+  auto config3 = makeSuppressConfig(other_ca_cert, false);
+  DefaultCertValidator validator3(config3.get(), stats, context);
+  bssl::UniquePtr<SSL_CTX> ssl_ctx3(SSL_CTX_new(TLS_method()));
+  std::vector<SSL_CTX*> contexts3 = {ssl_ctx3.get()};
+  ASSERT_OK(validator3.initializeSslContexts(contexts3, false, *store.rootScope()));
+  EXPECT_EQ(getCaCertCache(context.singletonManager())->size(), 2);
+}
+
 } // namespace Tls
 } // namespace TransportSockets
 } // namespace Extensions


### PR DESCRIPTION
Commit Message: upstream tls: make the ca certs be shared across clusters
Additional Description:

See https://github.com/envoyproxy/gateway/issues/9489 for why this makes sense.

Actually there are more context that could be shared. But the CA is the most safe/simple one to share. So, it should be a good start to reduce unnecessary memory footprint.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: n/a.
Platform Specific Features: n/a.