### PR TITLE
quic: add server initialized stream support to webtransport

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -57,7 +57,7 @@ message QuicKeepAliveSettings {
 }
 
 // QUIC protocol options which apply to both downstream and upstream connections.
-// [#next-free-field: 14]
+// [#next-free-field: 15]
 message QuicProtocolOptions {
   // Config for QUIC connection migration across network interfaces, i.e. cellular to WIFI, upon
   // network change events from the platform, i.e. the current network gets
@@ -184,6 +184,20 @@ message QuicProtocolOptions {
   // Communication with Network Elements) and process SCONE packets.
   // If not present, the QUICHE default behavior will be used.
   google.protobuf.BoolValue enable_scone = 13;
+
+  // If true, an upstream HTTP/3 connection will accept streams initiated by the server which
+  // belong to a negotiated WebTransport session, instead of rejecting them as a protocol violation.
+  //
+  // Only bidirectional streams are accepted for now. Server-initiated bidirectional streams which
+  // are not WebTransport data streams are still rejected by the HTTP/3 layer.
+  //
+  // This option is only honored on upstream (cluster) connections and is ignored when set on a
+  // listener. It additionally requires the ``envoy.reloadable_features.quic_support_web_transport``
+  // runtime feature to be enabled.
+  //
+  // Defaults to false.
+  bool accept_server_initiated_streams = 14
+      [(xds.annotations.v3.field_status).work_in_progress = true];
 }
 
 message UpstreamHttpProtocolOptions {

--- a/changelogs/current/new_features/quic__accept-server-initiated-streams.rst
+++ b/changelogs/current/new_features/quic__accept-server-initiated-streams.rst
@@ -1,0 +1,8 @@
+Added :ref:`accept_server_initiated_streams
+<envoy_v3_api_field_config.core.v3.QuicProtocolOptions.accept_server_initiated_streams>`,
+which lets an upstream HTTP/3 connection accept streams initiated by the server which belong to a
+negotiated WebTransport session instead of rejecting them as a protocol violation. Only
+bidirectional streams are accepted for now, and a server-initiated bidirectional stream which is
+not a WebTransport data stream still closes the connection as a protocol violation. Defaults to
+false, is ignored on listeners, and additionally requires the
+``envoy.reloadable_features.quic_support_web_transport`` runtime feature.

--- a/source/common/quic/BUILD
+++ b/source/common/quic/BUILD
@@ -338,6 +338,7 @@ envoy_cc_library(
         "//source/common/http:session_idle_list_lib",
         "//source/common/runtime:runtime_features_lib",
         "@quiche//:quic_server_http_spdy_session_lib",
+        "@quiche//:quic_core_http_server_initiated_spdy_stream_lib",
     ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
     ]),
@@ -376,6 +377,7 @@ envoy_cc_library(
         "//source/common/http:header_utility_lib",
         "@quiche//:quic_core_http_client_lib",
         "@quiche//:quic_core_error_codes_lib",
+        "@quiche//:quic_core_utils_lib",
     ]) + envoy_select_enable_http_datagrams([
         ":http_datagram_handler",
         ":web_transport_session_bridge_lib",

--- a/source/common/quic/client_codec_impl.cc
+++ b/source/common/quic/client_codec_impl.cc
@@ -43,16 +43,28 @@ QuicHttpClientConnectionImpl::newStream(Http::ResponseDecoder& response_decoder)
 
 void QuicHttpClientConnectionImpl::onUnderlyingConnectionAboveWriteBufferHighWatermark() {
   quic_client_session_.PerformActionOnActiveStreams([](quic::QuicStream* quic_stream) {
+    // Not every active stream is an Envoy codec stream: a WebTransport session activates
+    // QUICHE-owned data streams which have no watermark callbacks.
+    auto* stream = quicStreamToEnvoyClientStream(quic_stream);
+    if (stream == nullptr) {
+      return true;
+    }
     ENVOY_LOG(debug, "runHighWatermarkCallbacks on stream {}", quic_stream->id());
-    quicStreamToEnvoyClientStream(quic_stream)->runHighWatermarkCallbacks();
+    stream->runHighWatermarkCallbacks();
     return true;
   });
 }
 
 void QuicHttpClientConnectionImpl::onUnderlyingConnectionBelowWriteBufferLowWatermark() {
   quic_client_session_.PerformActionOnActiveStreams([](quic::QuicStream* quic_stream) {
+    // Not every active stream is an Envoy codec stream: a WebTransport session activates
+    // QUICHE-owned data streams which have no watermark callbacks.
+    auto* stream = quicStreamToEnvoyClientStream(quic_stream);
+    if (stream == nullptr) {
+      return true;
+    }
     ENVOY_LOG(debug, "runLowWatermarkCallbacks on stream {}", quic_stream->id());
-    quicStreamToEnvoyClientStream(quic_stream)->runLowWatermarkCallbacks();
+    stream->runLowWatermarkCallbacks();
     return true;
   });
 }

--- a/source/common/quic/envoy_quic_client_session.cc
+++ b/source/common/quic/envoy_quic_client_session.cc
@@ -15,6 +15,7 @@
 #include "source/common/runtime/runtime_features.h"
 
 #include "quiche/quic/core/quic_bandwidth.h"
+#include "quiche/quic/core/quic_utils.h"
 
 namespace Envoy {
 namespace Quic {
@@ -222,7 +223,21 @@ std::unique_ptr<quic::QuicSpdyClientStream> EnvoyQuicClientSession::CreateClient
                                                  http3_options_.value());
 }
 
-quic::QuicSpdyStream* EnvoyQuicClientSession::CreateIncomingStream(quic::QuicStreamId /*id*/) {
+quic::QuicSpdyStream* EnvoyQuicClientSession::CreateIncomingStream(quic::QuicStreamId id) {
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  // A server may open a bidirectional stream only as part of a WebTransport session. Delegate to
+  // QUICHE, which creates a QuicServerInitiatedSpdyStream: a carrier for a WEBTRANSPORT_STREAM
+  // frame which fails on any HTTP semantics, so a server-initiated stream that is not a
+  // WebTransport data stream is still rejected. ShouldCreateIncomingStream() of QUICHE closes the
+  // connection with QUIC_HTTP_SERVER_INITIATED_BIDIRECTIONAL_STREAM when WebTransport was not
+  // negotiated; that check keys off LocallySupportedWebTransportVersions(), which is already empty
+  // unless the WebTransport runtime feature is enabled.
+  if (accept_server_initiated_streams_ && quic::QuicUtils::IsBidirectionalStreamId(id, version())) {
+    return quic::QuicSpdyClientSession::CreateIncomingStream(id);
+  }
+#else
+  UNREFERENCED_PARAMETER(id);
+#endif
   // Envoy doesn't support server initiated stream.
   return nullptr;
 }
@@ -305,6 +320,12 @@ void EnvoyQuicClientSession::setHttp3Options(
   if (!http3_options_->has_quic_protocol_options()) {
     return;
   }
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  // Latched here rather than read on demand: setHttp3Options() runs before Initialize(), so the
+  // value is in place before any stream can arrive.
+  accept_server_initiated_streams_ =
+      http3_options_->quic_protocol_options().accept_server_initiated_streams();
+#endif
   static_cast<EnvoyQuicClientConnection*>(connection())
       ->setNumPtosForPortMigration(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           http3_options.quic_protocol_options(), num_timeouts_to_trigger_port_migration, 0));

--- a/source/common/quic/envoy_quic_client_session.h
+++ b/source/common/quic/envoy_quic_client_session.h
@@ -170,6 +170,11 @@ private:
   // IDs of client streams that buffered a WebTransport CONNECT request awaiting the peer's HTTP/3
   // SETTINGS. Flushed and cleared in OnSettingsFrame(). See registerStreamWaitingForSettings().
   absl::flat_hash_set<quic::QuicStreamId> streams_waiting_for_settings_;
+
+  // Whether to accept streams initiated by the server which belong to a WebTransport session, from
+  // QuicProtocolOptions.accept_server_initiated_streams. Only bidirectional streams are accepted
+  // for now. Set in setHttp3Options(), which runs before Initialize(). See CreateIncomingStream().
+  bool accept_server_initiated_streams_{false};
 #endif
 
   // These callbacks are owned by network filters and quic session should outlive

--- a/source/common/quic/envoy_quic_server_session.cc
+++ b/source/common/quic/envoy_quic_server_session.cc
@@ -19,6 +19,7 @@
 #include "source/common/quic/quic_server_transport_socket_factory.h"
 #include "source/common/runtime/runtime_features.h"
 
+#include "quiche/quic/core/http/quic_server_initiated_spdy_stream.h"
 #include "quiche/quic/core/quic_config.h"
 #include "quiche/quic/core/quic_error_codes.h"
 #include "quiche/quic/core/quic_stream.h"
@@ -146,6 +147,22 @@ quic::QuicSpdyStream* EnvoyQuicServerSession::CreateIncomingStream(quic::QuicStr
 }
 
 quic::QuicSpdyStream* EnvoyQuicServerSession::CreateOutgoingBidirectionalStream() {
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  // This virtual is protected, and on a server session QUICHE only calls it from
+  // CreateOutgoingBidirectionalWebTransportStream().
+  if (SupportsWebTransport()) {
+    // The caller does not consult ShouldCreateOutgoingBidirectionalStream(), so check it here to
+    // honor stream credit. Returning nullptr makes the bridge reset the paired upstream stream.
+    if (!ShouldCreateOutgoingBidirectionalStream()) {
+      ENVOY_LOG(debug, "Cannot create an outgoing WebTransport bidirectional stream.");
+      return nullptr;
+    }
+    auto* stream = new quic::QuicServerInitiatedSpdyStream(GetNextOutgoingBidirectionalStreamId(),
+                                                           this, quic::BIDIRECTIONAL);
+    ActivateStream(absl::WrapUnique(stream));
+    return stream;
+  }
+#endif
   IS_ENVOY_BUG("Unexpected disallowed server initiated stream");
   return nullptr;
 }

--- a/source/common/quic/server_codec_impl.cc
+++ b/source/common/quic/server_codec_impl.cc
@@ -38,16 +38,28 @@ QuicHttpServerConnectionImpl::QuicHttpServerConnectionImpl(
 
 void QuicHttpServerConnectionImpl::onUnderlyingConnectionAboveWriteBufferHighWatermark() {
   quic_server_session_.PerformActionOnActiveStreams([](quic::QuicStream* quic_stream) {
+    // Not every active stream is an Envoy codec stream: a WebTransport session activates
+    // QUICHE-owned data streams which have no watermark callbacks.
+    auto* stream = quicStreamToEnvoyStream(quic_stream);
+    if (stream == nullptr) {
+      return true;
+    }
     ENVOY_LOG(debug, "runHighWatermarkCallbacks on stream {}", quic_stream->id());
-    quicStreamToEnvoyStream(quic_stream)->runHighWatermarkCallbacks();
+    stream->runHighWatermarkCallbacks();
     return true;
   });
 }
 
 void QuicHttpServerConnectionImpl::onUnderlyingConnectionBelowWriteBufferLowWatermark() {
   quic_server_session_.PerformActionOnActiveStreams([](quic::QuicStream* quic_stream) {
+    // Not every active stream is an Envoy codec stream: a WebTransport session activates
+    // QUICHE-owned data streams which have no watermark callbacks.
+    auto* stream = quicStreamToEnvoyStream(quic_stream);
+    if (stream == nullptr) {
+      return true;
+    }
     ENVOY_LOG(debug, "runLowWatermarkCallbacks on stream {}", quic_stream->id());
-    quicStreamToEnvoyStream(quic_stream)->runLowWatermarkCallbacks();
+    stream->runLowWatermarkCallbacks();
     return true;
   });
 }

--- a/test/common/quic/BUILD
+++ b/test/common/quic/BUILD
@@ -232,6 +232,7 @@ envoy_cc_test(
         "@quiche//:quic_test_tools_config_peer_lib",
         "@quiche//:quic_test_tools_stream_peer_lib",
         "@quiche//:quic_test_tools_server_session_base_peer",
+        "@quiche//:quic_test_tools_session_peer_lib",
         "@quiche//:quic_test_tools_test_utils_lib",
     ]),
 )

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -209,6 +209,20 @@ public:
     return stream;
   }
 
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  // Drives real WebTransport negotiation by delivering the peer SETTINGS a WebTransport-capable
+  // server sends. SupportsWebTransport() also needs H3 datagram support (the client session always
+  // offers it) and, on a client, extended CONNECT, which the peer's SETTINGS turn on. The
+  // WebTransport runtime feature must already be enabled, or the WebTransport setting is ignored.
+  void negotiateWebTransport() {
+    quic::SettingsFrame settings;
+    settings.values[quic::SETTINGS_H3_DATAGRAM] = 1;
+    settings.values[quic::SETTINGS_WEBTRANS_DRAFT00] = 1;
+    settings.values[quic::SETTINGS_ENABLE_CONNECT_PROTOCOL] = 1;
+    EXPECT_TRUE(envoy_quic_session_->OnSettingsFrame(settings));
+  }
+#endif
+
 protected:
   Event::SimulatedTimeSystemHelper time_system_;
   Api::ApiPtr api_;
@@ -262,6 +276,108 @@ TEST_P(EnvoyQuicClientSessionTest, WebTransportNegotiationGatedByRuntimeFlag) {
   TestScopedRuntime scoped_runtime;
   scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
   EXPECT_TRUE(envoy_quic_session_->WillNegotiateWebTransport());
+}
+
+// IETF stream 1 is a server initiated bidirectional stream. Without
+// accept_server_initiated_streams it is dropped, as it always has been.
+TEST_P(EnvoyQuicClientSessionTest, ServerInitiatedBidirectionalStreamRejectedByDefault) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
+
+  EXPECT_FALSE(http3_options_.quic_protocol_options().accept_server_initiated_streams());
+  constexpr quic::QuicStreamId stream_id = 1u;
+  // GetOrCreateStream() is the lookup-or-create path QuicSession itself takes when a frame arrives
+  // for a stream id it does not have yet (OnStreamFrame(), OnRstStream(), ...), so for a
+  // peer-initiated id it ends up in EnvoyQuicClientSession::CreateIncomingStream(). Calling it
+  // directly stands in for "a frame for stream 1 arrived" without building a packet; the tests
+  // below use the same idiom.
+  EXPECT_EQ(nullptr, envoy_quic_session_->GetOrCreateStream(stream_id));
+  EXPECT_FALSE(quic::test::QuicSessionPeer::IsStreamCreated(envoy_quic_session_.get(), stream_id));
+}
+
+// With the option enabled and WebTransport negotiated, the stream is created. It is a QUICHE
+// QuicServerInitiatedSpdyStream carrying WebTransport data, not an Envoy codec stream.
+TEST_P(EnvoyQuicClientSessionTest, ServerInitiatedBidirectionalStreamAcceptedWhenConfigured) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
+  http3_options_.mutable_quic_protocol_options()->set_accept_server_initiated_streams(true);
+  envoy_quic_session_->setHttp3Options(http3_options_);
+
+  constexpr quic::QuicStreamId stream_id = 1u;
+  quic::QuicStream* stream = envoy_quic_session_->GetOrCreateStream(stream_id);
+  ASSERT_NE(nullptr, stream);
+  EXPECT_TRUE(quic::test::QuicSessionPeer::IsStreamCreated(envoy_quic_session_.get(), stream_id));
+  // Not an HTTP request stream: it must never reach the codec.
+  EXPECT_EQ(nullptr, dynamic_cast<EnvoyQuicClientStream*>(stream));
+
+  // Watermark callbacks iterate every active non-static stream, including this one.
+  http_connection_->onUnderlyingConnectionAboveWriteBufferHighWatermark();
+  http_connection_->onUnderlyingConnectionBelowWriteBufferLowWatermark();
+}
+
+// The option does not weaken HTTP/3: without WebTransport negotiated, a server initiated
+// bidirectional stream is a protocol violation and QUICHE closes the connection.
+TEST_P(EnvoyQuicClientSessionTest, ServerInitiatedBidirectionalStreamWithoutWebTransport) {
+  http3_options_.mutable_quic_protocol_options()->set_accept_server_initiated_streams(true);
+  envoy_quic_session_->setHttp3Options(http3_options_);
+  // The WebTransport runtime feature is off, so no WebTransport version is advertised.
+  ASSERT_FALSE(envoy_quic_session_->WillNegotiateWebTransport());
+
+  EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  EXPECT_CALL(*quic_connection_,
+              SendConnectionClosePacket(quic::QUIC_HTTP_SERVER_INITIATED_BIDIRECTIONAL_STREAM, _,
+                                        "Server created bidirectional stream."));
+  EXPECT_EQ(nullptr, envoy_quic_session_->GetOrCreateStream(1u));
+}
+
+// A server-initiated bidirectional stream is only a carrier for a WEBTRANSPORT_STREAM frame. In
+// the exact state where a WebTransport data stream would be accepted -- option on, WebTransport
+// negotiated -- an HTTP/3 HEADERS frame on that stream is still a protocol violation and QUICHE
+// closes the connection. This is what keeps the option from weakening HTTP/3.
+TEST_P(EnvoyQuicClientSessionTest, ServerInitiatedBidirectionalStreamRejectsHttpHeaders) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
+  http3_options_.mutable_quic_protocol_options()->set_accept_server_initiated_streams(true);
+  envoy_quic_session_->setHttp3Options(http3_options_);
+  negotiateWebTransport();
+  ASSERT_TRUE(envoy_quic_session_->SupportsWebTransport());
+
+  constexpr quic::QuicStreamId stream_id = 1u;
+  ASSERT_NE(nullptr, envoy_quic_session_->GetOrCreateStream(stream_id));
+
+  EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  EXPECT_CALL(*quic_connection_, SendConnectionClosePacket(
+                                     quic::IETF_QUIC_PROTOCOL_VIOLATION, _,
+                                     testing::HasSubstr("server-initiated bidirectional stream")));
+
+  quiche::HttpHeaderBlock response_headers;
+  response_headers[":status"] = "200";
+  envoy_quic_session_->OnStreamFrame(quic::QuicStreamFrame(
+      stream_id, /*fin=*/false, /*offset=*/0, spdyHeaderToHttp3StreamPayload(response_headers)));
+  EXPECT_FALSE(quic_connection_->connected());
+}
+
+// Same, for a stream whose first frame is DATA rather than WEBTRANSPORT_STREAM: rejected before
+// any body is surfaced, because the stream has no headers.
+TEST_P(EnvoyQuicClientSessionTest, ServerInitiatedBidirectionalStreamRejectsHttpBody) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
+  http3_options_.mutable_quic_protocol_options()->set_accept_server_initiated_streams(true);
+  envoy_quic_session_->setHttp3Options(http3_options_);
+  negotiateWebTransport();
+  ASSERT_TRUE(envoy_quic_session_->SupportsWebTransport());
+
+  constexpr quic::QuicStreamId stream_id = 1u;
+  ASSERT_NE(nullptr, envoy_quic_session_->GetOrCreateStream(stream_id));
+
+  EXPECT_CALL(network_connection_callbacks_, onEvent(Network::ConnectionEvent::LocalClose));
+  EXPECT_CALL(*quic_connection_,
+              SendConnectionClosePacket(quic::QUIC_HTTP_INVALID_FRAME_SEQUENCE_ON_SPDY_STREAM, _,
+                                        "Unexpected DATA frame received."));
+
+  envoy_quic_session_->OnStreamFrame(quic::QuicStreamFrame(
+      stream_id, /*fin=*/false, /*offset=*/0, bodyToHttp3StreamPayload("not webtransport")));
+  EXPECT_FALSE(quic_connection_->connected());
 }
 #endif
 

