### PR TITLE
clusters: fix missing dependency

### DIFF
--- a/source/extensions/clusters/aggregate/BUILD
+++ b/source/extensions/clusters/aggregate/BUILD
@@ -18,6 +18,7 @@ envoy_cc_extension(
     deps = [
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "//source/extensions/load_balancing_policies/common:load_balancer_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/aggregate/v3:pkg_cc_proto",

--- a/source/extensions/clusters/common/BUILD
+++ b/source/extensions/clusters/common/BUILD
@@ -14,6 +14,7 @@ envoy_cc_library(
     hdrs = ["logical_host.h"],
     deps = [
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
     ],

--- a/source/extensions/clusters/composite/BUILD
+++ b/source/extensions/clusters/composite/BUILD
@@ -19,6 +19,7 @@ envoy_cc_extension(
         "//source/common/runtime:runtime_features_lib",
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "//source/extensions/load_balancing_policies/common:load_balancer_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/clusters/composite/v3:pkg_cc_proto",

--- a/source/extensions/clusters/dns/BUILD
+++ b/source/extensions/clusters/dns/BUILD
@@ -18,6 +18,7 @@ envoy_cc_extension(
         "//source/common/network/dns_resolver:dns_factory_util_lib",
         "//source/common/upstream:cluster_factory_includes",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "//source/extensions/clusters/common:dns_cluster_backcompat_lib",
         "//source/extensions/clusters/common:logical_host_lib",
         "//source/extensions/clusters/logical_dns:logical_dns_cluster_lib",

--- a/source/extensions/clusters/eds/BUILD
+++ b/source/extensions/clusters/eds/BUILD
@@ -36,6 +36,7 @@ envoy_cc_extension(
         "//source/common/protobuf:utility_lib",
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",

--- a/source/extensions/clusters/logical_dns/BUILD
+++ b/source/extensions/clusters/logical_dns/BUILD
@@ -26,6 +26,7 @@ envoy_cc_extension(
         "//source/common/protobuf:utility_lib",
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "//source/extensions/clusters/common:dns_cluster_backcompat_lib",
         "//source/extensions/clusters/common:logical_host_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/source/extensions/clusters/original_dst/BUILD
+++ b/source/extensions/clusters/original_dst/BUILD
@@ -24,6 +24,7 @@ envoy_cc_extension(
         "//source/common/runtime:runtime_features_lib",
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",

--- a/source/extensions/clusters/reverse_connection/BUILD
+++ b/source/extensions/clusters/reverse_connection/BUILD
@@ -23,6 +23,7 @@ envoy_cc_extension(
         "//source/common/network:address_lib",
         "//source/common/upstream:cluster_factory_lib",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "//source/extensions/bootstrap/reverse_tunnel/upstream_socket_interface:reverse_tunnel_acceptor_lib",
         "//source/extensions/transport_sockets/raw_buffer:config",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",

--- a/source/extensions/clusters/static/BUILD
+++ b/source/extensions/clusters/static/BUILD
@@ -16,6 +16,7 @@ envoy_cc_extension(
     deps = [
         "//source/common/upstream:cluster_factory_includes",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",
     ],

--- a/source/extensions/clusters/strict_dns/BUILD
+++ b/source/extensions/clusters/strict_dns/BUILD
@@ -19,6 +19,7 @@ envoy_cc_extension(
         "//source/common/network/dns_resolver:dns_factory_util_lib",
         "//source/common/upstream:cluster_factory_includes",
         "//source/common/upstream:upstream_includes",
+        "//source/common/upstream:upstream_lib",
         "//source/extensions/clusters/common:dns_cluster_backcompat_lib",
         "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/endpoint/v3:pkg_cc_proto",


### PR DESCRIPTION
Several cluster extensions construct a subclass of types defined in `upstream_lib`, but these targets declare a dependency only on `upstream_includes`.

This went unnoticed because a full extension build config already pulls in `upstream_lib` through another extension. With a reduced extension set, that dependency can be missing, causing undefined-symbol errors at link time.

I came across it when building `schema_validator_tool` with a reduced extension config, but the missing dependency can apply globally. 

Commit Message: [clusters: add upstream_lib to build dependencies](https://github.com/envoyproxy/envoy/commit/122c01f1ec756ff3e67a26ea7daf3eace3a7a03d)
Additional Description:
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A