### PR TITLE
Deflake //test/extensions/filters/http/ext_proc:ext_proc_local_reply_streaming_integration_test

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc
@@ -31,6 +31,10 @@ using Http::LowerCaseString;
 class ExtProcLocalReplyStreamingIntegrationTest : public ExtProcIntegrationTest {
 public:
   void SetUp() override {
+    // Increase the per-message timeout to tolerate integration test scheduling delays. These tests
+    // exercise streamed local responses, while message timeout behavior is tested separately.
+    // The default timeout is 200ms.
+    proto_config_.mutable_message_timeout()->set_seconds(2);
     if (!IsEnvoyGrpc()) {
       GTEST_SKIP()
           << "Google gRPC client is not supported for local reply streaming integration tests";
@@ -122,7 +126,17 @@ TEST_P(ExtProcLocalReplyStreamingIntegrationTest, LocalHeadersOnlyRequestAndResp
   sendLocalResponseBody(true);
 
   ASSERT_TRUE(response->waitForEndStream());
-  ASSERT_EQ(response->body(), "local response body");
+  EXPECT_EQ("200", response->headers().getStatusValue()) << response->debugState();
+  ASSERT_EQ(response->body(), "local response body")
+      << response->debugState() << "\next_proc counters:"
+      << "\n  message_timeouts="
+      << test_server_->counter("http.config_test.ext_proc.message_timeouts")->value()
+      << "\n  streams_failed="
+      << test_server_->counter("http.config_test.ext_proc.streams_failed")->value()
+      << "\n  spurious_msgs_received="
+      << test_server_->counter("http.config_test.ext_proc.spurious_msgs_received")->value()
+      << "\n  immediate_responses_sent="
+      << test_server_->counter("http.config_test.ext_proc.immediate_responses_sent")->value();
   verifyDownstreamResponse(*response, 200);
 }
 


### PR DESCRIPTION
Commit Message: Deflake //test/extensions/filters/http/ext_proc:ext_proc_local_reply_streaming_integration_test
Additional Description: The hypothesis is that [this flaky run](https://github.com/envoyproxy/envoy/actions/runs/34241702318/job/102114570212#annotation:20:1247)
```
  [ RUN      ] IpVersionsClientTypeDeferredProcessing/ExtProcLocalReplyStreamingIntegrationTest.LocalHeadersOnlyRequestAndResponseWithBody/2
  test/extensions/filters/http/ext_proc/ext_proc_local_reply_streaming_integration_test.cc:125: Failure
  Expected equality of these values:
    response->body()
      Which is: ""
    "local response body"
  Stack trace:
    0x5590b95d9e70: Envoy::Extensions::HttpFilters::ExternalProcessing::(anonymous namespace)::ExtProcLocalReplyStreamingIntegrationTest_LocalHeadersOnlyRequestAndResponseWithBody_Test::TestBody()
    0x5590b95da12d: Envoy::Extensions::HttpFilters::ExternalProcessing::(anonymous namespace)::ExtProcLocalReplyStreamingIntegrationTest_LocalHeadersOnlyRequestAndResponseWithBody_Test::TestBody()
    0x5590c1c5fc36: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x5590c1c2e994: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x5590c1c0bff9: testing::Test::Run()
    0x5590c1c0cd3c: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_quic_always_support_server_preferred_address to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_reloadable_features_ext_proc_inject_data_with_state_update to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_reloadable_features_runtime_initialized to: false
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_quic_always_support_server_preferred_address to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_reloadable_features_ext_proc_inject_data_with_state_update to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_reloadable_features_runtime_initialized to: false
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_quic_always_support_server_preferred_address to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_reloadable_features_ext_proc_inject_data_with_state_update to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 148] RAW: Restore saved value of envoy_reloadable_features_runtime_initialized to: false
  [  FAILED  ] IpVersionsClientTypeDeferredProcessing/ExtProcLocalReplyStreamingIntegrationTest.LocalHeadersOnlyRequestAndResponseWithBody/2, where GetParam() = (4-byte object <01-00 00-00>, 4-byte object <00-00 00-00>) (6454 ms)
```
... is caused by a default 200ms timeout on ext_proc grpcs that sometimes isn't met in a slower tsan execution.

Increasing that duration so those timeouts can't impact this test suite is the first part of the PR.

Secondly, we add a bunch of extra information on test failure, so if the hypothesis is incorrect and the test still fails, we have more diagnostic information next time.

Though the test failure output is not a precise match, the hypothesis also matches what happened in https://github.com/envoyproxy/envoy/issues/44424 so this may also fix that issue.

This PR was assisted by Codex Sol. I have reviewed and understand what it's doing.
Risk Level: test-only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
