### PR TITLE
tests: update reverse_tunnel tests to prevent TSAN flakes

### DIFF
--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -107,8 +107,8 @@ protected:
   std::unique_ptr<ReverseConnectionIOHandle>
   createTestIOHandle(const ReverseConnectionSocketConfig& config) {
     return std::make_unique<ReverseConnectionIOHandle>(-1, // dummy fd
-                                                       config, cluster_manager_,
-                                                       extension_.get(), *stats_scope_);
+                                                       config, cluster_manager_, extension_.get(),
+                                                       *stats_scope_);
   }
 
   // Connection Management Helpers.

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/rc_connection_wrapper_test.cc
@@ -106,9 +106,8 @@ protected:
 
   std::unique_ptr<ReverseConnectionIOHandle>
   createTestIOHandle(const ReverseConnectionSocketConfig& config) {
-    int test_fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    EXPECT_GE(test_fd, 0);
-    return std::make_unique<ReverseConnectionIOHandle>(test_fd, config, cluster_manager_,
+    return std::make_unique<ReverseConnectionIOHandle>(-1, // dummy fd
+                                                       config, cluster_manager_,
                                                        extension_.get(), *stats_scope_);
   }
 
@@ -1885,10 +1884,8 @@ protected:
   void SetUp() override {
     stats_scope_ = Stats::ScopeSharedPtr(stats_store_.createScope("test_scope."));
 
-    // Create a mock IO handle.
-    auto mock_io_handle = std::make_unique<NiceMock<Network::MockConnection>>();
     io_handle_ = std::make_unique<ReverseConnectionIOHandle>(
-        7, // dummy fd
+        -1, // dummy fd
         ReverseConnectionSocketConfig{}, cluster_manager_,
         nullptr,        // extension
         *stats_scope_); // Use the created scope

--- a/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
+++ b/test/extensions/bootstrap/reverse_tunnel/downstream_socket_interface/reverse_connection_io_handle_test.cc
@@ -1319,7 +1319,7 @@ TEST_F(ReverseConnectionIOHandleTest, InitiateReverseConnectionWithCustomScope) 
 
   // Replace the class member io_handle_ with our custom one for this test
   auto original_io_handle = std::move(io_handle_);
-  io_handle_ = std::make_unique<ReverseConnectionIOHandle>(8, // dummy fd
+  io_handle_ = std::make_unique<ReverseConnectionIOHandle>(-1, // dummy fd
                                                            custom_prefix_config, cluster_manager_,
                                                            custom_extension.get(), *stats_scope_);
 


### PR DESCRIPTION
Commit Message: tests: update reverse_tunnel tests to prevent TSAN flakes
Additional Description:
An internal TSAN validator has found a couple of flaky tests. The issue is that when a `ReverseConnectionIOHandle` is created on an actual file-descriptor (say 7 or 8), then concurrent tests that are run on the same machine may race with the resetting of that file-descriptor.
Modified the file-descriptor to -1, as it is not really needed by the tests.

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A