### PR TITLE
http: add context to allow more complex header formatter

### DIFF
--- a/envoy/http/BUILD
+++ b/envoy/http/BUILD
@@ -201,8 +201,10 @@ envoy_cc_library(
     name = "header_formatter_interface",
     hdrs = ["header_formatter.h"],
     deps = [
+        "//envoy/common:exception_lib",
         "//envoy/common:optref_lib",
         "//envoy/config:typed_config_interface",
+        "@abseil-cpp//absl/status:statusor",
     ],
 )
 

--- a/envoy/http/header_formatter.h
+++ b/envoy/http/header_formatter.h
@@ -1,9 +1,18 @@
 #pragma once
 
+#include "envoy/common/exception.h"
 #include "envoy/common/optref.h"
 #include "envoy/config/typed_config.h"
 
+#include "absl/status/statusor.h"
+
 namespace Envoy {
+namespace Server {
+namespace Configuration {
+class GenericFactoryContext;
+} // namespace Configuration
+} // namespace Server
+
 namespace Http {
 
 /**
@@ -70,8 +79,39 @@ using StatefulHeaderKeyFormatterFactorySharedPtr =
  */
 class StatefulHeaderKeyFormatterFactoryConfig : public Config::TypedFactory {
 public:
+  [[deprecated("Use createFactoryFromProto instead")]]
   virtual StatefulHeaderKeyFormatterFactorySharedPtr
-  createFromProto(const Protobuf::Message& config) PURE;
+  createFromProto(const Protobuf::Message& /* config */) {
+    // This is the terminal of the delegation below, so it must not delegate back: an extension
+    // that implements neither method lands here.
+    throwEnvoyExceptionOrPanic(
+        "Stateful header key formatter factory implements neither createFactoryFromProto nor the "
+        "deprecated createFromProto");
+    return nullptr;
+  }
+
+  /**
+   * Create a factory from the given configuration. This is the method Envoy calls, and the one new
+   * extensions should implement.
+   *
+   * The factory is created on the main thread, but the formatters it produces are used - and
+   * released - by worker threads, so an implementation owning state that must not be torn down off
+   * the main thread needs the context (specifically
+   * serverFactoryContext().mainThreadDispatcher()) to schedule its own destruction.
+   *
+   * @param config the extension specific configuration.
+   * @param context the factory context of whatever owns the protocol options - a listener for the
+   * downstream connection manager, a cluster for upstream protocol options - which is why this is
+   * the generic context rather than a listener-scoped one.
+   * @return the formatter factory, or an error status if the configuration is invalid.
+   */
+  virtual absl::StatusOr<StatefulHeaderKeyFormatterFactorySharedPtr>
+  createFactoryFromProto(const Protobuf::Message& config,
+                         Server::Configuration::GenericFactoryContext&) {
+    // Delegate to the legacy entry point so that extensions which only implement it - out-of-tree
+    // extensions written before the context was threaded through - keep working.
+    return createFromProto(config);
+  }
 
   std::string category() const override { return "envoy.http.stateful_header_formatters"; }
 };

--- a/source/common/http/http1/BUILD
+++ b/source/common/http/http1/BUILD
@@ -96,6 +96,7 @@ envoy_cc_library(
         "//source/common/common:matchers_lib",
         "//source/common/config:utility_lib",
         "//source/common/runtime:runtime_features_lib",
+        "@abseil-cpp//absl/status",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )

--- a/source/common/http/http1/settings.cc
+++ b/source/common/http/http1/settings.cc
@@ -11,8 +11,8 @@ namespace Http {
 namespace Http1 {
 
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
-                                 Server::Configuration::CommonFactoryContext& context,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor) {
+                                 Server::Configuration::GenericFactoryContext& context,
+                                 absl::Status& creation_status) {
   Http1Settings ret;
   ret.allow_absolute_url_ = PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, allow_absolute_url, true);
   ret.accept_http_10_ = config.accept_http_10();
@@ -25,7 +25,8 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
     std::vector<Matchers::StringMatcherPtr> matchers;
     matchers.reserve(config.ignore_http_11_upgrade_size());
     for (const auto& matcher : config.ignore_http_11_upgrade()) {
-      matchers.emplace_back(std::make_unique<Envoy::Matchers::StringMatcherImpl>(matcher, context));
+      matchers.emplace_back(std::make_unique<Envoy::Matchers::StringMatcherImpl>(
+          matcher, context.serverFactoryContext()));
     }
     ret.ignore_upgrade_matchers_ =
         std::make_shared<const std::vector<Matchers::StringMatcherPtr>>(std::move(matchers));
@@ -38,10 +39,18 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
         Config::Utility::getAndCheckFactory<Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig>(
             config.header_key_format().stateful_formatter());
     auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
-        config.header_key_format().stateful_formatter().typed_config(), validation_visitor,
-        factory);
+        config.header_key_format().stateful_formatter().typed_config(),
+        context.messageValidationVisitor(), factory);
+    auto formatter_factory_or_error =
+        factory.createFactoryFromProto(*header_formatter_config, context);
+    if (!formatter_factory_or_error.ok()) {
+      // Return default settings rather than the half-populated ones, so a caller that stores the
+      // result before checking the status cannot end up using a partially configured protocol.
+      creation_status = formatter_factory_or_error.status();
+      return {};
+    }
     ret.header_key_format_ = Http1Settings::HeaderKeyFormat::StatefulFormatter;
-    ret.stateful_header_key_formatter_ = factory.createFromProto(*header_formatter_config);
+    ret.stateful_header_key_formatter_ = std::move(formatter_factory_or_error.value());
   }
 
   ret.allow_custom_methods_ = config.allow_custom_methods();
@@ -50,11 +59,13 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
 }
 
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
-                                 Server::Configuration::CommonFactoryContext& context,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor,
-                                 const Protobuf::BoolValue& hcm_stream_error,
-                                 bool validate_scheme) {
-  Http1Settings ret = parseHttp1Settings(config, context, validation_visitor);
+                                 Server::Configuration::GenericFactoryContext& context,
+                                 const Protobuf::BoolValue& hcm_stream_error, bool validate_scheme,
+                                 absl::Status& creation_status) {
+  Http1Settings ret = parseHttp1Settings(config, context, creation_status);
+  if (!creation_status.ok()) {
+    return {};
+  }
   ret.validate_scheme_ = validate_scheme;
 
   if (config.has_override_stream_error_on_invalid_http_message()) {

--- a/source/common/http/http1/settings.cc
+++ b/source/common/http/http1/settings.cc
@@ -49,6 +49,8 @@ Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOpt
       creation_status = formatter_factory_or_error.status();
       return {};
     }
+    // The factory should never return a nullptr when the creation is successful.
+    ASSERT(formatter_factory_or_error.value() != nullptr);
     ret.header_key_format_ = Http1Settings::HeaderKeyFormat::StatefulFormatter;
     ret.stateful_header_key_formatter_ = std::move(formatter_factory_or_error.value());
   }

