### PR TITLE
router: add route_provider virtual host extension point

### DIFF
--- a/api/envoy/config/route/v3/route_components.proto
+++ b/api/envoy/config/route/v3/route_components.proto
@@ -45,7 +45,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // host header. This allows a single listener to service multiple top level domain path trees. Once
 // a virtual host is selected based on the domain, the routes are processed in order to see which
 // upstream cluster to route to or whether to perform a redirect.
-// [#next-free-field: 26]
+// [#next-free-field: 27]
 message VirtualHost {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.route.VirtualHost";
 
@@ -102,6 +102,13 @@ message VirtualHost {
   // can be specified.
   xds.type.matcher.v3.Matcher matcher = 21
       [(udpa.annotations.field_migrate).oneof_promotion = "route_selection"];
+
+  // The route provider that selects and builds routes for incoming requests through a resolver
+  // extension. It may be set on its own, or alongside ``routes`` or ``matcher``, which then act as
+  // the baseline for :ref:`shadow_mode
+  // <envoy_v3_api_field_config.route.v3.RouteProvider.shadow_mode>` comparisons. If not specified,
+  // routing uses ``routes`` or ``matcher``.
+  RouteProvider route_provider = 26;
 
   // Specifies the type of TLS enforcement the virtual host expects. If this option is not
   // specified, there is no TLS requirement for the virtual host.
@@ -272,6 +279,41 @@ message FilterAction {
 message RouteList {
   // The list of routes that will be matched and run, in order. The first route that matches will be used.
   repeated Route routes = 1;
+}
+
+// A route provider owns route selection for a virtual host through a resolver extension. The
+// resolver selects one of the route templates for a request, so a small set of templates can serve
+// many product routes. The provider may run in shadow mode next to ``routes`` or ``matcher`` to
+// validate its results before serving real traffic.
+// Used in :ref:`VirtualHost.route_provider <envoy_v3_api_field_config.route.v3.VirtualHost.route_provider>`.
+message RouteProvider {
+  // A named route used as a base shape. When the resolver selects a template, its action and fields
+  // are used to build the route for the request.
+  message RouteTemplate {
+    // The template id. Must be unique within the provider and is used by the resolver to select
+    // this template.
+    string template_id = 1 [(validate.rules).string = {min_len: 1}];
+
+    // The route this template selects.
+    Route route = 2 [(validate.rules).message = {required: true}];
+  }
+
+  // The templates the resolver selects among. At least one template is required.
+  repeated RouteTemplate route_templates = 1 [(validate.rules).repeated = {min_items: 1}];
+
+  // The template selected when the resolver returns a use-default decision. If set, it must match
+  // the ``template_id`` of one of ``route_templates``. If not specified, a use-default decision is
+  // treated as no match.
+  string default_template_id = 2;
+
+  // The resolver extension that selects a template for each request. This field is required.
+  core.v3.TypedExtensionConfig resolver = 3 [(validate.rules).message = {required: true}];
+
+  // When ``true`` the provider runs in shadow mode. The route from ``routes`` or ``matcher`` is
+  // served while the provider route is computed only for comparison, so results can be validated
+  // before serving real traffic. ``routes`` or ``matcher`` must be set when this is ``true``. If
+  // not specified, defaults to ``false`` and the provider route is served.
+  bool shadow_mode = 4;
 }
 
 // A route is both a specification of how to match a request as well as an indication of what to do

--- a/envoy/router/BUILD
+++ b/envoy/router/BUILD
@@ -162,6 +162,19 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
+    name = "route_provider_interface",
+    hdrs = ["route_provider.h"],
+    deps = [
+        ":router_interface",
+        "//envoy/config:typed_config_interface",
+        "//envoy/http:header_map_interface",
+        "//envoy/server:factory_context_interface",
+        "//envoy/stream_info:stream_info_interface",
+        "@abseil-cpp//absl/status:statusor",
+    ],
+)
+
+envoy_cc_library(
     name = "path_matcher_interface",
     hdrs = ["path_matcher.h"],
     deps = [

--- a/envoy/router/route_provider.h
+++ b/envoy/router/route_provider.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "envoy/common/pure.h"
+#include "envoy/config/typed_config.h"
+#include "envoy/http/header_map.h"
+#include "envoy/router/router.h"
+#include "envoy/server/factory_context.h"
+#include "envoy/stream_info/stream_info.h"
+
+#include "absl/status/statusor.h"
+
+namespace Envoy {
+namespace Router {
+
+/**
+ * The instruction a resolver returns for a request. The core turns this into a route by selecting
+ * one of the configured templates. The resolver owns the matching decision and never builds a route
+ * itself.
+ */
+struct RouteDecision {
+  enum class Kind {
+    // Use the template named by `template_id`.
+    SelectTemplate,
+    // Use the template named by the provider's `default_template_id`.
+    UseDefault,
+    // Decline and let route selection continue with `routes` or `matcher`.
+    ContinueMatching,
+  };
+
+  Kind kind{Kind::ContinueMatching};
+  // The selected template id. Only read when `kind` is `SelectTemplate`.
+  std::string template_id;
+};
+
+/**
+ * Resolves the route for a request by selecting one of the configured route templates. Implemented
+ * by route provider extensions so the core owns the templates and the shadow comparison while the
+ * extension owns the matching decision.
+ */
+class DynamicRouteResolver {
+public:
+  virtual ~DynamicRouteResolver() = default;
+
+  /**
+   * Select a template for the request.
+   *
+   * @param headers the request headers.
+   * @param stream_info the stream info of the downstream request.
+   * @param random_value the random seed to use when a runtime choice is required.
+   * @return the selection instruction for the request.
+   */
+  virtual RouteDecision resolve(const Http::RequestHeaderMap& headers,
+                                const StreamInfo::StreamInfo& stream_info,
+                                uint64_t random_value) const PURE;
+
+  /**
+   * Report the provider and baseline routes when the provider runs in shadow mode. The default is a
+   * no-op so resolvers that do not compare need not implement it.
+   *
+   * @param provider_route the route the provider produced, or nullptr when it produced none.
+   * @param baseline_route the route the `routes` or `matcher` baseline produced, or nullptr when
+   * none.
+   * @param headers the request headers.
+   * @param stream_info the stream info of the downstream request.
+   */
+  virtual void onShadowResult(RouteConstSharedPtr, RouteConstSharedPtr,
+                              const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&) const {}
+};
+
+using DynamicRouteResolverSharedPtr = std::shared_ptr<const DynamicRouteResolver>;
+
+/**
+ * Extension configuration for a route provider resolver factory. A route provider owns route
+ * selection for a virtual host and selects among the templates defined next to it.
+ */
+class RouteProviderFactory : public Envoy::Config::TypedFactory {
+public:
+  /**
+   * Create a resolver from the resolver config.
+   *
+   * @param config the resolver configuration for this route provider.
+   * @param context the server factory context.
+   * @return the resolver, or an error when creation fails.
+   */
+  virtual absl::StatusOr<DynamicRouteResolverSharedPtr>
+  createRouteResolver(const Protobuf::Message& config,
+                      Server::Configuration::ServerFactoryContext& context) PURE;
+
+  std::string category() const override { return "envoy.router.route_provider"; }
+};
+
+} // namespace Router
+} // namespace Envoy

--- a/source/common/router/BUILD
+++ b/source/common/router/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
         "//envoy/http:header_map_interface",
         "//envoy/init:manager_interface",
         "//envoy/router:cluster_specifier_plugin_interface",
+        "//envoy/router:route_provider_interface",
         "//envoy/router:router_interface",
         "//envoy/runtime:runtime_interface",
         "//envoy/server:filter_config_interface",  # TODO(rodaine): break dependency on server

--- a/source/common/router/config_impl.cc
+++ b/source/common/router/config_impl.cc
@@ -1822,6 +1822,63 @@ VirtualHostImpl::VirtualHostImpl(const envoy::config::route::v3::VirtualHost& vi
       routes_.emplace_back(route_or_error.value());
     }
   }
+
+  if (virtual_host.has_route_provider()) {
+    const auto& provider_config = virtual_host.route_provider();
+    if (provider_config.shadow_mode() && !hasBaseline()) {
+      creation_status = absl::InvalidArgumentError(
+          "route provider shadow_mode requires routes or matcher on the virtual host");
+      return;
+    }
+
+    auto provider = std::make_unique<RouteProvider>();
+    provider->shadow_mode = provider_config.shadow_mode();
+    provider->default_template_id = provider_config.default_template_id();
+    provider->templates.reserve(provider_config.route_templates().size());
+    for (const auto& route_template : provider_config.route_templates()) {
+      if (provider->templates.contains(route_template.template_id())) {
+        creation_status = absl::InvalidArgumentError(
+            fmt::format("duplicate route provider template id '{}'", route_template.template_id()));
+        return;
+      }
+      auto route_or_error = RouteCreator::createAndValidateRoute(
+          route_template.route(), shared_virtual_host_, factory_context, validator, init_manager,
+          validate_clusters);
+      SET_AND_RETURN_IF_NOT_OK(route_or_error.status(), creation_status);
+      provider->templates.emplace(route_template.template_id(), std::move(route_or_error.value()));
+    }
+    if (!provider->default_template_id.empty() &&
+        !provider->templates.contains(provider->default_template_id)) {
+      creation_status = absl::InvalidArgumentError(
+          fmt::format("route provider default_template_id '{}' does not match any template",
+                      provider->default_template_id));
+      return;
+    }
+
+    auto* factory =
+        Envoy::Config::Utility::getFactory<RouteProviderFactory>(provider_config.resolver());
+    if (factory == nullptr) {
+      creation_status = absl::InvalidArgumentError(fmt::format(
+          "Didn't find a registered route provider resolver for '{}' with type URL: '{}'",
+          provider_config.resolver().name(),
+          Envoy::Config::Utility::getFactoryType(provider_config.resolver().typed_config())));
+      return;
+    }
+    auto resolver_config = Envoy::Config::Utility::translateToFactoryConfig(
+        provider_config.resolver(), validator, *factory);
+    auto resolver_or_error = factory->createRouteResolver(*resolver_config, factory_context);
+    SET_AND_RETURN_IF_NOT_OK(resolver_or_error.status(), creation_status);
+    provider->resolver = std::move(resolver_or_error.value());
+
+    Stats::StatNameManagedStorage provider_stat_name("route_provider",
+                                                     factory_context.scope().symbolTable());
+    provider->scope = Stats::Utility::scopeFromStatNames(
+        scope, {shared_virtual_host_->statName(), provider_stat_name.statName()});
+    provider->stats = std::make_unique<RouteProviderStats>(
+        RouteProviderStats{ALL_ROUTE_PROVIDER_STATS(POOL_COUNTER(*provider->scope))});
+
+    route_provider_ = std::move(provider);
+  }
 }
 
 RouteConstSharedPtr VirtualHostImpl::getRouteFromRoutes(
@@ -1885,6 +1942,16 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
     return ssl_redirect_route_;
   }
 
+  if (route_provider_ != nullptr) {
+    return getRouteFromProvider(cb, headers, stream_info, random_value);
+  }
+
+  return getRouteFromMatcherOrRoutes(cb, headers, stream_info, random_value);
+}
+
+RouteConstSharedPtr VirtualHostImpl::getRouteFromMatcherOrRoutes(
+    const RouteCallback& cb, const Http::RequestHeaderMap& headers,
+    const StreamInfo::StreamInfo& stream_info, uint64_t random_value) const {
   // Constructed once per request; derived values (query params, cookies, etc.) are computed
   // lazily on first access and reused across all route entries evaluated for this request.
   const RouteMatchContext route_match_context(
@@ -1919,6 +1986,102 @@ RouteConstSharedPtr VirtualHostImpl::getRouteFromEntries(const RouteCallback& cb
 
   // Check for a route that matches the request.
   return getRouteFromRoutes(cb, route_match_context, stream_info, random_value, routes_);
+}
+
+namespace {
+// Compare the provider route and the baseline route for a shadow mode result. Routes are treated as
+// equivalent when both are absent, when they route to the same cluster, or when they are both
+// direct responses with the same status code.
+bool routesEquivalent(const RouteConstSharedPtr& provider_route,
+                      const RouteConstSharedPtr& baseline_route) {
+  if (provider_route == nullptr || baseline_route == nullptr) {
+    return provider_route == baseline_route;
+  }
+  const RouteEntry* provider_entry = provider_route->routeEntry();
+  const RouteEntry* baseline_entry = baseline_route->routeEntry();
+  if ((provider_entry == nullptr) != (baseline_entry == nullptr)) {
+    return false;
+  }
+  if (provider_entry != nullptr) {
+    return provider_entry->clusterName() == baseline_entry->clusterName();
+  }
+  // Neither route is a route entry, so compare them as direct responses. A route that is neither a
+  // route entry nor a direct response has no outcome to compare, so treat both-absent as
+  // equivalent.
+  const DirectResponseEntry* provider_direct = provider_route->directResponseEntry();
+  const DirectResponseEntry* baseline_direct = baseline_route->directResponseEntry();
+  if (provider_direct == nullptr || baseline_direct == nullptr) {
+    return provider_direct == baseline_direct;
+  }
+  return provider_direct->responseCode() == baseline_direct->responseCode();
+}
+} // namespace
+
+RouteConstSharedPtr VirtualHostImpl::getRouteFromProvider(const RouteCallback& cb,
+                                                          const Http::RequestHeaderMap& headers,
+                                                          const StreamInfo::StreamInfo& stream_info,
+                                                          uint64_t random_value) const {
+  const RouteDecision decision =
+      route_provider_->resolver->resolve(headers, stream_info, random_value);
+  RouteConstSharedPtr provider_route =
+      materializeProviderRoute(decision, headers, stream_info, random_value);
+
+  if (route_provider_->shadow_mode) {
+    RouteConstSharedPtr baseline_route =
+        getRouteFromMatcherOrRoutes(cb, headers, stream_info, random_value);
+    if (routesEquivalent(provider_route, baseline_route)) {
+      route_provider_->stats->shadow_match_.inc();
+    } else {
+      route_provider_->stats->shadow_mismatch_.inc();
+    }
+    route_provider_->resolver->onShadowResult(provider_route, baseline_route, headers, stream_info);
+    return baseline_route;
+  }
+
+  if (provider_route != nullptr) {
+    if (cb == nullptr) {
+      return provider_route;
+    }
+    const RouteEvalStatus eval_status =
+        hasBaseline() ? RouteEvalStatus::HasMoreRoutes : RouteEvalStatus::NoMoreRoutes;
+    if (cb(provider_route, eval_status) == RouteMatchStatus::Accept) {
+      return provider_route;
+    }
+  }
+
+  if (hasBaseline()) {
+    return getRouteFromMatcherOrRoutes(cb, headers, stream_info, random_value);
+  }
+  return nullptr;
+}
+
+RouteConstSharedPtr VirtualHostImpl::materializeProviderRoute(
+    const RouteDecision& decision, const Http::RequestHeaderMap& headers,
+    const StreamInfo::StreamInfo& stream_info, uint64_t random_value) const {
+  const RouteEntryImplBase* selected = nullptr;
+  switch (decision.kind) {
+  case RouteDecision::Kind::SelectTemplate: {
+    const auto it = route_provider_->templates.find(decision.template_id);
+    if (it == route_provider_->templates.end()) {
+      ENVOY_LOG(debug, "route provider selected unknown template '{}'", decision.template_id);
+      return nullptr;
+    }
+    selected = it->second.get();
+    break;
+  }
+  case RouteDecision::Kind::UseDefault: {
+    if (route_provider_->default_template_id.empty()) {
+      return nullptr;
+    }
+    const auto it = route_provider_->templates.find(route_provider_->default_template_id);
+    ASSERT(it != route_provider_->templates.end());
+    selected = it->second.get();
+    break;
+  }
+  case RouteDecision::Kind::ContinueMatching:
+    return nullptr;
+  }
+  return selected->clusterEntry(headers, stream_info, random_value);
 }
 
 const VirtualHostImpl* RouteMatcher::findWildcardVirtualHost(

--- a/source/common/router/config_impl.h
+++ b/source/common/router/config_impl.h
@@ -17,9 +17,11 @@
 #include "envoy/init/manager.h"
 #include "envoy/registry/registry.h"
 #include "envoy/router/cluster_specifier_plugin.h"
+#include "envoy/router/route_provider.h"
 #include "envoy/router/router.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/server/filter_config.h"
+#include "envoy/stats/stats_macros.h"
 #include "envoy/type/v3/percent.pb.h"
 #include "envoy/upstream/cluster_manager.h"
 
@@ -468,6 +470,20 @@ private:
 };
 
 /**
+ * All route provider stats. @see stats_macros.h
+ */
+#define ALL_ROUTE_PROVIDER_STATS(COUNTER)                                                          \
+  COUNTER(shadow_match)                                                                            \
+  COUNTER(shadow_mismatch)
+
+/**
+ * Struct definition for all route provider stats. @see stats_macros.h
+ */
+struct RouteProviderStats {
+  ALL_ROUTE_PROVIDER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
  * Virtual host that holds a collection of routes.
  */
 class VirtualHostImpl : Logger::Loggable<Logger::Id::router> {
@@ -493,6 +509,39 @@ public:
 private:
   enum class SslRequirements : uint8_t { None, ExternalOnly, All };
 
+  // Route selection state for a virtual host that configures a route provider. The resolver picks a
+  // template for each request, and in shadow mode the provider route is compared against the
+  // baseline built from `routes_` or `matcher_`.
+  struct RouteProvider {
+    DynamicRouteResolverSharedPtr resolver;
+    absl::flat_hash_map<std::string, RouteEntryImplBaseConstSharedPtr> templates;
+    std::string default_template_id;
+    Stats::ScopeSharedPtr scope;
+    std::unique_ptr<RouteProviderStats> stats;
+    bool shadow_mode{false};
+  };
+
+  // Resolve the route through the configured route provider, running the shadow comparison when the
+  // provider is in shadow mode.
+  RouteConstSharedPtr getRouteFromProvider(const RouteCallback& cb,
+                                           const Http::RequestHeaderMap& headers,
+                                           const StreamInfo::StreamInfo& stream_info,
+                                           uint64_t random_value) const;
+
+  // Resolve the route from the `matcher_` or `routes_` baseline.
+  RouteConstSharedPtr getRouteFromMatcherOrRoutes(const RouteCallback& cb,
+                                                  const Http::RequestHeaderMap& headers,
+                                                  const StreamInfo::StreamInfo& stream_info,
+                                                  uint64_t random_value) const;
+
+  // Build the route for a resolver decision by selecting the template and applying its overrides.
+  RouteConstSharedPtr materializeProviderRoute(const RouteDecision& decision,
+                                               const Http::RequestHeaderMap& headers,
+                                               const StreamInfo::StreamInfo& stream_info,
+                                               uint64_t random_value) const;
+
+  bool hasBaseline() const { return matcher_ != nullptr || !routes_.empty(); }
+
   CommonVirtualHostSharedPtr shared_virtual_host_;
 
   std::shared_ptr<const SslRedirectRoute> ssl_redirect_route_;
@@ -500,6 +549,7 @@ private:
 
   absl::InlinedVector<RouteEntryImplBaseConstSharedPtr, 2> routes_;
   Matcher::MatchTreeSharedPtr<Http::HttpMatchingData> matcher_;
+  std::unique_ptr<RouteProvider> route_provider_;
 };
 
 using VirtualHostImplSharedPtr = std::shared_ptr<VirtualHostImpl>;
@@ -675,6 +725,9 @@ class RouteEntryImplBase : public RouteEntryAndRoute,
                            public Matcher::ActionBase<envoy::config::route::v3::Route>,
                            public std::enable_shared_from_this<RouteEntryImplBase>,
                            Logger::Loggable<Logger::Id::router> {
+  // Allow the virtual host to materialize a selected route provider template via clusterEntry().
+  friend class VirtualHostImpl;
+
 protected:
   /**
    * @throw EnvoyException or sets creation_status if the route configuration contains any errors

--- a/test/common/router/config_impl_test.cc
+++ b/test/common/router/config_impl_test.cc
@@ -4027,6 +4027,560 @@ TEST_F(RouteMatcherTest, WeightedClusterWithProvidedRandomValue) {
   EXPECT_EQ("cluster2", config.route(headers, 60)->routeEntry()->clusterName());
 }
 
+// A resolver used only in tests. It selects the template named by the `x-template` header, returns
+// the use-default decision for the `x-default` header, and otherwise continues matching. Shadow
+// results are recorded so tests can assert on the comparison.
+class TestRouteResolver : public DynamicRouteResolver {
+public:
+  RouteDecision resolve(const Http::RequestHeaderMap& headers, const StreamInfo::StreamInfo&,
+                        uint64_t) const override {
+    const auto template_header = headers.get(Http::LowerCaseString("x-template"));
+    if (!template_header.empty()) {
+      return {RouteDecision::Kind::SelectTemplate,
+              std::string(template_header[0]->value().getStringView())};
+    }
+    if (!headers.get(Http::LowerCaseString("x-default")).empty()) {
+      return {RouteDecision::Kind::UseDefault, ""};
+    }
+    return {RouteDecision::Kind::ContinueMatching, ""};
+  }
+
+  void onShadowResult(RouteConstSharedPtr provider_route, RouteConstSharedPtr baseline_route,
+                      const Http::RequestHeaderMap&, const StreamInfo::StreamInfo&) const override {
+    shadow_called_ = true;
+    shadow_provider_route_ = std::move(provider_route);
+    shadow_baseline_route_ = std::move(baseline_route);
+  }
+
+  mutable bool shadow_called_{false};
+  mutable RouteConstSharedPtr shadow_provider_route_;
+  mutable RouteConstSharedPtr shadow_baseline_route_;
+};
+
+class TestRouteProviderFactory : public RouteProviderFactory {
+public:
+  absl::StatusOr<DynamicRouteResolverSharedPtr>
+  createRouteResolver(const Protobuf::Message&,
+                      Server::Configuration::ServerFactoryContext&) override {
+    if (fail_) {
+      return absl::InvalidArgumentError("route provider creation failed");
+    }
+    resolver_ = std::make_shared<TestRouteResolver>();
+    return resolver_;
+  }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::Struct>();
+  }
+  std::string name() const override { return "envoy.router.route_provider.test"; }
+
+  std::shared_ptr<TestRouteResolver> resolver_;
+  bool fail_{false};
+};
+
+TEST_F(RouteMatcherTest, RouteProviderSelectsTemplate) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    - template_id: b
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_b}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a", "cluster_b"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  auto select_a = genHeaders("some.domain", "/", "GET");
+  select_a.addCopy("x-template", "a");
+  EXPECT_EQ("cluster_a", config.route(select_a, 0)->routeEntry()->clusterName());
+
+  auto select_b = genHeaders("some.domain", "/", "GET");
+  select_b.addCopy("x-template", "b");
+  EXPECT_EQ("cluster_b", config.route(select_b, 0)->routeEntry()->clusterName());
+
+  auto select_missing = genHeaders("some.domain", "/", "GET");
+  select_missing.addCopy("x-template", "missing");
+  EXPECT_LOG_CONTAINS("debug", "route provider selected unknown template 'missing'",
+                      { EXPECT_EQ(nullptr, config.route(select_missing, 0).route); });
+}
+
+TEST_F(RouteMatcherTest, RouteProviderUsesDefaultTemplate) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    default_template_id: a
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  auto headers = genHeaders("some.domain", "/", "GET");
+  headers.addCopy("x-default", "true");
+  EXPECT_EQ("cluster_a", config.route(headers, 0)->routeEntry()->clusterName());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderUseDefaultWithoutDefaultTemplate) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  // The resolver returns use-default but no default template is configured, so no route is
+  // produced.
+  auto headers = genHeaders("some.domain", "/", "GET");
+  headers.addCopy("x-default", "true");
+  EXPECT_EQ(nullptr, config.route(headers, 0).route);
+}
+
+TEST_F(RouteMatcherTest, RouteProviderContinueMatchingFallsThroughToBaseline) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  routes:
+  - match: {prefix: "/"}
+    route: {cluster: baseline_cluster}
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a", "baseline_cluster"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  // No selection header, so the resolver continues matching and the baseline route is used.
+  auto continue_headers = genHeaders("some.domain", "/", "GET");
+  EXPECT_EQ("baseline_cluster", config.route(continue_headers, 0)->routeEntry()->clusterName());
+
+  // The provider is live, so a selected template takes precedence over the baseline.
+  auto select_headers = genHeaders("some.domain", "/", "GET");
+  select_headers.addCopy("x-template", "a");
+  EXPECT_EQ("cluster_a", config.route(select_headers, 0)->routeEntry()->clusterName());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderRouteCallback) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  routes:
+  - match: {prefix: "/"}
+    route: {cluster: baseline_cluster}
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a", "baseline_cluster"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  auto headers = genHeaders("some.domain", "/", "GET");
+  headers.addCopy("x-template", "a");
+
+  // The callback accepts the provider route, which is offered with HasMoreRoutes because a baseline
+  // is configured.
+  RouteConstSharedPtr accepted = config.route(
+      [](RouteConstSharedPtr route, RouteEvalStatus status) -> RouteMatchStatus {
+        EXPECT_EQ("cluster_a", route->routeEntry()->clusterName());
+        EXPECT_EQ(RouteEvalStatus::HasMoreRoutes, status);
+        return RouteMatchStatus::Accept;
+      },
+      headers);
+  ASSERT_NE(nullptr, accepted);
+  EXPECT_EQ("cluster_a", accepted->routeEntry()->clusterName());
+
+  // When the callback continues past the provider route, matching falls through to the baseline.
+  bool provider_seen = false;
+  RouteConstSharedPtr fell_through = config.route(
+      [&provider_seen](RouteConstSharedPtr route, RouteEvalStatus) -> RouteMatchStatus {
+        if (route->routeEntry()->clusterName() == "cluster_a") {
+          provider_seen = true;
+          return RouteMatchStatus::Continue;
+        }
+        return RouteMatchStatus::Accept;
+      },
+      headers);
+  EXPECT_TRUE(provider_seen);
+  ASSERT_NE(nullptr, fell_through);
+  EXPECT_EQ("baseline_cluster", fell_through->routeEntry()->clusterName());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderRedirectTemplate) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    route_templates:
+    - template_id: r
+      route:
+        match: {prefix: "/"}
+        redirect: {host_redirect: "example.com"}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  auto headers = genHeaders("some.domain", "/", "GET");
+  headers.addCopy("x-template", "r");
+  const auto route = config.route(headers, 0);
+  ASSERT_NE(nullptr, route.route);
+  EXPECT_EQ(nullptr, route->routeEntry());
+  ASSERT_NE(nullptr, route->directResponseEntry());
+  EXPECT_EQ(Http::Code::MovedPermanently, route->directResponseEntry()->responseCode());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderShadowModeServesBaselineAndReportsMismatch) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  routes:
+  - match: {prefix: "/"}
+    route: {cluster: baseline_cluster}
+  route_provider:
+    shadow_mode: true
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a", "baseline_cluster"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  auto headers = genHeaders("some.domain", "/", "GET");
+  headers.addCopy("x-template", "a");
+  // Shadow mode serves the baseline route while the provider route is only computed for comparison.
+  EXPECT_EQ("baseline_cluster", config.route(headers, 0)->routeEntry()->clusterName());
+
+  ASSERT_NE(nullptr, factory.resolver_);
+  EXPECT_TRUE(factory.resolver_->shadow_called_);
+  ASSERT_NE(nullptr, factory.resolver_->shadow_provider_route_);
+  ASSERT_NE(nullptr, factory.resolver_->shadow_baseline_route_);
+  EXPECT_EQ("cluster_a", factory.resolver_->shadow_provider_route_->routeEntry()->clusterName());
+  EXPECT_EQ("baseline_cluster",
+            factory.resolver_->shadow_baseline_route_->routeEntry()->clusterName());
+  EXPECT_EQ(1U,
+            factory_context_.store_.counter("vhost.local_service.route_provider.shadow_mismatch")
+                .value());
+  EXPECT_EQ(
+      0U,
+      factory_context_.store_.counter("vhost.local_service.route_provider.shadow_match").value());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderShadowModeReportsMatch) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  routes:
+  - match: {prefix: "/"}
+    route: {cluster: baseline_cluster}
+  route_provider:
+    shadow_mode: true
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: baseline_cluster}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"baseline_cluster"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  auto headers = genHeaders("some.domain", "/", "GET");
+  headers.addCopy("x-template", "a");
+  EXPECT_EQ("baseline_cluster", config.route(headers, 0)->routeEntry()->clusterName());
+  EXPECT_EQ(
+      1U,
+      factory_context_.store_.counter("vhost.local_service.route_provider.shadow_match").value());
+  EXPECT_EQ(0U,
+            factory_context_.store_.counter("vhost.local_service.route_provider.shadow_mismatch")
+                .value());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderShadowModeComparesDirectResponses) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  routes:
+  - match: {prefix: "/"}
+    direct_response: {status: 404, body: {inline_string: "baseline"}}
+  route_provider:
+    shadow_mode: true
+    route_templates:
+    - template_id: same
+      route:
+        match: {prefix: "/"}
+        direct_response: {status: 404, body: {inline_string: "same"}}
+    - template_id: diff
+      route:
+        match: {prefix: "/"}
+        direct_response: {status: 500, body: {inline_string: "diff"}}
+    - template_id: cluster_tmpl
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+
+  // Two direct responses with the same status code are equivalent, so the shadow reports a match.
+  auto same = genHeaders("some.domain", "/", "GET");
+  same.addCopy("x-template", "same");
+  EXPECT_EQ(Http::Code::NotFound, config.route(same, 0)->directResponseEntry()->responseCode());
+  EXPECT_EQ(
+      1U,
+      factory_context_.store_.counter("vhost.local_service.route_provider.shadow_match").value());
+
+  // Different status codes are a mismatch.
+  auto diff = genHeaders("some.domain", "/", "GET");
+  diff.addCopy("x-template", "diff");
+  config.route(diff, 0);
+  EXPECT_EQ(1U,
+            factory_context_.store_.counter("vhost.local_service.route_provider.shadow_mismatch")
+                .value());
+
+  // A provider route entry against a baseline direct response is a mismatch, since only one has a
+  // route entry.
+  auto cluster = genHeaders("some.domain", "/", "GET");
+  cluster.addCopy("x-template", "cluster_tmpl");
+  config.route(cluster, 0);
+  EXPECT_EQ(2U,
+            factory_context_.store_.counter("vhost.local_service.route_provider.shadow_mismatch")
+                .value());
+}
+
+TEST_F(RouteMatcherTest, RouteProviderShadowModeRequiresBaseline) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    shadow_mode: true
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_THAT(creation_status_.message(),
+              testing::ContainsRegex("route provider shadow_mode requires routes or matcher"));
+}
+
+TEST_F(RouteMatcherTest, RouteProviderDuplicateTemplateId) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_b}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a", "cluster_b"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_THAT(creation_status_.message(),
+              testing::ContainsRegex("duplicate route provider template id 'a'"));
+}
+
+TEST_F(RouteMatcherTest, RouteProviderDefaultTemplateIdNotFound) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    default_template_id: missing
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_THAT(creation_status_.message(),
+              testing::ContainsRegex("default_template_id 'missing' does not match any template"));
+}
+
+TEST_F(RouteMatcherTest, RouteProviderUnknownResolver) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.does_not_exist
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_THAT(creation_status_.message(),
+              testing::ContainsRegex("Didn't find a registered route provider resolver"));
+}
+
+TEST_F(RouteMatcherTest, RouteProviderCreationFailure) {
+  const std::string yaml = R"EOF(
+virtual_hosts:
+- name: local_service
+  domains: ["*"]
+  route_provider:
+    route_templates:
+    - template_id: a
+      route:
+        match: {prefix: "/"}
+        route: {cluster: cluster_a}
+    resolver:
+      name: envoy.router.route_provider.test
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.Struct
+  )EOF";
+
+  TestRouteProviderFactory factory;
+  factory.fail_ = true;
+  Registry::InjectFactory<RouteProviderFactory> registered(factory);
+  factory_context_.cluster_manager_.initializeClusters({"cluster_a"}, {});
+  TestConfigImpl config(parseRouteConfigurationFromYaml(yaml), factory_context_, true,
+                        creation_status_);
+  EXPECT_THAT(creation_status_.message(), testing::ContainsRegex("route provider creation failed"));
+}
+
 TEST_F(RouteMatcherTest, InlineClusterSpecifierPlugin) {
   const std::string yaml = R"EOF(
 virtual_hosts:


### PR DESCRIPTION
## Description

This PR adds a new route provider extension point on the virtual host. A resolver selects one of a set of named route templates for each request and the core builds the route from the selected template. The provider can run in shadow mode next to routes or matcher to compare results before serving real traffic.

---

**Commit Message:** router: add route_provider virtual host extension point
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added