### PR TITLE
redis_proxy: avoid per-slot host selection in shardSize() for generic clusters

### DIFF
--- a/changelogs/current/bug_fixes/redis_proxy__shard-size-generic-load-balancer.rst
+++ b/changelogs/current/bug_fixes/redis_proxy__shard-size-generic-load-balancer.rst
@@ -1,0 +1,8 @@
+Fixed excessive CPU usage in the :ref:`Redis proxy
+<config_network_filters_redis_proxy>` when cluster-scope commands such as ``SELECT``, ``KEYS`` or
+``SCAN`` are routed to a cluster that does not use the ``envoy.clusters.redis`` cluster type. Such
+a cluster's load balancer ignores the Redis shard index, so determining the shard count previously
+performed one host selection per Redis hash slot (16384) on every cluster-scope command. The shard
+count is now taken from the number of healthy hosts in the cluster, which returns the same value
+without the per-slot host selections. Clusters using the ``envoy.clusters.redis`` cluster type are
+unaffected.

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -1,5 +1,6 @@
 #include "source/extensions/filters/network/redis_proxy/conn_pool_impl.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -314,6 +315,21 @@ uint16_t InstanceImpl::ThreadLocalPool::shardSize() {
     ASSERT(client_map_.empty());
     ASSERT(host_set_member_update_cb_handle_ == nullptr);
     return 0;
+  }
+
+  // Only the Redis cluster load balancer interprets the shard index in
+  // RedisSpecifyShardContextImpl and returns nullptr past the last shard. A generic load balancer
+  // ignores the index and keeps returning hosts, so walking the slot space would call chooseHost()
+  // MaxSlot times on every cluster-scope command just to rediscover the configured hosts.
+  if (!is_redis_cluster_) {
+    absl::flat_hash_set<Upstream::HostConstSharedPtr> unique_hosts;
+    for (const auto& host_set : cluster_->prioritySet().hostSetsPerPriority()) {
+      for (const auto& host : host_set->healthyHosts()) {
+        unique_hosts.insert(host);
+      }
+    }
+    return static_cast<uint16_t>(
+        std::min<size_t>(unique_hosts.size(), Envoy::Extensions::Clusters::Redis::MaxSlot));
   }
 
   Common::Redis::RespValue request;