--- a/source/common/http/http1/settings.h
+++ b/source/common/http/http1/settings.h
@@ -5,22 +5,30 @@
 #include "envoy/protobuf/message_validator.h"
 #include "envoy/server/factory_context.h"
 
+#include "absl/status/status.h"
+
 namespace Envoy {
 namespace Http {
 namespace Http1 {
 
 /**
+ * @param config the protocol options to parse.
+ * @param context the factory context of whatever owns the options, which also supplies the
+ * validation visitor used for any extension configuration referenced by them.
+ * @param creation_status is set to an error when a configured extension - today only the stateful
+ * header formatter - cannot be created, and default settings are returned in that case. It is left
+ * untouched on success, so it can be threaded through a chain of member initializers.
  * @return Http1Settings An Http1Settings populated from the
  * envoy::config::core::v3::Http1ProtocolOptions config.
  */
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
-                                 Server::Configuration::CommonFactoryContext& context,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor);
+                                 Server::Configuration::GenericFactoryContext& context,
+                                 absl::Status& creation_status);
 
 Http1Settings parseHttp1Settings(const envoy::config::core::v3::Http1ProtocolOptions& config,
-                                 Server::Configuration::CommonFactoryContext& context,
-                                 ProtobufMessage::ValidationVisitor& validation_visitor,
-                                 const Protobuf::BoolValue& hcm_stream_error, bool validate_scheme);
+                                 Server::Configuration::GenericFactoryContext& context,
+                                 const Protobuf::BoolValue& hcm_stream_error, bool validate_scheme,
+                                 absl::Status& creation_status);
 
 } // namespace Http1
 } // namespace Http

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1183,8 +1183,7 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
                : std::nullopt),
           config.protocol_selection() ==
               envoy::config::cluster::v3::Cluster::USE_DOWNSTREAM_PROTOCOL,
