### PR TITLE
Deflake //test/extensions/filters/http/on_demand:on_demand_integration_test

### DIFF
--- a/test/integration/scoped_rds.h
+++ b/test/integration/scoped_rds.h
@@ -42,6 +42,16 @@ protected:
 
   ~ScopedRdsIntegrationTest() override { resetConnections(); }
 
+  void TearDown() override {
+    // Stop the server before fixture destruction starts. Otherwise, late xDS work on the server
+    // thread can race with the vptr update in HttpIntegrationTest's destructor.
+    resetConnections();
+    cleanupUpstreamAndDownstream();
+    upstream_request_.reset();
+    codec_client_.reset();
+    test_server_.reset();
+  }
+
   void setupModifications() {
     if (modifications_set_up_) {
       return;
@@ -187,21 +197,22 @@ fragments:
   }
 
   void resetFakeUpstreamInfo(FakeUpstreamInfo* upstream_info) {
-    if (upstream_info->upstream_ == nullptr) {
-      return;
+    if (upstream_info->connection_ != nullptr) {
+      AssertionResult result = upstream_info->connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = upstream_info->connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+      result = upstream_info->connection_->waitForNoPost();
+      RELEASE_ASSERT(result, result.message());
+      upstream_info->connection_.reset();
     }
 
-    AssertionResult result = upstream_info->connection_->close();
-    RELEASE_ASSERT(result, result.message());
-    result = upstream_info->connection_->waitForDisconnect();
-    RELEASE_ASSERT(result, result.message());
-    upstream_info->connection_.reset();
+    upstream_info->stream_by_resource_name_.clear();
+    upstream_info->upstream_ = nullptr;
   }
 
   void resetConnections() {
-    if (rds_upstream_info_.upstream_ != nullptr) {
-      resetFakeUpstreamInfo(&rds_upstream_info_);
-    }
+    resetFakeUpstreamInfo(&rds_upstream_info_);
     resetFakeUpstreamInfo(&scoped_rds_upstream_info_);
   }
 


### PR DESCRIPTION
Commit Message: Deflake //test/extensions/filters/http/on_demand:on_demand_integration_test
Additional Description:
[Example tsan failure](https://github.com/envoyproxy/envoy/actions/runs/34498979842/job/102960182728#annotation:20:1805)
```
  [ RUN      ] IpVersionsAndGrpcTypes/OnDemandScopedRdsIntegrationTest.OnDemandUpdateVirtualHostNotMatch/5
  WARNING: ThreadSanitizer: data race (pid=25)
    Write of size 1 at 0x561c6c1f9630 by main thread:
      #0 <null> <null> (on_demand_integration_test+0x3748395) (BuildId: f27b1319d603e22f99b79db198e45c2d)
```
The output is all unreadable offsets, but they map to `HttpIntegrationTest::~HttpIntegrationTest()` in one thread, `IntegrationTestServerImpl::createAndRunEnvoyServer()` and `server.run()` in the other. The implication is that the server thread is still running when the fixture destruction begins.

The fix stops and joins the server in `TearDown`, before the fixture destruction, destroys downstream and xDS codec/stream state first, preserving the requirement that the server runtime outlive those objects, and makes scoped-RDS connection cleanup idempotent and drains pending fake-upstream posts before releasing streams.

This was AI assisted with Codex Sol.

Risk Level: test only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