--- a/test/common/quic/envoy_quic_server_session_test.cc
+++ b/test/common/quic/envoy_quic_server_session_test.cc
@@ -42,6 +42,7 @@
 #include "quiche/quic/test_tools/crypto_test_utils.h"
 #include "quiche/quic/test_tools/quic_connection_peer.h"
 #include "quiche/quic/test_tools/quic_server_session_base_peer.h"
+#include "quiche/quic/test_tools/quic_session_peer.h"
 #include "quiche/quic/test_tools/quic_stream_peer.h"
 #include "quiche/quic/test_tools/quic_test_utils.h"
 
@@ -66,6 +67,7 @@ public:
     return false;
   }
 
+  using EnvoyQuicServerSession::CreateOutgoingBidirectionalStream;
   using EnvoyQuicServerSession::GetCryptoStream;
   using EnvoyQuicServerSession::GetSSLConfig;
 };
@@ -212,6 +214,19 @@ public:
         std::make_unique<quic::test::TaggingEncrypter>(quic::ENCRYPTION_FORWARD_SECURE));
     quic_connection_->SetDefaultEncryptionLevel(quic::ENCRYPTION_FORWARD_SECURE);
   }
+
+#ifdef ENVOY_ENABLE_HTTP_DATAGRAMS
+  // Drives real WebTransport negotiation by delivering the peer SETTINGS a WebTransport-capable
+  // client sends. SupportsWebTransport() additionally needs H3 datagram support and extended
+  // CONNECT, so the caller must have enabled both before calling this.
+  void negotiateWebTransport() {
+    quic::SettingsFrame settings;
+    settings.values[quic::SETTINGS_H3_DATAGRAM] = 1;
+    settings.values[quic::SETTINGS_WEBTRANS_DRAFT00] = 1;
+    settings.values[quic::SETTINGS_ENABLE_CONNECT_PROTOCOL] = 1;
+    EXPECT_TRUE(envoy_quic_session_.OnSettingsFrame(settings));
+  }
+#endif
 
   bool installReadFilter() {
     // Setup read filter.
@@ -1354,6 +1369,54 @@ TEST_F(EnvoyQuicServerSessionTest, WebTransportNegotiationGatedByRuntimeFlag) {
   EXPECT_FALSE(envoy_quic_session_.WillNegotiateWebTransport());
 
   installReadFilter();
+}
+
+// Server initiated bidirectional streams stay disallowed on a plain HTTP/3 session.
+TEST_F(EnvoyQuicServerSessionTest, OutgoingBidirectionalStreamRejectedWithoutWebTransport) {
+  installReadFilter();
+  ASSERT_FALSE(envoy_quic_session_.SupportsWebTransport());
+  EXPECT_ENVOY_BUG(EXPECT_EQ(nullptr, envoy_quic_session_.CreateOutgoingBidirectionalStream()),
+                   "Unexpected disallowed server initiated stream");
+}
+
+// On a WebTransport session the stream is created so the bridge can mirror a backend initiated
+// stream to the downstream client. It is a QUICHE WebTransport data stream, never an HTTP request.
+TEST_F(EnvoyQuicServerSessionTest, OutgoingBidirectionalStreamCreatedForWebTransport) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
+  // Set on the fixture's options: installReadFilter() builds the codec, which re-applies them and
+  // would otherwise clear allow_extended_connect.
+  http3_options_.set_allow_extended_connect(true);
+  installReadFilter();
+  negotiateWebTransport();
+  ASSERT_TRUE(envoy_quic_session_.SupportsWebTransport());
+
+  quic::QuicSpdyStream* stream = envoy_quic_session_.CreateOutgoingBidirectionalStream();
+  ASSERT_NE(nullptr, stream);
+  EXPECT_TRUE(quic::test::QuicSessionPeer::IsStreamCreated(&envoy_quic_session_, stream->id()));
+  EXPECT_EQ(nullptr, dynamic_cast<EnvoyQuicServerStream*>(stream));
+}
+
+// Running out of stream credit is a normal condition, not a bug: return nullptr rather than
+// tripping the ENVOY_BUG, so the bridge can reset the paired upstream stream. (In debug builds an
+// ENVOY_BUG aborts, so reaching the end of this test is itself the assertion that none fired.)
+TEST_F(EnvoyQuicServerSessionTest, OutgoingBidirectionalStreamRespectsStreamCredit) {
+  TestScopedRuntime scoped_runtime;
+  scoped_runtime.mergeValues({{"envoy.reloadable_features.quic_support_web_transport", "true"}});
+  http3_options_.set_allow_extended_connect(true);
+  installReadFilter();
+  negotiateWebTransport();
+  ASSERT_TRUE(envoy_quic_session_.SupportsWebTransport());
+
+  // Exhaust the peer-granted outgoing bidirectional stream credit. QuicSessionPeer only ever raises
+  // the limit, so it cannot be forced to zero; open streams until the session refuses.
+  int created = 0;
+  while (envoy_quic_session_.CreateOutgoingBidirectionalStream() != nullptr) {
+    ASSERT_LT(++created, 1000) << "stream credit never ran out";
+  }
+  EXPECT_GT(created, 0);
+  // Still nullptr once exhausted, and still no ENVOY_BUG.
+  EXPECT_EQ(nullptr, envoy_quic_session_.CreateOutgoingBidirectionalStream());
 }
 #endif
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -284,6 +284,10 @@ IntegrationCodecClientPtr HttpIntegrationTest::makeRawHttpConnection(
       http2_options.value(), quic::kStreamReceiveWindowLimit);
   cluster->http3_options_.set_allow_extended_connect(true);
   cluster->http3_options_.set_allow_metadata(true);