-          config.has_http2_protocol_options(), factory_context.serverFactoryContext(),
-          factory_context.messageValidationVisitor());
+          config.has_http2_protocol_options(), factory_context);
   RETURN_IF_NOT_OK_REF(options_or_error.status());
   return options_or_error.value();
 }

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -381,9 +381,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
           config.http3_protocol_options(), config.has_stream_error_on_invalid_http_message(),
           config.stream_error_on_invalid_http_message())),
       http1_settings_(Http::Http1::parseHttp1Settings(
-          config.http_protocol_options(), context.serverFactoryContext(),
-          context.messageValidationVisitor(), config.stream_error_on_invalid_http_message(),
-          xff_num_trusted_hops_ == 0 && use_remote_address_)),
+          config.http_protocol_options(), context, config.stream_error_on_invalid_http_message(),
+          xff_num_trusted_hops_ == 0 && use_remote_address_, creation_status)),
       max_request_headers_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, max_request_headers_kb,
           context.serverFactoryContext().runtime().snapshot().getInteger(

--- a/source/extensions/http/header_formatters/preserve_case/config.cc
+++ b/source/extensions/http/header_formatters/preserve_case/config.cc
@@ -11,15 +11,17 @@ namespace Http {
 namespace HeaderFormatters {
 namespace PreserveCase {
 
-Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr
-PreserveCaseFormatterFactoryConfig::createFromProto(const Protobuf::Message& message) {
+absl::StatusOr<Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr>
+PreserveCaseFormatterFactoryConfig::createFactoryFromProto(
+    const Protobuf::Message& message, Server::Configuration::GenericFactoryContext&) {
   auto config =
       MessageUtil::downcastAndValidate<const envoy::extensions::http::header_formatters::
                                            preserve_case::v3::PreserveCaseFormatterConfig&>(
           message, ProtobufMessage::getStrictValidationVisitor());
 
-  return std::make_shared<PreserveCaseFormatterFactory>(config.forward_reason_phrase(),
-                                                        config.formatter_type_on_envoy_headers());
+  return Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr{
+      std::make_shared<PreserveCaseFormatterFactory>(config.forward_reason_phrase(),
+                                                     config.formatter_type_on_envoy_headers())};
 }
 
 LEGACY_REGISTER_FACTORY(PreserveCaseFormatterFactoryConfig,

--- a/source/extensions/http/header_formatters/preserve_case/config.h
+++ b/source/extensions/http/header_formatters/preserve_case/config.h
@@ -42,8 +42,9 @@ public:
     return "envoy.http.stateful_header_formatters.preserve_case";
   }
 
-  Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr
-  createFromProto(const Protobuf::Message& message) override;
+  absl::StatusOr<Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr>
+  createFactoryFromProto(const Protobuf::Message& message,
+                         Server::Configuration::GenericFactoryContext& context) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return std::make_unique<envoy::extensions::http::header_formatters::preserve_case::v3::

--- a/source/extensions/upstreams/http/config.cc
+++ b/source/extensions/upstreams/http/config.cc
@@ -226,7 +226,8 @@ absl::StatusOr<std::unique_ptr<Envoy::Http::HashPolicy>> ProtocolOptionsConfigIm
 absl::StatusOr<std::shared_ptr<ProtocolOptionsConfigImpl>>
 ProtocolOptionsConfigImpl::createProtocolOptionsConfig(
     const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options,
-    Server::Configuration::ServerFactoryContext& server_context) {
+    Server::Configuration::GenericFactoryContext& context) {
+  auto& server_context = context.serverFactoryContext();
   auto options_or_error = Http2::Utility::initializeAndValidateOptions(getHttp2Options(options));
   RETURN_IF_NOT_OK_REF(options_or_error.status());
 
@@ -249,11 +250,14 @@ ProtocolOptionsConfigImpl::createProtocolOptionsConfig(
   RETURN_IF_NOT_OK_REF(retry_policy_or_error.status());
   auto hash_policy_or_error = buildHashPolicy(options, server_context);
   RETURN_IF_NOT_OK_REF(hash_policy_or_error.status());
-  return std::shared_ptr<ProtocolOptionsConfigImpl>(new ProtocolOptionsConfigImpl(
+  absl::Status creation_status = absl::OkStatus();
+  auto config = std::shared_ptr<ProtocolOptionsConfigImpl>(new ProtocolOptionsConfigImpl(
       options, options_or_error.value(), std::move(validator_factory_or_error.value()),
       cache_options_or_error.value(), std::move(shadow_policies_or_error.value()),
-      std::move(retry_policy_or_error.value()), std::move(hash_policy_or_error.value()),
-      server_context));
+      std::move(retry_policy_or_error.value()), std::move(hash_policy_or_error.value()), context,
+      creation_status));
+  RETURN_IF_NOT_OK(creation_status);
+  return config;
 }
 
 absl::StatusOr<std::shared_ptr<ProtocolOptionsConfigImpl>>
@@ -263,8 +267,7 @@ ProtocolOptionsConfigImpl::createProtocolOptionsConfig(
     const envoy::config::core::v3::HttpProtocolOptions& common_options,
     const std::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions> upstream_options,
     bool use_downstream_protocol, bool use_http2,
-    Server::Configuration::ServerFactoryContext& server_context,
-    ProtobufMessage::ValidationVisitor& validation_visitor) {
+    Server::Configuration::GenericFactoryContext& context) {
   auto options_or_error = Http2::Utility::initializeAndValidateOptions(http2_options);
   RETURN_IF_NOT_OK_REF(options_or_error.status());
 
@@ -276,9 +279,12 @@ ProtocolOptionsConfigImpl::createProtocolOptionsConfig(
         "max_header_field_size_kb must not exceed max_response_headers_kb");
   }
 
-  return std::shared_ptr<ProtocolOptionsConfigImpl>(new ProtocolOptionsConfigImpl(
+  absl::Status creation_status = absl::OkStatus();
+  auto config = std::shared_ptr<ProtocolOptionsConfigImpl>(new ProtocolOptionsConfigImpl(
       http1_settings, options_or_error.value(), common_options, upstream_options,
-      use_downstream_protocol, use_http2, server_context, validation_visitor));
+      use_downstream_protocol, use_http2, context, creation_status));
+  RETURN_IF_NOT_OK(creation_status);
+  return config;
 }
 
 ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
@@ -289,9 +295,9 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
     std::vector<Envoy::Router::ShadowPolicyPtr>&& shadow_policies,
     std::shared_ptr<const Envoy::Router::RetryPolicy>&& retry_policy,
     std::unique_ptr<Envoy::Http::HashPolicy>&& hash_policy,
-    Server::Configuration::ServerFactoryContext& server_context)
-    : http1_settings_(Envoy::Http::Http1::parseHttp1Settings(
-          getHttpOptions(options), server_context, server_context.messageValidationVisitor())),
+    Server::Configuration::GenericFactoryContext& context, absl::Status& creation_status)
+    : http1_settings_(Envoy::Http::Http1::parseHttp1Settings(getHttpOptions(options), context,
+                                                             creation_status)),
       http2_options_(std::move(http2_options)), http3_options_(getHttp3Options(options)),
       common_http_protocol_options_(options.common_http_protocol_options()),
       upstream_http_protocol_options_(
@@ -311,7 +317,7 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
 
   if (options.has_outlier_detection()) {
     buildMatcher(options.outlier_detection().error_matcher(), outlier_detection_http_error_matcher_,
-                 server_context);
+                 context.serverFactoryContext());
   }
 }
 
@@ -321,10 +327,9 @@ ProtocolOptionsConfigImpl::ProtocolOptionsConfigImpl(
     const envoy::config::core::v3::HttpProtocolOptions& common_options,
     const std::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions> upstream_options,
     bool use_downstream_protocol, bool use_http2,
-    Server::Configuration::ServerFactoryContext& server_context,
-    ProtobufMessage::ValidationVisitor& validation_visitor)
-    : http1_settings_(Envoy::Http::Http1::parseHttp1Settings(http1_settings, server_context,
-                                                             validation_visitor)),
+    Server::Configuration::GenericFactoryContext& context, absl::Status& creation_status)
+    : http1_settings_(
+          Envoy::Http::Http1::parseHttp1Settings(http1_settings, context, creation_status)),
       http2_options_(validated_http2_options), common_http_protocol_options_(common_options),
       upstream_http_protocol_options_(upstream_options),
       use_downstream_protocol_(use_downstream_protocol), use_http2_(use_http2) {

--- a/source/extensions/upstreams/http/config.h
+++ b/source/extensions/upstreams/http/config.h
@@ -32,15 +32,14 @@ class ProtocolOptionsConfigImpl : public Upstream::HttpProtocolOptionsConfig {
 public:
   static absl::StatusOr<std::shared_ptr<ProtocolOptionsConfigImpl>> createProtocolOptionsConfig(
       const envoy::extensions::upstreams::http::v3::HttpProtocolOptions& options,
-      Server::Configuration::ServerFactoryContext& server_context);
+      Server::Configuration::GenericFactoryContext& context);
   static absl::StatusOr<std::shared_ptr<ProtocolOptionsConfigImpl>> createProtocolOptionsConfig(
       const envoy::config::core::v3::Http1ProtocolOptions& http1_settings,
       const envoy::config::core::v3::Http2ProtocolOptions& http2_options,
       const envoy::config::core::v3::HttpProtocolOptions& common_options,
       const std::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions> upstream_options,
       bool use_downstream_protocol, bool use_http2,
-      Server::Configuration::ServerFactoryContext& server_context,
-      ProtobufMessage::ValidationVisitor& validation_visitor);
+      Server::Configuration::GenericFactoryContext& context);
 
   // Given the supplied cluster config, and protocol options configuration,
   // returns a unit64_t representing the enabled Upstream::ClusterInfo::Features.
@@ -116,7 +115,7 @@ private:
       std::vector<Envoy::Router::ShadowPolicyPtr>&& shadow_policies,
       std::shared_ptr<const Envoy::Router::RetryPolicy>&& retry_policy,
       std::unique_ptr<Envoy::Http::HashPolicy>&& hash_policy,
-      Server::Configuration::ServerFactoryContext& server_context);
+      Server::Configuration::GenericFactoryContext& context, absl::Status& creation_status);
   // Constructor for legacy (deprecated) config.
   ProtocolOptionsConfigImpl(
       const envoy::config::core::v3::Http1ProtocolOptions& http1_settings,
@@ -124,8 +123,7 @@ private:
       const envoy::config::core::v3::HttpProtocolOptions& common_options,
       const std::optional<envoy::config::core::v3::UpstreamHttpProtocolOptions> upstream_options,
       bool use_downstream_protocol, bool use_http2,
-      Server::Configuration::ServerFactoryContext& server_context,
-      ProtobufMessage::ValidationVisitor& validation_visitor);
+      Server::Configuration::GenericFactoryContext& context, absl::Status& creation_status);
 };
 
 class ProtocolOptionsConfigFactory : public Server::Configuration::ProtocolOptionsFactory {
@@ -136,8 +134,7 @@ public:
     const auto& typed_config = MessageUtil::downcastAndValidate<
         const envoy::extensions::upstreams::http::v3::HttpProtocolOptions&>(
         config, context.messageValidationVisitor());
-    auto result = ProtocolOptionsConfigImpl::createProtocolOptionsConfig(
-        typed_config, context.serverFactoryContext());
+    auto result = ProtocolOptionsConfigImpl::createProtocolOptionsConfig(typed_config, context);
     if (!result.ok()) {
       return result.status();
     }

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -514,11 +514,22 @@ envoy_cc_fuzz_test(
     ],
 )
 