--- a/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/conn_pool_impl_test.cc
@@ -395,6 +395,14 @@ TEST_F(RedisConnPoolImplTest, Basic) {
 TEST_F(RedisConnPoolImplTest, ShardSize) {
   InSequence s;
 
+  // The Redis cluster load balancer interprets the shard index and returns nullptr past the last
+  // shard, so shardSize() walks the slot space until that happens.
+  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type;
+  cluster_type.set_name("envoy.clusters.redis");
+  EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
+      .WillOnce(Return(
+          makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type)));
+
   setup();
 
   Common::Redis::RespValueSharedPtr value = std::make_shared<Common::Redis::RespValue>();
@@ -407,7 +415,6 @@ TEST_F(RedisConnPoolImplTest, ShardSize) {
           Invoke([&](Upstream::LoadBalancerContext* context) -> Upstream::HostConstSharedPtr {
             EXPECT_EQ(context->metadataMatchCriteria(), nullptr);
             EXPECT_EQ(context->downstreamConnection(), nullptr);
-            std::cout << (context->computeHashKey().value()) << std::endl;
             if (context->computeHashKey() < shard_size) {
               return cm_.thread_local_cluster_.lb_.host_;
             }
@@ -424,6 +431,43 @@ TEST_F(RedisConnPoolImplTest, ShardSize) {
   }
 
   delete client;
+  tls_.shutdownThread();
+};
+
+// A generic (non-Redis-cluster) load balancer ignores the shard index, so shardSize() must report
+// the number of healthy hosts without probing the load balancer once per slot.
+TEST_F(RedisConnPoolImplTest, ShardSizeGenericLoadBalancer) {
+  InSequence s;
+
+  setup();
+
+  auto& host_set = *cm_.thread_local_cluster_.cluster_.prioritySet().getMockHostSet(0);
+  std::vector<std::shared_ptr<NiceMock<Upstream::MockHost>>> mock_hosts;
+  for (uint16_t i = 0; i < 3; i++) {
+    mock_hosts.push_back(std::make_shared<NiceMock<Upstream::MockHost>>());
+    host_set.hosts_.push_back(mock_hosts.back());
+    host_set.healthy_hosts_.push_back(mock_hosts.back());
+  }
+
+  // The load balancer must not be consulted at all on this path.
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).Times(0);
+
+  EXPECT_EQ(conn_pool_->shardSize(), 3);
+
+  tls_.shutdownThread();
+};
+
+// With no healthy hosts, shardSize() returns 0, which callers translate into a "no upstream host"
+// error response.
+TEST_F(RedisConnPoolImplTest, ShardSizeGenericLoadBalancerNoHealthyHosts) {
+  InSequence s;
+
+  setup();
+
+  EXPECT_CALL(cm_.thread_local_cluster_.lb_, chooseHost(_)).Times(0);
+
+  EXPECT_EQ(conn_pool_->shardSize(), 0);
+
   tls_.shutdownThread();
 };
 
@@ -482,8 +526,16 @@ TEST_F(RedisConnPoolImplTest, ShardNoHost) {
   tls_.shutdownThread();
 };
 
+// A Redis cluster load balancer that never returns nullptr is still bounded by MaxSlot, and
+// duplicate hosts are counted once.
 TEST_F(RedisConnPoolImplTest, ShardSizeDuplicateHosts) {
   InSequence s;
+
+  envoy::config::cluster::v3::Cluster::CustomClusterType cluster_type;
+  cluster_type.set_name("envoy.clusters.redis");
+  EXPECT_CALL(*cm_.thread_local_cluster_.cluster_.info_, clusterType())
+      .WillOnce(Return(
+          makeOptRef<const envoy::config::cluster::v3::Cluster::CustomClusterType>(cluster_type)));
 
   setup();
 


### PR DESCRIPTION
Commit Message: redis_proxy: avoid per-slot host selection in shardSize() for generic clusters

Additional Description:

`ThreadLocalPool::shardSize()` decides how many shards a cluster-scope command (`SELECT`, `KEYS`, `SCAN`, `INFO`, …) must fan out to. It determined that by walking the Redis hash slot space, calling `chooseHost()` once per slot with a `RedisSpecifyShardContextImpl` and deduplicating the hosts it got back.

That is right for the `envoy.clusters.redis` cluster type, whose load balancer interprets the shard index and returns `nullptr` past the last shard, ending the loop after a handful of iterations.

A generic load balancer — `STATIC` or `STRICT_DNS` with `ROUND_ROBIN` — ignores the shard index and keeps returning hosts. The loop therefore runs all **16384** iterations (and reserves a 16384-entry hash set) only to conclude that the cluster has as many shards as it has hosts. That cost is paid on *every* cluster-scope command.

The reporter's measurements, against a single upstream host at 200 req/s:

| Request | Envoy CPU | Avg latency |
|---|---:|---:|
| `GET` | 0–1% of a core | 0.31 ms |
| `SELECT 0`, generic `ROUND_ROBIN` | **35–36% of a core** | 1.95 ms |
| `SELECT 0`, `envoy.clusters.redis` | 0–1% of a core | 0.20 ms |

**Fix.** When the cluster is not a Redis cluster, take the shard count from the number of healthy hosts instead of probing the load balancer per slot. The pool already computes `is_redis_cluster_` once at cluster initialization, with a comment saying it exists "to minimize overhead in the data path" — this is the same kind of decision, so the change follows the file's existing pattern rather than introducing a new mechanism.

The value is unchanged: a generic load balancer can only return hosts drawn from the cluster's host set, so the old walk converged on exactly the set of healthy hosts. Callers fan out over the same number of shards, and the `shardSize() == 0` → `no_healthy_upstream` contract is preserved when there are no healthy hosts.

The `MaxSlot` upper bound and the deduplication added in #39024 (fixing the infinite loop in #38508) are untouched on the Redis-cluster path; this only removes the remaining amplification on the generic path.

Risk Level: Low — the Redis-cluster path is byte-for-byte unchanged, and the generic path returns the same value by a cheaper route. Not runtime guarded: it is a pure performance fix with no user-visible behavioural difference (happy to add a guard if a reviewer would prefer one).

Testing:

`ShardSize` and `ShardSizeDuplicateHosts` both used the **default** mock cluster, whose `clusterType()` is unset — so despite their names they were exercising the *generic* path, and `ShardSizeDuplicateHosts` asserted `EXPECT_GT(call_count, max_hosts)`, i.e. it pinned the very per-slot walk this fixes. Both now set `clusterType()` to `envoy.clusters.redis` so they test the Redis-cluster path they were written to describe, and their assertions are unchanged.

Two tests cover the new path:

* `ShardSizeGenericLoadBalancer` — three healthy hosts, expects `shardSize() == 3` and `EXPECT_CALL(lb_, chooseHost(_)).Times(0)`, so a regression back to per-slot probing fails the test rather than merely being slow.
* `ShardSizeGenericLoadBalancerNoHealthyHosts` — no hosts, expects `0`, covering the `no_healthy_upstream` path.

Because a full Bazel build is not feasible on my machine, I additionally extracted both implementations into a standalone harness and ran them against a simulated generic (index-ignoring, round-robin) load balancer:

```
hosts=0    old=0     (     1 chooseHost calls)   new=0     (0 calls)   MATCH
hosts=1    old=1     ( 16384 chooseHost calls)   new=1     (0 calls)   MATCH
hosts=2    old=2     ( 16384 chooseHost calls)   new=2     (0 calls)   MATCH
hosts=3    old=3     ( 16384 chooseHost calls)   new=3     (0 calls)   MATCH
hosts=5    old=5     ( 16384 chooseHost calls)   new=5     (0 calls)   MATCH
hosts=17   old=17    ( 16384 chooseHost calls)   new=17    (0 calls)   MATCH
hosts=256  old=256   ( 16384 chooseHost calls)   new=256   (0 calls)   MATCH
```

Identical results at every host count, with 16384 load-balancer calls replaced by none — reproducing the single-host figure from the issue. **I have not been able to run the Bazel test suite locally, so CI is the real check here.**

One unrelated line: I removed a stray `std::cout << ... << std::endl;` debug statement from inside the `ShardSize` lambda. It is in a test I was already editing and would otherwise print 16384 lines per run. Happy to restore it if you would rather keep this diff strictly scoped.

Docs Changes: N/A

Release Notes: Added `changelogs/current/bug_fixes/redis_proxy__shard-size-generic-load-balancer.rst`.

Platform Specific Features: N/A

Fixes #47336

---

Generative AI disclosure, per the [policy](https://github.com/envoyproxy/envoy/blob/main/CONTRIBUTING.md?plain=1#L41) and `AGENTS.md`: this change was prepared with AI assistance (Claude Code). I have reviewed and understand it and take full ownership. The call sites, the `is_redis_cluster_` precedent, and the fact that the two existing tests were covering the generic rather than the cluster path were each verified against the source rather than assumed.