+  if (client_accepts_server_initiated_streams_) {
+    cluster->http3_options_.mutable_quic_protocol_options()->set_accept_server_initiated_streams(
+        true);
+  }
 #endif
 
   cluster->http2_options_ = http2_options.value();

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -386,6 +386,10 @@ protected:
   // Set this to true when sending malformed requests to avoid test client codec rejecting it.
   // This flag is only valid when UHV build flag is enabled.
   bool disable_client_header_validation_{false};
+  // Set this to true to let the HTTP/3 test client accept server-initiated bidirectional streams
+  // belonging to a WebTransport session, the way a real WebTransport client does. Must be set
+  // before makeHttpConnection(); off by default so other tests keep the strict HTTP/3 behavior.
+  bool client_accepts_server_initiated_streams_{false};
 
 #ifdef ENVOY_ENABLE_QUIC
   quic::DeterministicConnectionIdGenerator connection_id_generator_{

--- a/test/integration/web_transport_integration_test.cc
+++ b/test/integration/web_transport_integration_test.cc
@@ -128,6 +128,81 @@ private:
   std::vector<std::string> datagrams_;
 };
 
+// Session visitor installed on the upstream WebTransport session for the server-initiated case.
+// openStream() opens a bidirectional stream toward the proxy and writes a payload, which the
+// bridge must mirror to a stream opened toward the downstream client.
+class ServerInitiatingSessionVisitor : public webtransport::SessionVisitor {
+public:
+  ServerInitiatingSessionVisitor(webtransport::Session* session, std::string payload)
+      : session_(session), payload_(std::move(payload)) {}
+
+  // The session is already established by the time this visitor is installed, so open immediately.
+  void openStream() {
+    stream_ = session_->OpenOutgoingBidirectionalStream();
+    if (stream_ == nullptr) {
+      return;
+    }
+    stream_->SetVisitor(std::make_unique<EchoStreamVisitor>(stream_));
+    quiche::QuicheMemSlice slice(
+        quiche::QuicheBuffer::Copy(quiche::SimpleBufferAllocator::Get(), payload_));
+    absl::Span<quiche::QuicheMemSlice> span(&slice, 1);
+    write_ok_ = stream_->Writev(span, webtransport::StreamWriteOptions()).ok();
+  }
+
+  bool opened() const { return stream_ != nullptr && write_ok_; }
+
+  void OnSessionReady() override {}
+  void OnSessionClosed(webtransport::SessionErrorCode /*error_code*/,
+                       const std::string& /*error_message*/) override {}
+  void OnIncomingBidirectionalStreamAvailable() override {}
+  void OnIncomingUnidirectionalStreamAvailable() override {}
+  void OnDatagramReceived(absl::string_view /*datagram*/) override {}
+  void OnCanCreateNewOutgoingBidirectionalStream() override {}
+  void OnCanCreateNewOutgoingUnidirectionalStream() override {}
+
+private:
+  webtransport::Session* session_;
+  std::string payload_;
+  webtransport::Stream* stream_{nullptr};
+  bool write_ok_{false};
+};
+
+// Session visitor installed on the downstream client's session: accepts a bidirectional stream
+// opened by the peer (i.e. mirrored by the bridge from the upstream) and captures its bytes.
+class AcceptingSessionVisitor : public webtransport::SessionVisitor {
+public:
+  explicit AcceptingSessionVisitor(webtransport::Session* session) : session_(session) {}
+
+  void OnIncomingBidirectionalStreamAvailable() override {
+    while (webtransport::Stream* stream = session_->AcceptIncomingBidirectionalStream()) {
+      auto visitor = std::make_unique<CaptureStreamVisitor>(stream);
+      captured_.push_back(visitor.get());
+      CaptureStreamVisitor* raw = visitor.get();
+      stream->SetVisitor(std::move(visitor));
+      // Drain anything that arrived before the visitor was installed.
+      raw->OnCanRead();
+    }
+  }
+  void OnSessionReady() override {}
+  void OnSessionClosed(webtransport::SessionErrorCode /*error_code*/,
+                       const std::string& /*error_message*/) override {}
+  void OnIncomingUnidirectionalStreamAvailable() override {}
+  void OnDatagramReceived(absl::string_view /*datagram*/) override {}
+  void OnCanCreateNewOutgoingBidirectionalStream() override {}
+  void OnCanCreateNewOutgoingUnidirectionalStream() override {}
+
+  // True if any accepted stream has received exactly `payload`.
+  bool received(absl::string_view payload) const {
+    return std::any_of(captured_.begin(), captured_.end(),
+                       [&](const CaptureStreamVisitor* v) { return v->received() == payload; });
+  }
+  size_t streamCount() const { return captured_.size(); }
+
+private:
+  webtransport::Session* session_;
+  std::vector<CaptureStreamVisitor*> captured_;
+};
+
 // End-to-end WebTransport bridging: a real HTTP/3 client opens a WebTransport CONNECT that Envoy
 // proxies to an HTTP/3 upstream, and the per-session bridge forwards WebTransport streams/datagrams
 // between the two QUIC sessions. Pinned to HTTP/3 on both hops (WebTransport is HTTP/3 only).