+envoy_cc_test_library(
+    name = "header_formatter_test_lib",
+    hdrs = ["header_formatter_test_utils.h"],
+    deps = [
+        "//envoy/http:header_formatter_interface",
+        "//source/common/protobuf",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
 envoy_cc_test(
     name = "utility_test",
     srcs = ["utility_test.cc"],
     rbe_pool = "linux_x64_small",
     deps = [
+        ":header_formatter_test_lib",
         "//envoy/http:header_formatter_interface",
         "//source/common/http:exception_lib",
         "//source/common/http:header_map_lib",
@@ -528,6 +539,7 @@ envoy_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:upstream_mocks",
         "//test/test_common:registry_lib",
+        "//test/test_common:status_utility_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -519,6 +519,7 @@ envoy_cc_test(
     srcs = ["utility_test.cc"],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/http:header_formatter_interface",
         "//source/common/http:exception_lib",
         "//source/common/http:header_map_lib",
         "//source/common/http:utility_lib",
@@ -526,6 +527,7 @@ envoy_cc_test(
         "//test/mocks/http:http_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/mocks/upstream:upstream_mocks",
+        "//test/test_common:registry_lib",
         "//test/test_common:test_runtime_lib",
         "//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",

--- a/test/common/http/header_formatter_test_utils.h
+++ b/test/common/http/header_formatter_test_utils.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "envoy/config/core/v3/protocol.pb.h"
+#include "envoy/http/header_formatter.h"
+
+#include "source/common/protobuf/protobuf.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Http {
+
+// A stateful header key formatter factory config that always rejects its configuration. It covers
+// the path where parseHttp1Settings() has to surface a formatter creation failure through
+// creation_status instead of returning half-built settings, which is otherwise unreachable in
+// tests because every in-tree formatter accepts any valid configuration.
+class RejectingStatefulFormatterFactoryConfig : public StatefulHeaderKeyFormatterFactoryConfig {
+public:
+  static constexpr absl::string_view kName = "envoy.test.rejecting_formatter";
+  static constexpr absl::string_view kError = "rejecting formatter rejected the configuration";
+
+  std::string name() const override { return std::string(kName); }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::StringValue>();
+  }
+
+  absl::StatusOr<StatefulHeaderKeyFormatterFactorySharedPtr>
+  createFactoryFromProto(const Protobuf::Message&,
+                         Server::Configuration::GenericFactoryContext&) override {
+    return absl::InvalidArgumentError(kError);
+  }
+};
+
+// Configures the given HTTP/1 protocol options to use the formatter above. The equivalent YAML,
+// for the config entry points that are exercised through it, is:
+//
+//   header_key_format:
+//     stateful_formatter:
+//       name: envoy.test.rejecting_formatter
+//       typed_config:
+//         "@type": type.googleapis.com/google.protobuf.StringValue
+inline void
+useRejectingStatefulFormatter(envoy::config::core::v3::Http1ProtocolOptions& http1_options) {
+  auto* stateful_formatter =
+      http1_options.mutable_header_key_format()->mutable_stateful_formatter();
+  stateful_formatter->set_name(std::string(RejectingStatefulFormatterFactoryConfig::kName));
+  Protobuf::StringValue formatter_config;
+  std::ignore = stateful_formatter->mutable_typed_config()->PackFrom(formatter_config);
+}
+
+} // namespace Http
+} // namespace Envoy

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -14,9 +14,9 @@
 #include "source/common/network/address_impl.h"
 
 #include "test/mocks/http/mocks.h"
-#include "test/mocks/protobuf/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/printers.h"
+#include "test/test_common/registry.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
@@ -747,58 +747,95 @@ TEST(HttpUtility, ValidateStreamErrorsWithHcm) {
 TEST(HttpUtility, ValidateStreamErrorConfigurationForHttp1) {
   envoy::config::core::v3::Http1ProtocolOptions http1_options;
   Protobuf::BoolValue hcm_value;
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  absl::Status creation_status = absl::OkStatus();
 
   // nothing explicitly configured, default to false (i.e. default stream error behavior for HCM)
-  EXPECT_FALSE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .stream_error_on_invalid_http_message_);
+  EXPECT_FALSE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                   .stream_error_on_invalid_http_message_);
 
   // http1_options.stream_error overrides HCM.stream_error
   http1_options.mutable_override_stream_error_on_invalid_http_message()->set_value(true);
   hcm_value.set_value(false);
-  EXPECT_TRUE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .stream_error_on_invalid_http_message_);
+  EXPECT_TRUE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                  .stream_error_on_invalid_http_message_);
 
   // http1_options.stream_error overrides HCM.stream_error (flip boolean value)
   http1_options.mutable_override_stream_error_on_invalid_http_message()->set_value(false);
   hcm_value.set_value(true);
-  EXPECT_FALSE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .stream_error_on_invalid_http_message_);
+  EXPECT_FALSE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                   .stream_error_on_invalid_http_message_);
 
   http1_options.clear_override_stream_error_on_invalid_http_message();
 
   // fallback to HCM.stream_error
   hcm_value.set_value(true);
