### PR TITLE
dynamic_modules: fix virtual host and virtual cluster attributes

### DIFF
--- a/changelogs/current/behavior_changes/dynamic_modules__virtual-host-attribute.rst
+++ b/changelogs/current/behavior_changes/dynamic_modules__virtual-host-attribute.rst
@@ -1,0 +1,3 @@
+dynamic modules: fixed ``xds.virtual_host_name`` to return the selected virtual host name instead of
+the virtual cluster name. Added ``xds.virtual_cluster_name`` for the virtual cluster name and updated
+the deprecated access logger callback to use it.

--- a/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
+++ b/source/extensions/access_loggers/dynamic_modules/abi_impl.cc
@@ -949,7 +949,7 @@ bool envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(
     envoy_dynamic_module_type_access_logger_envoy_ptr logger_envoy_ptr,
     envoy_dynamic_module_type_envoy_buffer* result) {
   return envoy_dynamic_module_callback_access_logger_get_attribute_string(
-      logger_envoy_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualHostName, result);
+      logger_envoy_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName, result);
 }
 
 uint32_t envoy_dynamic_module_callback_access_logger_get_attempt_count(

--- a/source/extensions/dynamic_modules/abi/abi.h
+++ b/source/extensions/dynamic_modules/abi/abi.h
@@ -388,6 +388,8 @@ typedef enum envoy_dynamic_module_type_attribute_id {
   envoy_dynamic_module_type_attribute_id_HealthCheck,
   // upstream.server_name
   envoy_dynamic_module_type_attribute_id_UpstreamRequestedServerName,
+  // xds.virtual_cluster_name
+  envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName,
 } envoy_dynamic_module_type_attribute_id;
 
 /**
@@ -7209,7 +7211,7 @@ bool envoy_dynamic_module_callback_access_logger_get_route_name(
 
 /**
  * @deprecated Use envoy_dynamic_module_callback_access_logger_get_attribute_string with
- * envoy_dynamic_module_type_attribute_id_XdsVirtualHostName instead.
+ * envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName instead.
  *
  * Get the virtual cluster name.
  *

--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -170,6 +170,15 @@ bool ContextAccessor::getAttributeString(const StreamInfo::StreamInfo& stream_in
     break;
   }
   case envoy_dynamic_module_type_attribute_id_XdsVirtualHostName: {
+    const auto virtual_host = stream_info.virtualHost();
+    if (virtual_host.has_value()) {
+      const auto& name = virtual_host->name();
+      *result = {const_cast<char*>(name.data()), name.size()};
+      ok = true;
+    }
+    break;
+  }
+  case envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName: {
     const auto& name = stream_info.virtualClusterName();
     if (name.has_value() && !name->empty()) {
       *result = {const_cast<char*>(name->data()), name->size()};

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -247,7 +247,8 @@ enum class AttributeID : uint32_t {
   XdsUpstreamHostMetadata,
   XdsFilterChainName,
   HealthCheck,
-  UpstreamRequestedServerName
+  UpstreamRequestedServerName,
+  XdsVirtualClusterName
 };
 
 enum class LogLevel : uint32_t { Trace, Debug, Info, Warn, Error, Critical, Off };

--- a/source/extensions/dynamic_modules/sdk/go/shared/types.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/types.go
@@ -199,6 +199,8 @@ const (
 	AttributeIDHealthCheck
 	// upstream.server_name
 	AttributeIDUpstreamRequestedServerName
+	// xds.virtual_cluster_name
+	AttributeIDXdsVirtualClusterName
 )
 
 // LogLevel is the log level for messages logged via the host environment's logging mechanism.

--- a/source/extensions/dynamic_modules/sdk/go/shared/types_test.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/types_test.go
@@ -11,6 +11,7 @@ func TestAttributeIDOrdering(t *testing.T) {
 	}{
 		{AttributeIDHealthCheck, 67},
 		{AttributeIDUpstreamRequestedServerName, 68},
+		{AttributeIDXdsVirtualClusterName, 69},
 	}
 	for _, test := range tests {
 		if test.id != test.want {

--- a/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/access_log.rs
@@ -590,7 +590,7 @@ impl LogContext {
 
   /// Get the virtual cluster name.
   pub fn virtual_cluster_name(&self) -> Option<EnvoyBuffer<'_>> {
-    self.get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::XdsVirtualHostName)
+    self.get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::XdsVirtualClusterName)
   }
 
   /// Check if this is a health check request.

--- a/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/lib_test.rs
@@ -9915,6 +9915,10 @@ fn test_attribute_id_ordering() {
     68,
     abi::envoy_dynamic_module_type_attribute_id::UpstreamRequestedServerName as u32
   );
+  assert_eq!(
+    69,
+    abi::envoy_dynamic_module_type_attribute_id::XdsVirtualClusterName as u32
+  );
 }
 
 #[test]

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -334,6 +334,16 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterName) {
   EXPECT_TRUE(
       envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(env_ptr, &result));
   EXPECT_EQ("test_vcluster", std::string(result.ptr, result.length));
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName, &result));
+  EXPECT_EQ("test_vcluster", std::string(result.ptr, result.length));
+
+  uint64_t number_result;
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_int(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName, &number_result));
+  bool bool_result;
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_bool(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName, &bool_result));
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterNameEmpty) {
@@ -344,6 +354,8 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterNameEmpty) {
   envoy_dynamic_module_type_envoy_buffer result;
   EXPECT_FALSE(
       envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(env_ptr, &result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName, &result));
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterNameNotSet) {
@@ -354,6 +366,8 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetVirtualClusterNameNotSet) {
   envoy_dynamic_module_type_envoy_buffer result;
   EXPECT_FALSE(
       envoy_dynamic_module_callback_access_logger_get_virtual_cluster_name(env_ptr, &result));
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+      env_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualClusterName, &result));
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttemptCount) {
@@ -2438,8 +2452,9 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringResponseCodeDetailsNotSe
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringVirtualHostName) {
   Formatter::Context log_context(nullptr, nullptr, nullptr);
-  std::optional<std::string> vhost = "my_vhost";
-  ON_CALL(stream_info_, virtualClusterName()).WillByDefault(testing::ReturnRef(vhost));
+  auto virtual_host = std::make_shared<NiceMock<Router::MockVirtualHost>>();
+  virtual_host->name_ = "my_vhost";
+  stream_info_.virtual_host_ = virtual_host;
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   envoy_dynamic_module_type_envoy_buffer result{};
@@ -2450,19 +2465,20 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringVirtualHostName) {
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringVirtualHostNameEmpty) {
   Formatter::Context log_context(nullptr, nullptr, nullptr);
-  std::optional<std::string> vhost = "";
-  ON_CALL(stream_info_, virtualClusterName()).WillByDefault(testing::ReturnRef(vhost));
+  auto virtual_host = std::make_shared<NiceMock<Router::MockVirtualHost>>();
+  virtual_host->name_.clear();
+  stream_info_.virtual_host_ = virtual_host;
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   envoy_dynamic_module_type_envoy_buffer result{};
-  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
+  EXPECT_TRUE(envoy_dynamic_module_callback_access_logger_get_attribute_string(
       env_ptr, envoy_dynamic_module_type_attribute_id_XdsVirtualHostName, &result));
+  EXPECT_EQ(0, result.length);
 }
 
 TEST_F(DynamicModuleAccessLogAbiTest, GetAttributeStringVirtualHostNameNotSet) {
   Formatter::Context log_context(nullptr, nullptr, nullptr);
-  std::optional<std::string> vhost = std::nullopt;
-  ON_CALL(stream_info_, virtualClusterName()).WillByDefault(testing::ReturnRef(vhost));
+  stream_info_.virtual_host_.reset();
   void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
 
   envoy_dynamic_module_type_envoy_buffer result{};

--- a/test/extensions/access_loggers/dynamic_modules/integration_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/integration_test.cc
@@ -23,6 +23,16 @@ public:
     config_helper_.addConfigModifier(
         [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                hcm) {
+          auto* route_config = hcm.mutable_route_config();
+          ASSERT_EQ(1, route_config->virtual_hosts_size());
+          auto* virtual_host = route_config->mutable_virtual_hosts(0);
+          virtual_host->set_name("test_vhost");
+          auto* virtual_cluster = virtual_host->add_virtual_clusters();
+          virtual_cluster->set_name("test_vcluster");
+          auto* header = virtual_cluster->add_headers();
+          header->set_name(":path");
+          header->mutable_string_match()->set_exact("/test");
+
           constexpr auto config = R"EOF(
 name: envoy.access_loggers.dynamic_modules
 typed_config:

--- a/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/access_log_integration_test.rs
@@ -112,6 +112,17 @@ impl AccessLogger for TestAccessLogger {
     let _response_code = ctx.response_code();
     let _protocol = ctx.protocol();
     let _route_name = ctx.route_name();
+    assert_eq!(
+      ctx
+        .get_attribute_string(abi::envoy_dynamic_module_type_attribute_id::XdsVirtualHostName)
+        .unwrap()
+        .as_slice(),
+      b"test_vhost"
+    );
+    assert_eq!(
+      ctx.virtual_cluster_name().unwrap().as_slice(),
+      b"test_vcluster"
+    );
     let _is_health_check = ctx.is_health_check();
     let _timing = ctx.timing_info();
     let _bytes = ctx.bytes_info();


### PR DESCRIPTION
Corrects `xds.virtual_host_name` to return the selected virtual host name instead of the virtual cluster name. Adds a `xds.virtual_cluster_name` attribute, updates the deprecated access logger callback to use it, and exposes it through the C++/Go/Rust SDKs.

Risk Level: Low
Testing: Added ABI, SDK ordering, access logger, and Rust integration coverage for virtual host and virtual cluster values
Docs Changes: Updated ABI callback documentation
Release Notes: Added

AI assistance was used; I reviewed and understand the changes.