### PR TITLE
mcp: early-terminate body parsing once routing attributes are collected

### DIFF
--- a/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
+++ b/api/envoy/extensions/filters/http/mcp/v3/mcp.proto
@@ -21,7 +21,7 @@ option (xds.annotations.v3.file_status).work_in_progress = true;
 // [#extension: envoy.filters.http.mcp]
 
 // This filter will inspect and get attributes from MCP traffic.
-// [#next-free-field: 10]
+// [#next-free-field: 11]
 message Mcp {
   // Traffic handling mode for non-MCP traffic.
   enum TrafficMode {
@@ -140,6 +140,28 @@ message Mcp {
   // and the method-specific identifier carried by ``Mcp-Name``; other configured
   // extraction rules still require body parsing.
   AttributeSource attribute_source = 9 [(validate.rules).enum = {defined_only: true}];
+
+  // When true, stop parsing (and buffering) the request body as soon as all the
+  // required routing attributes for the request's method have been collected
+  // (for example ``method`` and ``params.name`` for ``tools/call``), even if
+  // optional attributes such as ``params._meta`` or the remainder of the body
+  // have not been parsed yet. This decouples routing from body size, so a large
+  // trailing payload (for example ``params.arguments``) does not need to be
+  // buffered at the proxy just to route the request.
+  //
+  // Early termination is intentionally skipped when it could change observable
+  // behavior, so it has no effect when any of the following holds:
+  //
+  // - ``reject_duplicate_keys`` is set (duplicate detection needs a full-body scan);
+  // - ``propagate_trace_context`` or ``propagate_baggage`` is set (both read
+  //   ``params._meta``, which may appear after the routing attributes);
+  // - ``attribute_source`` is not ``BODY``.
+  //
+  // Requests whose body arrives complete in a single chunk are unaffected, since
+  // the whole root object is observed before iteration continues.
+  //
+  // Defaults to false.
+  bool early_terminate_when_routable = 10;
 }
 
 // Parser configuration with method-specific rules.

--- a/changelogs/current/new_features/mcp__early-terminate-when-routable.rst
+++ b/changelogs/current/new_features/mcp__early-terminate-when-routable.rst
@@ -1,0 +1,10 @@
+Added :ref:`early_terminate_when_routable
+<envoy_v3_api_field_extensions.filters.http.mcp.v3.Mcp.early_terminate_when_routable>` to the
+:ref:`MCP filter <config_http_filters_mcp>`. When enabled, the filter stops parsing and buffering
+the request body as soon as all required routing attributes for the request's method have been
+collected (for example ``method`` and ``params.name`` for ``tools/call``), instead of buffering up
+to ``max_request_body_size`` and waiting for the root JSON object to close. This decouples routing
+from body size so a large trailing payload (for example ``params.arguments``) does not need to be
+buffered just to route the request. Early termination is skipped when ``reject_duplicate_keys``,
+trace context or baggage propagation is configured, or when ``attribute_source`` is not ``BODY``.
+Defaults to false.

--- a/source/extensions/filters/http/mcp/mcp_filter.cc
+++ b/source/extensions/filters/http/mcp/mcp_filter.cc
@@ -133,6 +133,7 @@ McpFilterConfig::McpFilterConfig(const envoy::extensions::filters::http::mcp::v3
                                  : 8192), // Default: 8KB
       request_storage_mode_(proto_config.request_storage_mode()),
       attribute_source_(proto_config.attribute_source()),
+      early_terminate_when_routable_(proto_config.early_terminate_when_routable()),
       metadata_namespace_(Filters::Common::Mcp::metadataNamespace()),
       parser_config_(proto_config.has_parser_config()
                          ? McpParserConfig::fromProto(proto_config.parser_config())
@@ -303,6 +304,18 @@ bool McpFilter::rejectDuplicateKeys() const {
   return config_->rejectDuplicateKeys();
 }
 
+bool McpFilter::canEarlyTerminate() {
+  // Stop buffering once the routing attributes (method + name/uri) are collected.
+  // Disabled for REJECT_NO_MCP mode, reject_duplicate_keys, trace/baggage
+  // propagation, and non-BODY attribute_source, which all need the rest of the
+  // body. Single-chunk bodies still take isParsingComplete() (last-key-wins);
+  // malformed content in the unparsed tail is not validated at this hop.
+  return config_->earlyTerminateWhenRoutable() && !shouldRejectRequest() &&
+         config_->attributeSource() == envoy::extensions::filters::http::mcp::v3::Mcp::BODY &&
+         !rejectDuplicateKeys() && !config_->propagateTraceContext().has_value() &&
+         !config_->propagateBaggage().has_value();
+}
+
 bool McpFilter::needsBody() const {
   if (config_->attributeSource() != envoy::extensions::filters::http::mcp::v3::Mcp::HEADERS) {
     return true;
@@ -432,6 +445,7 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
 
   const uint32_t max_size = getMaxRequestBodySize();
   uint32_t bytes_parsed_in_this_call = 0;
+  const bool early_terminate = canEarlyTerminate();
 
   for (const Buffer::RawSlice& slice : data.getRawSlices()) {
     const char* start = static_cast<const char*>(slice.mem_);
@@ -454,6 +468,18 @@ Http::FilterDataStatus McpFilter::decodeData(Buffer::Instance& data, bool end_st
 
       if (parser_->isParsingComplete()) {
         ENVOY_LOG(debug, "mcp parse complete: found all fields");
+        return completeParsing();
+      }
+
+      // Stop buffering once routing attributes are collected, even if the root
+      // object is still open, to avoid buffering a large trailing payload.
+      if (early_terminate && parser_->hasAllRequiredFields()) {
+        ENVOY_LOG(debug, "mcp early termination: routing attributes collected at {} bytes",
+                  bytes_parsed_);
+        // Finalize extraction into metadata; the still-open root object's
+        // partial-parse error is expected and intentionally ignored.
+        const absl::Status finalize_status = parser_->finishParse();
+        ENVOY_LOG(trace, "mcp early termination finalize status: {}", finalize_status.message());
         return completeParsing();
       }
     }

--- a/source/extensions/filters/http/mcp/mcp_filter.h
+++ b/source/extensions/filters/http/mcp/mcp_filter.h
@@ -72,6 +72,7 @@ public:
   envoy::extensions::filters::http::mcp::v3::Mcp::AttributeSource attributeSource() const {
     return attribute_source_;
   }
+  bool earlyTerminateWhenRoutable() const { return early_terminate_when_routable_; }
   const ParserConfig& parserConfig() const { return parser_config_; }
   bool shouldStoreToDynamicMetadata() const {
     return request_storage_mode_ ==
@@ -100,6 +101,7 @@ private:
   const uint32_t max_request_body_size_;
   const envoy::extensions::filters::http::mcp::v3::Mcp::RequestStorageMode request_storage_mode_;
   const envoy::extensions::filters::http::mcp::v3::Mcp::AttributeSource attribute_source_;
+  const bool early_terminate_when_routable_;
   const std::string metadata_namespace_;
   ParserConfig parser_config_;
   McpFilterStats stats_;
@@ -177,6 +179,9 @@ private:
   bool shouldStoreToDynamicMetadata() const;
   bool shouldStoreToFilterState() const;
   bool rejectDuplicateKeys() const;
+  // Whether buffering may stop once routing attributes are collected (see .cc
+  // for gating). Non-const because it resolves the latched traffic mode.
+  bool canEarlyTerminate();
   const McpOverrideConfig* routeOverride() const;
 
   void sendErrorReply(absl::string_view error_msg, Filters::Common::Mcp::Status status);

--- a/test/extensions/filters/http/mcp/mcp_filter_test.cc
+++ b/test/extensions/filters/http/mcp/mcp_filter_test.cc
@@ -1456,6 +1456,162 @@ TEST_F(McpFilterTest, ChunkByChunkParsingWithOptionalFields) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer2, true));
 }
 
+// Early termination stops buffering once routing attributes are collected; a
+// large trailing payload in a later chunk is neither parsed nor buffered.
+TEST_F(McpFilterTest, EarlyTerminationStopsBufferingWhenRoutable) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::PASS_THROUGH);
+  proto_config.set_early_terminate_when_routable(true);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+  filter_->decodeHeaders(headers, false);
+
+  // First chunk carries method + params.name but leaves the root object open.
+  std::string chunk1 =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "id": 1, "params": {"name": "mytool", )";
+  Buffer::OwnedImpl buffer1(chunk1);
+
+  EXPECT_CALL(decoder_callbacks_, sendLocalReply(_, _, _, _, _)).Times(0);
+  EXPECT_CALL(decoder_callbacks_.stream_info_, setDynamicMetadata("envoy.filters.http.mcp", _))
+      .WillOnce([](const std::string&, const Protobuf::Struct& metadata) {
+        EXPECT_THAT(
+            metadata.fields(),
+            Contains(Pair(
+                "params",
+                Property(&Protobuf::Value::struct_value,
+                         Property(&Protobuf::Struct::fields,
+                                  Contains(Pair("name", Property(&Protobuf::Value::string_value,
+                                                                 "mytool"))))))));
+      });
+
+  // Routing attributes are available, so the filter continues without buffering
+  // the remainder of the body.
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer1, false));
+
+  // A large trailing payload arriving later is passed through untouched: parsing
+  // is already complete, so it is neither parsed nor buffered.
+  std::string chunk2 = R"("arguments": {"blob": ")" + std::string(100000, 'x') + R"("}}})";
+  Buffer::OwnedImpl buffer2(chunk2);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(buffer2, true));
+}
+
+// Early termination is skipped when trace context propagation is configured.
+TEST_F(McpFilterTest, EarlyTerminationSkippedWhenTracePropagationConfigured) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_early_terminate_when_routable(true);
+  proto_config.mutable_propagate_trace_context();
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+  filter_->decodeHeaders(headers, false);
+
+  std::string chunk1 =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "id": 1, "params": {"name": "mytool", )";
+  Buffer::OwnedImpl buffer1(chunk1);
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer1, false));
+}
+
+// Early termination is skipped when baggage propagation is configured.
+TEST_F(McpFilterTest, EarlyTerminationSkippedWhenBaggagePropagationConfigured) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_early_terminate_when_routable(true);
+  proto_config.mutable_propagate_baggage();
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+  filter_->decodeHeaders(headers, false);
+
+  std::string chunk1 =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "id": 1, "params": {"name": "mytool", )";
+  Buffer::OwnedImpl buffer1(chunk1);
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer1, false));
+}
+
+// Early termination is skipped when duplicate-key rejection is enabled.
+TEST_F(McpFilterTest, EarlyTerminationSkippedWhenRejectDuplicateKeys) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_early_terminate_when_routable(true);
+  proto_config.mutable_reject_duplicate_keys()->set_value(true);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+  filter_->decodeHeaders(headers, false);
+
+  std::string chunk1 =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "id": 1, "params": {"name": "mytool", )";
+  Buffer::OwnedImpl buffer1(chunk1);
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer1, false));
+}
+
+// Early termination is skipped in REJECT_NO_MCP mode, which must validate the
+// complete root JSON object.
+TEST_F(McpFilterTest, EarlyTerminationSkippedInRejectMode) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_traffic_mode(envoy::extensions::filters::http::mcp::v3::Mcp::REJECT_NO_MCP);
+  proto_config.set_early_terminate_when_routable(true);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+  filter_->decodeHeaders(headers, false);
+
+  std::string chunk1 =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "id": 1, "params": {"name": "mytool", )";
+  Buffer::OwnedImpl buffer1(chunk1);
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer1, false));
+}
+
+// Early termination is skipped when attribute_source is not BODY.
+TEST_F(McpFilterTest, EarlyTerminationSkippedWhenAttributeSourceNotBody) {
+  envoy::extensions::filters::http::mcp::v3::Mcp proto_config;
+  proto_config.set_early_terminate_when_routable(true);
+  proto_config.set_attribute_source(envoy::extensions::filters::http::mcp::v3::Mcp::VERIFY);
+  config_ = std::make_shared<McpFilterConfig>(proto_config, "test.", factory_context_.scope());
+  filter_ = std::make_unique<McpFilter>(config_);
+  filter_->setDecoderFilterCallbacks(decoder_callbacks_);
+
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {"content-type", "application/json"},
+                                         {"accept", "application/json"},
+                                         {"accept", "text/event-stream"}};
+  filter_->decodeHeaders(headers, false);
+
+  std::string chunk1 =
+      R"({"jsonrpc": "2.0", "method": "tools/call", "id": 1, "params": {"name": "mytool", )";
+  Buffer::OwnedImpl buffer1(chunk1);
+
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark, filter_->decodeData(buffer1, false));
+}
+
 // Test request body with limit disabled (0 = no limit) allows large bodies
 TEST_F(McpFilterTest, RequestBodyWithDisabledLimitAllowsLargeBodies) {
   envoy::extensions::filters::http::mcp::v3::Mcp proto_config;


### PR DESCRIPTION
Commit Message:
The MCP filter buffers the request body up to max_request_body_size and only completes once the root JSON object closes. For large tools/call requests (e.g. a big params.arguments blob) this buffers far more than routing needs, since routing only depends on method + params.name. When the body exceeds the limit before the root object closes, the routing attributes can be missed and the request is mis-routed (falling back to a base route).

Add an opt-in 'early_terminate_when_routable' option. When enabled, the filter stops parsing and buffering as soon as all required routing attributes for the method have been collected, by wiring the parser's existing hasAllRequiredFields() into decodeData. It is gated to attribute_source BODY and skipped when reject_duplicate_keys or trace/baggage propagation is configured (those need the rest of the body). Default false preserves existing behavior; a body that arrives complete in a single chunk still takes the isParsingComplete() path, so last-key-wins is preserved for the common case.

A possible follow-up is to migrate onto source/common/json/json_rpc_field_extractor.cc, which already early-stops once required fields are collected.

Adds unit tests (early termination plus each gating branch) and a changelog fragment.
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
