### PR TITLE
Support rbac in postgres_proxy filter

### DIFF
--- a/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/BUILD
+++ b/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
+        "//envoy/config/rbac/v3:pkg",
         "@xds//udpa/annotations:pkg",
     ],
 )

--- a/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
+++ b/api/contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package envoy.extensions.filters.network.postgres_proxy.v3alpha;
 
+import "envoy/config/rbac/v3/rbac.proto";
+
 import "google/protobuf/wrappers.proto";
 
 import "envoy/annotations/deprecation.proto";
@@ -20,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // <config_network_filters_postgres_proxy>`.
 // [#extension: envoy.filters.network.postgres_proxy]
 
-// [#next-free-field: 6]
+// [#next-free-field: 7]
 message PostgresProxy {
   // Downstream and Upstream SSL operational modes.
   enum SSLMode {
@@ -80,4 +82,12 @@ message PostgresProxy {
   // :ref:`starttls transport socket <envoy_v3_api_msg_extensions.transport_sockets.starttls.v3.UpstreamStartTlsConfig>`.
   // Defaults to ``DISABLE``.
   SSLMode downstream_ssl = 5;
+
+  // The connection is evaluated against these RBAC rules when a StartupMessage is decoded.
+  // Startup attributes, such as user and database, are exposed as dynamic metadata under
+  // envoy.filters.network.postgres_proxy. Rules can also match TCP connection properties
+  // and SSL peer identity when Envoy terminates downstream TLS.
+  // For SSL passthrough, rules are evaluated when the SSLRequest is received using only
+  // available connection properties.
+  config.rbac.v3.RBAC rules = 6;
 }

--- a/contrib/postgres_proxy/filters/network/source/BUILD
+++ b/contrib/postgres_proxy/filters/network/source/BUILD
@@ -39,6 +39,8 @@ envoy_cc_library(
         "//envoy/stats:stats_macros",
         "//source/common/buffer:buffer_lib",
         "//source/common/network:filter_lib",
+        "//source/extensions/filters/common/rbac:engine_interface",
+        "//source/extensions/filters/common/rbac:utility_lib",
         "//source/extensions/filters/network:well_known_names",
         "@envoy_api//contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha:pkg_cc_proto",
     ],
@@ -51,6 +53,7 @@ envoy_cc_contrib_extension(
     repository = "@envoy",
     deps = [
         ":filter",
+        "//source/extensions/filters/common/rbac:engine_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha:pkg_cc_proto",

--- a/contrib/postgres_proxy/filters/network/source/config.cc
+++ b/contrib/postgres_proxy/filters/network/source/config.cc
@@ -2,6 +2,8 @@
 
 #include <format>
 
+#include "source/extensions/filters/common/rbac/engine_impl.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
@@ -30,6 +32,12 @@ NetworkFilters::PostgresProxy::PostgresConfigFactory::createFilterFactoryFromPro
 
   PostgresFilterConfigSharedPtr filter_config(
       std::make_shared<PostgresFilterConfig>(config_options, context.scope()));
+  if (proto_config.has_rules()) {
+    filter_config->engine_ =
+        std::make_unique<Filters::Common::RBAC::RoleBasedAccessControlEngineImpl>(
+            proto_config.rules(), context.messageValidationVisitor(),
+            context.serverFactoryContext());
+  }
   return [filter_config](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<PostgresFilter>(filter_config));
   };

--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -249,7 +249,7 @@ Decoder::Result DecoderImpl::onDataInit(Buffer::Instance& data, bool) {
   Decoder::Result result = Decoder::Result::ReadyForNext;
   uint32_t code = data.peekBEInt<uint32_t>(4);
   // Populate basic attributes and perform rbac
-  if (callbacks_->authorizationEnabled()){
+  if (callbacks_->authorizationEnabled()) {
     bool ssl_request = code == Postgres::Protocol::SSL_REQUEST_CODE;
     if (!ssl_request) {
       message_.resize(message_len_ - 4);
@@ -264,7 +264,6 @@ Decoder::Result DecoderImpl::onDataInit(Buffer::Instance& data, bool) {
       state_ = State::RejectedState;
       return Decoder::Result::Stopped;
     }
-    
   }
 
   // Startup message with 1234 in the most significant 16 bits indicate request to encrypt.
@@ -573,10 +572,10 @@ void DecoderImpl::onQuery() { callbacks_->processQuery(message_); }
 // The message format is continuous string of the following format:
 // user<username>database<database-name>application_name<application>encoding<encoding-type>
 void DecoderImpl::onStartup() {
-  if (callbacks_->authorizationEnabled()){
+  if (callbacks_->authorizationEnabled()) {
     // keep key/value pair for empty values
     attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'));
-  } else{
+  } else {
     // First 4 bytes of startup message contains version code.
     // It is skipped. After that message contains attributes.
     attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'), absl::SkipEmpty());

--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.cc
@@ -184,6 +184,9 @@ void DecoderImpl::initialize() {
 */
 Decoder::Result DecoderImpl::onData(Buffer::Instance& data, bool frontend) {
   switch (state_) {
+  case State::RejectedState:
+    data.drain(data.length());
+    return Decoder::Result::Stopped;
   case State::InitState:
     return onDataInit(data, frontend);
   case State::OutOfSyncState:
@@ -245,6 +248,25 @@ Decoder::Result DecoderImpl::onDataInit(Buffer::Instance& data, bool) {
 
   Decoder::Result result = Decoder::Result::ReadyForNext;
   uint32_t code = data.peekBEInt<uint32_t>(4);
+  // Populate basic attributes and perform rbac
+  if (callbacks_->authorizationEnabled()){
+    bool ssl_request = code == Postgres::Protocol::SSL_REQUEST_CODE;
+    if (!ssl_request) {
+      message_.resize(message_len_ - 4);
+      data.copyOut(4, message_.size(), message_.data());
+      onStartup();
+      message_.clear();
+    }
+
+    // perform rbac on StartupMessage and SSL passthrough connections
+    if ((!ssl_request || callbacks_->shouldPassthroughSSL()) && !callbacks_->authorizeStartup()) {
+      data.drain(data.length());
+      state_ = State::RejectedState;
+      return Decoder::Result::Stopped;
+    }
+    
+  }
+
   // Startup message with 1234 in the most significant 16 bits indicate request to encrypt.
   if (code >= Postgres::Protocol::ENCRYPTION_REQUEST_BASE_CODE) {
     encrypted_ = true;
@@ -551,10 +573,14 @@ void DecoderImpl::onQuery() { callbacks_->processQuery(message_); }
 // The message format is continuous string of the following format:
 // user<username>database<database-name>application_name<application>encoding<encoding-type>
 void DecoderImpl::onStartup() {
-  // First 4 bytes of startup message contains version code.
-  // It is skipped. After that message contains attributes.
-  attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'), absl::SkipEmpty());
-
+  if (callbacks_->authorizationEnabled()){
+    // keep key/value pair for empty values
+    attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'));
+  } else{
+    // First 4 bytes of startup message contains version code.
+    // It is skipped. After that message contains attributes.
+    attributes_ = absl::StrSplit(message_.substr(4), absl::ByChar('\0'), absl::SkipEmpty());
+  }
   // If "database" attribute is not found, default it to "user" attribute.
   if (!attributes_.contains("database") && attributes_.contains("user")) {
     attributes_["database"] = attributes_["user"];

--- a/contrib/postgres_proxy/filters/network/source/postgres_decoder.h
+++ b/contrib/postgres_proxy/filters/network/source/postgres_decoder.h
@@ -44,6 +44,10 @@ public:
 
   virtual void processQuery(const std::string&) PURE;
 
+  virtual bool authorizationEnabled() const PURE;
+  virtual bool authorizeStartup() PURE;
+  virtual void rejectStartup(absl::string_view log_policy_id) PURE;
+  virtual bool shouldPassthroughSSL() const PURE;
   virtual bool onSSLRequest() PURE;
   virtual bool shouldEncryptUpstream() const PURE;
   virtual void sendUpstream(Buffer::Instance&) PURE;
@@ -101,7 +105,8 @@ public:
     InSyncState,
     OutOfSyncState,
     EncryptedState,
-    NegotiatingUpstreamSSL
+    NegotiatingUpstreamSSL,
+    RejectedState
   };
   State state() const { return state_; }
   void state(State state) { state_ = state; }

--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
@@ -7,6 +7,7 @@
 #include "source/extensions/filters/network/well_known_names.h"
 
 #include "contrib/postgres_proxy/filters/network/source/postgres_decoder.h"
+#include "source/extensions/filters/common/rbac/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -205,9 +206,7 @@ void PostgresFilter::processQuery(const std::string& sql) {
 }
 
 bool PostgresFilter::onSSLRequest() {
-  if (config_->downstream_ssl_ ==
-          envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::DISABLE &&
-      !config_->terminate_ssl_) {
+  if (shouldPassthroughSSL()) {
     // Signal to the decoder to continue.
     return true;
   }
@@ -287,6 +286,38 @@ bool PostgresFilter::encryptUpstream(bool upstream_agreed, Buffer::Instance& dat
   }
 
   return encrypted;
+}
+
+bool PostgresFilter::authorizeStartup() {
+  // set basic attributes to metadata
+  Protobuf::Struct metadata;
+  auto& fields = *metadata.mutable_fields();
+  for (const auto& [key, val] : decoder_->getAttributes()) {
+    fields[key].set_string_value(val);
+  }
+  
+  auto& info = read_callbacks_->connection().streamInfo();
+  info.setDynamicMetadata(NetworkFilterNames::get().PostgresProxy, metadata);
+  std::string log_policy_id;
+  const bool allowed = config_->engine_->handleAction(read_callbacks_->connection(), info, &log_policy_id);
+  
+  if (!allowed) {
+    rejectStartup(log_policy_id);
+    return false;
+  }
+  config_->stats_.authorization_allowed_.inc();
+  return true;
+}
+
+void PostgresFilter::rejectStartup(absl::string_view log_policy_id) {
+  config_->stats_.authorization_denied_.inc();
+  
+  // send error response to downstream client
+  auto response = encoder_->buildErrorResponse("FATAL", "connection denied by Envoy proxy: rbac denied", "28000");
+  write_callbacks_->injectWriteDataToFilterChain(response, false);
+  // close downstream client connection
+  read_callbacks_->connection().streamInfo().setConnectionTerminationDetails(Filters::Common::RBAC::responseDetail(log_policy_id));
+  read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
 }
 
 void PostgresFilter::verifyDownstreamSSL() {

--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.cc
@@ -4,10 +4,10 @@
 #include "envoy/network/connection.h"
 
 #include "source/common/common/assert.h"
+#include "source/extensions/filters/common/rbac/utility.h"
 #include "source/extensions/filters/network/well_known_names.h"
 
 #include "contrib/postgres_proxy/filters/network/source/postgres_decoder.h"
-#include "source/extensions/filters/common/rbac/utility.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -295,12 +295,13 @@ bool PostgresFilter::authorizeStartup() {
   for (const auto& [key, val] : decoder_->getAttributes()) {
     fields[key].set_string_value(val);
   }
-  
+
   auto& info = read_callbacks_->connection().streamInfo();
   info.setDynamicMetadata(NetworkFilterNames::get().PostgresProxy, metadata);
   std::string log_policy_id;
-  const bool allowed = config_->engine_->handleAction(read_callbacks_->connection(), info, &log_policy_id);
-  
+  const bool allowed =
+      config_->engine_->handleAction(read_callbacks_->connection(), info, &log_policy_id);
+
   if (!allowed) {
     rejectStartup(log_policy_id);
     return false;
@@ -311,12 +312,14 @@ bool PostgresFilter::authorizeStartup() {
 
 void PostgresFilter::rejectStartup(absl::string_view log_policy_id) {
   config_->stats_.authorization_denied_.inc();
-  
+
   // send error response to downstream client
-  auto response = encoder_->buildErrorResponse("FATAL", "connection denied by Envoy proxy: rbac denied", "28000");
+  auto response = encoder_->buildErrorResponse(
+      "FATAL", "connection denied by Envoy proxy: rbac denied", "28000");
   write_callbacks_->injectWriteDataToFilterChain(response, false);
   // close downstream client connection
-  read_callbacks_->connection().streamInfo().setConnectionTerminationDetails(Filters::Common::RBAC::responseDetail(log_policy_id));
+  read_callbacks_->connection().streamInfo().setConnectionTerminationDetails(
+      Filters::Common::RBAC::responseDetail(log_policy_id));
   read_callbacks_->connection().close(Network::ConnectionCloseType::FlushWrite);
 }
 

--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.h
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.h
@@ -7,6 +7,7 @@
 
 #include "source/common/buffer/buffer_impl.h"
 #include "source/common/common/logger.h"
+#include "source/extensions/filters/common/rbac/engine.h"
 
 #include "contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.pb.h"
 #include "contrib/postgres_proxy/filters/network/source/postgres_decoder.h"
@@ -53,7 +54,9 @@ namespace PostgresProxy {
   COUNTER(notices_debug)                                                                           \
   COUNTER(notices_info)                                                                            \
   COUNTER(notices_log)                                                                             \
-  COUNTER(notices_unknown)
+  COUNTER(notices_unknown)                                                                         \
+  COUNTER(authorization_allowed)                                                                   \
+  COUNTER(authorization_denied)
 
 /**
  * Struct definition for all Postgres proxy stats. @see stats_macros.h
@@ -88,6 +91,7 @@ public:
           envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::DISABLE};
   Stats::Scope& scope_;
   PostgresProxyStats stats_;
+  std::unique_ptr<Filters::Common::RBAC::RoleBasedAccessControlEngine> engine_;
 
 private:
   PostgresProxyStats generateStats(const std::string& prefix, Stats::Scope& scope) {
@@ -131,6 +135,12 @@ public:
   void sendUpstream(Buffer::Instance&) override;
   bool encryptUpstream(bool, Buffer::Instance&) override;
   void verifyDownstreamSSL() override;
+  bool authorizationEnabled() const override { return config_->engine_ != nullptr; }
+  bool authorizeStartup() override;
+  void rejectStartup(absl::string_view log_policy_id) override;
+  bool shouldPassthroughSSL() const override { return config_->downstream_ssl_ ==
+          envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::DISABLE &&
+      !config_->terminate_ssl_; }
 
   void closeConn();
   bool isSwitchedToTls() { return switched_to_tls_; };

--- a/contrib/postgres_proxy/filters/network/source/postgres_filter.h
+++ b/contrib/postgres_proxy/filters/network/source/postgres_filter.h
@@ -138,9 +138,11 @@ public:
   bool authorizationEnabled() const override { return config_->engine_ != nullptr; }
   bool authorizeStartup() override;
   void rejectStartup(absl::string_view log_policy_id) override;
-  bool shouldPassthroughSSL() const override { return config_->downstream_ssl_ ==
-          envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::DISABLE &&
-      !config_->terminate_ssl_; }
+  bool shouldPassthroughSSL() const override {
+    return config_->downstream_ssl_ == envoy::extensions::filters::network::postgres_proxy::
+                                           v3alpha::PostgresProxy::DISABLE &&
+           !config_->terminate_ssl_;
+  }
 
   void closeConn();
   bool isSwitchedToTls() { return switched_to_tls_; };

--- a/contrib/postgres_proxy/filters/network/test/BUILD
+++ b/contrib/postgres_proxy/filters/network/test/BUILD
@@ -84,6 +84,7 @@ envoy_cc_test(
     deps = [
         ":postgres_integration_proto_cc_proto",
         ":postgres_test_utils_lib",
+        "//contrib/postgres/protocol:postgres_protocol_lib",
         "//contrib/postgres_proxy/filters/network/source:config",
         "//contrib/postgres_proxy/filters/network/source:filter",
         "//source/common/tcp_proxy",
@@ -94,5 +95,32 @@ envoy_cc_test(
         "//test/mocks/server:server_factory_context_mocks",
         "//test/test_common:registry_lib",
         "@envoy_api//contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/transport_sockets/starttls/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "postgres_rbac_tests",
+    srcs = ["postgres_rbac_test.cc"],
+    deps = [
+        "//contrib/postgres_proxy/filters/network/source:filter",
+        "//source/extensions/filters/common/rbac:engine_lib",
+        "//source/extensions/filters/network:well_known_names",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:server_factory_context_mocks",
+        "//test/mocks/ssl:ssl_mocks",
+        "//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    deps = [
+        "//contrib/postgres_proxy/filters/network/source:config",
+        "//test/mocks/network:network_mocks",
+        "//test/mocks/server:factory_context_mocks",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/contrib/postgres_proxy/filters/network/test/config_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/config_test.cc
@@ -54,7 +54,6 @@ rules:
   EXPECT_TRUE(factory.createFilterFactoryFromProto(config, context).ok());
 }
 
-
 } // namespace
 } // namespace PostgresProxy
 } // namespace NetworkFilters

--- a/contrib/postgres_proxy/filters/network/test/config_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/config_test.cc
@@ -1,0 +1,62 @@
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/server/factory_context.h"
+#include "test/test_common/utility.h"
+
+#include "contrib/postgres_proxy/filters/network/source/config.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::StrictMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgresProxy {
+namespace {
+
+TEST(PostgresConfigTest, CreatesFilterWithRules) {
+  envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy config;
+  config.set_stat_prefix("postgres");
+  config.mutable_rules();
+
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  PostgresConfigFactory factory;
+  auto rules_result = factory.createFilterFactoryFromProto(config, context);
+  ASSERT_TRUE(rules_result.ok());
+  StrictMock<Network::MockFilterManager> manager;
+  EXPECT_CALL(manager, addFilter(_));
+  (*rules_result)(manager);
+}
+
+TEST(PostgresConfigTest, CreatesNetworkRules) {
+  envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy config;
+  TestUtility::loadFromYaml(R"EOF(
+stat_prefix: postgres
+rules:
+  policies:
+    network:
+      permissions:
+      - and_rules:
+          rules:
+          - or_rules:
+              rules:
+              - not_rule: {destination_port: 1}
+      principals:
+      - and_ids:
+          ids:
+          - or_ids:
+              ids:
+              - not_id: {direct_remote_ip: {address_prefix: "127.0.0.1", prefix_len: 32}}
+)EOF",
+                            config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  PostgresConfigFactory factory;
+  EXPECT_TRUE(factory.createFilterFactoryFromProto(config, context).ok());
+}
+
+
+} // namespace
+} // namespace PostgresProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_decoder_test.cc
@@ -27,11 +27,15 @@ public:
   MOCK_METHOD(void, incNotices, (NoticeType), (override));
   MOCK_METHOD(void, incErrors, (ErrorType), (override));
   MOCK_METHOD(void, processQuery, (const std::string&), (override));
+  MOCK_METHOD(bool, authorizationEnabled, (), (const, override));
+  MOCK_METHOD(bool, authorizeStartup, (), (override));
+  MOCK_METHOD(void, rejectStartup, (absl::string_view policy_id), (override));
   MOCK_METHOD(bool, onSSLRequest, (), (override));
   MOCK_METHOD(bool, shouldEncryptUpstream, (), (const));
   MOCK_METHOD(void, sendUpstream, (Buffer::Instance&));
   MOCK_METHOD(bool, encryptUpstream, (bool, Buffer::Instance&));
   MOCK_METHOD(void, verifyDownstreamSSL, (), (override));
+  MOCK_METHOD(bool, shouldPassthroughSSL, (), (const, override));
 };
 
 // Define fixture class with decoder and mock callbacks.
@@ -122,6 +126,41 @@ TEST_F(PostgresProxyDecoderTest, StartupMessage) {
   ASSERT_THAT(decoder_->getAttributes().at("database"), "testdb");
   // This attribute should not be found
   ASSERT_THAT(decoder_->getAttributes().find("no"), decoder_->getAttributes().end());
+}
+
+TEST_F(PostgresProxyDecoderTest, AuthorizesBeforeUpstreamSSL) {
+  decoder_->state(DecoderImpl::State::InitState);
+  ON_CALL(callbacks_, authorizationEnabled()).WillByDefault(testing::Return(true));
+  const std::string attributes = "user\0postgres\0database\0testdb\0\0"s;
+  data_.writeBEInt<uint32_t>(8 + attributes.size());
+  data_.writeBEInt<uint32_t>(0x00030000);
+  data_.add(attributes);
+  testing::InSequence s;
+  EXPECT_CALL(callbacks_, authorizeStartup()).WillOnce(testing::Invoke([this]() {
+    EXPECT_THAT(decoder_->getAttributes().at("user"), "postgres");
+    EXPECT_THAT(decoder_->getAttributes().at("database"), "testdb");
+    return true;
+  }));
+  EXPECT_CALL(callbacks_, shouldEncryptUpstream()).WillOnce(testing::Return(true));
+  EXPECT_CALL(callbacks_, sendUpstream(testing::_));
+  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::Stopped);
+  ASSERT_THAT(decoder_->state(), DecoderImpl::State::NegotiatingUpstreamSSL);
+}
+
+TEST_F(PostgresProxyDecoderTest, RejectedStartupStopDecoding) {
+  decoder_->state(DecoderImpl::State::InitState);
+  ON_CALL(callbacks_, authorizationEnabled()).WillByDefault(testing::Return(true));
+  const std::string attributes = "user\0postgres\0\0"s;
+  data_.writeBEInt<uint32_t>(8 + attributes.size());
+  data_.writeBEInt<uint32_t>(0x00030000);
+  data_.add(attributes);
+  EXPECT_CALL(callbacks_, authorizeStartup()).WillOnce(testing::Return(false));
+  EXPECT_CALL(callbacks_, shouldEncryptUpstream()).Times(0);
+  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::Stopped);
+  ASSERT_THAT(decoder_->state(), DecoderImpl::State::RejectedState);
+  data_.add("more data");
+  ASSERT_THAT(decoder_->onData(data_, true), Decoder::Result::Stopped);
+  ASSERT_THAT(0, data_.length());
 }
 
 // Test verifies that when Startup message does not carry

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -1,5 +1,8 @@
 #include <format>
 
+#include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.h"
+#include "envoy/extensions/transport_sockets/starttls/v3/starttls.pb.h"
+
 #include "source/common/network/connection_impl.h"
 #include "source/common/tls/client_ssl_socket.h"
 #include "source/common/tls/server_context_config_impl.h"
@@ -17,6 +20,7 @@
 
 #include "contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.pb.h"
 #include "contrib/envoy/extensions/filters/network/postgres_proxy/v3alpha/postgres_proxy.pb.validate.h"
+#include "contrib/postgres/protocol/postgres_protocol.h"
 #include "contrib/postgres_proxy/filters/network/test/postgres_integration_test.pb.h"
 #include "contrib/postgres_proxy/filters/network/test/postgres_integration_test.pb.validate.h"
 #include "contrib/postgres_proxy/filters/network/test/postgres_test_utils.h"
@@ -747,6 +751,150 @@ TEST_P(UpstreamAndDownstreamSSLIntegrationTest, ServerRejectsSSL) {
 }
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, UpstreamAndDownstreamSSLIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+class RbacPostgresIntegrationTest : public DownstreamSSLPostgresIntegrationTest {
+public:
+  void SetUp() override {}
+
+  void initializeRbac(const std::string& identity, bool defer_upstream = false) {
+    config_helper_.addConfigModifier([identity, defer_upstream](
+                                         envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* chain =
+          bootstrap.mutable_static_resources()->mutable_listeners(0)->mutable_filter_chains(0);
+      envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy postgres;
+      ASSERT_TRUE(chain->filters(0).typed_config().UnpackTo(&postgres));
+      postgres.mutable_enable_sql_parsing()->set_value(false);
+      auto& policy = (*postgres.mutable_rules()->mutable_policies())["client"];
+      policy.add_principals()->mutable_authenticated()->mutable_principal_name()->set_exact(
+          identity);
+      auto* metadata =
+          policy.add_permissions()->mutable_sourced_metadata()->mutable_metadata_matcher();
+      metadata->set_filter("envoy.filters.network.postgres_proxy");
+      metadata->add_path()->set_key("database");
+      metadata->mutable_value()->mutable_string_match()->set_exact("testdb");
+      ASSERT_THAT(chain->mutable_filters(0)->mutable_typed_config()->PackFrom(postgres), true);
+      if (defer_upstream) {
+        envoy::extensions::filters::network::tcp_proxy::v3::TcpProxy tcp;
+        ASSERT_TRUE(chain->filters(1).typed_config().UnpackTo(&tcp));
+        tcp.set_upstream_connect_mode(
+            envoy::extensions::filters::network::tcp_proxy::v3::ON_DOWNSTREAM_DATA);
+        tcp.mutable_max_early_data_bytes()->set_value(16384);
+        ASSERT_THAT(chain->mutable_filters(1)->mutable_typed_config()->PackFrom(tcp), true);
+      }
+
+      envoy::extensions::transport_sockets::starttls::v3::StartTlsConfig starttls;
+      ASSERT_TRUE(chain->transport_socket().typed_config().UnpackTo(&starttls));
+      auto* tls = starttls.mutable_tls_socket_config();
+      tls->mutable_require_client_certificate()->set_value(true);
+      tls->mutable_common_tls_context()
+          ->mutable_validation_context()
+          ->mutable_trusted_ca()
+          ->set_filename(TestEnvironment::runfilesPath("test/config/integration/certs/cacert.pem"));
+      ASSERT_THAT(chain->mutable_transport_socket()->mutable_typed_config()->PackFrom(starttls),
+                  true);
+    });
+    BaseIntegrationTest::initialize();
+  }
+
+  void enableClientTls(const IntegrationTcpClientPtr& client) {
+    auto manager = std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(
+        server_factory_context_);
+    envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext tls;
+    auto* cert = tls.mutable_common_tls_context()->add_tls_certificates();
+    cert->mutable_certificate_chain()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
+    cert->mutable_private_key()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+    NiceMock<Server::Configuration::MockTransportSocketFactoryContext> context;
+    ON_CALL(context.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
+    auto config = *Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(tls, context);
+    auto factory = *Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
+        std::move(config), *manager, *client_store_.rootScope());
+    auto* connection = dynamic_cast<Network::ConnectionImpl*>(client->connection());
+    connection->transportSocket() = factory->createTransportSocket(
+        nullptr, connection->streamInfo().upstreamInfo()->upstreamHost());
+    connection->transportSocket()->setTransportSocketCallbacks(*connection);
+  }
+
+  void checkAuthorization(const std::string& identity, bool allowed) {
+    initializeRbac(identity);
+    auto client = makeTcpConnection(lookupPort("listener_0"));
+    FakeRawConnectionPtr upstream;
+    ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream));
+    Buffer::OwnedImpl ssl_request;
+    ssl_request.writeBEInt<uint32_t>(8);
+    ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
+    ASSERT_TRUE(client->write(ssl_request.toString()));
+    client->waitForData("S", true);
+    enableClientTls(client);
+
+    using namespace std::literals::string_literals;
+    const std::string attributes = "user\0postgres\0database\0testdb\0\0"s;
+    Buffer::OwnedImpl startup;
+    startup.writeBEInt<uint32_t>(8 + attributes.size());
+    startup.writeBEInt<uint32_t>(0x00030000);
+    startup.add(attributes);
+    ASSERT_TRUE(client->write(startup.toString()));
+    if (allowed) {
+      std::string received;
+      ASSERT_TRUE(upstream->waitForData(startup.length(), &received));
+      ASSERT_THAT(received, startup.toString());
+      test_server_->waitForCounter("postgres.postgres_stats.authorization_allowed", Eq(1));
+      client->close();
+    } else {
+      client->waitForData("28000", false);
+      client->waitForDisconnect();
+      ASSERT_THAT(client->data(), testing::HasSubstr("28000"));
+      test_server_->waitForCounter("postgres.postgres_stats.authorization_denied", Eq(1));
+    }
+    ASSERT_TRUE(upstream->waitForDisconnect());
+    if (!allowed) {
+      std::string received;
+      ASSERT_TRUE(upstream->waitForData(0, &received));
+      ASSERT_THAT(received, "");
+    }
+  }
+
+  Stats::IsolatedStoreImpl client_store_;
+};
+
+TEST_P(RbacPostgresIntegrationTest, AllowsValidatedUriSan) {
+  checkAuthorization("spiffe://lyft.com/frontend-team", true);
+}
+
+TEST_P(RbacPostgresIntegrationTest, AllowsValidatedDnsSan) {
+  checkAuthorization("www.lyft.com", true);
+}
+
+TEST_P(RbacPostgresIntegrationTest, FlushesDenialForUnmatchedIdentity) {
+  checkAuthorization("spiffe://example.com/other", false);
+}
+
+TEST_P(RbacPostgresIntegrationTest, DenialDoesNotOpenDeferredUpstream) {
+  initializeRbac("spiffe://example.com/other", true);
+  auto client = makeTcpConnection(lookupPort("listener_0"));
+  Buffer::OwnedImpl ssl_request;
+  ssl_request.writeBEInt<uint32_t>(8);
+  ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
+  ASSERT_TRUE(client->write(ssl_request.toString()));
+  client->waitForData("S", true);
+  enableClientTls(client);
+  using namespace std::literals::string_literals;
+  const std::string attributes = "user\0postgres\0database\0testdb\0\0"s;
+  Buffer::OwnedImpl startup;
+  startup.writeBEInt<uint32_t>(8 + attributes.size());
+  startup.writeBEInt<uint32_t>(0x00030000);
+  startup.add(attributes);
+  ASSERT_TRUE(client->write(startup.toString()));
+  client->waitForData("28000", false);
+  client->waitForDisconnect();
+  ASSERT_THAT(client->data(), testing::HasSubstr("28000"));
+  test_server_->waitForCounter("postgres.postgres_stats.authorization_denied", Eq(1));
+  test_server_->waitForCounter("cluster.cluster_0.upstream_cx_total", Eq(0));
+}
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, RbacPostgresIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
 } // namespace PostgresProxy

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -825,7 +825,7 @@ public:
     Buffer::OwnedImpl ssl_request;
     ssl_request.writeBEInt<uint32_t>(8);
     ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
-    ASSERT_TRUE(client->write(ssl_request.toString()));
+    ASSERT_TRUE(client->write(ssl_request.toString(), false, allowed));
     ASSERT_TRUE(client->waitForData(1, TestUtility::DefaultTimeout));
     ASSERT_THAT(client->data(), "S");
     enableClientTls(client);
@@ -836,7 +836,7 @@ public:
     startup.writeBEInt<uint32_t>(8 + attributes.size());
     startup.writeBEInt<uint32_t>(0x00030000);
     startup.add(attributes);
-    ASSERT_TRUE(client->write(startup.toString()));
+    ASSERT_TRUE(client->write(startup.toString(), false, allowed));
     if (allowed) {
       std::string received;
       ASSERT_TRUE(upstream->waitForData(startup.length(), &received));
@@ -876,7 +876,7 @@ TEST_P(RbacPostgresIntegrationTest, DenialDoesNotOpenDeferredUpstream) {
   Buffer::OwnedImpl ssl_request;
   ssl_request.writeBEInt<uint32_t>(8);
   ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
-  ASSERT_TRUE(client->write(ssl_request.toString()));
+  ASSERT_TRUE(client->write(ssl_request.toString(), false, false));
   ASSERT_TRUE(client->waitForData(1, TestUtility::DefaultTimeout));
   ASSERT_THAT(client->data(), "S");
   enableClientTls(client);
@@ -886,7 +886,7 @@ TEST_P(RbacPostgresIntegrationTest, DenialDoesNotOpenDeferredUpstream) {
   startup.writeBEInt<uint32_t>(8 + attributes.size());
   startup.writeBEInt<uint32_t>(0x00030000);
   startup.add(attributes);
-  ASSERT_TRUE(client->write(startup.toString()));
+  ASSERT_TRUE(client->write(startup.toString(), false, false));
   client->waitForData("28000", false);
   client->waitForDisconnect();
   ASSERT_THAT(client->data(), testing::HasSubstr("28000"));

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -1,4 +1,3 @@
-#include <cstdio>
 #include <format>
 
 #include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.h"
@@ -811,7 +810,7 @@ public:
     ON_CALL(context.server_context_, api()).WillByDefault(testing::ReturnRef(*api_));
     auto config = *Extensions::TransportSockets::Tls::ClientContextConfigImpl::create(tls, context);
     auto factory = *Extensions::TransportSockets::Tls::ClientSslSocketFactory::create(
-        std::move(config), *manager, *client_store_.rootScope());
+        std::move(config), *manager, server_factory_context_.serverScope());
     auto* connection = dynamic_cast<Network::ConnectionImpl*>(client->connection());
     connection->transportSocket() = factory->createTransportSocket(
         nullptr, connection->streamInfo().upstreamInfo()->upstreamHost());
@@ -819,28 +818,17 @@ public:
   }
 
   void checkAuthorization(const std::string& identity, bool allowed) {
-    auto checkpoint = [](const char* stage) {
-      std::fprintf(stderr, "RBAC test: %s\n", stage);
-      std::fflush(stderr);
-    };
-    checkpoint("before initialize");
     initializeRbac(identity);
-    checkpoint("initialized");
     auto client = makeTcpConnection(lookupPort("listener_0"));
-    checkpoint("client created");
     FakeRawConnectionPtr upstream;
     ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream));
-    checkpoint("upstream connected");
     Buffer::OwnedImpl ssl_request;
     ssl_request.writeBEInt<uint32_t>(8);
     ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
     ASSERT_TRUE(client->write(ssl_request.toString()));
-    checkpoint("SSLRequest written");
     ASSERT_TRUE(client->waitForData(1, TestUtility::DefaultTimeout));
     ASSERT_THAT(client->data(), "S");
-    checkpoint("received SSL acceptance S");
     enableClientTls(client);
-    checkpoint("client TLS socket installed");
 
     using namespace std::literals::string_literals;
     const std::string attributes = "user\0postgres\0database\0testdb\0\0"s;
@@ -849,36 +837,25 @@ public:
     startup.writeBEInt<uint32_t>(0x00030000);
     startup.add(attributes);
     ASSERT_TRUE(client->write(startup.toString()));
-    checkpoint("StartupMessage written");
     if (allowed) {
       std::string received;
       ASSERT_TRUE(upstream->waitForData(startup.length(), &received));
-      checkpoint("upstream received StartupMessage");
       ASSERT_THAT(received, startup.toString());
       test_server_->waitForCounter("postgres.postgres_stats.authorization_allowed", Eq(1));
-      checkpoint("authorization allowed counter verified");
       client->close();
-      checkpoint("client closed");
     } else {
       client->waitForData("28000", false);
-      checkpoint("received denial response");
       client->waitForDisconnect();
-      checkpoint("client disconnected");
       ASSERT_THAT(client->data(), testing::HasSubstr("28000"));
       test_server_->waitForCounter("postgres.postgres_stats.authorization_denied", Eq(1));
-      checkpoint("authorization denied counter verified");
     }
     ASSERT_TRUE(upstream->waitForDisconnect());
-    checkpoint("upstream disconnected");
     if (!allowed) {
       std::string received;
       ASSERT_TRUE(upstream->waitForData(0, &received));
       ASSERT_THAT(received, "");
-      checkpoint("upstream received no denied data");
     }
   }
-
-  Stats::IsolatedStoreImpl client_store_;
 };
 
 TEST_P(RbacPostgresIntegrationTest, AllowsValidatedUriSan) {

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -826,7 +826,8 @@ public:
     ssl_request.writeBEInt<uint32_t>(8);
     ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
     ASSERT_TRUE(client->write(ssl_request.toString()));
-    client->waitForData("S", true);
+    ASSERT_TRUE(client->waitForData(1, TestUtility::DefaultTimeout));
+    ASSERT_THAT(client->data(), "S");
     enableClientTls(client);
 
     using namespace std::literals::string_literals;
@@ -878,7 +879,8 @@ TEST_P(RbacPostgresIntegrationTest, DenialDoesNotOpenDeferredUpstream) {
   ssl_request.writeBEInt<uint32_t>(8);
   ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
   ASSERT_TRUE(client->write(ssl_request.toString()));
-  client->waitForData("S", true);
+  ASSERT_TRUE(client->waitForData(1, TestUtility::DefaultTimeout));
+  ASSERT_THAT(client->data(), "S");
   enableClientTls(client);
   using namespace std::literals::string_literals;
   const std::string attributes = "user\0postgres\0database\0testdb\0\0"s;

--- a/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_integration_test.cc
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <format>
 
 #include "envoy/extensions/filters/network/tcp_proxy/v3/tcp_proxy.pb.h"
@@ -818,17 +819,28 @@ public:
   }
 
   void checkAuthorization(const std::string& identity, bool allowed) {
+    auto checkpoint = [](const char* stage) {
+      std::fprintf(stderr, "RBAC test: %s\n", stage);
+      std::fflush(stderr);
+    };
+    checkpoint("before initialize");
     initializeRbac(identity);
+    checkpoint("initialized");
     auto client = makeTcpConnection(lookupPort("listener_0"));
+    checkpoint("client created");
     FakeRawConnectionPtr upstream;
     ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream));
+    checkpoint("upstream connected");
     Buffer::OwnedImpl ssl_request;
     ssl_request.writeBEInt<uint32_t>(8);
     ssl_request.writeBEInt<uint32_t>(Postgres::Protocol::SSL_REQUEST_CODE);
     ASSERT_TRUE(client->write(ssl_request.toString()));
+    checkpoint("SSLRequest written");
     ASSERT_TRUE(client->waitForData(1, TestUtility::DefaultTimeout));
     ASSERT_THAT(client->data(), "S");
+    checkpoint("received SSL acceptance S");
     enableClientTls(client);
+    checkpoint("client TLS socket installed");
 
     using namespace std::literals::string_literals;
     const std::string attributes = "user\0postgres\0database\0testdb\0\0"s;
@@ -837,23 +849,32 @@ public:
     startup.writeBEInt<uint32_t>(0x00030000);
     startup.add(attributes);
     ASSERT_TRUE(client->write(startup.toString()));
+    checkpoint("StartupMessage written");
     if (allowed) {
       std::string received;
       ASSERT_TRUE(upstream->waitForData(startup.length(), &received));
+      checkpoint("upstream received StartupMessage");
       ASSERT_THAT(received, startup.toString());
       test_server_->waitForCounter("postgres.postgres_stats.authorization_allowed", Eq(1));
+      checkpoint("authorization allowed counter verified");
       client->close();
+      checkpoint("client closed");
     } else {
       client->waitForData("28000", false);
+      checkpoint("received denial response");
       client->waitForDisconnect();
+      checkpoint("client disconnected");
       ASSERT_THAT(client->data(), testing::HasSubstr("28000"));
       test_server_->waitForCounter("postgres.postgres_stats.authorization_denied", Eq(1));
+      checkpoint("authorization denied counter verified");
     }
     ASSERT_TRUE(upstream->waitForDisconnect());
+    checkpoint("upstream disconnected");
     if (!allowed) {
       std::string received;
       ASSERT_TRUE(upstream->waitForData(0, &received));
       ASSERT_THAT(received, "");
+      checkpoint("upstream received no denied data");
     }
   }
 

--- a/contrib/postgres_proxy/filters/network/test/postgres_rbac_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_rbac_test.cc
@@ -1,0 +1,253 @@
+#include "source/extensions/filters/common/rbac/engine_impl.h"
+#include "source/extensions/filters/network/well_known_names.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/server/server_factory_context.h"
+#include "test/mocks/ssl/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "contrib/postgres_proxy/filters/network/source/postgres_filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace PostgresProxy {
+namespace {
+
+using testing::_;
+using testing::Invoke;
+using testing::Return;
+using testing::ReturnRef;
+using namespace std::literals::string_literals;
+
+class PostgresRbacTest : public testing::Test {
+public:
+  PostgresRbacTest() {
+    PostgresFilterConfig::PostgresFilterConfigOptions options{
+        "test.", false, false,
+        envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::DISABLE,
+        envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::DISABLE};
+    config_ = std::make_shared<PostgresFilterConfig>(options, *store_.rootScope());
+    filter_ = std::make_unique<PostgresFilter>(config_);
+    EXPECT_CALL(read_, connection()).WillRepeatedly(ReturnRef(connection_));
+    EXPECT_CALL(connection_, streamInfo()).WillRepeatedly(ReturnRef(info_));
+    ON_CALL(info_, setDynamicMetadata(_, _))
+        .WillByDefault(Invoke([this](const std::string& name, const Protobuf::Struct& value) {
+          (*info_.metadata_.mutable_filter_metadata())[name].MergeFrom(value);
+        }));
+    ON_CALL(connection_, ssl()).WillByDefault(Return(nullptr));
+    filter_->initializeReadFilterCallbacks(read_);
+    filter_->initializeWriteFilterCallbacks(write_);
+  }
+
+  void rules(const std::string& yaml) {
+    envoy::config::rbac::v3::RBAC rules;
+    TestUtility::loadFromYaml(yaml, rules);
+    config_->engine_ = std::make_unique<Filters::Common::RBAC::RoleBasedAccessControlEngineImpl>(
+        rules, ProtobufMessage::getStrictValidationVisitor(), context_);
+  }
+
+  std::string startup(const std::string& attributes = "user\0postgres\0database\0testdb\0\0"s) {
+    Buffer::OwnedImpl body;
+    body.writeBEInt<uint32_t>(8 + attributes.size());
+    body.writeBEInt<uint32_t>(0x00030000);
+    body.add(attributes);
+    return body.toString();
+  }
+
+  void expectDenied(absl::string_view details = "rbac_access_denied_matched_policy[]") {
+    EXPECT_CALL(info_, setConnectionTerminationDetails(details));
+    EXPECT_CALL(read_, injectReadDataToFilterChain(_, _)).Times(0);
+    EXPECT_CALL(write_, injectWriteDataToFilterChain(_, false))
+        .WillOnce(Invoke([](Buffer::Instance& data, bool) {
+          ASSERT_THAT(data.peekBEInt<char>(0), 'E');
+          ASSERT_THAT(data.toString(), testing::HasSubstr("28000"));
+        }));
+    EXPECT_CALL(connection_, close(Network::ConnectionCloseType::FlushWrite));
+  }
+
+  const Protobuf::Struct& metadata() {
+    return info_.metadata_.filter_metadata().at(NetworkFilterNames::get().PostgresProxy);
+  }
+
+  Stats::IsolatedStoreImpl store_;
+  testing::NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+  testing::StrictMock<Network::MockReadFilterCallbacks> read_;
+  testing::StrictMock<Network::MockWriteFilterCallbacks> write_;
+  testing::NiceMock<Network::MockConnection> connection_;
+  testing::NiceMock<StreamInfo::MockStreamInfo> info_;
+  PostgresFilterConfigSharedPtr config_;
+  std::unique_ptr<PostgresFilter> filter_;
+};
+
+constexpr char Rules[] = R"EOF(
+action: ALLOW
+policies:
+  foo:
+    principals:
+    - any: true
+    permissions:
+    - and_rules:
+        rules:
+        - metadata:
+            filter: envoy.filters.network.postgres_proxy
+            path: [{key: user}]
+            value: {string_match: {exact: postgres}}
+        - metadata:
+            filter: envoy.filters.network.postgres_proxy
+            path: [{key: database}]
+            value: {string_match: {exact: testdb}}
+)EOF";
+
+TEST_F(PostgresRbacTest, AllowsStartup) {
+  rules(Rules);
+  const std::string packet = startup();
+  Buffer::OwnedImpl data(packet);
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::Continue);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 1);
+  ASSERT_THAT(metadata().fields().at("user").string_value(), "postgres");
+  ASSERT_THAT(metadata().fields().at("database").string_value(), "testdb");
+}
+
+TEST_F(PostgresRbacTest, DeniesBeforeUpstreamSSL) {
+  rules(Rules);
+  config_->upstream_ssl_ =
+      envoy::extensions::filters::network::postgres_proxy::v3alpha::PostgresProxy::REQUIRE;
+  expectDenied();
+  Buffer::OwnedImpl data(startup("user\0app\0database\0other\0\0"s));
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+  ASSERT_THAT(data.length(), 0);
+  data.add(startup());
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+  ASSERT_THAT(data.length(), 0);
+  ASSERT_THAT(config_->stats_.authorization_denied_.value(), 1);
+}
+
+TEST_F(PostgresRbacTest, EmptyRulesDeny) {
+  rules("{}");
+  expectDenied();
+  Buffer::OwnedImpl data(startup());
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+}
+
+TEST_F(PostgresRbacTest, DenyRulesAllowUnmatchedConnections) {
+  rules("action: DENY\npolicies: {}\n");
+  Buffer::OwnedImpl data(startup("user\0app\0\0"s));
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::Continue);
+  ASSERT_THAT(metadata().fields().at("database").string_value(), "app");
+}
+
+TEST_F(PostgresRbacTest, LogRulesAllow) {
+  rules("action: LOG\npolicies: {}\n");
+  Buffer::OwnedImpl data(startup());
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::Continue);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 1);
+}
+
+TEST_F(PostgresRbacTest, MatchesPeerUriSan) {
+  rules(R"EOF(
+action: ALLOW
+policies:
+  client:
+    permissions: [{any: true}]
+    principals:
+    - authenticated:
+        principal_name: {exact: "spiffe://example.com/app"}
+)EOF");
+  auto ssl = std::make_shared<testing::NiceMock<Ssl::MockConnectionInfo>>();
+  std::vector<std::string> sans{"spiffe://example.com/app"};
+  ON_CALL(connection_, ssl()).WillByDefault(Return(ssl));
+  EXPECT_CALL(*ssl, uriSanPeerCertificate()).WillRepeatedly(Return(absl::MakeConstSpan(sans)));
+  Buffer::OwnedImpl data(startup());
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::Continue);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 1);
+}
+
+TEST_F(PostgresRbacTest, MissingPeerIdentityDenied) {
+  rules(R"EOF(
+action: ALLOW
+policies:
+  client:
+    permissions: [{any: true}]
+    principals:
+    - authenticated:
+        principal_name: {exact: "spiffe://example.com/app"}
+)EOF");
+  auto ssl = std::make_shared<testing::NiceMock<Ssl::MockConnectionInfo>>();
+  ON_CALL(connection_, ssl()).WillByDefault(Return(ssl));
+  const std::string empty_subject;
+  EXPECT_CALL(*ssl, subjectPeerCertificate()).WillOnce(ReturnRef(empty_subject));
+  expectDenied();
+  Buffer::OwnedImpl data(startup());
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+}
+
+
+TEST_F(PostgresRbacTest, DenyRuleRecordsMatchedPolicyID) {
+  rules(R"EOF(
+action: DENY
+policies:
+  "blocked client":
+    principals: [{any: true}]
+    permissions: [{any: true}]
+)EOF");
+  expectDenied("rbac_access_denied_matched_policy[blocked_client]");
+  Buffer::OwnedImpl data(startup());
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+  ASSERT_THAT(data.length(), 0);
+  ASSERT_THAT(config_->stats_.authorization_denied_.value(), 1);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 0);
+}
+
+TEST_F(PostgresRbacTest, DenySSLPassthrough) {
+  rules("{}");
+  // deny all rules should reject ssl passthrough conns
+  expectDenied();
+  Buffer::OwnedImpl data;
+  data.writeBEInt<uint32_t>(8);
+  data.writeBEInt<uint32_t>(80877103);
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+  ASSERT_THAT(data.length(), 0);
+  ASSERT_THAT(config_->stats_.authorization_denied_.value(), 1);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 0);
+}
+
+TEST_F(PostgresRbacTest, AllowSSLPassthrough) {
+  rules("action: LOG\npolicies: {}\n");
+  
+  Buffer::OwnedImpl data;
+  data.writeBEInt<uint32_t>(8);
+  data.writeBEInt<uint32_t>(80877103);
+
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::Continue);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 1);
+  ASSERT_THAT(config_->stats_.authorization_denied_.value(), 0);
+}
+
+TEST_F(PostgresRbacTest, EmptyStartupValueDoesNotBypassUserDenyRule) {
+  rules(R"EOF(
+action: DENY
+policies:
+  blocked_user:
+    principals: [{any: true}]
+    permissions:
+    - metadata:
+        filter: envoy.filters.network.postgres_proxy
+        path: [{key: user}]
+        value: {string_match: {exact: blocked}}
+)EOF");
+  expectDenied("rbac_access_denied_matched_policy[blocked_user]");
+  Buffer::OwnedImpl data(startup("application_name\0\0user\0blocked\0database\0testdb\0\0"s));
+  ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
+  ASSERT_THAT(data.length(), 0);
+  ASSERT_THAT(metadata().fields().at("user").string_value(), "blocked");
+  ASSERT_THAT(config_->stats_.authorization_denied_.value(), 1);
+  ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 0);
+}
+
+
+} // namespace
+} // namespace PostgresProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/contrib/postgres_proxy/filters/network/test/postgres_rbac_test.cc
+++ b/contrib/postgres_proxy/filters/network/test/postgres_rbac_test.cc
@@ -182,7 +182,6 @@ policies:
   ASSERT_THAT(filter_->onData(data, false), Network::FilterStatus::StopIteration);
 }
 
-
 TEST_F(PostgresRbacTest, DenyRuleRecordsMatchedPolicyID) {
   rules(R"EOF(
 action: DENY
@@ -214,7 +213,7 @@ TEST_F(PostgresRbacTest, DenySSLPassthrough) {
 
 TEST_F(PostgresRbacTest, AllowSSLPassthrough) {
   rules("action: LOG\npolicies: {}\n");
-  
+
   Buffer::OwnedImpl data;
   data.writeBEInt<uint32_t>(8);
   data.writeBEInt<uint32_t>(80877103);
@@ -244,7 +243,6 @@ policies:
   ASSERT_THAT(config_->stats_.authorization_denied_.value(), 1);
   ASSERT_THAT(config_->stats_.authorization_allowed_.value(), 0);
 }
-
 
 } // namespace
 } // namespace PostgresProxy


### PR DESCRIPTION
Commit Message:
support https://github.com/envoyproxy/envoy/issues/15270

Support rbac rules at connection level in postgres_proxy filter. This change is backward compatible. 

- perform rbac check at StartMessage and for ssl passthrough
- set attributes like user and database in dynamic metadata
- If the connection is not allowed, send the error msg to client and close the connection

There are 3 scenarios:
- SSLRequest + ssl passthrough config: evaluate rbac using available connection info(IP/port) when SSLRequest message arrives
- SSLRequest + terminate downstream ssl config: evaluate rbac with connection info, ssl info, and startup attributes when decrypted StartupMessage arrives
- plaintext StartupMessage: evaluate rbac with connection and startup attributes

Additional Description:
Risk Level: low
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
