### PR TITLE
Promote envoy.filters.network.sni_dynamic_forward_proxy to stable

### DIFF
--- a/source/extensions/extensions_metadata.yaml
+++ b/source/extensions/extensions_metadata.yaml
@@ -1018,8 +1018,8 @@ envoy.filters.network.sni_cluster:
 envoy.filters.network.sni_dynamic_forward_proxy:
   categories:
   - envoy.filters.network
-  security_posture: unknown
-  status: alpha
+  security_posture: robust_to_untrusted_downstream_and_upstream
+  status: stable
   type_urls:
   - envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3.FilterConfig
 envoy.filters.network.tcp_bandwidth_limit:


### PR DESCRIPTION
This extension has been around for a long time and is used in Google prod. Extension is very simple and just passes SNI (or filter state value) to DNS resolver. There are no parsers in the extension.

Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes:  n/a
Platform Specific Features:  n/a