-  EXPECT_TRUE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .stream_error_on_invalid_http_message_);
+  EXPECT_TRUE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                  .stream_error_on_invalid_http_message_);
 
   // fallback to HCM.stream_error (flip boolean value)
   hcm_value.set_value(false);
-  EXPECT_FALSE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .stream_error_on_invalid_http_message_);
+  EXPECT_FALSE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                   .stream_error_on_invalid_http_message_);
+}
+
+// StatefulHeaderKeyFormatterFactoryConfig::createFromProto() was replaced by
+// createFactoryFromProto(), which takes a factory context and returns a status, and the old method
+// is deprecated rather than removed. An extension that only implements the deprecated method -
+// which is what every out-of-tree extension written before the change does - must still be reached
+// when Envoy calls the new one.
+class LegacyOnlyFormatterFactory : public StatefulHeaderKeyFormatterFactory {
+public:
+  StatefulHeaderKeyFormatterPtr create() override { return nullptr; }
+};
+
+class LegacyOnlyFormatterFactoryConfig : public StatefulHeaderKeyFormatterFactoryConfig {
+public:
+  std::string name() const override { return "envoy.test.legacy_only_formatter"; }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::StringValue>();
+  }
+
+  // Deliberately implements only the deprecated method.
+  StatefulHeaderKeyFormatterFactorySharedPtr createFromProto(const Protobuf::Message&) override {
+    return std::make_shared<LegacyOnlyFormatterFactory>();
+  }
+};
+
+TEST(HttpUtility, StatefulFormatterDeprecatedFactoryOverloadStillReached) {
+  LegacyOnlyFormatterFactoryConfig factory;
+  Registry::InjectFactory<StatefulHeaderKeyFormatterFactoryConfig> registered(factory);
+
+  envoy::config::core::v3::Http1ProtocolOptions http1_options;
+  auto* stateful_formatter =
+      http1_options.mutable_header_key_format()->mutable_stateful_formatter();
+  stateful_formatter->set_name("envoy.test.legacy_only_formatter");
+  Protobuf::StringValue formatter_config;
+  ASSERT_TRUE(stateful_formatter->mutable_typed_config()->PackFrom(formatter_config));
+
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  absl::Status creation_status = absl::OkStatus();
+  auto settings = Http1::parseHttp1Settings(http1_options, context, creation_status);
+
+  EXPECT_TRUE(creation_status.ok());
+  EXPECT_EQ(Http1Settings::HeaderKeyFormat::StatefulFormatter, settings.header_key_format_);
+  EXPECT_NE(nullptr, settings.stateful_header_key_formatter_);
 }
 
 TEST(HttpUtility, AllowCustomMethods) {
   envoy::config::core::v3::Http1ProtocolOptions http1_options;
   Protobuf::BoolValue hcm_value;
-  NiceMock<Server::Configuration::MockServerFactoryContext> context;
-  NiceMock<ProtobufMessage::MockValidationVisitor> validation_visitor;
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  absl::Status creation_status = absl::OkStatus();
 
   EXPECT_FALSE(http1_options.allow_custom_methods());
-  EXPECT_FALSE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .allow_custom_methods_);
+  EXPECT_FALSE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                   .allow_custom_methods_);
 
   http1_options.set_allow_custom_methods(true);
