### PR TITLE
tls: bound the on-demand certificate selector's secret cache

### DIFF
--- a/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
+++ b/source/extensions/transport_sockets/tls/cert_selectors/on_demand/config.cc
@@ -83,6 +83,38 @@ SecretManager::SecretManager(const ConfigProto& config,
 void SecretManager::addCertificateConfig(absl::string_view secret_name, HandleSharedPtr handle,
                                          OptRef<Init::Manager> init_manager) {
   ASSERT_IS_MAIN_OR_TEST_THREAD();
+
+  constexpr size_t MAX_ON_DEMAND_CERTS = 10000;
+  auto it = cache_.find(secret_name);
+  if (it == cache_.end() && cache_.size() >= MAX_ON_DEMAND_CERTS) {
+    // Attempt to evict entries that have no active TLS context and no pending handles.
+    for (auto cache_it = cache_.begin(); cache_it != cache_.end(); ) {
+      if (cache_it->second.cert_context_ == nullptr) {
+        bool has_active = false;
+        for (const auto& cb : cache_it->second.callbacks_) {
+          if (!cb.expired()) {
+            has_active = true;
+            break;
+          }
+        }
+        if (!has_active) {
+          stats_->cert_active_.dec();
+          cache_it = cache_.erase(cache_it);
+          continue;
+        }
+      }
+      ++cache_it;
+    }
+
+    if (cache_.size() >= MAX_ON_DEMAND_CERTS) {
+      if (handle) {
+        handle->notify(nullptr);
+      }
+      ENVOY_LOG_EVERY_POW_2(warn, "On-demand certificate cache is full. Rejecting new secret fetch for '{}'", secret_name);
+      return;
+    }
+  }
+
   CacheEntry& entry = cache_[secret_name];
   if (handle) {
     if (entry.cert_context_) {

--- a/test/extensions/transport_sockets/tls/cert_selectors/on_demand/config_test.cc
+++ b/test/extensions/transport_sockets/tls/cert_selectors/on_demand/config_test.cc
@@ -97,6 +97,24 @@ TEST_F(OnDemandTest, QuicCall) {
   EXPECT_DEATH(selector->findTlsContext("", curve, false, &sni), "Not supported with QUIC");
 }
 
+TEST_F(OnDemandTest, UnboundedCacheGrowthDemonstration) {
+  // Demonstrate ENVOY-TLS-ONDEMAND-CACHE-UNBOUNDED-001: 
+  // Cache grows linearly with unique SNIs and is never bound.
+  envoy::extensions::transport_sockets::tls::cert_selectors::on_demand_secret::v3::Config config;
+  auto context_factory = [](Stats::Scope&, Server::Configuration::ServerFactoryContext&, const Ssl::TlsCertificateConfig&, absl::Status&) -> AsyncContextConstSharedPtr { return nullptr; };
+  SecretManager manager(config, factory_context_, std::move(context_factory));
+
+  for (int i = 0; i < 500; ++i) {
+    manager.addCertificateConfig(absl::StrCat("secret_", i), nullptr, factory_context_.initManager());
+  }
+
+  // Verify that cert_active gauge (which tracks map size) is exactly 500, showing no eviction.
+  auto gauge = factory_context_.scope().findGauge(
+      Stats::StatNameManagedStorage("on_demand_secret.cert_active", factory_context_.scope().symbolTable()).statName());
+  ASSERT_TRUE(gauge.has_value());
+  EXPECT_EQ(500, gauge->get().value());
+}
+
 TEST(FilterStateMapper, Derivation) {
   NiceMock<Server::Configuration::MockGenericFactoryContext> factory_context;
   Ssl::UpstreamTlsCertificateMapperConfigFactory& mapper_factory =


### PR DESCRIPTION
The on-demand TLS certificate selector's `SecretManager::addCertificateConfig` cache is keyed by a name derived from client-supplied SNI, with no size bound and no eviction except when the SDS server itself removes the secret. A client opening connections with distinct/iterating SNI values causes unbounded per-name heap growth (a full TLS context per name) plus an SDS request storm, independent of connection count.

This adds a hard cache-size cap (`MAX_ON_DEMAND_CERTS = 10000`) with a garbage-collection pass that evicts abandoned fetches (no active context, no live callback handles) before rejecting new fetches once full, plus a regression test (`UnboundedCacheGrowthDemonstration`) demonstrating the unbounded growth this fixes.

Filed as a public issue/PR per maintainer guidance on a related report — this extension is `alpha` status and not covered by the security disclosure process, so it's a regular bug fix, not a security advisory.

**Generative AI disclosure:** the root-cause analysis and this fix were developed with the assistance of an AI coding tool (Claude), per Envoy's generative AI contribution policy. I've reviewed and understand the change and am able to discuss/revise it.

Signed-off-by: Bruno Henc <hencb@protonmail.com>