@@ -136,6 +211,19 @@ public:
   void initialize() override {
     config_helper_.addRuntimeOverride("envoy.reloadable_features.quic_support_web_transport",
                                       "true");
+    if (accept_server_initiated_streams_) {
+      // Opt the upstream cluster in to server-initiated bidirectional streams. Default-off, so the
+      // other tests in this file keep exercising the rejecting path.
+      config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+        ConfigHelper::HttpProtocolOptions protocol_options;
+        protocol_options.mutable_explicit_http_config()
+            ->mutable_http3_protocol_options()
+            ->mutable_quic_protocol_options()
+            ->set_accept_server_initiated_streams(true);
+        ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
+                                         protocol_options);
+      });
+    }
     config_helper_.addConfigModifier(
         [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                hcm) {
@@ -181,6 +269,29 @@ public:
     EXPECT_TRUE(done.WaitForNotificationWithTimeout(absl::Seconds(15)));
     return ok;
   }
+
+  // Installs a visitor on the upstream WebTransport session which opens a bidirectional stream
+  // toward the proxy and writes `payload`. Runs on the upstream dispatcher thread.
+  bool openUpstreamInitiatedStream(const std::string& payload) {
+    absl::Notification done;
+    bool ok = false;
+    fake_upstreams_[0]->runOnDispatcherThread([&]() {
+      OptRef<Http::WebTransportSession> session = upstream_request_->webTransportSession();
+      if (session.has_value() && session->rawWebTransportSession() != nullptr) {
+        auto visitor = std::make_unique<ServerInitiatingSessionVisitor>(
+            session->rawWebTransportSession(), payload);
+        ServerInitiatingSessionVisitor* raw = visitor.get();
+        session->setWebTransportVisitor(std::move(visitor));
+        raw->openStream();
+        ok = raw->opened();
+      }
+      done.Notify();
+    });
+    EXPECT_TRUE(done.WaitForNotificationWithTimeout(absl::Seconds(15)));
+    return ok;
+  }
+
+  bool accept_server_initiated_streams_{false};
 };
 
 INSTANTIATE_TEST_SUITE_P(Protocols, WebTransportIntegrationTest,
@@ -266,6 +377,94 @@ TEST_P(WebTransportIntegrationTest, EchoesBidirectionalStreamThroughBridge) {
     }
   }
   EXPECT_TRUE(echoed) << "received: '" << capture_ptr->received() << "'";
