### PR TITLE
mcp_json_rest_bridge: fix test build using private config constructor

### DIFF
--- a/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
+++ b/test/extensions/filters/http/mcp_json_rest_bridge/mcp_json_rest_bridge_filter_test.cc
@@ -2519,7 +2519,7 @@ TEST_F(McpJsonRestBridgeStreamingFilterTest, SseResponseExceedsMaxResponseBodySi
     max_response_body_size: 10
   )yaml",
                             proto_config);
-  config_ = std::make_shared<McpJsonRestBridgeFilterConfig>(proto_config);
+  ASSERT_OK_AND_ASSIGN(config_, McpJsonRestBridgeFilterConfig::create(proto_config));
   filter_ = std::make_unique<McpJsonRestBridgeFilter>(config_);
   filter_->setDecoderFilterCallbacks(decoder_callbacks_);
   filter_->setEncoderFilterCallbacks(encoder_callbacks_);


### PR DESCRIPTION
The config class constructor is private and creation goes through the `McpJsonRestBridgeFilterConfig::create()` factory. One test call site still used std::make_shared, which broke the build.
