### PR TITLE
website/docs: add copy-link permalinks to proto fields

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,11 +98,18 @@ def dockerhub_envoy_role(
     return [pnode], []
 
 
+def _blank_permalink_icon(app):
+    # sphinx_rtd_theme overwrites this with a Font Awesome glyph when it loads,
+    # after conf.py has run; the stylesheet draws the `#` itself.
+    app.config.html_permalinks_icon = ''
+
+
 def setup(app):
     app.add_config_value('release_level', '', 'env')
     app.add_config_value('substitutions', [], 'html')
     app.add_directive('substitution-code-block', SubstitutionCodeBlock)
     app.add_role('dockerhub_envoy', dockerhub_envoy_role)
+    app.connect('builder-inited', _blank_permalink_icon)
 
 
 missing_config = (

--- a/docs/root/_static/css/envoy/content.css
+++ b/docs/root/_static/css/envoy/content.css
@@ -122,22 +122,33 @@
 
 /* --- permalinks ----------------------------------------------------------
 
-   The anchor follows its text and is a positioned box, so the copied bubble
-   below has something to sit on. conf.py blanks the theme's Font Awesome
-   glyph; the `#` drawn here is the only mark. */
+   A link icon sized to its line and never below 13px, so it reads as a link
+   at a glance; conf.py blanks the theme's Font Awesome glyph so this is the
+   only mark. The anchor spans its line, which makes the hit target the line
+   rather than the icon, and is a positioned box so the copied bubble has
+   something to sit on. */
 
 .envoy-content-main .rst-content a.headerlink {
-  color: var(--envoy-rule-strong);
-  font-family: inherit;
-  font-size: 0.7em;
-  font-weight: 400;
-  /* the padding widens the hit target; the negative margin keeps the layout */
-  margin: -0.2em 0 -0.2em 0.5em;
+  color: var(--envoy-ink-muted);
+  display: inline-block;
+  font-size: inherit;
+  line-height: inherit;
+  margin-left: 0.2em;
   opacity: 0;
-  padding: 0.2em 0.5em 0.2em 0;
+  padding: 0 0.3em;
   position: relative;
   text-decoration: none;
   visibility: visible;
+}
+
+.envoy-content-main .rst-content a.headerlink::after {
+  background: currentColor;
+  content: "";
+  display: inline-block;
+  height: clamp(13px, 0.75em, 18px);
+  mask: url("../../img/link.svg") center / contain no-repeat;
+  vertical-align: middle;
+  width: clamp(13px, 0.75em, 18px);
 }
 
 /* in a heading it hangs in the margin, so linking one never reflows the line */
@@ -147,31 +158,36 @@
 .envoy-content-main .rst-content h4 > a.headerlink,
 .envoy-content-main .rst-content h5 > a.headerlink,
 .envoy-content-main .rst-content h6 > a.headerlink {
-  left: -1.35em;
-  margin-left: 0;
+  margin: 0 0.2em 0 0;
   position: absolute;
-  top: 0.28em;
+  right: 100%;
+  top: 0;
 }
 
-.envoy-content-main .rst-content a.headerlink::after {
-  content: "#";
+/* a definition's anchor stays faintly in view: fields are what gets shared,
+   and a page holds dozens to discover it from */
+.envoy-content-main .rst-content dl > dt > a.headerlink {
+  color: var(--envoy-rule-strong);
+  opacity: 1;
 }
 
 .envoy-content-main .rst-content :hover > a.headerlink,
 .envoy-content-main .rst-content a.headerlink:focus-visible,
 .envoy-content-main .rst-content a.headerlink.envoy-copied {
+  color: var(--envoy-ink-muted);
   opacity: 1;
 }
 
+/* the accent marks interaction everywhere else, and this is a link */
 .envoy-content-main .rst-content a.headerlink:hover {
-  color: var(--envoy-ink);
+  color: var(--envoy-accent);
 }
 
 /* permalinks.js holds the class for a moment after the link is copied */
 .envoy-content-main .rst-content a.headerlink.envoy-copied::before {
   background: var(--envoy-ink);
   border-radius: 4px;
-  bottom: calc(100% + 4px);
+  bottom: calc(50% + 11px);
   color: var(--envoy-ground);
   content: "Copied";
   font: 500 11px/1 var(--envoy-font-sans);

--- a/docs/root/_static/css/envoy/content.css
+++ b/docs/root/_static/css/envoy/content.css
@@ -120,17 +120,37 @@
   margin: 28px 0 8px;
 }
 
-/* the anchor hangs in the margin, so linking a heading never reflows the line */
+/* --- permalinks ----------------------------------------------------------
+
+   The anchor follows its text and is a positioned box, so the copied bubble
+   below has something to sit on. conf.py blanks the theme's Font Awesome
+   glyph; the `#` drawn here is the only mark. */
+
 .envoy-content-main .rst-content a.headerlink {
   color: var(--envoy-rule-strong);
+  font-family: inherit;
   font-size: 0.7em;
   font-weight: 400;
-  left: -1.35em;
+  /* the padding widens the hit target; the negative margin keeps the layout */
+  margin: -0.2em 0 -0.2em 0.5em;
   opacity: 0;
-  position: absolute;
+  padding: 0.2em 0.5em 0.2em 0;
+  position: relative;
   text-decoration: none;
-  top: 0.28em;
   visibility: visible;
+}
+
+/* in a heading it hangs in the margin, so linking one never reflows the line */
+.envoy-content-main .rst-content h1 > a.headerlink,
+.envoy-content-main .rst-content h2 > a.headerlink,
+.envoy-content-main .rst-content h3 > a.headerlink,
+.envoy-content-main .rst-content h4 > a.headerlink,
+.envoy-content-main .rst-content h5 > a.headerlink,
+.envoy-content-main .rst-content h6 > a.headerlink {
+  left: -1.35em;
+  margin-left: 0;
+  position: absolute;
+  top: 0.28em;
 }
 
 .envoy-content-main .rst-content a.headerlink::after {
@@ -138,12 +158,27 @@
 }
 
 .envoy-content-main .rst-content :hover > a.headerlink,
-.envoy-content-main .rst-content a.headerlink:focus-visible {
+.envoy-content-main .rst-content a.headerlink:focus-visible,
+.envoy-content-main .rst-content a.headerlink.envoy-copied {
   opacity: 1;
 }
 
 .envoy-content-main .rst-content a.headerlink:hover {
   color: var(--envoy-ink);
+}
+
+/* permalinks.js holds the class for a moment after the link is copied */
+.envoy-content-main .rst-content a.headerlink.envoy-copied::before {
+  background: var(--envoy-ink);
+  border-radius: 4px;
+  bottom: calc(100% + 4px);
+  color: var(--envoy-ground);
+  content: "Copied";
+  font: 500 11px/1 var(--envoy-font-sans);
+  left: 0;
+  padding: 4px 7px;
+  pointer-events: none;
+  position: absolute;
 }
 
 /* --- text ---------------------------------------------------------------- */

--- a/docs/root/_static/css/envoy/proto.css
+++ b/docs/root/_static/css/envoy/proto.css
@@ -92,7 +92,8 @@
 .envoy-content-main .rst-content .envoy-proto-symbol > h5 > a.headerlink {
   left: auto;
   margin-left: 0.5em;
-  position: static;
+  position: relative;
+  top: auto;
 }
 
 /* --- fields --------------------------------------------------------------

--- a/docs/root/_static/css/envoy/proto.css
+++ b/docs/root/_static/css/envoy/proto.css
@@ -90,9 +90,9 @@
 .envoy-content-main .rst-content .envoy-proto-symbol > h3 > a.headerlink,
 .envoy-content-main .rst-content .envoy-proto-symbol > h4 > a.headerlink,
 .envoy-content-main .rst-content .envoy-proto-symbol > h5 > a.headerlink {
-  left: auto;
-  margin-left: 0.5em;
+  margin: 0 0 0 0.2em;
   position: relative;
+  right: auto;
   top: auto;
 }
 

--- a/docs/root/_static/css/envoy/responsive.css
+++ b/docs/root/_static/css/envoy/responsive.css
@@ -76,10 +76,16 @@
 
 @media screen and (max-width: 1100px) {
   /* below this the margin is too tight to hang the anchor in it */
-  .envoy-content-main .rst-content a.headerlink {
+  .envoy-content-main .rst-content h1 > a.headerlink,
+  .envoy-content-main .rst-content h2 > a.headerlink,
+  .envoy-content-main .rst-content h3 > a.headerlink,
+  .envoy-content-main .rst-content h4 > a.headerlink,
+  .envoy-content-main .rst-content h5 > a.headerlink,
+  .envoy-content-main .rst-content h6 > a.headerlink {
     left: auto;
     margin-left: 0.4em;
-    position: static;
+    position: relative;
+    top: auto;
   }
 }
 

--- a/docs/root/_static/css/envoy/responsive.css
+++ b/docs/root/_static/css/envoy/responsive.css
@@ -82,9 +82,9 @@
   .envoy-content-main .rst-content h4 > a.headerlink,
   .envoy-content-main .rst-content h5 > a.headerlink,
   .envoy-content-main .rst-content h6 > a.headerlink {
-    left: auto;
-    margin-left: 0.4em;
+    margin: 0 0 0 0.2em;
     position: relative;
+    right: auto;
     top: auto;
   }
 }

--- a/docs/root/_static/img/link.svg
+++ b/docs/root/_static/img/link.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6.67 8.67a3.33 3.33 0 0 0 5.03.36l2-2a3.33 3.33 0 0 0-4.71-4.71l-1.15 1.14"/>
+  <path d="M9.33 7.33a3.33 3.33 0 0 0-5.03-.36l-2 2a3.33 3.33 0 0 0 4.71 4.71l1.14-1.14"/>
+</svg>

--- a/docs/root/_static/js/envoy.js
+++ b/docs/root/_static/js/envoy.js
@@ -13,6 +13,7 @@
 import * as code from './envoy/code.js';
 import * as lists from './envoy/lists.js';
 import * as nav from './envoy/nav.js';
+import * as permalinks from './envoy/permalinks.js';
 import * as proto from './envoy/proto.js';
 import * as search from './envoy/search.js';
 import * as theme from './envoy/theme.js';
@@ -21,7 +22,7 @@ import * as versions from './envoy/versions.js';
 
 // proto runs after toc: the outline links are rewritten there, and the kind
 // dots are prepended to whatever is left.
-const MODULES = [theme, nav, versions, code, lists, toc, proto, search];
+const MODULES = [theme, nav, versions, code, lists, toc, proto, permalinks, search];
 
 function start() {
   MODULES.forEach((module) => {

--- a/docs/root/_static/js/envoy/permalinks.js
+++ b/docs/root/_static/js/envoy/permalinks.js
@@ -1,0 +1,73 @@
+/**
+ * Permalinks: every addressable definition gets one, and clicking one copies it.
+ *
+ * Sphinx puts a `#` anchor on headings only. protodoc emits each field and
+ * enum value as a definition list carrying the symbol's target, so those are
+ * addressable too but have nothing to grab; here they get the same anchor a
+ * heading has.
+ *
+ * Clicking any anchor then copies its absolute URL. The click still jumps to
+ * the target as before, so nothing that worked stops working and the address
+ * bar remains the fallback where the clipboard is out of reach. A modified
+ * click is opening the link somewhere else and is left alone.
+ */
+
+/** How long the "Copied" confirmation stays up. */
+const COPIED_MS = 1600;
+
+/** A targeted definition list with a single term: the shape protodoc emits. */
+const DEFINITION_TERMS = 'dl[id] > dt:only-of-type';
+
+function linkDefinitions(content) {
+  content.querySelectorAll(DEFINITION_TERMS).forEach((term) => {
+    const link = document.createElement('a');
+    link.className = 'headerlink';
+    link.href = `#${term.parentElement.id}`;
+    link.title = 'Link to this definition';
+    term.append(link);
+  });
+}
+
+/** Sighted readers see it on the anchor; the live region says it aloud. */
+function flash(link, status) {
+  link.classList.add('envoy-copied');
+  status.textContent = 'Link copied';
+  window.setTimeout(() => {
+    link.classList.remove('envoy-copied');
+    status.textContent = '';
+  }, COPIED_MS);
+}
+
+function copyOnClick(content) {
+  const status = document.createElement('div');
+  status.className = 'envoy-visually-hidden';
+  status.setAttribute('role', 'status');
+  content.append(status);
+
+  content.addEventListener('click', async (event) => {
+    const link = event.target.closest('a.headerlink');
+    if (!link || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(link.href);
+    } catch {
+      return;
+    }
+    flash(link, status);
+  });
+}
+
+export function init() {
+  const content = document.querySelector('.envoy-content-main');
+  if (!content) {
+    return;
+  }
+
+  linkDefinitions(content);
+
+  if (navigator.clipboard) {
+    copyOnClick(content);
+  }
+}

--- a/docs/root/_static/js/envoy/permalinks.js
+++ b/docs/root/_static/js/envoy/permalinks.js
@@ -1,10 +1,10 @@
 /**
  * Permalinks: every addressable definition gets one, and clicking one copies it.
  *
- * Sphinx puts a `#` anchor on headings only. protodoc emits each field and
- * enum value as a definition list carrying the symbol's target, so those are
- * addressable too but have nothing to grab; here they get the same anchor a
- * heading has.
+ * Sphinx puts a permalink anchor on headings only. protodoc emits each field
+ * and enum value as a definition list carrying the symbol's target, so those
+ * are addressable too but have nothing to grab; here they get the same anchor
+ * a heading has.
  *
  * Clicking any anchor then copies its absolute URL. The click still jumps to
  * the target as before, so nothing that worked stops working and the address
@@ -39,6 +39,10 @@ function flash(link, status) {
 }
 
 function copyOnClick(content) {
+  content.querySelectorAll('a.headerlink').forEach((link) => {
+    link.title = 'Copy link';
+  });
+
   const status = document.createElement('div');
   status.className = 'envoy-visually-hidden';
   status.setAttribute('role', 'status');

--- a/docs/root/_static/js/envoy/proto.js
+++ b/docs/root/_static/js/envoy/proto.js
@@ -37,9 +37,9 @@ function headingOf(section) {
 /**
  * The heading's own text, without the permalink.
  *
- * sphinx_rtd_theme puts a Font Awesome glyph inside `a.headerlink` as a real
- * character rather than generated content, so `textContent` on the heading
- * comes back with a U+F0C1 on the end and nothing matches.
+ * conf.py blanks the Font Awesome glyph sphinx_rtd_theme puts inside
+ * `a.headerlink`; the anchor is skipped regardless, so a build that keeps the
+ * glyph still recognises its symbols.
  */
 function titleOf(heading) {
   return Array.from(heading.childNodes)


### PR DESCRIPTION
protodoc emits each field and enum value as a targeted definition list, which Sphinx never permalinks. The theme now gives those the same anchor a heading has, and clicking any permalink copies its absolute URL while still jumping to the target.

So for communication purpose, we just click the `#` along with each proto field - very convenient!

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