+
+  cleanupUpstreamAndDownstream();
+}
+
+// The upstream opens a bidirectional WebTransport stream toward Envoy; the bridge mirrors it to a
+// stream opened toward the downstream client and forwards the payload. Requires
+// accept_server_initiated_streams on the upstream cluster.
+TEST_P(WebTransportIntegrationTest, EchoesServerInitiatedBidirectionalStreamThroughBridge) {
+  accept_server_initiated_streams_ = true;
+  // The downstream test client must accept the peer-opened stream too, the way a real WebTransport
+  // client does; the H/3 test codec rejects server-initiated streams unless told otherwise.
+  client_accepts_server_initiated_streams_ = true;
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(webTransportHeaders());
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  response->waitForHeaders();
+
+  // Accept peer-opened streams on the downstream client session before the upstream opens one.
+  OptRef<Http::WebTransportSession> client = request_encoder_->getStream().webTransportSession();
+  ASSERT_TRUE(client.has_value());
+  ASSERT_NE(client->rawWebTransportSession(), nullptr);
+  auto accepting = std::make_unique<AcceptingSessionVisitor>(client->rawWebTransportSession());
+  AcceptingSessionVisitor* accepting_ptr = accepting.get();
+  client->setWebTransportVisitor(std::move(accepting));
+
+  const std::string payload = "hello from the server";
+  ASSERT_TRUE(openUpstreamInitiatedStream(payload));
+
+  // Pump the client event loop until the mirrored stream and its payload arrive.
+  Event::TestTimeSystem& time_system = timeSystem();
+  bool got = false;
+  for (int i = 0; i < 200 && !got; i++) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    got = accepting_ptr->received(payload);
+    if (!got) {
+      time_system.advanceTimeWait(std::chrono::milliseconds(10));
+    }
+  }
+  EXPECT_TRUE(got) << "streams accepted: " << accepting_ptr->streamCount();
+
+  cleanupUpstreamAndDownstream();
+}
+
+// Without the option, an upstream-initiated bidirectional stream is not proxied: the downstream
+// client never sees a peer-opened stream. This is the default and guards plain HTTP/3 conformance.
+TEST_P(WebTransportIntegrationTest, ServerInitiatedStreamNotBridgedByDefault) {
+  // Let the downstream client accept peer-opened streams, so that the only thing keeping the
+  // stream from reaching it is Envoy's upstream-side rejection.
+  client_accepts_server_initiated_streams_ = true;
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(webTransportHeaders());
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForHeadersComplete());
+
+  upstream_request_->encodeHeaders(default_response_headers_, false);
+  response->waitForHeaders();
+
+  OptRef<Http::WebTransportSession> client = request_encoder_->getStream().webTransportSession();
+  ASSERT_TRUE(client.has_value());
+  ASSERT_NE(client->rawWebTransportSession(), nullptr);
+  auto accepting = std::make_unique<AcceptingSessionVisitor>(client->rawWebTransportSession());
+  AcceptingSessionVisitor* accepting_ptr = accepting.get();
+  client->setWebTransportVisitor(std::move(accepting));
+
+  // The upstream can still open the stream on its own session; Envoy just drops it.
+  ASSERT_TRUE(openUpstreamInitiatedStream("hello from the server"));
+
+  Event::TestTimeSystem& time_system = timeSystem();
+  for (int i = 0; i < 50; i++) {
+    dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    time_system.advanceTimeWait(std::chrono::milliseconds(10));
+  }
+  EXPECT_EQ(0, accepting_ptr->streamCount());
 
   cleanupUpstreamAndDownstream();
 }


### PR DESCRIPTION

Commit Message: quic: add server initialized stream support to webtransport
Additional Description:

To close https://github.com/envoyproxy/envoy/issues/47171

Risk Level: mid.
Testing: unit/integration.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.