### PR TITLE
mcp: fix mcp_json_rest_bridge_filter test

### DIFF
--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -729,7 +729,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolCallWithEscapedQueryParamKey) {
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, ToolCallWithHeaderCookiesParams) {
-  makeFilter();
+  ASSERT_OK(makeFilter());
   request_headers_ = {{":path", "/mcp"}, {":method", "POST"}};
   Buffer::OwnedImpl request_body(
       R"json({"jsonrpc":"2.0","id":123,"method":"tools/call","params":{"name":"list_api_keys","arguments":{"parent":"projects/test","pageSize":1,"header":"header_value","cookie":"cookie_value","header_2":"header_2_value","cookie_2":"cookie_2_value"}}})json");
@@ -756,7 +756,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolCallWithHeaderCookiesParams) {
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, ToolCallWithHeaderOnlyParams) {
-  makeFilter();
+  ASSERT_OK(makeFilter());
   request_headers_ = {{":path", "/mcp"}, {":method", "POST"}};
   // Only header arguments are present, no cookie arguments.
   Buffer::OwnedImpl request_body(
@@ -782,7 +782,7 @@ TEST_F(McpJsonRestBridgeFilterTest, ToolCallWithHeaderOnlyParams) {
 }
 
 TEST_F(McpJsonRestBridgeFilterTest, ToolCallWithCookieOnlyParams) {
-  makeFilter();
+  ASSERT_OK(makeFilter());
   request_headers_ = {{":path", "/mcp"}, {":method", "POST"}};
   // Only cookie arguments are present, no header arguments.
   Buffer::OwnedImpl request_body(


### PR DESCRIPTION
## Description

This PR fixes the broken test.

---
 
**Commit Message**: mcp: fix mcp_json_rest_bridge_filter test
**Risk Level:** Low
**Testing**: CI
**Docs Changes**: N/A
**Release Notes**: N/A