### PR TITLE
test: skip test under hwasan

### DIFF
--- a/test/exe/main_common_test.cc
+++ b/test/exe/main_common_test.cc
@@ -38,7 +38,7 @@ namespace {
 #if !(defined(__clang_analyzer__) ||                                                               \
       (defined(__has_feature) &&                                                                   \
        (__has_feature(thread_sanitizer) || __has_feature(address_sanitizer) ||                     \
-        __has_feature(memory_sanitizer))))
+        __has_feature(hwaddress_sanitizer) || __has_feature(memory_sanitizer))))
 const std::string& outOfMemoryPattern() {
 #if defined(TCMALLOC)
   CONSTRUCT_ON_FIRST_USE(std::string, ".*Unable to allocate.*");
@@ -227,9 +227,10 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, MainCommonDeathTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(MainCommonDeathTest, OutOfMemoryHandler) {
-#if defined(__clang_analyzer__) || (defined(__has_feature) && (__has_feature(thread_sanitizer) ||  \
-                                                               __has_feature(address_sanitizer) || \
-                                                               __has_feature(memory_sanitizer)))
+#if defined(__clang_analyzer__) ||                                                                 \
+    (defined(__has_feature) &&                                                                     \
+     (__has_feature(thread_sanitizer) || __has_feature(address_sanitizer) ||                       \
+      __has_feature(hwaddress_sanitizer) || __has_feature(memory_sanitizer)))
   ENVOY_LOG_MISC(critical,
                  "MainCommonTest::OutOfMemoryHandler not supported by this compiler configuration");
 #else


### PR DESCRIPTION
Commit Message: test: skip test under hwasan
Additional Description:
The test `MainCommonDeathTest.OutOfMemoryHandler` allocates a lot of memory and doesn't work well with ASAN, TSAN, and MSAN (currently disabled).
This PR disables the test also for [Hardware-Address-Sanitizer](https://clang.llvm.org/docs/HardwareAssistedAddressSanitizer.html) (`__has_feature(hwaddress_sanitizer)`).

Risk Level: low - tests only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Platform Specific Features: N/A
