### PR TITLE
ai_protocol_manager: add AiRequest::json()

### DIFF
--- a/source/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/source/extensions/filters/http/ai_protocol_manager/BUILD
@@ -169,6 +169,7 @@ envoy_cc_library(
     hdrs = ["ai_request.h"],
     deps = [
         ":json_with_ext_buf_lib",
+        "@nlohmann_json//:json",
     ],
 )
 

--- a/source/extensions/filters/http/ai_protocol_manager/ai_request.h
+++ b/source/extensions/filters/http/ai_protocol_manager/ai_request.h
@@ -5,6 +5,8 @@
 
 #include "source/extensions/filters/http/ai_protocol_manager/json_with_ext_buf.h"
 
+#include "nlohmann/json.hpp"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -24,9 +26,12 @@ public:
   AiRequest(AiRequest&&) = delete;
   AiRequest& operator=(AiRequest&&) = delete;
 
-  // Index access
+  // The payload DOM -- the request's only mutable surface.
+  const nlohmann::json& json() const { return request_index_.json(); }
+  nlohmann::json& json() { return request_index_.json(); }
+
+  // The whole index, external-buffer references included; only serialization needs it.
   const JsonWithExtBuf& request_index() const { return request_index_; }
-  JsonWithExtBuf& request_index() { return request_index_; }
 
   // TODO(penguingao): Implement field streaming (AiRequest::stream, FieldStreamingSpec,
   // and FieldStreamingSession).

--- a/test/extensions/filters/http/ai_protocol_manager/BUILD
+++ b/test/extensions/filters/http/ai_protocol_manager/BUILD
@@ -159,6 +159,18 @@ envoy_extension_cc_test(
 )
 
 envoy_extension_cc_test(
+    name = "ai_request_test",
+    srcs = ["ai_request_test.cc"],
+    extension_names = ["envoy.filters.http.ai_protocol_manager"],
+    rbe_pool = "linux_x64_small",
+    deps = [
+        "//source/extensions/filters/http/ai_protocol_manager:ai_request_lib",
+        "//test/test_common:status_utility_lib",
+        "@nlohmann_json//:json",
+    ],
+)
+
+envoy_extension_cc_test(
     name = "filter_manager_test",
     srcs = ["filter_manager_test.cc"],
     extension_names = ["envoy.filters.http.ai_protocol_manager"],

--- a/test/extensions/filters/http/ai_protocol_manager/ai_request_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/ai_request_test.cc
@@ -1,0 +1,70 @@
+#include <type_traits>
+#include <utility>
+
+#include "source/extensions/filters/http/ai_protocol_manager/ai_request.h"
+
+#include "test/test_common/status_utility.h"
+
+#include "gtest/gtest.h"
+#include "nlohmann/json.hpp"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AiProtocolManager {
+namespace {
+
+// The single-ownership contract the handoff queues rely on.
+static_assert(!std::is_copy_constructible_v<AiRequest>);
+static_assert(!std::is_copy_assignable_v<AiRequest>);
+static_assert(!std::is_move_constructible_v<AiRequest>);
+static_assert(!std::is_move_assignable_v<AiRequest>);
+
+// json() hands out the stored document itself, so a filter's edit is what serialization
+// later reads.
+TEST(AiRequestTest, JsonAliasesTheIndex) {
+  JsonWithExtBuf index;
+  index.setJson(nlohmann::json{{"model", "gpt-4"}});
+  AiRequest request(std::move(index));
+
+  EXPECT_EQ(request.json()["model"], "gpt-4");
+
+  request.json()["model"] = "gpt-4-turbo";
+  EXPECT_EQ(request.request_index().json()["model"], "gpt-4-turbo");
+  EXPECT_EQ(&request.json(), &request.request_index().json());
+
+  const AiRequest& const_request = request;
+  EXPECT_EQ(&const_request.json(), &request.json());
+}
+
+// A transcoding filter swaps the payload wholesale rather than editing fields.
+TEST(AiRequestTest, AssigningJsonReplacesTheDocument) {
+  JsonWithExtBuf index;
+  index.setJson(nlohmann::json{{"model", "gpt-4"}, {"temperature", 0.5}});
+  AiRequest request(std::move(index));
+
+  request.json() = nlohmann::json{{"model", "claude-opus-4"}};
+
+  EXPECT_EQ(request.json()["model"], "claude-opus-4");
+  EXPECT_FALSE(request.request_index().json().contains("temperature"));
+}
+
+// Offloaded values reach a filter as reference nodes, not as bytes.
+TEST(AiRequestTest, ExternalRefsSurviveTheWrapper) {
+  const JsonWithExtBuf::ExternalRef ref{/*offset=*/64, /*length=*/4096};
+  JsonWithExtBuf index;
+  index.setJson(nlohmann::json{{"prompt", JsonWithExtBuf::makeExternalRef(ref)}});
+  AiRequest request(std::move(index));
+
+  const nlohmann::json& prompt = request.json()["prompt"];
+  ASSERT_TRUE(JsonWithExtBuf::isExternalRef(prompt));
+  const absl::StatusOr<JsonWithExtBuf::ExternalRef> decoded = JsonWithExtBuf::externalRef(prompt);
+  ASSERT_OK(decoded);
+  EXPECT_EQ(*decoded, ref);
+}
+
+} // namespace
+} // namespace AiProtocolManager
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/filter_manager_test.cc
@@ -92,7 +92,7 @@ public:
                                        AiRequestPropagator propagate_request,
                                        LocalReplier) override {
     ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
-    req->request_index().json()["model"] = target_model_;
+    req->json()["model"] = target_model_;
     co_return co_await std::move(propagate_request)(std::move(req));
   }
 
@@ -131,7 +131,7 @@ public:
                                        AiRequestPropagator propagate_request,
                                        LocalReplier) override {
     ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
-    req->request_index().json()["temperature"] = 0.5;
+    req->json()["temperature"] = 0.5;
     co_return co_await std::move(propagate_request)(std::move(req));
   }
 };
@@ -142,8 +142,8 @@ public:
                                        AiRequestPropagator propagate_request,
                                        LocalReplier) override {
     ASSIGN_OR_CO_RETURN(AiRequestPtr req, co_await std::move(receive_request)());
-    EXPECT_DOUBLE_EQ(req->request_index().json()["temperature"].get<double>(), 0.5);
-    req->request_index().json()["temperature"] = 0.9;
+    EXPECT_DOUBLE_EQ(req->json()["temperature"].get<double>(), 0.5);
+    req->json()["temperature"] = 0.9;
     co_return co_await std::move(propagate_request)(std::move(req));
   }
 };


### PR DESCRIPTION
Filters reach the payload as req->request_index().json(). Forward the DOM off AiRequest so that reads req->json(), and drop the mutable request_index() overload, which then has no callers left: json() becomes the one mutable path to the document, while the whole index stays reachable read-only for serialization.

AiRequest had no direct test; add one covering the aliasing and the single-ownership contract.

<!--
!!!ATTENTION!!!

If you are fixing **any** crash or **any** potential security issue, **do not
open a pull request**.

Instead, please
[open a GitHub Security Advisory](https://github.com/envoyproxy/envoy/security/advisories/new)
(preferred). Alternatively, you may email
envoy-security@googlegroups.com.

Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)

!!!ATTENTION!!!

Please check the [use of generative AI policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41).

You may use generative AI only if you fully understand the code. You need to disclose
this usage in the PR description to ensure transparency.
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
