### PR TITLE
Deflake //test/extensions/filters/udp/udp_proxy:udp_session_extension_discovery_integration_test

### DIFF
--- a/test/extensions/filters/udp/udp_proxy/udp_session_extension_discovery_integration_test.cc
+++ b/test/extensions/filters/udp/udp_proxy/udp_session_extension_discovery_integration_test.cc
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/extensions/filters/udp/udp_proxy/v3/udp_proxy.pb.h"
@@ -291,11 +292,17 @@ typed_config:
     test_server_->waitForGauge("udp.foo.downstream_sess_active", Eq(active_sessions_));
   }
 
+  Network::Test::UdpSyncPeer& createUdpClient() {
+    udp_clients_.push_back(std::make_unique<Network::Test::UdpSyncPeer>(
+        version_, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE));
+    return *udp_clients_.back();
+  }
+
   void requestResponseWithListenerAddress(const Network::Address::Instance& listener_address,
                                           std::string request, std::string expected_request,
                                           std::string response, std::string expected_response) {
     // Send datagram to be proxied.
-    Network::Test::UdpSyncPeer client(version_, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
+    Network::Test::UdpSyncPeer& client = createUdpClient();
     client.write(request, listener_address);
 
     // Wait for the upstream datagram.
@@ -334,7 +341,7 @@ typed_config:
     const uint32_t port = lookupPort(port_name_);
     const auto listener_address = *Network::Utility::resolveUrl(
         fmt::format("tcp://{}:{}", Network::Test::getLoopbackAddressUrlString(version_), port));
-    Network::Test::UdpSyncPeer client(version_, Network::DEFAULT_UDP_MAX_DATAGRAM_SIZE);
+    Network::Test::UdpSyncPeer& client = createUdpClient();
     client.write("hello", *listener_address);
 
     // The new datagram is expected to create a session that will be destroyed, since the session
@@ -391,6 +398,10 @@ typed_config:
   const std::string filter_name_ = "foo";
   const std::string port_name_ = "udp";
   bool two_connections_{false};
+
+  // Each helper call is expected to create a new UDP session. Keep the client sockets open so the
+  // OS cannot reuse an earlier client's source port while its corresponding Envoy session exists.
+  std::vector<std::unique_ptr<Network::Test::UdpSyncPeer>> udp_clients_;
 
   FakeUpstream& getEcdsFakeUpstream() const { return *fake_upstreams_[1]; }
   FakeUpstream& getLdsFakeUpstream() const { return *fake_upstreams_[2]; }


### PR DESCRIPTION
Commit Message: Deflake //test/extensions/filters/udp/udp_proxy:udp_session_extension_discovery_integration_test
Additional Description:
[Example flake](https://github.com/envoyproxy/envoy/actions/runs/34498979842/job/102945581014#annotation:20:4575)
```
  [ RUN      ] IpVersionsClientType/UdpSessionExtensionDiscoveryIntegrationTest.BasicSuccessWithTtl/2
  test/extensions/filters/udp/udp_proxy/udp_session_extension_discovery_integration_test.cc:304: Failure
  Expected equality of these values:
    expected_request
      Which is: "lohellohello"
    request_datagram.buffer_->toString()
      Which is: "hellohello"
  Stack trace:
    0x55f47f5551a2: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::requestResponseWithListenerAddress()
    0x55f47f555b93: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::sendDataVerifyResults()
    0x55f47f55804e: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest_BasicSuccessWithTtl_Test::TestBody()
    0x55f48404f739: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x55f484049b59: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x55f484029b0c: testing::Test::Run()
    0x55f48402a587: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  test/extensions/filters/udp/udp_proxy/udp_session_extension_discovery_integration_test.cc:310: Failure
  Expected equality of these values:
    expected_response
      Which is: "ldworldworld"
    response_datagram.buffer_->toString()
      Which is: "worldworld"
  Stack trace:
    0x55f47f55530f: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::requestResponseWithListenerAddress()
    0x55f47f555b93: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::sendDataVerifyResults()
    0x55f47f55804e: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest_BasicSuccessWithTtl_Test::TestBody()
    0x55f48404f739: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x55f484049b59: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x55f484029b0c: testing::Test::Run()
    0x55f48402a587: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  ./test/integration/server.h:507: Failure
  Value of: TestUtility::waitForCounter(statStore(), name, value_matcher, time_system_, timeout, dispatcher)
    Actual: false (timed out waiting for cluster.cluster_0.upstream_cx_tx_bytes_total to is equal to 22: current value 20)
  Expected: true
  Stack trace:
    0x55f47fbabc57: Envoy::IntegrationTestServer::waitForCounter()
    0x55f47f554747: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::verifyStats()
    0x55f47f555503: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::requestResponseWithListenerAddress()
    0x55f47f555b93: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::sendDataVerifyResults()
    0x55f47f55804e: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest_BasicSuccessWithTtl_Test::TestBody()
    0x55f48404f739: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x55f484049b59: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x55f484029b0c: testing::Test::Run()
    0x55f48402a587: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  ./test/integration/server.h:507: Failure
  Value of: TestUtility::waitForCounter(statStore(), name, value_matcher, time_system_, timeout, dispatcher)
    Actual: false (timed out waiting for udp.foo.downstream_sess_tx_bytes to is equal to 22: current value 20)
  Expected: true
  Stack trace:
    0x55f47fbabc57: Envoy::IntegrationTestServer::waitForCounter()
    0x55f47f554a14: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::verifyStats()
    0x55f47f555503: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::requestResponseWithListenerAddress()
    0x55f47f555b93: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::sendDataVerifyResults()
    0x55f47f55804e: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest_BasicSuccessWithTtl_Test::TestBody()
    0x55f48404f739: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x55f484049b59: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x55f484029b0c: testing::Test::Run()
    0x55f48402a587: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  ./test/integration/server.h:507: Failure
  Value of: TestUtility::waitForCounter(statStore(), name, value_matcher, time_system_, timeout, dispatcher)
    Actual: false (timed out waiting for udp.foo.downstream_sess_total to is equal to 3: current value 2)
  Expected: true
  Stack trace:
    0x55f47fbabc57: Envoy::IntegrationTestServer::waitForCounter()
    0x55f47f554b76: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::verifyStats()
    0x55f47f555503: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::requestResponseWithListenerAddress()
    0x55f47f555b93: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::sendDataVerifyResults()
    0x55f47f55804e: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest_BasicSuccessWithTtl_Test::TestBody()
    0x55f48404f739: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x55f484049b59: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x55f484029b0c: testing::Test::Run()
    0x55f48402a587: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  ./test/integration/server.h:525: Failure
  Value of: TestUtility::waitForGauge(statStore(), name, value_matcher, time_system_, timeout)
    Actual: false (timed out waiting for udp.foo.downstream_sess_active to is equal to 2: current value 1)
  Expected: true
  Stack trace:
    0x55f47fbabe86: Envoy::IntegrationTestServer::waitForGauge()
    0x55f47f554c21: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::verifyStats()
    0x55f47f555503: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::requestResponseWithListenerAddress()
    0x55f47f555b93: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest::sendDataVerifyResults()
    0x55f47f55804e: Envoy::(anonymous namespace)::UdpSessionExtensionDiscoveryIntegrationTest_BasicSuccessWithTtl_Test::TestBody()
    0x55f48404f739: testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    0x55f484049b59: testing::internal::HandleExceptionsInMethodIfSupported<>()
    0x55f484029b0c: testing::Test::Run()
    0x55f48402a587: testing::TestInfo::Run()
  ... Google Test internal frames ...
  
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 146] RAW: Restore saved value of envoy_quic_always_support_server_preferred_address to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 146] RAW: Restore saved value of envoy_reloadable_features_runtime_initialized to: false
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 146] RAW: Restore saved value of envoy_quic_always_support_server_preferred_address to: true
  [external/abseil-cpp+/absl/flags/internal/flag.cc : 146] RAW: Restore saved value of envoy_reloadable_features_runtime_initialized to: false
  [  FAILED  ] IpVersionsClientType/UdpSessionExtensionDiscoveryIntegrationTest.BasicSuccessWithTtl/2, where GetParam() = (4-byte object <01-00 00-00>, 4-byte object <00-00 00-00>) (41675 ms)
```
Helper function destroyed its UDP client socket after one exchange.
Envoy kept the corresponding UDP session alive.
The OS reused the closed client’s ephemeral source port (this is why it's flaky).
The final request then matched the original session and retained its old filter configuration.
The fix: helper-created client sockets are now retained for the fixture’s lifetime, preventing source-port reuse and guaranteeing distinct intended sessions.

This was AI assisted with Codex Sol.
Risk Level: test-only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
