### PR TITLE
server: respect cgroup mount root

### DIFF
--- a/changelogs/current/bug_fixes/server__respect-cgroup-mount-root.rst
+++ b/changelogs/current/bug_fixes/server__respect-cgroup-mount-root.rst
@@ -1,0 +1,1 @@
+Fixed container-aware CPU limit detection for cgroup mounts whose mountinfo root is not ``/``.

--- a/source/server/cgroup_cpu_util.cc
+++ b/source/server/cgroup_cpu_util.cc
@@ -9,6 +9,7 @@
 
 #include "source/common/common/logger.h"
 
+#include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
@@ -73,15 +74,15 @@ void CgroupDetectorImpl::logResult() {
 std::optional<uint32_t> CgroupCpuUtil::getCpuLimit(Filesystem::Instance& fs,
                                                    CgroupDetectionDiagnostic* diag) {
   // Step 1: Mount Discovery - call once and reuse
-  std::optional<std::string> mount_opt = discoverCgroupMount(fs);
+  std::optional<CgroupMount> mount_opt = discoverCgroupMount(fs);
   if (!mount_opt.has_value()) {
     setReason(diag, "no cgroup filesystem mounts found");
     return std::nullopt;
   }
-  const std::string& mount_point = mount_opt.value();
+  const CgroupMount& mount = mount_opt.value();
 
   // Steps 2-3: Process Assignment + Path Construction
-  std::optional<CgroupInfo> cgroup_info_opt = constructCgroupPath(mount_point, fs);
+  std::optional<CgroupInfo> cgroup_info_opt = constructCgroupPath(mount, fs);
   if (!cgroup_info_opt.has_value()) {
     setReason(diag, "no valid cgroup path found");
     return std::nullopt;
@@ -201,8 +202,8 @@ std::optional<CgroupPathInfo> CgroupCpuUtil::getCurrentCgroupPath(Filesystem::In
   return CgroupPathInfo{v2_path, "v2"};
 }
 
-// Constructs complete cgroup path by combining mount point and process assignment.
-std::optional<CgroupInfo> CgroupCpuUtil::constructCgroupPath(const std::string& mount_point,
+// Constructs complete cgroup path by combining mount metadata and process assignment.
+std::optional<CgroupInfo> CgroupCpuUtil::constructCgroupPath(const CgroupMount& mount,
                                                              Filesystem::Instance& fs) {
 
   // Process Assignment - get relative path and determine version
@@ -212,17 +213,32 @@ std::optional<CgroupInfo> CgroupCpuUtil::constructCgroupPath(const std::string& 
     return std::nullopt;
   }
   const CgroupPathInfo& path_info = path_info_opt.value();
-  const std::string& relative_path = path_info.relative_path;
   const std::string& version = path_info.version;
+
+  // /proc/self/cgroup reports a path relative to the cgroup hierarchy root, while mountinfo's
+  // root may identify a subdirectory of that hierarchy. Only strip a complete path component.
+  const std::string& cgroup_path = path_info.relative_path;
+  std::string relative_path;
+  if (mount.root == "/") {
+    relative_path = cgroup_path;
+  } else if (cgroup_path == mount.root) {
+    relative_path.clear();
+  } else if (absl::StartsWith(cgroup_path, mount.root) && cgroup_path.size() > mount.root.size() &&
+             cgroup_path[mount.root.size()] == '/') {
+    relative_path = cgroup_path.substr(mount.root.size());
+  } else {
+    ENVOY_LOG_MISC(warn, "Cgroup path {} is outside mount root {}", cgroup_path, mount.root);
+    return std::nullopt;
+  }
 
   // Path Construction - combine mount point and relative path
   CgroupInfo info;
 
   // Construct full path using absl::StrCat (efficient concatenation)
   if (!relative_path.empty() && relative_path[0] != '/') {
-    info.full_path = absl::StrCat(mount_point, "/", relative_path);
+    info.full_path = absl::StrCat(mount.mount_point, "/", relative_path);
   } else {
-    info.full_path = absl::StrCat(mount_point, relative_path);
+    info.full_path = absl::StrCat(mount.mount_point, relative_path);
   }
 
   // Version determination from getCurrentCgroupPath
@@ -415,7 +431,7 @@ std::optional<double> CgroupCpuUtil::readActualLimits(const CpuFiles& cpu_files,
 // - If cgroup v2: save mount point, continue searching
 // - Result: single mount point with highest priority
 //
-std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instance& fs) {
+std::optional<CgroupMount> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instance& fs) {
   const auto result = fs.fileReadToEnd(std::string(PROC_MOUNTINFO_PATH));
   if (!result.ok()) {
     // /proc/self/mountinfo doesn't exist - not in a cgroup
@@ -426,7 +442,7 @@ std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instan
   absl::string_view content = result.value();
   const std::vector<absl::string_view> lines = absl::StrSplit(content, '\n');
 
-  std::string v2_mount_point; // Save v2 mount in case no v1 found
+  std::optional<CgroupMount> v2_mount; // Save v2 mount in case no v1 found
 
   for (absl::string_view line : lines) {
     if (line.empty()) {
@@ -435,8 +451,8 @@ std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instan
 
     bool line_valid = true;
 
-    // Skip first four fields
-    for (int field = 0; field < 4; field++) {
+    // Skip the first three fields; retain field 4 (the cgroup root).
+    for (int field = 0; field < 3; field++) {
       size_t space_pos = line.find(' ');
       if (space_pos == absl::string_view::npos) {
         ENVOY_LOG_MISC(warn, "Malformed mountinfo line: not enough fields");
@@ -448,6 +464,15 @@ std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instan
     if (!line_valid) {
       continue;
     }
+
+    // (4) root: root of the cgroup mount within the filesystem
+    size_t root_end = line.find(' ');
+    if (root_end == absl::string_view::npos) {
+      ENVOY_LOG_MISC(warn, "Malformed mountinfo line: no root");
+      continue;
+    }
+    absl::string_view root_escaped = line.substr(0, root_end);
+    line = line.substr(root_end + 1);
 
     // (5) mount point: extract mount point
     size_t mount_end = line.find(' ');
@@ -501,12 +526,15 @@ std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instan
     }
 
     // Unescape mount point
-    std::string mount_point = unescapePath(std::string(mount_point_escaped));
+    CgroupMount mount;
+    mount.root = unescapePath(root_escaped);
+    mount.mount_point = unescapePath(mount_point_escaped);
+    mount.filesystem_type = std::string(fs_type);
 
     // As in Go: cgroup v1 with a CPU controller takes precedence over cgroup v2
     if (fs_type == "cgroup2") {
       // v2 hierarchy - save mount point but keep searching
-      v2_mount_point = mount_point;
+      v2_mount = mount;
       continue; // Keep searching, we might find a v1 hierarchy with CPU controller
     }
 
@@ -526,13 +554,14 @@ std::optional<std::string> CgroupCpuUtil::discoverCgroupMount(Filesystem::Instan
     // v1 hierarchy - check for CPU controller
     if (containsToken(super_options, "cpu")) {
       // Found a v1 CPU controller. This must be the only one, so we're done
-      return mount_point; // Return immediately - v1 CPU wins
+      mount.has_cpu_controller = true;
+      return mount; // Return immediately - v1 CPU wins
     }
   }
 
   // Return v2 mount if no v1 with CPU found
-  if (!v2_mount_point.empty()) {
-    return v2_mount_point;
+  if (v2_mount.has_value()) {
+    return v2_mount;
   }
 
   // No cgroup filesystem found

--- a/source/server/cgroup_cpu_util.h
+++ b/source/server/cgroup_cpu_util.h
@@ -64,6 +64,7 @@ using CgroupDetectorSingleton = ThreadSafeSingleton<CgroupDetectorImpl>;
  */
 struct CgroupMount {
   std::string mount_point;
+  std::string root;
   std::string filesystem_type;
   std::string mount_options;
   bool has_cpu_controller = false;
@@ -145,14 +146,14 @@ private:
    * Discovers cgroup filesystem mounts by parsing `/proc/self/mountinfo`.
    * Priority handling: `cgroup` `v1` with CPU controller wins over `cgroup` `v2`.
    * @param fs Filesystem instance.
-   * @return Mount point string on success, nullopt if no suitable `cgroup` found.
+   * @return Cgroup mount metadata on success, nullopt if no suitable `cgroup` found.
    */
-  static std::optional<std::string> discoverCgroupMount(Filesystem::Instance& fs);
+  static std::optional<CgroupMount> discoverCgroupMount(Filesystem::Instance& fs);
 
   /**
    * Parses a single line from `/proc/self/mountinfo` to extract cgroup mount point.
    * Format: `mountID parentID major:minor root mountPoint options - fsType source superOptions`
-   * We extract field 5 (mount point) for `cgroup`/`cgroup2` filesystem only.
+   * This helper extracts field 5 (mount point) for `cgroup`/`cgroup2` filesystems.
    * @param line Single line from `/proc/self/mountinfo`
    * @return Mount point string if line contains `cgroup` filesystem, nullopt if not a `cgroup`
    * line.
@@ -169,15 +170,15 @@ private:
   static std::string unescapePath(absl::string_view path);
 
   /**
-   * Constructs complete `cgroup` path by combining mount point and process assignment.
-   * Logic: Use provided mount point (already discovered)
+   * Constructs complete `cgroup` path by combining mount metadata and process assignment.
+   * Logic: Use the cgroup path relative to the mount root and append it to the mount point.
    *        Call process assignment → Get relative path
    *        Combine mount point and relative path
-   * @param mount_point The `cgroup` mount point (from discoverCgroupMount).
+   * @param mount The `cgroup` mount metadata (from discoverCgroupMount).
    * @param fs Filesystem instance.
    * @return CgroupInfo with combined path + final version, nullopt if not found.
    */
-  static std::optional<CgroupInfo> constructCgroupPath(const std::string& mount_point,
+  static std::optional<CgroupInfo> constructCgroupPath(const CgroupMount& mount,
                                                        Filesystem::Instance& fs);
 
   /**
@@ -269,8 +270,13 @@ public:
     return CgroupCpuUtil::getCurrentCgroupPath(fs);
   }
 
-  static std::optional<std::string> discoverCgroupMount(Filesystem::Instance& fs) {
+  static std::optional<CgroupMount> discoverCgroupMount(Filesystem::Instance& fs) {
     return CgroupCpuUtil::discoverCgroupMount(fs);
+  }
+
+  static std::optional<CgroupInfo> constructCgroupPath(const CgroupMount& mount,
+                                                       Filesystem::Instance& fs) {
+    return CgroupCpuUtil::constructCgroupPath(mount, fs);
   }
 
   static std::optional<std::string> parseMountInfoLine(const std::string& line) {

--- a/test/server/cgroup_cpu_util_test.cc
+++ b/test/server/cgroup_cpu_util_test.cc
@@ -230,8 +230,7 @@ TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_V1) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::parseMountInfoLine(line);
   ASSERT_TRUE(mount_opt.has_value());
-  const auto& mount_point = mount_opt.value();
-  EXPECT_EQ(mount_point, "/sys/fs/cgroup/cpu");
+  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup/cpu");
 }
 
 TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_V2) {
@@ -239,8 +238,7 @@ TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_V2) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::parseMountInfoLine(line);
   ASSERT_TRUE(mount_opt.has_value());
-  const auto& mount_point = mount_opt.value();
-  EXPECT_EQ(mount_point, "/sys/fs/cgroup");
+  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup");
 }
 
 TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_V1NoCPU) {
@@ -248,8 +246,7 @@ TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_V1NoCPU) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::parseMountInfoLine(line);
   ASSERT_TRUE(mount_opt.has_value());
-  const auto& mount_point = mount_opt.value();
-  EXPECT_EQ(mount_point, "/sys/fs/cgroup/memory");
+  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup/memory");
 }
 
 TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_Escaped) {
@@ -258,8 +255,7 @@ TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_Escaped) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::parseMountInfoLine(line);
   ASSERT_TRUE(mount_opt.has_value());
-  const auto& mount_point = mount_opt.value();
-  EXPECT_EQ(mount_point, "/sys/fs/cgroup/tab\ttab"); // Unescaped
+  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup/tab\ttab"); // Unescaped
 }
 
 TEST_F(CgroupCpuUtilTest, ParseMountInfoLine_NotCgroup) {
@@ -313,7 +309,9 @@ TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_V1) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
   ASSERT_TRUE(mount_opt.has_value());
-  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup/cpu"); // Should return v1 CPU mount point
+  EXPECT_EQ(mount_opt.value().mount_point,
+            "/sys/fs/cgroup/cpu"); // Should return v1 CPU mount point
+  EXPECT_EQ(mount_opt.value().root, "/");
 }
 
 TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_V2) {
@@ -327,7 +325,8 @@ TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_V2) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
   ASSERT_TRUE(mount_opt.has_value());
-  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup"); // Should return v2 mount point
+  EXPECT_EQ(mount_opt.value().mount_point, "/sys/fs/cgroup"); // Should return v2 mount point
+  EXPECT_EQ(mount_opt.value().root, "/");
 }
 
 TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_ControllerNameContainingCpu) {
@@ -338,7 +337,8 @@ TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_ControllerNameContainingCpu) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
   ASSERT_TRUE(mount_opt.has_value());
-  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup");
+  EXPECT_EQ(mount_opt.value().mount_point, "/sys/fs/cgroup");
+  EXPECT_EQ(mount_opt.value().root, "/");
 }
 
 TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_Mixed_V1Wins) {
@@ -357,7 +357,8 @@ TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_Mixed_V1Wins) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
   ASSERT_TRUE(mount_opt.has_value());
-  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup/cpu"); // v1 CPU takes precedence over v2
+  EXPECT_EQ(mount_opt.value().mount_point, "/sys/fs/cgroup/cpu"); // v1 CPU takes precedence over v2
+  EXPECT_EQ(mount_opt.value().root, "/");
 }
 
 TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_V2Escaped) {
@@ -371,7 +372,18 @@ TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_V2Escaped) {
 
   auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
   ASSERT_TRUE(mount_opt.has_value());
-  EXPECT_EQ(mount_opt.value(), "/sys/fs/cgroup/tab\ttab"); // Should be unescaped
+  EXPECT_EQ(mount_opt.value().mount_point, "/sys/fs/cgroup/tab\ttab"); // Should be unescaped
+  EXPECT_EQ(mount_opt.value().root, "/");
+}
+
+TEST_F(CgroupCpuUtilTest, DiscoverCgroupMount_NonRoot) {
+  fs_.setFileContents("/proc/self/mountinfo",
+                      "25 21 0:22 /kubepods.slice/pod123 /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n");
+
+  auto mount_opt = CgroupCpuUtil::TestUtil::discoverCgroupMount(fs_);
+  ASSERT_TRUE(mount_opt.has_value());
+  EXPECT_EQ(mount_opt.value().mount_point, "/sys/fs/cgroup");
+  EXPECT_EQ(mount_opt.value().root, "/kubepods.slice/pod123");
 }
 
 // =============================================================================
@@ -775,6 +787,40 @@ TEST_F(CgroupCpuUtilTest, DetectorImpl_V2DetectedLimitLogged) {
   EXPECT_LOG_CONTAINS("debug", "cgroup CPU limit detected: 2", { detector.logResult(); });
   // Result is consumed; a second logResult() is a no-op.
   EXPECT_NO_LOGS({ detector.logResult(); });
+}
+
+TEST_F(CgroupCpuUtilTest, DetectorImpl_V2DetectedLimitWithNonRootMount) {
+  fs_.setFileContents("/proc/self/mountinfo",
+                      "25 21 0:22 /kubepods.slice/pod123 /sys/fs/cgroup rw - cgroup2 cgroup2 rw\n");
+  fs_.setFileContents("/proc/self/cgroup", "0::/kubepods.slice/pod123/containerA\n");
+  fs_.setFileContents("/sys/fs/cgroup/containerA/cpu.max", "250000 100000\n");
+
+  CgroupDetectorImpl detector;
+  auto limit = detector.getCpuLimit(fs_);
+  ASSERT_TRUE(limit.has_value());
+  EXPECT_EQ(limit.value(), 2U);
+}
+
+TEST_F(CgroupCpuUtilTest, DetectorImpl_NonRootMountRequiresPathBoundary) {
+  fs_.setFileContents("/proc/self/cgroup", "0::/kubepods.slice/pod1234/containerA\n");
+  CgroupMount mount;
+  mount.mount_point = "/sys/fs/cgroup";
+  mount.root = "/kubepods.slice/pod123";
+
+  auto cgroup_info = CgroupCpuUtil::TestUtil::constructCgroupPath(mount, fs_);
+  EXPECT_FALSE(cgroup_info.has_value());
+}
+
+TEST_F(CgroupCpuUtilTest, ConstructCgroupPath_NonRootMountRootItself) {
+  fs_.setFileContents("/proc/self/cgroup", "0::/kubepods.slice/pod123\n");
+  CgroupMount mount;
+  mount.mount_point = "/sys/fs/cgroup";
+  mount.root = "/kubepods.slice/pod123";
+
+  auto cgroup_info = CgroupCpuUtil::TestUtil::constructCgroupPath(mount, fs_);
+  ASSERT_TRUE(cgroup_info.has_value());
+  EXPECT_EQ(cgroup_info.value().full_path, "/sys/fs/cgroup");
+  EXPECT_EQ(cgroup_info.value().version, "v2");
 }
 
 TEST_F(CgroupCpuUtilTest, DetectorImpl_V1DetectedLimit) {


### PR DESCRIPTION


The cgroup mount discovery code currently discards the root field from /proc/self/mountinfo. The detected cgroup path is then appended directly to the mount point, which produces an incorrect path when the cgroup mount root is not /.

Preserve the mount root and resolve the process cgroup path relative to it before constructing the final cgroup file path.

Additional Description:
For example, when mountinfo reports:

  root: /kubepods.slice/pod123
  mount point: /sys/fs/cgroup

and /proc/self/cgroup reports:

  /kubepods.slice/pod123/containerA

Envoy now reads the cgroup files from:

  /sys/fs/cgroup/containerA

The implementation validates the root prefix on a complete path-component boundary and rejects cgroup paths outside the mount root.

Docs Changes:
N/A

Release Notes:
Added changelogs/current/bug_fixes/server__respect-cgroup-mount-root.rst


[Optional Runtime guard:]
N/A