### PR TITLE
ai_protocol_manager: pass end_stream to ExternalBuffer::write

### DIFF
--- a/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/buffer_manager.cc
@@ -141,7 +141,7 @@ void BufferManager::maybeIssueWrite() {
   in_flight_write_size_ = pending_.length();
   owned->move(pending_);
   write_in_flight_ = true;
-  buffer_->write(std::move(owned),
+  buffer_->write(std::move(owned), end_stream_seen_,
                  [this](ExternalBufferStatus status) { onWriteComplete(status); });
 }
 

--- a/source/extensions/filters/http/ai_protocol_manager/external_buffer.h
+++ b/source/extensions/filters/http/ai_protocol_manager/external_buffer.h
@@ -48,8 +48,9 @@ public:
   // Appends owned `data` to the store, taking ownership; `cb` fires once the bytes
   // are durable. The caller issues at most one write at a time -- it will not call
   // write() again until `cb` fires -- so an implementation needs no write queue of
-  // its own and can apply back-pressure simply by deferring `cb`.
-  virtual void write(Buffer::InstancePtr data, WriteCallback cb) PURE;
+  // its own and can apply back-pressure simply by deferring `cb`. If `end_stream`
+  // is true, this is the final write for the buffer.
+  virtual void write(Buffer::InstancePtr data, bool end_stream, WriteCallback cb) PURE;
 
   // Reads `length` bytes starting at absolute byte offset `offset`. It is an
   // error to request a range that extends past the current length(). `cb`

--- a/source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.cc
+++ b/source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.cc
@@ -18,7 +18,8 @@ InMemoryExternalBuffer::~InMemoryExternalBuffer() {
   *alive_ = false;
 }
 
-void InMemoryExternalBuffer::write(Buffer::InstancePtr data, WriteCallback cb) {
+void InMemoryExternalBuffer::write(Buffer::InstancePtr data, bool /*end_stream*/,
+                                   WriteCallback cb) {
   // The bytes only become visible to length() / read() once the (asynchronous)
   // completion callback below runs, modelling a write that is not durable until
   // acknowledged.

--- a/source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.h
+++ b/source/extensions/filters/http/ai_protocol_manager/external_buffer_impl.h
@@ -26,7 +26,7 @@ public:
   ~InMemoryExternalBuffer() override;
 
   // ExternalBuffer
-  void write(Buffer::InstancePtr data, WriteCallback cb) override;
+  void write(Buffer::InstancePtr data, bool end_stream, WriteCallback cb) override;
   void read(uint64_t offset, uint64_t length, ReadCallback cb) override;
   uint64_t length() const override { return data_.length(); }
 

--- a/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/buffer_manager_test.cc
@@ -32,13 +32,14 @@ public:
   explicit PostingExternalBuffer(Event::Dispatcher& dispatcher) : dispatcher_(dispatcher) {}
   ~PostingExternalBuffer() override { *alive_ = false; }
 
-  void write(Buffer::InstancePtr data, WriteCallback cb) override {
+  void write(Buffer::InstancePtr data, bool end_stream, WriteCallback cb) override {
     // Enforce the single-writer contract: the manager must never issue a write
     // while another is outstanding.
     EXPECT_FALSE(write_active_);
     write_active_ = true;
     ++write_calls_;
     write_sizes_.push_back(data->length());
+    write_end_streams_.push_back(end_stream);
     dispatcher_.post([this, alive = alive_, data = std::move(data), cb = std::move(cb)]() mutable {
       if (!*alive) {
         return;
@@ -68,6 +69,7 @@ public:
   // that the manager serializes and coalesces queued writes.
   int write_calls_{0};
   std::vector<uint64_t> write_sizes_;
+  std::vector<bool> write_end_streams_;
 
 private:
   Event::Dispatcher& dispatcher_;
@@ -101,7 +103,7 @@ public:
       : dispatcher_(dispatcher), mode_(mode) {}
   ~FailingExternalBuffer() override { *alive_ = false; }
 
-  void write(Buffer::InstancePtr data, WriteCallback cb) override {
+  void write(Buffer::InstancePtr data, bool /*end_stream*/, WriteCallback cb) override {
     dispatcher_.post([this, alive = alive_, data = std::move(data), cb = std::move(cb)]() mutable {
       if (!*alive) {
         return;
@@ -527,6 +529,7 @@ TEST_F(BufferManagerTest, BatchesSmallFramesUntilEndStream) {
   // endStream() flushes the batched backlog as a single write.
   EXPECT_EQ(buffer->write_calls_, 1);
   EXPECT_THAT(buffer->write_sizes_, testing::ElementsAre(8)); // "aaa"+"bbb"+"cc".
+  EXPECT_THAT(buffer->write_end_streams_, testing::ElementsAre(true));
 
   replayAll();
   drain();
@@ -565,6 +568,7 @@ TEST_F(BufferManagerTest, SerializesAndCoalescesQueuedWrites) {
   // never overlapping (asserted in the fake) -- and the payload round-trips.
   EXPECT_EQ(buffer->write_calls_, 2);
   EXPECT_THAT(buffer->write_sizes_, testing::ElementsAre(threshold, 2 * threshold));
+  EXPECT_THAT(buffer->write_end_streams_, testing::ElementsAre(false, true));
   EXPECT_TRUE(replay_done_);
   EXPECT_EQ(bridge_->injected_.toString(), chunk + chunk + chunk);
 }

--- a/test/extensions/filters/http/ai_protocol_manager/external_buffer_impl_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/external_buffer_impl_test.cc
@@ -32,7 +32,7 @@ public:
 // Writes are asynchronous: nothing is durable until the event loop runs.
 TEST_F(InMemoryExternalBufferTest, WriteIsAsynchronous) {
   bool acked = false;
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("hello"),
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("hello"), false,
                 [&acked](ExternalBufferStatus status) {
                   EXPECT_EQ(status, ExternalBufferStatus::Ok);
                   acked = true;
@@ -51,7 +51,7 @@ TEST_F(InMemoryExternalBufferTest, WriteIsAsynchronous) {
 // Successive writes accumulate in order and read-back returns the bytes verbatim.
 TEST_F(InMemoryExternalBufferTest, WriteThenReadRoundTrips) {
   for (absl::string_view chunk : {"abc", "def", "ghij"}) {
-    buffer_.write(std::make_unique<Buffer::OwnedImpl>(chunk),
+    buffer_.write(std::make_unique<Buffer::OwnedImpl>(chunk), false,
                   [](ExternalBufferStatus status) { EXPECT_EQ(status, ExternalBufferStatus::Ok); });
   }
   drain();
@@ -69,7 +69,8 @@ TEST_F(InMemoryExternalBufferTest, WriteThenReadRoundTrips) {
 
 // Reads honor arbitrary byte offsets and are non-destructive (repeatable).
 TEST_F(InMemoryExternalBufferTest, ReadAtOffsetIsRepeatable) {
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("0123456789"), [](ExternalBufferStatus) {});
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("0123456789"), false,
+                [](ExternalBufferStatus) {});
   drain();
 
   std::vector<std::string> results;
@@ -92,7 +93,7 @@ TEST_F(InMemoryExternalBufferTest, PendingCallbacksCancelledOnDestruction) {
   bool acked = false;
   {
     InMemoryExternalBuffer scoped(*dispatcher_);
-    scoped.write(std::make_unique<Buffer::OwnedImpl>("data"),
+    scoped.write(std::make_unique<Buffer::OwnedImpl>("data"), false,
                  [&acked](ExternalBufferStatus) { acked = true; });
     // scoped goes out of scope before the dispatcher runs.
   }
@@ -107,7 +108,7 @@ TEST_F(InMemoryExternalBufferTest, AllPendingWritesCancelledOnDestruction) {
   {
     InMemoryExternalBuffer scoped(*dispatcher_);
     for (int i = 0; i < 3; ++i) {
-      scoped.write(std::make_unique<Buffer::OwnedImpl>("x"),
+      scoped.write(std::make_unique<Buffer::OwnedImpl>("x"), false,
                    [&acked](ExternalBufferStatus) { ++acked; });
     }
   }
@@ -118,7 +119,8 @@ TEST_F(InMemoryExternalBufferTest, AllPendingWritesCancelledOnDestruction) {
 // The read callback runs on-stack, before read() returns -- the synchronous
 // completion the BufferManager relies on for its re-entrant replay burst.
 TEST_F(InMemoryExternalBufferTest, ReadInvokesCallbackBeforeReturning) {
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("0123456789"), [](ExternalBufferStatus) {});
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("0123456789"), false,
+                [](ExternalBufferStatus) {});
   drain();
 
   bool ran = false;
@@ -143,7 +145,7 @@ TEST_F(InMemoryExternalBufferTest, ZeroLengthReadReturnsEmptyBuffer) {
   });
   EXPECT_TRUE(ran);
 
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("data"), [](ExternalBufferStatus) {});
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("data"), false, [](ExternalBufferStatus) {});
   drain();
   ran = false;
   buffer_.read(2, 0, [&ran](ExternalBufferStatus status, Buffer::InstancePtr data) {
@@ -158,10 +160,11 @@ TEST_F(InMemoryExternalBufferTest, ZeroLengthReadReturnsEmptyBuffer) {
 // An empty write still completes (asynchronously) with Ok and leaves length at 0.
 TEST_F(InMemoryExternalBufferTest, EmptyWriteIsAcknowledged) {
   bool acked = false;
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>(), [&acked](ExternalBufferStatus status) {
-    EXPECT_EQ(status, ExternalBufferStatus::Ok);
-    acked = true;
-  });
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>(), false,
+                [&acked](ExternalBufferStatus status) {
+                  EXPECT_EQ(status, ExternalBufferStatus::Ok);
+                  acked = true;
+                });
   EXPECT_FALSE(acked);
   drain();
   EXPECT_TRUE(acked);
@@ -173,7 +176,7 @@ TEST_F(InMemoryExternalBufferTest, EmptyWriteIsAcknowledged) {
 TEST_F(InMemoryExternalBufferTest, WriteCompletionsFireInOrder) {
   std::vector<int> order;
   for (int i = 0; i < 3; ++i) {
-    buffer_.write(std::make_unique<Buffer::OwnedImpl>(std::to_string(i)),
+    buffer_.write(std::make_unique<Buffer::OwnedImpl>(std::to_string(i)), false,
                   [&order, i](ExternalBufferStatus status) {
                     EXPECT_EQ(status, ExternalBufferStatus::Ok);
                     order.push_back(i);
@@ -193,12 +196,12 @@ TEST_F(InMemoryExternalBufferTest, WriteCompletionsFireInOrder) {
 // write does not count until the event loop runs. A read may then span writes and
 // reach the exact end boundary (offset + length == length()).
 TEST_F(InMemoryExternalBufferTest, LengthReflectsOnlyDurableWrites) {
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("aaaa"), [](ExternalBufferStatus) {});
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("aaaa"), false, [](ExternalBufferStatus) {});
   EXPECT_EQ(buffer_.length(), 0); // Not yet acknowledged.
   drain();
   EXPECT_EQ(buffer_.length(), 4);
 
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("bb"), [](ExternalBufferStatus) {});
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("bb"), false, [](ExternalBufferStatus) {});
   EXPECT_EQ(buffer_.length(), 4); // Second write still in flight.
   drain();
   EXPECT_EQ(buffer_.length(), 6);
@@ -214,7 +217,7 @@ TEST_F(InMemoryExternalBufferTest, LengthReflectsOnlyDurableWrites) {
 // Reading past the acknowledged length violates the precondition and trips the
 // debug assertion.
 TEST_F(InMemoryExternalBufferTest, ReadPastLengthIsDebugDeath) {
-  buffer_.write(std::make_unique<Buffer::OwnedImpl>("short"), [](ExternalBufferStatus) {});
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("short"), false, [](ExternalBufferStatus) {});
   drain();
   ASSERT_EQ(buffer_.length(), 5);
   EXPECT_DEBUG_DEATH(buffer_.read(0, 6, [](ExternalBufferStatus, Buffer::InstancePtr) {}),
@@ -227,7 +230,8 @@ TEST_F(InMemoryExternalBufferTest, FactoryCreatesUsableBuffer) {
   ExternalBufferPtr buffer = factory.createBuffer(*dispatcher_);
   ASSERT_NE(buffer, nullptr);
 
-  buffer->write(std::make_unique<Buffer::OwnedImpl>("via-factory"), [](ExternalBufferStatus) {});
+  buffer->write(std::make_unique<Buffer::OwnedImpl>("via-factory"), false,
+                [](ExternalBufferStatus) {});
   drain();
   EXPECT_EQ(buffer->length(), 11);
 
@@ -238,6 +242,19 @@ TEST_F(InMemoryExternalBufferTest, FactoryCreatesUsableBuffer) {
                  read_back = data->toString();
                });
   EXPECT_EQ(read_back, "via-factory");
+}
+
+// Writing with end_stream set to true succeeds and completes asynchronously.
+TEST_F(InMemoryExternalBufferTest, WriteWithEndStreamAcknowledged) {
+  bool acked = false;
+  buffer_.write(std::make_unique<Buffer::OwnedImpl>("final"), true,
+                [&acked](ExternalBufferStatus status) {
+                  EXPECT_EQ(status, ExternalBufferStatus::Ok);
+                  acked = true;
+                });
+  drain();
+  EXPECT_TRUE(acked);
+  EXPECT_EQ(buffer_.length(), 5);
 }
 
 } // namespace

--- a/test/extensions/filters/http/ai_protocol_manager/json_with_ext_buf_parser_test.cc
+++ b/test/extensions/filters/http/ai_protocol_manager/json_with_ext_buf_parser_test.cc
@@ -176,7 +176,7 @@ TEST_F(JsonWithExtBufParserTest, ReferenceResolvesAgainstTheOffloadedBody) {
 
   // Offload as the BufferManager does -- verbatim from offset 0 -- which is what
   // makes the recorded offsets valid buffer offsets.
-  buffer.write(std::make_unique<Buffer::OwnedImpl>(body),
+  buffer.write(std::make_unique<Buffer::OwnedImpl>(body), false,
                [](ExternalBufferStatus status) { EXPECT_EQ(status, ExternalBufferStatus::Ok); });
   dispatcher->run(Event::Dispatcher::RunType::NonBlock);
   ASSERT_EQ(buffer.length(), body.size());


### PR DESCRIPTION
Pass the boolean end_stream indicator to ExternalBuffer::write() to inform the backing store when the final payload chunk is being written.

This enables external buffer implementations (such as streaming storage or RPC offload backends) to detect stream completion and cleanly finalize sessions without needing separate heuristic out-of-band signaling.

Risk Level: Low
Testing: Added unit test coverage for end_stream propagation in BufferManager and InMemoryExternalBuffer.
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A