-  EXPECT_TRUE(
-      Http1::parseHttp1Settings(http1_options, context, validation_visitor, hcm_value, false)
-          .allow_custom_methods_);
+  EXPECT_TRUE(Http1::parseHttp1Settings(http1_options, context, hcm_value, false, creation_status)
+                  .allow_custom_methods_);
 }
 
 TEST(HttpUtility, getLastAddressFromXFF) {

--- a/test/common/http/utility_test.cc
+++ b/test/common/http/utility_test.cc
@@ -13,16 +13,21 @@
 #include "source/common/http/utility.h"
 #include "source/common/network/address_impl.h"
 
+#include "test/common/http/header_formatter_test_utils.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/registry.h"
+#include "test/test_common/status_utility.h"
 #include "test/test_common/test_runtime.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::HasStatus;
+using ::Envoy::StatusHelpers::IsOk;
 using testing::_;
+using testing::Eq;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
 
@@ -818,9 +823,57 @@ TEST(HttpUtility, StatefulFormatterDeprecatedFactoryOverloadStillReached) {
   absl::Status creation_status = absl::OkStatus();
   auto settings = Http1::parseHttp1Settings(http1_options, context, creation_status);
 
-  EXPECT_TRUE(creation_status.ok());
+  EXPECT_THAT(creation_status, IsOk());
   EXPECT_EQ(Http1Settings::HeaderKeyFormat::StatefulFormatter, settings.header_key_format_);
   EXPECT_NE(nullptr, settings.stateful_header_key_formatter_);
+}
+
+// A formatter that rejects its configuration must have the failure reported through
+// creation_status, and parseHttp1Settings() must return default settings rather than the
+// half-populated ones it had built before it reached the formatter.
+TEST(HttpUtility, StatefulFormatterCreationFailureIsPropagated) {
+  RejectingStatefulFormatterFactoryConfig factory;
+  Registry::InjectFactory<StatefulHeaderKeyFormatterFactoryConfig> registered(factory);
+
+  envoy::config::core::v3::Http1ProtocolOptions http1_options;
+  // Set a field that is populated before the formatter is created, so that default settings can be
+  // told apart from partially populated ones.
+  http1_options.set_allow_chunked_length(true);
+  useRejectingStatefulFormatter(http1_options);
+
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  absl::Status creation_status = absl::OkStatus();
+  auto settings = Http1::parseHttp1Settings(http1_options, context, creation_status);
+
+  EXPECT_THAT(creation_status, HasStatus(absl::StatusCode::kInvalidArgument,
+                                         Eq(RejectingStatefulFormatterFactoryConfig::kError)));
+  EXPECT_EQ(Http1Settings::HeaderKeyFormat::Default, settings.header_key_format_);
+  EXPECT_EQ(nullptr, settings.stateful_header_key_formatter_);
+  EXPECT_FALSE(settings.allow_chunked_length_);
+}
+
+TEST(HttpUtility, StatefulFormatterCreationFailureIsPropagatedWithHcmOverload) {
+  RejectingStatefulFormatterFactoryConfig factory;
+  Registry::InjectFactory<StatefulHeaderKeyFormatterFactoryConfig> registered(factory);
+
+  envoy::config::core::v3::Http1ProtocolOptions http1_options;
+  http1_options.set_allow_chunked_length(true);
+  useRejectingStatefulFormatter(http1_options);
+
+  Protobuf::BoolValue hcm_value;
+  hcm_value.set_value(true);
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  absl::Status creation_status = absl::OkStatus();
+  auto settings =
+      Http1::parseHttp1Settings(http1_options, context, hcm_value, true, creation_status);
+
+  EXPECT_THAT(creation_status, HasStatus(absl::StatusCode::kInvalidArgument,
+                                         Eq(RejectingStatefulFormatterFactoryConfig::kError)));
+  EXPECT_EQ(Http1Settings::HeaderKeyFormat::Default, settings.header_key_format_);
+  EXPECT_EQ(nullptr, settings.stateful_header_key_formatter_);
+  EXPECT_FALSE(settings.allow_chunked_length_);
+  EXPECT_FALSE(settings.validate_scheme_);
+  EXPECT_FALSE(settings.stream_error_on_invalid_http_message_);
 }
 
 TEST(HttpUtility, AllowCustomMethods) {

--- a/test/extensions/filters/network/http_connection_manager/BUILD
+++ b/test/extensions/filters/network/http_connection_manager/BUILD
@@ -55,6 +55,7 @@ envoy_extension_cc_test(
         "//source/extensions/filters/network/http_connection_manager:config",
         "//source/extensions/http/early_header_mutation/header_mutation:config",
         "//source/extensions/http/original_ip_detection/custom_header:config",
+        "//test/common/http:header_formatter_test_lib",
         "//test/integration/filters:encoder_decoder_buffer_filter_lib",
         "//test/mocks/http:header_validator_mocks",
         "//test/mocks/network:network_mocks",

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -16,6 +16,7 @@
 #include "source/extensions/filters/network/http_connection_manager/config.h"
 #include "source/extensions/request_id/uuid/config.h"
 
+#include "test/common/http/header_formatter_test_utils.h"
 #include "test/extensions/filters/network/http_connection_manager/config.pb.h"
 #include "test/extensions/filters/network/http_connection_manager/config.pb.validate.h"
 #include "test/extensions/filters/network/http_connection_manager/config_test_base.h"
@@ -36,6 +37,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::Envoy::StatusHelpers::HasStatus;
 using ::Envoy::StatusHelpers::IsOk;
 using testing::_;
 using testing::An;
@@ -285,6 +287,47 @@ http_filters:
 
   EXPECT_THROW_WITH_MESSAGE(createHttpConnectionManagerConfig(yaml_string), EnvoyException,
                             "Non-HTTP/3 codec configured on QUIC listener.");
+}
+
+// A stateful header formatter that rejects its configuration must fail listener config creation
+// rather than leaving the connection manager with silently defaulted HTTP/1 settings.
+TEST_F(HttpConnectionManagerConfigTest, StatefulFormatterCreationFailureIsPropagated) {
+  Http::RejectingStatefulFormatterFactoryConfig factory;
+  Registry::InjectFactory<Http::StatefulHeaderKeyFormatterFactoryConfig> registered(factory);
+
+  const std::string yaml_string = fmt::format(R"EOF(
+codec_type: http1
+stat_prefix: router
+route_config:
+  virtual_hosts:
+  - name: service
+    domains:
+    - "*"
+    routes:
+    - match:
+        prefix: "/"
+      route:
+        cluster: cluster
+http_protocol_options:
+  header_key_format:
+    stateful_formatter:
+      name: {}
+      typed_config:
+        "@type": type.googleapis.com/google.protobuf.StringValue
+http_filters:
+- name: envoy.filters.http.router
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  )EOF",
+                                              Http::RejectingStatefulFormatterFactoryConfig::kName);
+
+  [[maybe_unused]] HttpConnectionManagerConfig config(
+      parseHttpConnectionManagerFromYaml(yaml_string), context_, date_provider_,
+      route_config_provider_manager_, &scoped_routes_config_provider_manager_, tracer_manager_,
+      filter_config_provider_manager_, creation_status_);
+  EXPECT_THAT(creation_status_,
+              HasStatus(absl::StatusCode::kInvalidArgument,
+                        Eq(Http::RejectingStatefulFormatterFactoryConfig::kError)));
 }
 
 TEST_F(HttpConnectionManagerConfigTest, TracingNotEnabledAndNoTracingConfigInBootstrap) {

--- a/test/extensions/http/header_formatters/preserve_case/BUILD
+++ b/test/extensions/http/header_formatters/preserve_case/BUILD
@@ -80,6 +80,7 @@ envoy_extension_cc_test(
         "//source/common/common:utility_lib",
         "//source/extensions/http/header_formatters/preserve_case:config",
         "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
+        "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/http/header_formatters/preserve_case/config_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/config_test.cc
@@ -4,6 +4,7 @@
 #include "source/extensions/http/header_formatters/preserve_case/config.h"
 #include "source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
+#include "test/mocks/server/server_factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -31,7 +32,10 @@ TEST(PreserveCaseFormatterFactoryConfigTest, Basic) {
   TestUtility::loadFromYaml(yaml, typed_config);
   auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
       typed_config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
-  EXPECT_NE(factory->createFromProto(*header_formatter_config), nullptr);
+  testing::NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  auto formatter_factory = factory->createFactoryFromProto(*header_formatter_config, context);
+  ASSERT_TRUE(formatter_factory.ok());
+  EXPECT_NE(formatter_factory.value(), nullptr);
 }
 
 TEST(PreserveCaseFormatterFactoryConfigTest, InvalidfFormatterTypeOnEnvoyHeaders) {
@@ -66,8 +70,10 @@ TEST(PreserveCaseFormatterFactoryConfigTest, PreserveCaseFormatterFactoryConfig_
   TestUtility::loadFromYaml(yaml, typed_config);
   auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
       typed_config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
-  auto formatter_factory = factory->createFromProto(*header_formatter_config);
-  auto formatter = formatter_factory->create();
+  testing::NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  auto formatter_factory = factory->createFactoryFromProto(*header_formatter_config, context);
+  ASSERT_TRUE(formatter_factory.ok());
+  auto formatter = formatter_factory.value()->create();
 
   formatter->processKey("Foo");
   EXPECT_EQ("Foo", formatter->format("foo"));
@@ -90,8 +96,10 @@ TEST(PreserveCaseFormatterFactoryConfigTest, PreserveCaseFormatterFactoryConfig_
   TestUtility::loadFromYaml(yaml, typed_config);
   auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
       typed_config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
-  auto formatter_factory = factory->createFromProto(*header_formatter_config);
-  auto formatter = formatter_factory->create();
+  testing::NiceMock<Server::Configuration::MockGenericFactoryContext> context;
+  auto formatter_factory = factory->createFactoryFromProto(*header_formatter_config, context);
+  ASSERT_TRUE(formatter_factory.ok());
+  auto formatter = formatter_factory.value()->create();
 
   formatter->processKey("Foo");
   EXPECT_EQ("Foo", formatter->format("foo"));

--- a/test/extensions/upstreams/http/BUILD
+++ b/test/extensions/upstreams/http/BUILD
@@ -25,6 +25,7 @@ envoy_cc_test(
         "//source/common/upstream:upstream_includes",
         "//source/common/upstream:upstream_lib",
         "//source/extensions/upstreams/http:config",
+        "//test/common/http:header_formatter_test_lib",
         "//test/mocks/http:header_validator_mocks",
         "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:registry_lib",

--- a/test/extensions/upstreams/http/config_test.cc
+++ b/test/extensions/upstreams/http/config_test.cc
@@ -5,6 +5,7 @@
 #include "source/common/config/utility.h"
 #include "source/extensions/upstreams/http/config.h"
 
+#include "test/common/http/header_formatter_test_utils.h"
 #include "test/extensions/upstreams/http/config.pb.h"
 #include "test/extensions/upstreams/http/config.pb.validate.h"
 #include "test/mocks/http/header_validator.h"
@@ -22,8 +23,10 @@ namespace Extensions {
 namespace Upstreams {
 namespace Http {
 
+using ::Envoy::StatusHelpers::HasStatus;
 using ::Envoy::StatusHelpers::IsOk;
 using ::testing::ContainsRegex;
+using ::testing::Eq;
 using ::testing::InvokeWithoutArgs;
 using ::testing::NiceMock;
 using ::testing::Not;
@@ -119,6 +122,37 @@ TEST_F(ConfigTest, KvStoreConcurrencyFail) {
       ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status().message(),
       ContainsRegex("(?s)options has key value store but Envoy has concurrency = 2 "
                     ":.*key_value_store_config {\n}\n"));
+}
+
+// A stateful header formatter that rejects its configuration must fail cluster protocol options
+// creation rather than leaving the cluster with silently defaulted HTTP/1 settings.
+TEST_F(ConfigTest, StatefulFormatterCreationFailureIsPropagated) {
+  ::Envoy::Http::RejectingStatefulFormatterFactoryConfig factory;
+  Registry::InjectFactory<::Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig> registered(
+      factory);
+
+  ::Envoy::Http::useRejectingStatefulFormatter(
+      *options_.mutable_explicit_http_config()->mutable_http_protocol_options());
+
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_),
+              HasStatus(absl::StatusCode::kInvalidArgument,
+                        Eq(::Envoy::Http::RejectingStatefulFormatterFactoryConfig::kError)));
+}
+
+TEST_F(ConfigTest, LegacyStatefulFormatterCreationFailureIsPropagated) {
+  ::Envoy::Http::RejectingStatefulFormatterFactoryConfig factory;
+  Registry::InjectFactory<::Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig> registered(
+      factory);
+
+  envoy::config::core::v3::Http1ProtocolOptions http1_options;
+  ::Envoy::Http::useRejectingStatefulFormatter(http1_options);
+
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(
+                  http1_options, envoy::config::core::v3::Http2ProtocolOptions(),
+                  envoy::config::core::v3::HttpProtocolOptions(), std::nullopt, false, false,
+                  context_),
+              HasStatus(absl::StatusCode::kInvalidArgument,
+                        Eq(::Envoy::Http::RejectingStatefulFormatterFactoryConfig::kError)));
 }
 
 namespace {

--- a/test/extensions/upstreams/http/config_test.cc
+++ b/test/extensions/upstreams/http/config_test.cc
@@ -32,12 +32,15 @@ using ::testing::StrictMock;
 class ConfigTest : public ::testing::Test {
 public:
   envoy::extensions::upstreams::http::v3::HttpProtocolOptions options_;
-  NiceMock<Server::Configuration::MockServerFactoryContext> server_context_;
+  NiceMock<Server::Configuration::MockGenericFactoryContext> context_;
+  // The server context the generic one hands out, which the tests below set expectations on.
+  NiceMock<Server::Configuration::MockServerFactoryContext>& server_context_{
+      context_.server_context_};
 };
 
 TEST_F(ConfigTest, Basic) {
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_FALSE(config->use_downstream_protocol_);
   EXPECT_FALSE(config->use_http2_);
 }
@@ -46,7 +49,7 @@ TEST_F(ConfigTest, Downstream) {
   options_.mutable_use_downstream_protocol_config();
   {
     std::shared_ptr<ProtocolOptionsConfigImpl> config =
-        ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+        ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
     EXPECT_TRUE(config->use_downstream_protocol_);
     EXPECT_FALSE(config->use_http2_);
   }
@@ -54,7 +57,7 @@ TEST_F(ConfigTest, Downstream) {
   options_.mutable_use_downstream_protocol_config()->mutable_http2_protocol_options();
   {
     std::shared_ptr<ProtocolOptionsConfigImpl> config =
-        ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+        ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
     EXPECT_TRUE(config->use_downstream_protocol_);
     EXPECT_TRUE(config->use_http2_);
   }
@@ -68,7 +71,7 @@ TEST(FactoryTest, EmptyProto) {
 TEST_F(ConfigTest, Auto) {
   options_.mutable_auto_config();
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_FALSE(config->use_downstream_protocol_);
   EXPECT_TRUE(config->use_http2_);
   EXPECT_FALSE(config->use_http3_);
@@ -80,7 +83,7 @@ TEST_F(ConfigTest, AutoHttp3) {
   options_.mutable_auto_config()->mutable_http3_protocol_options();
   options_.mutable_auto_config()->mutable_alternate_protocols_cache_options();
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_TRUE(config->use_http2_);
   EXPECT_TRUE(config->use_http3_);
   EXPECT_TRUE(config->use_alpn_);
@@ -89,10 +92,9 @@ TEST_F(ConfigTest, AutoHttp3) {
 TEST_F(ConfigTest, AutoHttp3NoCache) {
   options_.mutable_auto_config();
   options_.mutable_auto_config()->mutable_http3_protocol_options();
-  EXPECT_EQ(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_)
-                .status()
-                .message(),
-            "alternate protocols cache must be configured when HTTP/3 is enabled with auto_config");
+  EXPECT_EQ(
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status().message(),
+      "alternate protocols cache must be configured when HTTP/3 is enabled with auto_config");
 }
 
 TEST_F(ConfigTest, MaxHeaderFieldSizeKbExceedsMaxResponseHeadersKb) {
@@ -101,10 +103,9 @@ TEST_F(ConfigTest, MaxHeaderFieldSizeKbExceedsMaxResponseHeadersKb) {
       ->mutable_max_header_field_size_kb()
       ->set_value(128);
   options_.mutable_common_http_protocol_options()->mutable_max_response_headers_kb()->set_value(64);
-  EXPECT_EQ(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_)
-                .status()
-                .message(),
-            "max_header_field_size_kb must not exceed max_response_headers_kb");
+  EXPECT_EQ(
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status().message(),
+      "max_header_field_size_kb must not exceed max_response_headers_kb");
 }
 
 TEST_F(ConfigTest, KvStoreConcurrencyFail) {
@@ -114,11 +115,10 @@ TEST_F(ConfigTest, KvStoreConcurrencyFail) {
       ->mutable_alternate_protocols_cache_options()
       ->mutable_key_value_store_config();
   server_context_.options_.concurrency_ = 2;
-  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_)
-                  .status()
-                  .message(),
-              ContainsRegex("(?s)options has key value store but Envoy has concurrency = 2 "
-                            ":.*key_value_store_config {\n}\n"));
+  EXPECT_THAT(
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status().message(),
+      ContainsRegex("(?s)options has key value store but Envoy has concurrency = 2 "
+                    ":.*key_value_store_config {\n}\n"));
 }
 
 namespace {
@@ -205,15 +205,14 @@ TEST_F(ConfigTest, HeaderValidatorConfig) {
   TestUtility::loadFromYamlAndValidate(yaml_string, options_);
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
   EXPECT_NE(nullptr, config->header_validator_factory_->createClientHeaderValidator(
                          ::Envoy::Http::Protocol::Http2, stats));
 #else
   // If UHV is disabled, providing config should result in rejection
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 
@@ -232,15 +231,14 @@ TEST_F(ConfigTest, HeaderValidatorConfigWithRuntimeDisabled) {
   TestUtility::loadFromYamlAndValidate(yaml_string, options_);
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
   // Without envoy.reloadable_features.enable_universal_header_validator set UHV is always disabled
   EXPECT_EQ(nullptr, config->header_validator_factory_);
 #else
   // If UHV is disabled, providing config should result in rejection
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 
@@ -256,16 +254,15 @@ TEST_F(ConfigTest, DefaultHeaderValidatorConfigWithRuntimeEnabled) {
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_NE(nullptr, config->header_validator_factory_->createClientHeaderValidator(
                          ::Envoy::Http::Protocol::Http2, stats));
   EXPECT_FALSE(proto_config.http1_protocol_options().allow_chunked_length());
 #else
   // If UHV is disabled but envoy.reloadable_features.enable_universal_header_validator is set, the
   // config is rejected
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 
@@ -276,7 +273,7 @@ TEST_F(ConfigTest, DefaultHeaderValidatorConfigWithoutOverride) {
   Registry::InjectFactory<::Envoy::Http::HeaderValidatorFactoryConfig> registration(factory);
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   // By default envoy.reloadable_features.enable_universal_header_validator is false preventing UHV
   // use
   EXPECT_EQ(nullptr, config->header_validator_factory_);
@@ -301,16 +298,15 @@ TEST_F(ConfigTest, TranslateDownstreamLegacyConfigToDefaultHeaderValidatorConfig
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_NE(nullptr, config->header_validator_factory_->createClientHeaderValidator(
                          ::Envoy::Http::Protocol::Http2, stats));
   EXPECT_TRUE(proto_config.http1_protocol_options().allow_chunked_length());
 #else
   // If UHV is disabled but envoy.reloadable_features.enable_universal_header_validator is set, the
   // config is rejected
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 
@@ -333,16 +329,15 @@ TEST_F(ConfigTest, TranslateAutoLegacyConfigToDefaultHeaderValidatorConfig) {
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_NE(nullptr, config->header_validator_factory_->createClientHeaderValidator(
                          ::Envoy::Http::Protocol::Http2, stats));
   EXPECT_TRUE(proto_config.http1_protocol_options().allow_chunked_length());
 #else
   // If UHV is disabled but envoy.reloadable_features.enable_universal_header_validator is set, the
   // config is rejected
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 
@@ -365,16 +360,15 @@ TEST_F(ConfigTest, TranslateExplicitLegacyConfigToDefaultHeaderValidatorConfig) 
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_NE(nullptr, config->header_validator_factory_->createClientHeaderValidator(
                          ::Envoy::Http::Protocol::Http2, stats));
   EXPECT_TRUE(proto_config.http1_protocol_options().allow_chunked_length());
 #else
   // If UHV is disabled but envoy.reloadable_features.enable_universal_header_validator is set, the
   // config is rejected
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 
@@ -397,16 +391,15 @@ TEST_F(ConfigTest, TranslateExplicitH2LegacyConfigToDefaultHeaderValidatorConfig
   NiceMock<::Envoy::Http::MockHeaderValidatorStats> stats;
 #ifdef ENVOY_ENABLE_UHV
   std::shared_ptr<ProtocolOptionsConfigImpl> config =
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).value();
+      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).value();
   EXPECT_NE(nullptr, config->header_validator_factory_->createClientHeaderValidator(
                          ::Envoy::Http::Protocol::Http2, stats));
   EXPECT_FALSE(proto_config.http1_protocol_options().allow_chunked_length());
 #else
   // If UHV is disabled but envoy.reloadable_features.enable_universal_header_validator is set, the
   // config is rejected
-  EXPECT_THAT(
-      ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, server_context_).status(),
-      Not(IsOk()));
+  EXPECT_THAT(ProtocolOptionsConfigImpl::createProtocolOptionsConfig(options_, context_).status(),
+              Not(IsOk()));
 #endif
 }
 


### PR DESCRIPTION
Commit Message: http: add context to allow more complex header formatter
Additional Description:

A pre-PR to support dynamic modules. This PR added a generic factory context as input of the factory and added the ability to handle the failure.

Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
