### PR TITLE
Fix underflowing flow control high_watermark_count_

### DIFF
--- a/changelogs/current/bug_fixes/http2__reentrant-low-watermark-callbacks.rst
+++ b/changelogs/current/bug_fixes/http2__reentrant-low-watermark-callbacks.rst
@@ -1,0 +1,3 @@
+Fixed HTTP/2 connection write-buffer low-watermark callback delivery when a callback reentrantly
+encodes data. Previously, reordering the active-stream list during callback delivery could notify
+one stream twice and skip another, leading to a stalled response.

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -18,9 +18,9 @@ public:
     if (reset_callbacks_started_ || local_end_stream_) {
       return;
     }
-    ENVOY_BUG(high_watermark_callbacks_ > 0,
-              "HTTP stream low watermark callback without a preceding high watermark callback");
     if (high_watermark_callbacks_ == 0) {
+      IS_ENVOY_BUG(
+          "HTTP stream low watermark callback without a preceding high watermark callback");
       return;
     }
     --high_watermark_callbacks_;

--- a/source/common/http/codec_helper.h
+++ b/source/common/http/codec_helper.h
@@ -18,7 +18,11 @@ public:
     if (reset_callbacks_started_ || local_end_stream_) {
       return;
     }
-    ASSERT(high_watermark_callbacks_ > 0);
+    ENVOY_BUG(high_watermark_callbacks_ > 0,
+              "HTTP stream low watermark callback without a preceding high watermark callback");
+    if (high_watermark_callbacks_ == 0) {
+      return;
+    }
     --high_watermark_callbacks_;
     for (StreamCallbacks* callbacks : callbacks_) {
       if (callbacks) {

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1759,7 +1759,12 @@ void FilterManager::callHighWatermarkCallbacks() {
 }
 
 void FilterManager::callLowWatermarkCallbacks() {
-  ASSERT(high_watermark_count_ > 0);
+  ENVOY_BUG(high_watermark_count_ > 0,
+            "HTTP filter manager low watermark callback without a preceding high watermark "
+            "callback");
+  if (high_watermark_count_ == 0) {
+    return;
+  }
   --high_watermark_count_;
   for (auto watermark_callbacks : watermark_callbacks_) {
     watermark_callbacks->onBelowWriteBufferLowWatermark();

--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1759,10 +1759,9 @@ void FilterManager::callHighWatermarkCallbacks() {
 }
 
 void FilterManager::callLowWatermarkCallbacks() {
-  ENVOY_BUG(high_watermark_count_ > 0,
-            "HTTP filter manager low watermark callback without a preceding high watermark "
-            "callback");
   if (high_watermark_count_ == 0) {
+    IS_ENVOY_BUG("HTTP filter manager low watermark callback without a preceding high watermark "
+                 "callback");
     return;
   }
   --high_watermark_count_;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -1882,10 +1882,17 @@ void ConnectionImpl::onProtocolConstraintViolation() {
 }
 
 void ConnectionImpl::onUnderlyingConnectionBelowWriteBufferLowWatermark() {
-  // Notify the streams based on least recently encoding to the connection.
-  // NOLINTNEXTLINE(modernize-loop-convert)
+  // Snapshot the streams in least-recently-encoded order before invoking callbacks. A callback may
+  // encode on its stream and reorder active_streams_, invalidating the traversal. Stream deletion
+  // is deferred, so the pointers remain valid for the duration of this synchronous callback fanout.
+  std::vector<StreamImpl*> streams;
+  streams.reserve(active_streams_.size());
   for (auto it = active_streams_.rbegin(); it != active_streams_.rend(); ++it) {
-    (*it)->runLowWatermarkCallbacks();
+    streams.push_back(it->get());
+  }
+
+  for (StreamImpl* stream : streams) {
+    stream->runLowWatermarkCallbacks();
   }
 }
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -145,6 +145,7 @@ envoy_cc_test(
         "//test/mocks/network:network_mocks",
         "//test/mocks/server:overload_manager_mocks",
         "//test/test_common:test_runtime_lib",
+        "//test/test_common:utility_lib",
     ],
 )
 

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -63,6 +63,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "codec_helper_test",
+    srcs = ["codec_helper_test.cc"],
+    deps = [
+        "//source/common/http:codec_helper_lib",
+        "//test/mocks/http:http_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "codec_client_test",
     srcs = ["codec_client_test.cc"],
     rbe_pool = "linux_x64_small",

--- a/test/common/http/codec_helper_test.cc
+++ b/test/common/http/codec_helper_test.cc
@@ -1,0 +1,40 @@
+#include "source/common/http/codec_helper.h"
+
+#include "test/mocks/http/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Mock;
+using testing::StrictMock;
+
+namespace Envoy {
+namespace Http {
+namespace {
+
+class TestStreamCallbackHelper : public StreamCallbackHelper {
+public:
+  using StreamCallbackHelper::addCallbacksHelper;
+};
+
+TEST(StreamCallbackHelperTest, LowWatermarkWithoutHighWatermarkDoesNotUnderflowCounter) {
+  TestStreamCallbackHelper helper;
+  StrictMock<MockStreamCallbacks> callbacks;
+  helper.addCallbacksHelper(callbacks);
+
+  EXPECT_CALL(callbacks, onBelowWriteBufferLowWatermark()).Times(0);
+  EXPECT_ENVOY_BUG(
+      helper.runLowWatermarkCallbacks(),
+      "HTTP stream low watermark callback without a preceding high watermark callback");
+  Mock::VerifyAndClearExpectations(&callbacks);
+
+  EXPECT_CALL(callbacks, onAboveWriteBufferHighWatermark());
+  helper.runHighWatermarkCallbacks();
+  EXPECT_CALL(callbacks, onBelowWriteBufferLowWatermark());
+  helper.runLowWatermarkCallbacks();
+}
+
+} // namespace
+} // namespace Http
+} // namespace Envoy

--- a/test/common/http/filter_manager_test.cc
+++ b/test/common/http/filter_manager_test.cc
@@ -20,6 +20,7 @@
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/overload_manager.h"
 #include "test/test_common/test_runtime.h"
+#include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
@@ -168,6 +169,16 @@ public:
       std::make_shared<StreamInfo::FilterStateImpl>(StreamInfo::FilterState::LifeSpan::Connection);
   NiceMock<Server::MockOverloadManager> overload_manager_;
 };
+
+TEST_F(FilterManagerTest, LowWatermarkWithoutHighWatermark) {
+  initialize();
+
+  EXPECT_ENVOY_BUG(
+      filter_manager_->callLowWatermarkCallbacks(),
+      "HTTP filter manager low watermark callback without a preceding high watermark callback");
+  EXPECT_FALSE(filter_manager_->aboveHighWatermark());
+  filter_manager_->destroyFilters();
+}
 
 TEST_F(FilterManagerTest, RequestHeadersOrResponseHeadersAccess) {
   initialize();

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -4556,6 +4556,54 @@ TEST_P(Http2CodecImplTest, ShouldTrackWhichStreamLeastRecentlyEncodedIfDeferProc
   EXPECT_THAT(getActiveStreamsIds(*server_), ElementsAre(1, 3));
 }
 
+// Regression test for reentrant encoding during connection-level low watermark callbacks. This
+// test intentionally fails until onUnderlyingConnectionBelowWriteBufferLowWatermark() tolerates an
+// encode operation reordering active_streams_ while it is traversing the list.
+TEST_P(Http2CodecImplTest, LowWatermarkCallbackCanReorderActiveStreams) {
+  initialize();
+
+  RequestEncoder* request_encoder1 = request_encoder_;
+  TestRequestHeaderMapImpl request_headers;
+  HttpTestUtility::addDefaultHeaders(request_headers);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_OK(request_encoder1->encodeHeaders(request_headers, false));
+  driveToCompletion();
+
+  RequestEncoder* request_encoder2 = &client_->newStream(response_decoder_);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_OK(request_encoder2->encodeHeaders(request_headers, false));
+  driveToCompletion();
+
+  RequestEncoder* request_encoder3 = &client_->newStream(response_decoder_);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
+  EXPECT_OK(request_encoder3->encodeHeaders(request_headers, false));
+  driveToCompletion();
+
+  EXPECT_THAT(getActiveStreamsIds(*client_), ElementsAre(5, 3, 1));
+
+  MockStreamCallbacks callbacks1;
+  MockStreamCallbacks callbacks2;
+  MockStreamCallbacks callbacks3;
+  request_encoder1->getStream().addCallbacks(callbacks1);
+  request_encoder2->getStream().addCallbacks(callbacks2);
+  request_encoder3->getStream().addCallbacks(callbacks3);
+
+  EXPECT_CALL(callbacks1, onAboveWriteBufferHighWatermark());
+  EXPECT_CALL(callbacks2, onAboveWriteBufferHighWatermark());
+  EXPECT_CALL(callbacks3, onAboveWriteBufferHighWatermark());
+  client_->onUnderlyingConnectionAboveWriteBufferHighWatermark();
+
+  Buffer::OwnedImpl data("a");
+  EXPECT_CALL(request_decoder_, decodeData(_, false));
+  EXPECT_CALL(callbacks1, onBelowWriteBufferLowWatermark()).WillOnce(Invoke([&]() {
+    request_encoder1->encodeData(data, false);
+  }));
+  EXPECT_CALL(callbacks2, onBelowWriteBufferLowWatermark());
+  EXPECT_CALL(callbacks3, onBelowWriteBufferLowWatermark());
+  client_->onUnderlyingConnectionBelowWriteBufferLowWatermark();
+  driveToCompletion();
+}
+
 TEST_P(Http2CodecImplTest, ChunksLargeBodyDuringDeferredProcessing) {
   server_settings_.emplace(smallWindowHttp2Settings());
   // We must initialize before dtor, otherwise we'll touch uninitialized

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -4556,9 +4556,9 @@ TEST_P(Http2CodecImplTest, ShouldTrackWhichStreamLeastRecentlyEncodedIfDeferProc
   EXPECT_THAT(getActiveStreamsIds(*server_), ElementsAre(1, 3));
 }
 
-// Regression test for reentrant encoding during connection-level low watermark callbacks. This
-// test intentionally fails until onUnderlyingConnectionBelowWriteBufferLowWatermark() tolerates an
-// encode operation reordering active_streams_ while it is traversing the list.
+// Regression test for reentrant encoding during connection-level low watermark callbacks. The
+// callback fanout must tolerate an encode operation reordering active_streams_ while still
+// notifying every stream exactly once in the original LRU order.
 TEST_P(Http2CodecImplTest, LowWatermarkCallbackCanReorderActiveStreams) {
   initialize();
 
@@ -4601,6 +4601,7 @@ TEST_P(Http2CodecImplTest, LowWatermarkCallbackCanReorderActiveStreams) {
   EXPECT_CALL(callbacks2, onBelowWriteBufferLowWatermark());
   EXPECT_CALL(callbacks3, onBelowWriteBufferLowWatermark());
   client_->onUnderlyingConnectionBelowWriteBufferLowWatermark();
+  EXPECT_THAT(getActiveStreamsIds(*client_), ElementsAre(1, 5, 3));
   driveToCompletion();
 }
 


### PR DESCRIPTION
Commit Message: Fix underflowing flow control high_watermark_count_
Additional Description:

What a fun bug this is.

This was detected via the `cache_v2` filter ENVOY_BUG: `envoy bug failure: false. Details: low watermark not preceded by high watermark should not happen`

It turns out there are some debug-build-only ASSERTs in the main code that should have been catching this under similar conditions, but they're debug-build-only ASSERTs so it has gone unnoticed.

I believe the consequence of this bug *can be* a stream that never unblocks (and so eventually times out).

Part 1 of this PR is upgrading those `ASSERT`s to release-scoped checks with `ENVOY_BUG`, so if there's another route to the same issue it doesn't just continue to fly under the radar for any users without cache filters detecting it.

Along with that change, the integration-regression test `LowWatermarkCallbackCanReorderActiveStreams` proves the failure; at the first commit of the PR, where the fix is not yet included, that test consistently fails.

Part 2 of the PR is fixing the issue: `onUnderlyingConnectionBelowWriteBufferLowWatermark` iterates over a list calling a function which, under some conditions, modifies the list order, invalidating the iteration (one stream gets low-watermark-event twice, another stream gets none). Making a local copy of the streams to be notified ensures each is called once.

This adds a small performance cost, but watermark events are already an intentional performance-reducing branch so that cost shouldn't be a problem.

This was AI assisted with Codex Sol.

Risk Level: Small. It's core code, but the behavioral change is negligible.
Testing: Added regression test and coverage.
Docs Changes: n/a
Release Notes: bugfix
Platform Specific Features: n/a
