### PR TITLE
feat: mTLS support for client-credential injector

### DIFF
--- a/api/envoy/extensions/http/injected_credentials/oauth2/v3/oauth2.proto
+++ b/api/envoy/extensions/http/injected_credentials/oauth2/v3/oauth2.proto
@@ -35,6 +35,14 @@ message OAuth2 {
     // The ``client_id`` and ``client_secret`` will be sent in the URL encoded request body.
     // This type should only be used when Auth server does not support Basic authentication.
     URL_ENCODED_BODY = 1;
+
+    // Client authentication via mutual TLS (mTLS) as defined in
+    // [RFC 8705](https://www.rfc-editor.org/rfc/rfc8705).
+    // Only client_id and ``grant_type`` will be sent in the request body; ``client_secret``
+    // is not required and will be ignored if set.
+    // The mTLS client certificate must be configured on the TLS transport of the token endpoint
+    // cluster (``transport_socket`` with ``tls_certificates``).
+    MTLS_AUTH = 2;
   }
 
   // Credentials to authenticate client to the authorization server.
@@ -46,8 +54,8 @@ message OAuth2 {
 
     // Client secret.
     // Refer to `RFC 6749: The OAuth 2.0 Authorization Framework <https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1>`__ for details.
-    transport_sockets.tls.v3.SdsSecretConfig client_secret = 2
-        [(validate.rules).message = {required: true}];
+    // Required when ``auth_type`` is ``BASIC_AUTH`` or ``URL_ENCODED_BODY``.
+    transport_sockets.tls.v3.SdsSecretConfig client_secret = 2;
 
     // The method to use when sending credentials to the authorization server.
     // Refer to `RFC 6749: The OAuth 2.0 Authorization Framework <https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1>`__ for details.

--- a/changelogs/current/new_features/oauth2__mtls-auth-for-credential-injector.rst
+++ b/changelogs/current/new_features/oauth2__mtls-auth-for-credential-injector.rst
@@ -1,0 +1,8 @@
+Added :ref:`MTLS_AUTH
+<envoy_v3_api_enum_value_extensions.http.injected_credentials.oauth2.v3.OAuth2.AuthType.MTLS_AUTH>`
+to the OAuth2 credential injector, which authenticates the client to the token endpoint using mutual
+TLS as described in `RFC 8705 <https://www.rfc-editor.org/rfc/rfc8705>`_. The token request body
+contains only ``grant_type`` and ``client_id``, and the client certificate is taken from the
+``transport_socket`` configured on the token endpoint cluster. :ref:`client_secret
+<envoy_v3_api_field_extensions.http.injected_credentials.oauth2.v3.OAuth2.ClientCredentials.client_secret>`
+is not required when this auth type is used.

--- a/source/extensions/http/injected_credentials/oauth2/BUILD
+++ b/source/extensions/http/injected_credentials/oauth2/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
     hdrs = ["token_provider.h"],
     deps = [
         ":oauth_client",
+        "//source/common/common:empty_string",
         "//source/extensions/http/injected_credentials/common:credential_interface",
         "//source/extensions/http/injected_credentials/common:secret_reader_lib",
         "@envoy_api//envoy/extensions/http/injected_credentials/oauth2/v3:pkg_cc_proto",
@@ -59,6 +60,7 @@ envoy_cc_library(
         "//source/common/http:utility_lib",
         "//source/common/protobuf:message_validator_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/http/injected_credentials/oauth2/v3:pkg_cc_proto",
     ],
 )
 

--- a/source/extensions/http/injected_credentials/oauth2/config.cc
+++ b/source/extensions/http/injected_credentials/oauth2/config.cc
@@ -46,15 +46,19 @@ OAuth2CredentialInjectorFactory::createOauth2ClientCredentialInjector(
     Server::Configuration::ServerFactoryContext& context, Init::Manager& init_manager) {
   auto& cluster_manager = context.clusterManager();
 
-  const auto& client_secret_secret = proto_config.client_credentials().client_secret();
+  Common::SecretReaderConstSharedPtr secret_reader;
+  const auto auth_type = proto_config.client_credentials().auth_type();
 
-  auto client_secret_provider = secretsProvider(client_secret_secret, context, init_manager);
-  if (client_secret_provider == nullptr) {
-    throw EnvoyException("Invalid oauth2 client secret configuration");
+  if (auth_type != envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::MTLS_AUTH) {
+    const auto& client_secret_secret = proto_config.client_credentials().client_secret();
+    auto client_secret_provider = secretsProvider(client_secret_secret, context, init_manager);
+    if (client_secret_provider == nullptr) {
+      throw EnvoyException("Invalid oauth2 client secret configuration");
+    }
+    secret_reader = std::make_shared<const Common::SDSSecretReader>(
+        std::move(client_secret_provider), context.threadLocal(), context.api());
   }
 
-  auto secret_reader = std::make_shared<const Common::SDSSecretReader>(
-      std::move(client_secret_provider), context.threadLocal(), context.api());
   auto token_reader = std::make_shared<const TokenProvider>(
       secret_reader, context.threadLocal(), cluster_manager, proto_config,
       context.mainThreadDispatcher(), stats_prefix, context.scope());

--- a/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
+++ b/source/extensions/http/injected_credentials/oauth2/oauth_client.cc
@@ -26,27 +26,41 @@ constexpr const char* GetAccessTokenBodyFormatString =
     "grant_type=client_credentials&client_id={0}&client_secret={1}";
 constexpr const char* GetAccessTokenBodyFormatStringWithScopes =
     "grant_type=client_credentials&client_id={0}&client_secret={1}&scope={2}";
-
+constexpr const char* GetAccessTokenBodyMtlsFormatString =
+    "grant_type=client_credentials&client_id={0}";
+constexpr const char* GetAccessTokenBodyMtlsFormatStringWithScopes =
+    "grant_type=client_credentials&client_id={0}&scope={1}";
 } // namespace
 
-OAuth2Client::GetTokenResult
-OAuth2ClientImpl::asyncGetAccessToken(const std::string& client_id, const std::string& secret,
-                                      const std::string& scopes,
-                                      const std::map<std::string, std::string>& endpoint_params) {
+OAuth2Client::GetTokenResult OAuth2ClientImpl::asyncGetAccessToken(
+    const std::string& client_id, const std::string& secret, const std::string& scopes,
+    const std::map<std::string, std::string>& endpoint_params,
+    envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::AuthType auth_type) {
   if (in_flight_request_ != nullptr) {
     return GetTokenResult::NotDispatchedAlreadyInFlight;
   }
   const auto encoded_client_id = Envoy::Http::Utility::PercentEncoding::encode(client_id, ":/=&?");
-  const auto encoded_secret = Envoy::Http::Utility::PercentEncoding::encode(secret, ":/=&?");
 
   Envoy::Http::RequestMessagePtr request = createPostRequest();
   std::string body;
-  if (scopes.empty()) {
-    body = fmt::format(GetAccessTokenBodyFormatString, encoded_client_id, encoded_secret);
+
+  if (auth_type == envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::MTLS_AUTH) {
+    if (scopes.empty()) {
+      body = fmt::format(GetAccessTokenBodyMtlsFormatString, encoded_client_id);
+    } else {
+      const auto encoded_scopes = Envoy::Http::Utility::PercentEncoding::encode(scopes, ":/=&?");
+      body = fmt::format(GetAccessTokenBodyMtlsFormatStringWithScopes, encoded_client_id,
+                         encoded_scopes);
+    }
   } else {
-    const auto encoded_scopes = Envoy::Http::Utility::PercentEncoding::encode(scopes, ":/=&?");
-    body = fmt::format(GetAccessTokenBodyFormatStringWithScopes, encoded_client_id, encoded_secret,
-                       encoded_scopes);
+    const auto encoded_secret = Envoy::Http::Utility::PercentEncoding::encode(secret, ":/=&?");
+    if (scopes.empty()) {
+      body = fmt::format(GetAccessTokenBodyFormatString, encoded_client_id, encoded_secret);
+    } else {
+      const auto encoded_scopes = Envoy::Http::Utility::PercentEncoding::encode(scopes, ":/=&?");
+      body = fmt::format(GetAccessTokenBodyFormatStringWithScopes, encoded_client_id,
+                         encoded_secret, encoded_scopes);
+    }
   }
 
   for (const auto& [param_name, param_value] : endpoint_params) {

--- a/source/extensions/http/injected_credentials/oauth2/oauth_client.h
+++ b/source/extensions/http/injected_credentials/oauth2/oauth_client.h
@@ -5,6 +5,7 @@
 
 #include "envoy/common/pure.h"
 #include "envoy/config/core/v3/http_uri.pb.h"
+#include "envoy/extensions/http/injected_credentials/oauth2/v3/oauth2.pb.h"
 #include "envoy/http/async_client.h"
 #include "envoy/http/message.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -32,10 +33,10 @@ public:
     NotDispatchedAlreadyInFlight,
     DispatchedRequest,
   };
-  virtual GetTokenResult
-  asyncGetAccessToken(const std::string& client_id, const std::string& secret,
-                      const std::string& scopes,
-                      const std::map<std::string, std::string>& endpoint_params) PURE;
+  virtual GetTokenResult asyncGetAccessToken(
+      const std::string& client_id, const std::string& secret, const std::string& scopes,
+      const std::map<std::string, std::string>& endpoint_params,
+      envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::AuthType auth_type) PURE;
   virtual void setCallbacks(FilterCallbacks& callbacks) PURE;
 
   // Http::AsyncClient::Callbacks
@@ -60,10 +61,11 @@ public:
   /**
    * Request the access token from the OAuth server. Calls the `onSuccess` on `onFailure` callbacks.
    */
-  GetTokenResult
-  asyncGetAccessToken(const std::string& client_id, const std::string& secret,
-                      const std::string& scopes,
-                      const std::map<std::string, std::string>& endpoint_params) override;
+  GetTokenResult asyncGetAccessToken(
+      const std::string& client_id, const std::string& secret, const std::string& scopes,
+      const std::map<std::string, std::string>& endpoint_params,
+      envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2::AuthType auth_type)
+      override;
 
   void setCallbacks(FilterCallbacks& callbacks) override { parent_ = &callbacks; }
 

--- a/source/extensions/http/injected_credentials/oauth2/token_provider.cc
+++ b/source/extensions/http/injected_credentials/oauth2/token_provider.cc
@@ -2,6 +2,8 @@
 
 #include <chrono>
 
+#include "source/common/common/empty_string.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace Http {
@@ -55,7 +57,8 @@ TokenProvider::TokenProvider(Common::SecretReaderConstSharedPtr secret_reader,
       retry_interval_(
           proto_config.token_fetch_retry_interval().seconds() > 0
               ? std::chrono::seconds(proto_config.token_fetch_retry_interval().seconds())
-              : std::chrono::seconds(2)) {
+              : std::chrono::seconds(2)),
+      auth_type_(proto_config.client_credentials().auth_type()) {
   timer_ = dispatcher_->createTimer([this]() -> void { asyncGetAccessToken(); });
   ThreadLocalOauth2ClientCredentialsTokenSharedPtr empty(
       new ThreadLocalOauth2ClientCredentialsToken(""));
@@ -74,15 +77,18 @@ void TokenProvider::asyncGetAccessToken() {
   if (timer_->enabled()) {
     timer_->disableTimer();
   }
-  if (secret_reader_->credential().empty()) {
+  // For MTLS_AUTH, secret_reader_ is null and no client secret is needed.
+  if (secret_reader_ != nullptr && secret_reader_->credential().empty()) {
     ENVOY_LOG(error, "asyncGetAccessToken: client secret is empty, retrying in {} seconds.",
               retry_interval_.count());
     timer_->enableTimer(std::chrono::seconds(retry_interval_));
     stats_.token_fetch_failed_on_client_secret_.inc();
     return;
   }
-  auto result = oauth2_client_->asyncGetAccessToken(client_id_, secret_reader_->credential(),
-                                                    oauth_scopes_, endpoint_params_);
+  const std::string& secret =
+      secret_reader_ != nullptr ? secret_reader_->credential() : EMPTY_STRING;
+  auto result = oauth2_client_->asyncGetAccessToken(client_id_, secret, oauth_scopes_,
+                                                    endpoint_params_, auth_type_);
   if (result == OAuth2Client::GetTokenResult::NotDispatchedAlreadyInFlight) {
     return;
   }

--- a/source/extensions/http/injected_credentials/oauth2/token_provider.h
+++ b/source/extensions/http/injected_credentials/oauth2/token_provider.h
@@ -94,6 +94,7 @@ private:
   TokenProviderStats stats_;
   // retry interval for fetching the token
   const std::chrono::seconds retry_interval_{2};
+  const OAuth2::AuthType auth_type_;
 };
 
 } // namespace OAuth2

--- a/test/extensions/http/credential_injector/oauth2/config_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/config_test.cc
@@ -47,6 +47,29 @@ TEST(Config, NullClientSecret) {
                           EnvoyException, "Invalid oauth2 client secret configuration");
 }
 
+TEST(Config, MtlsAuthNoClientSecretRequired) {
+  const std::string yaml_string = R"EOF(
+      token_fetch_retry_interval: 1s
+      token_endpoint:
+        cluster: non-existing-cluster
+        timeout: 0.5s
+        uri: "oauth.com/token"
+      client_credentials:
+        client_id: "client-id"
+        auth_type: MTLS_AUTH
+  )EOF";
+
+  envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2 proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  OAuth2CredentialInjectorFactory factory;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_factory_context;
+  NiceMock<Init::MockManager> init_manager;
+
+  // With MTLS_AUTH, no client_secret is required - should not throw
+  EXPECT_NO_THROW(factory.createOauth2ClientCredentialInjector(
+      proto_config, "stats", server_factory_context, init_manager));
+}
+
 TEST(Config, ValidConfigWithEndpointParams) {
   const std::string yaml_string = R"EOF(
       token_fetch_retry_interval: 1s

--- a/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
@@ -19,6 +19,17 @@ MATCHER_P(HasClientSecret, m, "") {
   return testing::ExplainMatchResult(testing::Optional(m), secret, result_listener);
 }
 
+MATCHER(HasNoClientSecret, "") {
+  const auto query_parameters = Http::Utility::QueryParamsMulti::parseParameters(arg, 0, true);
+  return !query_parameters.getFirstValue("client_secret").has_value();
+}
+
+MATCHER_P(HasClientId, m, "") {
+  const auto query_parameters = Http::Utility::QueryParamsMulti::parseParameters(arg, 0, true);
+  auto client_id = query_parameters.getFirstValue("client_id");
+  return testing::ExplainMatchResult(testing::Optional(m), client_id, result_listener);
+}
+
 MATCHER_P(HasScope, m, "") {
   const auto query_parameters = Http::Utility::QueryParamsMulti::parseParameters(arg, 0, true);
   auto actual_scope = query_parameters.getFirstValue("scope");
@@ -777,6 +788,105 @@ typed_config:
                                std::chrono::milliseconds(2500));
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  waitForNextUpstreamRequest();
+
+  EXPECT_EQ("Bearer test-access-token", upstream_request_->headers()
+                                            .get(Http::LowerCaseString("Authorization"))[0]
+                                            ->value()
+                                            .getStringView());
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// MTLS_AUTH: token request body contains only client_id and grant_type (no client_secret)
+TEST_P(CredentialInjectorIntegrationTest, MtlsAuthNoClientSecret) {
+  const std::string filter_config =
+      R"EOF(
+name: envoy.filters.http.credential_injector
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.credential_injector.v3.CredentialInjector
+  overwrite: false
+  credential:
+    name: envoy.http.injected_credentials.oauth2
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.http.injected_credentials.oauth2.v3.OAuth2
+      token_endpoint:
+        cluster: oauth
+        timeout: 3s
+        uri: "oauth.com/token"
+      client_credentials:
+        client_id: test_client_id
+        auth_type: MTLS_AUTH
+)EOF";
+  initializeFilter(filter_config);
+
+  getFakeOauth2Connection();
+  acceptNewStream();
+  EXPECT_THAT(request_body_, HasNoClientSecret());
+  EXPECT_THAT(request_body_, HasClientId("test_client_id"));
+  oauth2_request_->encodeHeaders(jsonResponseHeaders(), false);
+  encodeGoodJsonResponseBody();
+
+  test_server_->waitForCounterEq("http.config_test.credential_injector.oauth2.token_fetched", 1,
+                                 std::chrono::milliseconds(2500));
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  waitForNextUpstreamRequest();
+
+  EXPECT_EQ("Bearer test-access-token", upstream_request_->headers()
+                                            .get(Http::LowerCaseString("Authorization"))[0]
+                                            ->value()
+                                            .getStringView());
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+// MTLS_AUTH with scopes: request body contains client_id and scope, no client_secret
+TEST_P(CredentialInjectorIntegrationTest, MtlsAuthWithScopesNoClientSecret) {
+  const std::string filter_config =
+      R"EOF(
+name: envoy.filters.http.credential_injector
+typed_config:
+  "@type": type.googleapis.com/envoy.extensions.filters.http.credential_injector.v3.CredentialInjector
+  overwrite: false
+  credential:
+    name: envoy.http.injected_credentials.oauth2
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.http.injected_credentials.oauth2.v3.OAuth2
+      token_endpoint:
+        cluster: oauth
+        timeout: 3s
+        uri: "oauth.com/token"
+      scopes:
+        - "openid"
+      client_credentials:
+        client_id: test_client_id
+        auth_type: MTLS_AUTH
+)EOF";
+  initializeFilter(filter_config);
+
+  getFakeOauth2Connection();
+  acceptNewStream();
+  EXPECT_THAT(request_body_, HasNoClientSecret());
+  EXPECT_THAT(request_body_, HasClientId("test_client_id"));
+  EXPECT_THAT(request_body_, HasScope("openid"));
+  oauth2_request_->encodeHeaders(jsonResponseHeaders(), false);
+  encodeGoodJsonResponseBody();
+
+  test_server_->waitForCounterEq("http.config_test.credential_injector.oauth2.token_fetched", 1,
+                                 std::chrono::milliseconds(2500));
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
   waitForNextUpstreamRequest();

--- a/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/credential_injector_oauth_integration_test.cc
@@ -832,8 +832,8 @@ typed_config:
   oauth2_request_->encodeHeaders(jsonResponseHeaders(), false);
   encodeGoodJsonResponseBody();
 
-  test_server_->waitForCounterEq("http.config_test.credential_injector.oauth2.token_fetched", 1,
-                                 std::chrono::milliseconds(2500));
+  test_server_->waitForCounter("http.config_test.credential_injector.oauth2.token_fetched", Eq(1),
+                               std::chrono::milliseconds(2500));
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
@@ -883,8 +883,8 @@ typed_config:
   oauth2_request_->encodeHeaders(jsonResponseHeaders(), false);
   encodeGoodJsonResponseBody();
 
-  test_server_->waitForCounterEq("http.config_test.credential_injector.oauth2.token_fetched", 1,
-                                 std::chrono::milliseconds(2500));
+  test_server_->waitForCounter("http.config_test.credential_injector.oauth2.token_fetched", Eq(1),
+                               std::chrono::milliseconds(2500));
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);

--- a/test/extensions/http/credential_injector/oauth2/token_provider_test.cc
+++ b/test/extensions/http/credential_injector/oauth2/token_provider_test.cc
@@ -140,6 +140,33 @@ TEST(TokenProvider, FetchFailureClearsExpiredTokenAndInjectFails) {
   EXPECT_TRUE(headers.get(Envoy::Http::CustomHeaders::get().Authorization).empty());
 }
 
+TEST(TokenProvider, TokenProviderMtlsAuthNullSecretReader) {
+  const std::string yaml_string = R"EOF(
+      token_fetch_retry_interval: 5s
+      token_endpoint:
+        cluster: non-existing-cluster
+        timeout: 0.5s
+        uri: "oauth.com/token"
+      client_credentials:
+        client_id: "client-id"
+        auth_type: MTLS_AUTH
+  )EOF";
+
+  envoy::extensions::http::injected_credentials::oauth2::v3::OAuth2 proto_config;
+  TestUtility::loadFromYaml(yaml_string, proto_config);
+  NiceMock<Upstream::MockClusterManager> cluster_manager;
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  NiceMock<ThreadLocal::MockInstance> tls;
+  NiceMock<Event::MockDispatcher> dispatcher;
+  auto token_provider =
+      std::make_shared<TokenProvider>(nullptr, tls, cluster_manager, proto_config, dispatcher,
+                                      "stats_prefix", context.serverFactoryContext().scope());
+  EXPECT_NO_THROW(token_provider->asyncGetAccessToken());
+  EXPECT_NO_THROW(token_provider->onGetAccessTokenSuccess("token", std::chrono::seconds(10)));
+  EXPECT_NO_THROW(
+      token_provider->onGetAccessTokenFailure(FilterCallbacks::FailureReason::StreamReset));
+}
+
 } // namespace OAuth2
 } // namespace InjectedCredentials
 } // namespace Http


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message: Fixes https://github.com/envoyproxy/envoy/issues/39183: Add oauth2 credential injection implementation to support mTLS

Additional Description:
Adds `MTLS_AUTH` to the OAuth2 credential injector's `auth_type`, implementing the client credentials grant with mTLS client authentication (RFC 8705). Under this auth type the token request body carries only `grant_type` and `client_id`. The client certificate comes from the `transport_socket` already configured on the token endpoint cluster.

Risk Level: Low
Testing: UT, Integration test and manual test on KIND with envoy and keycloak
Docs Changes: None
Release Notes: Added
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
