### PR TITLE
dynamic_modules: support tracing spans across event hooks

### DIFF
--- a/changelogs/current/new_features/dynamic_modules__tracing-spans-across-event-hooks.rst
+++ b/changelogs/current/new_features/dynamic_modules__tracing-spans-across-event-hooks.rst
@@ -1,0 +1,5 @@
+The dynamic modules SDKs can now keep a tracing span past the event hook that created it. The Rust
+SDK ``get_active_span`` and ``spawn_child_span`` return owned spans, so a module can store a child
+span in the filter and finish it from a later event hook such as ``on_scheduled``, which lets a
+span cover off-thread work. The C++ and Go SDKs already supported this and are now documented to
+guarantee it.

--- a/source/extensions/dynamic_modules/sdk/cpp/sdk.h
+++ b/source/extensions/dynamic_modules/sdk/cpp/sdk.h
@@ -352,6 +352,11 @@ struct ClusterHostCounts {
 
 class ChildSpan;
 
+/**
+ * A tracing span for the current HTTP stream. The active span is owned by Envoy and must not be
+ * finished by the module. A span may be stored and used in a later event hook on the same worker
+ * thread. Do not use a span after the stream has ended or move it to another thread.
+ */
 class Span {
 public:
   virtual ~Span() = default;
@@ -367,6 +372,11 @@ public:
   virtual std::unique_ptr<ChildSpan> spawnChild(std::string_view operation) = 0;
 };
 
+/**
+ * A tracing span owned by the module. Call finish when done. A child span may be stored and
+ * finished in a later event hook on the same worker thread, for example to cover off-thread work
+ * that resumes in a scheduled callback.
+ */
 class ChildSpan : public Span {
 public:
   virtual void finish() = 0;
@@ -735,7 +745,8 @@ public:
                                                                SocketDirection direction) = 0;
 
   /**
-   * Retrieves the active tracing span for the current stream.
+   * Retrieves the active tracing span for the current stream. The returned span may be stored and
+   * used in a later event hook on the same worker thread.
    */
   virtual std::unique_ptr<Span> getActiveSpan() = 0;
 

--- a/source/extensions/dynamic_modules/sdk/go/shared/http.go
+++ b/source/extensions/dynamic_modules/sdk/go/shared/http.go
@@ -91,8 +91,10 @@ const (
 )
 
 // Span is a tracing span associated with the current HTTP stream. It is owned by Envoy and is
-// valid for the lifetime of the HTTP stream. Modules MUST NOT call Finish on the active span -
-// it is managed by Envoy. Use SpawnChild to create child spans whose lifetime the module owns.
+// valid for the lifetime of the HTTP stream. Modules MUST NOT call Finish on the active span
+// because it is managed by Envoy. Use SpawnChild to create child spans whose lifetime the module
+// owns. A span may be stored and used in a later event hook on the same worker thread. Do not use
+// a span after the stream has ended or move it to another goroutine.
 type Span interface {
 	// SetTag sets a key/value tag on the span.
 	SetTag(key, value string)
@@ -136,7 +138,8 @@ type Span interface {
 }
 
 // ChildSpan is a tracing span owned by the module. It must be finished by calling Finish when
-// the module is done with it.
+// the module is done with it. A child span may be stored and finished in a later event hook on the
+// same worker thread, for example to cover off-thread work that resumes in a scheduled callback.
 type ChildSpan interface {
 	Span
 

--- a/source/extensions/dynamic_modules/sdk/rust/src/http.rs
+++ b/source/extensions/dynamic_modules/sdk/rust/src/http.rs
@@ -2013,7 +2013,10 @@ pub trait EnvoyHttpFilter {
   ///
   /// The returned span can be used to add tags, logs, or spawn child spans.
   /// The active span is managed by Envoy and should not be finished by the module.
-  fn get_active_span<'a>(&'a self) -> Option<Box<dyn EnvoySpan + 'a>>;
+  ///
+  /// The span may be stored and used in a later event hook on the same worker thread. Do not use
+  /// the active span after the stream has ended and do not move a span to another thread.
+  fn get_active_span(&self) -> Option<Box<dyn EnvoySpan>>;
 
   /// Create a child span from the active span with the given operation name.
   ///
@@ -2022,7 +2025,44 @@ pub trait EnvoyHttpFilter {
   ///
   /// The returned child span must be finished by calling [`EnvoyChildSpan::finish`]
   /// when done. Failing to finish the span will result in incomplete trace data.
-  fn spawn_child_span<'a>(&'a self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan + 'a>>;
+  ///
+  /// The child span is owned by the module, so it may be stored and finished in a later event hook
+  /// on the same worker thread. This is how a span can cover off-thread work, by keeping it in the
+  /// filter and finishing it from [`HttpFilter::on_scheduled`]. Do not move a span to another
+  /// thread.
+  ///
+  /// ```
+  /// use abi::*;
+  /// use envoy_proxy_dynamic_modules_rust_sdk::*;
+  /// use std::cell::RefCell;
+  ///
+  /// struct MyFilter {
+  ///   active_span: RefCell<Option<Box<dyn EnvoySpan>>>,
+  ///   child_span: RefCell<Option<Box<dyn EnvoyChildSpan>>>,
+  /// }
+  /// impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for MyFilter {
+  ///   fn on_request_headers(
+  ///     &self,
+  ///     envoy_filter: &mut EHF,
+  ///     _end_of_stream: bool,
+  ///   ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
+  ///     // Keep the active and child spans so on_scheduled can use them after off-thread work.
+  ///     *self.active_span.borrow_mut() = envoy_filter.get_active_span();
+  ///     *self.child_span.borrow_mut() = envoy_filter.spawn_child_span("off_thread_work");
+  ///     envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+  ///   }
+  ///   fn on_scheduled(&self, envoy_filter: &mut EHF, _event_id: u64) {
+  ///     if let Some(span) = self.active_span.borrow().as_ref() {
+  ///       span.set_tag("completed", "true");
+  ///     }
+  ///     if let Some(mut child) = self.child_span.borrow_mut().take() {
+  ///       child.finish();
+  ///     }
+  ///     envoy_filter.continue_decoding();
+  ///   }
+  /// }
+  /// ```
+  fn spawn_child_span(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan>>;
 
   // ------------------- Cluster/Upstream Information methods -------------------------
 
@@ -2139,7 +2179,9 @@ pub trait EnvoyHttpFilter {
 /// This trait provides methods to interact with a tracing span, such as setting tags,
 /// logging events, and spawning child spans.
 ///
-/// The span is managed by Envoy and should not be finished by the module.
+/// The span is managed by Envoy and should not be finished by the module. A span may be stored and
+/// used in a later event hook on the same worker thread. Do not use a span after the stream has
+/// ended or move it to another thread.
 pub trait EnvoySpan {
   /// Set a tag on this span.
   ///
@@ -2199,7 +2241,7 @@ pub trait EnvoySpan {
   /// Create a child span with the given operation name.
   ///
   /// The child span must be finished by calling [`EnvoyChildSpan::finish`] when done.
-  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan + '_>>;
+  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan>>;
 }
 
 /// Implementation of [`EnvoySpan`] that wraps the raw span pointer from Envoy.
@@ -2324,7 +2366,7 @@ impl EnvoySpan for EnvoySpanImpl {
     }
   }
 
-  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan + '_>> {
+  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan>> {
     let raw_ptr = unsafe {
       abi::envoy_dynamic_module_callback_http_span_spawn_child(
         self.filter_ptr,
@@ -2347,7 +2389,9 @@ impl EnvoySpan for EnvoySpanImpl {
 /// Trait representing a child tracing span created by the module.
 ///
 /// Child spans are owned by the module and must be finished by calling
-/// [`EnvoyChildSpan::finish`] when done.
+/// [`EnvoyChildSpan::finish`] when done. A child span may be stored and finished in a later event
+/// hook on the same worker thread, for example to cover off-thread work. Do not move a span to
+/// another thread.
 pub trait EnvoyChildSpan {
   /// Set a tag on this span.
   fn set_tag(&self, key: &str, value: &str);
@@ -2365,7 +2409,7 @@ pub trait EnvoyChildSpan {
   fn set_baggage(&self, key: &str, value: &str);
 
   /// Create a child span from this span with the given operation name.
-  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan + '_>>;
+  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan>>;
 
   /// Finish and release this span.
   ///
@@ -2431,7 +2475,7 @@ impl EnvoyChildSpan for EnvoyChildSpanImpl {
     }
   }
 
-  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan + '_>> {
+  fn spawn_child(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan>> {
     let raw_ptr = unsafe {
       abi::envoy_dynamic_module_callback_http_span_spawn_child(
         self.filter_ptr,
@@ -4009,7 +4053,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     unsafe { abi::envoy_dynamic_module_callback_http_set_buffer_limit(self.raw_ptr, limit) }
   }
 
-  fn get_active_span<'a>(&'a self) -> Option<Box<dyn EnvoySpan + 'a>> {
+  fn get_active_span(&self) -> Option<Box<dyn EnvoySpan>> {
     let raw_ptr = unsafe { abi::envoy_dynamic_module_callback_http_get_active_span(self.raw_ptr) };
     if raw_ptr.is_null() {
       None
@@ -4021,7 +4065,7 @@ impl EnvoyHttpFilter for EnvoyHttpFilterImpl {
     }
   }
 
-  fn spawn_child_span<'a>(&'a self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan + 'a>> {
+  fn spawn_child_span(&self, operation_name: &str) -> Option<Box<dyn EnvoyChildSpan>> {
     // Get the active span pointer directly.
     let span_ptr = unsafe { abi::envoy_dynamic_module_callback_http_get_active_span(self.raw_ptr) };
     if span_ptr.is_null() {

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -164,7 +164,11 @@ envoy_cc_dyn_module_test(
     },
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/registry",
+        "//envoy/server:tracer_config_interface",
+        "//envoy/tracing:trace_driver_interface",
         "//source/common/common:minimal_logger_lib",
+        "//source/common/protobuf",
         "//source/extensions/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:abi_impl",
         "//source/extensions/filters/http/dynamic_modules:factory_registration",

--- a/test/extensions/dynamic_modules/http/filter_test.cc
+++ b/test/extensions/dynamic_modules/http/filter_test.cc
@@ -874,6 +874,51 @@ TEST_P(DynamicModuleHttpLanguageTests, SpanCallbacks) {
   filter->onDestroy();
 }
 
+TEST_P(DynamicModuleHttpLanguageTests, SpanAcrossCallbacks) {
+  const std::string filter_name = "span_across_callbacks";
+  const std::string filter_config = "";
+
+  auto dynamic_module = newDynamicModule(testSharedObjectPath("http", GetParam()), false);
+  EXPECT_OK(dynamic_module);
+
+  NiceMock<Server::Configuration::MockServerFactoryContext> context;
+  Stats::IsolatedStoreImpl stats_store;
+  auto filter_config_or_status =
+      Envoy::Extensions::DynamicModules::HttpFilters::newDynamicModuleHttpFilterConfig(
+          filter_name, filter_config, DefaultMetricsNamespace, false,
+          std::move(dynamic_module.value()), *stats_store.createScope(""), context);
+  ASSERT_OK(filter_config_or_status);
+
+  auto filter = std::make_shared<DynamicModuleHttpFilter>(filter_config_or_status.value(),
+                                                          stats_store.symbolTable(), 0);
+  filter->initializeInModuleFilter();
+
+  NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks;
+  NiceMock<Tracing::MockSpan> span;
+  auto* child_span = new NiceMock<Tracing::MockSpan>();
+  EXPECT_CALL(callbacks, activeSpan()).WillRepeatedly(testing::ReturnRef(span));
+  EXPECT_CALL(span, spawnChild_(_, "child", _)).WillOnce(testing::Return(child_span));
+  Http::TestRequestHeaderMapImpl request_headers{{}};
+  EXPECT_CALL(callbacks, requestHeaders())
+      .WillRepeatedly(testing::Return(makeOptRef<RequestHeaderMap>(request_headers)));
+  filter->setDecoderFilterCallbacks(callbacks);
+
+  // The first event hook spawns and stores the child span. It must not be tagged or finished yet.
+  EXPECT_CALL(*child_span, setTag(_, _)).Times(0);
+  EXPECT_CALL(*child_span, finishSpan()).Times(0);
+  EXPECT_EQ(FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
+  EXPECT_EQ(request_headers.get_("x-span-stored"), "true");
+  testing::Mock::VerifyAndClearExpectations(child_span);
+
+  // The stored child span is finished in a later event hook, proving it outlived the first one.
+  EXPECT_CALL(*child_span, setTag("child-key", "child-value"));
+  EXPECT_CALL(*child_span, finishSpan());
+  Http::TestRequestTrailerMapImpl request_trailers{};
+  EXPECT_EQ(FilterTrailersStatus::Continue, filter->decodeTrailers(request_trailers));
+
+  filter->onDestroy();
+}
+
 TEST_P(DynamicModuleHttpLanguageTests, ClusterCallbacks) {
   const std::string filter_name = "cluster_callbacks";
   const std::string filter_config = "";

--- a/test/extensions/dynamic_modules/http/integration_test.cc
+++ b/test/extensions/dynamic_modules/http/integration_test.cc
@@ -1,13 +1,84 @@
+#include <atomic>
+
 #include "envoy/extensions/filters/http/dynamic_modules/v3/dynamic_modules.pb.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/tracer_config.h"
+#include "envoy/tracing/trace_driver.h"
 
 #include "source/common/common/base64.h"
 #include "source/common/common/logger.h"
+#include "source/common/protobuf/protobuf.h"
 
 #include "test/extensions/dynamic_modules/util.h"
 #include "test/integration/http_integration.h"
 #include "test/test_common/logging.h"
 
 namespace Envoy {
+
+namespace {
+
+// Counts child spans named "off_thread_work" that were finished, so SpanAcrossCallbacks can confirm
+// a span spawned in on_request_headers was finished from a later event hook.
+std::atomic<uint32_t>& offThreadWorkSpansFinished() {
+  static std::atomic<uint32_t> counter{0};
+  return counter;
+}
+
+// A minimal tracer that keeps the active span non-null so a module can spawn and finish real child
+// spans. Only the child operation name matters here, so every other method is a no-op.
+class TestTracerSpan : public Tracing::Span {
+public:
+  explicit TestTracerSpan(std::string operation) : operation_(std::move(operation)) {}
+  void setOperation(absl::string_view operation) override { operation_ = std::string(operation); }
+  void setTag(absl::string_view, absl::string_view) override {}
+  void log(SystemTime, const std::string&) override {}
+  void finishSpan() override {
+    if (operation_ == "off_thread_work") {
+      offThreadWorkSpansFinished().fetch_add(1);
+    }
+  }
+  void injectContext(Tracing::TraceContext&, const Tracing::UpstreamContext&) override {}
+  Tracing::SpanPtr spawnChild(const Tracing::Config&, const std::string& name,
+                              SystemTime) override {
+    return std::make_unique<TestTracerSpan>(name);
+  }
+  void setSampled(bool) override {}
+  bool exportedSpan() const override { return false; }
+  bool useLocalDecision() const override { return false; }
+  std::string getBaggage(absl::string_view) override { return ""; }
+  void setBaggage(absl::string_view, absl::string_view) override {}
+  std::string getTraceId() const override { return ""; }
+  std::string getSpanId() const override { return ""; }
+
+private:
+  std::string operation_;
+};
+
+class TestTracerDriver : public Tracing::Driver {
+public:
+  Tracing::SpanPtr startSpan(const Tracing::Config&, Tracing::TraceContext&,
+                             const StreamInfo::StreamInfo&, const std::string& operation_name,
+                             Tracing::Decision) override {
+    return std::make_unique<TestTracerSpan>(operation_name);
+  }
+};
+
+class TestTracerFactory : public Server::Configuration::TracerFactory {
+public:
+  Tracing::DriverSharedPtr
+  createTracerDriver(const Protobuf::Message&,
+                     Server::Configuration::TracerFactoryContext&) override {
+    return std::make_shared<TestTracerDriver>();
+  }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<Protobuf::Struct>();
+  }
+  std::string name() const override { return "envoy.tracers.dynamic_modules_test"; }
+};
+
+REGISTER_FACTORY(TestTracerFactory, Server::Configuration::TracerFactory);
+
+} // namespace
 
 class DynamicModulesIntegrationTest : public testing::TestWithParam<std::string>,
                                       public HttpIntegrationTest {
@@ -780,6 +851,36 @@ TEST_P(DynamicModulesIntegrationTest, Scheduler) {
   ASSERT_TRUE(response->waitForEndStream());
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
+// A module spawns a child span in on_request_headers, does off-thread work, and finishes the span
+// from the scheduled event hook. The request completes and the tracer confirms the span was
+// finished, proving a span can outlive the event hook that created it.
+TEST_P(DynamicModulesIntegrationTest, SpanAcrossCallbacks) {
+  config_helper_.addConfigModifier(
+      [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+             hcm) {
+        auto* tracing = hcm.mutable_tracing();
+        // Always trace so the active span is present and the module can spawn a child span.
+        tracing->mutable_random_sampling()->set_value(100.0);
+        auto* provider = tracing->mutable_provider();
+        provider->set_name("envoy.tracers.dynamic_modules_test");
+        std::ignore = provider->mutable_typed_config()->PackFrom(Protobuf::Struct());
+      });
+  const uint32_t before = offThreadWorkSpansFinished().load();
+  initializeFilter("span_across_callbacks");
+  codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
+
+  auto encoder_decoder = codec_client_->startRequest(default_request_headers_, true);
+  auto response = std::move(encoder_decoder.second);
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_GE(offThreadWorkSpansFinished().load(), before + 1);
 }
 
 // Regression test for the shared continue-flag wedge. The upstream replies complete at headers

--- a/test/extensions/dynamic_modules/test_data/cpp/http.cc
+++ b/test/extensions/dynamic_modules/test_data/cpp/http.cc
@@ -554,6 +554,60 @@ public:
 
 REGISTER_HTTP_FILTER_CONFIG_FACTORY(SpanCallbacksConfigFactory, "span_callbacks");
 
+// --- span_across_callbacks ---
+
+// Spawns a child span in onRequestHeaders, keeps it, and finishes it in onRequestTrailers to show
+// that a span can outlive the event hook that created it.
+class SpanAcrossCallbacksFilter : public HttpFilter {
+public:
+  explicit SpanAcrossCallbacksFilter(HttpFilterHandle& handle) : handle_(handle) {}
+
+  HeadersStatus onRequestHeaders(HeaderMap& headers, bool) override {
+    auto span = handle_.getActiveSpan();
+    if (span != nullptr) {
+      child_span_ = span->spawnChild("child");
+    }
+    headers.set("x-span-stored", "true");
+    return HeadersStatus::Continue;
+  }
+
+  TrailersStatus onRequestTrailers(HeaderMap&) override {
+    if (child_span_ != nullptr) {
+      child_span_->setTag("child-key", "child-value");
+      child_span_->finish();
+      child_span_.reset();
+    }
+    return TrailersStatus::Continue;
+  }
+
+  BodyStatus onRequestBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
+  HeadersStatus onResponseHeaders(HeaderMap&, bool) override { return HeadersStatus::Continue; }
+  BodyStatus onResponseBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
+  TrailersStatus onResponseTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
+  void onStreamComplete() override {}
+  void onDestroy() override {}
+
+private:
+  HttpFilterHandle& handle_;
+  std::unique_ptr<ChildSpan> child_span_;
+};
+
+class SpanAcrossCallbacksFactory : public HttpFilterFactory {
+public:
+  std::unique_ptr<HttpFilter> create(HttpFilterHandle& handle) override {
+    return std::make_unique<SpanAcrossCallbacksFilter>(handle);
+  }
+};
+
+class SpanAcrossCallbacksConfigFactory : public HttpFilterConfigFactory {
+public:
+  std::unique_ptr<HttpFilterFactory> create(HttpFilterConfigHandle&, std::string_view) override {
+    return std::make_unique<SpanAcrossCallbacksFactory>();
+  }
+};
+
+REGISTER_HTTP_FILTER_CONFIG_FACTORY(SpanAcrossCallbacksConfigFactory, "span_across_callbacks");
+
 // --- cluster_callbacks ---
 
 class ClusterCallbacksFilter : public HttpFilter {

--- a/test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
+++ b/test/extensions/dynamic_modules/test_data/cpp/http_integration_test.cc
@@ -887,6 +887,62 @@ public:
 REGISTER_HTTP_FILTER_CONFIG_FACTORY(HttpFilterSchedulerConfigFactory, "http_filter_scheduler");
 
 // -----------------------------------------------------------------------------
+// SpanAcrossCallbacks
+// -----------------------------------------------------------------------------
+
+// Spawns a child span in onRequestHeaders, starts off-thread work, and finishes the span from the
+// scheduled callback to show that a span can cover work that runs between event hooks.
+class SpanAcrossCallbacksFilter : public HttpFilter {
+public:
+  SpanAcrossCallbacksFilter(HttpFilterHandle& handle) : handle_(handle) {}
+
+  HeadersStatus onRequestHeaders(HeaderMap&, bool) override {
+    auto span = handle_.getActiveSpan();
+    if (span != nullptr) {
+      child_span_ = span->spawnChild("off_thread_work");
+    }
+    auto sched = handle_.getScheduler();
+    sched->schedule([this]() {
+      if (child_span_ != nullptr) {
+        child_span_->setTag("completed", "true");
+        child_span_->finish();
+        child_span_.reset();
+      }
+      handle_.continueRequest();
+    });
+    return HeadersStatus::StopAllAndBuffer;
+  }
+
+  void onStreamComplete() override {}
+  void onDestroy() override {}
+  TrailersStatus onRequestTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
+  BodyStatus onRequestBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
+  HeadersStatus onResponseHeaders(HeaderMap&, bool) override { return HeadersStatus::Continue; }
+  BodyStatus onResponseBody(BodyBuffer&, bool) override { return BodyStatus::Continue; }
+  TrailersStatus onResponseTrailers(HeaderMap&) override { return TrailersStatus::Continue; }
+
+private:
+  HttpFilterHandle& handle_;
+  std::unique_ptr<ChildSpan> child_span_;
+};
+
+class SpanAcrossCallbacksFilterFactory : public HttpFilterFactory {
+public:
+  std::unique_ptr<HttpFilter> create(HttpFilterHandle& handle) override {
+    return std::make_unique<SpanAcrossCallbacksFilter>(handle);
+  }
+};
+
+class SpanAcrossCallbacksConfigFactory : public HttpFilterConfigFactory {
+public:
+  std::unique_ptr<HttpFilterFactory> create(HttpFilterConfigHandle&, std::string_view) override {
+    return std::make_unique<SpanAcrossCallbacksFilterFactory>();
+  }
+};
+
+REGISTER_HTTP_FILTER_CONFIG_FACTORY(SpanAcrossCallbacksConfigFactory, "span_across_callbacks");
+
+// -----------------------------------------------------------------------------
 // FakeExternalCache
 // -----------------------------------------------------------------------------
 

--- a/test/extensions/dynamic_modules/test_data/go/http/http.go
+++ b/test/extensions/dynamic_modules/test_data/go/http/http.go
@@ -18,6 +18,7 @@ func init() {
 		"recreate_stream":            &recreateStreamConfigFactory{},
 		"socket_option_callbacks":    &socketOptionCallbacksConfigFactory{},
 		"span_callbacks":             &spanCallbacksConfigFactory{},
+		"span_across_callbacks":      &spanAcrossCallbacksConfigFactory{},
 		"cluster_callbacks":          &clusterCallbacksConfigFactory{},
 		"send_response":              &sendResponseConfigFactory{},
 		"dynamic_metadata_callbacks": &dynamicMetadataCallbacksConfigFactory{},
@@ -443,6 +444,51 @@ func (p *spanCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
 	}
 	headers.Set("x-span-callbacks", "true")
 	return shared.HeadersStatusContinue
+}
+
+// --- span_across_callbacks ---
+type spanAcrossCallbacksConfigFactory struct {
+	shared.EmptyHttpFilterConfigFactory
+}
+
+type spanAcrossCallbacksFactory struct {
+	shared.EmptyHttpFilterFactory
+}
+
+func (f *spanAcrossCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
+	config []byte) (shared.HttpFilterFactory, error) {
+	return &spanAcrossCallbacksFactory{}, nil
+}
+
+// spanAcrossCallbacksFilter spawns a child span in OnRequestHeaders, keeps it, and finishes it in
+// OnRequestTrailers to show that a span can outlive the event hook that created it.
+type spanAcrossCallbacksFilter struct {
+	handle    shared.HttpFilterHandle
+	childSpan shared.ChildSpan
+	shared.EmptyHttpFilter
+}
+
+func (f *spanAcrossCallbacksFactory) Create(handle shared.HttpFilterHandle) shared.HttpFilter {
+	return &spanAcrossCallbacksFilter{handle: handle}
+}
+
+func (p *spanAcrossCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
+	endOfStream bool) shared.HeadersStatus {
+	if span := p.handle.GetActiveSpan(); span != nil {
+		p.childSpan = span.SpawnChild("child")
+	}
+	headers.Set("x-span-stored", "true")
+	return shared.HeadersStatusContinue
+}
+
+func (p *spanAcrossCallbacksFilter) OnRequestTrailers(
+	trailers shared.HeaderMap) shared.TrailersStatus {
+	if p.childSpan != nil {
+		p.childSpan.SetTag("child-key", "child-value")
+		p.childSpan.Finish()
+		p.childSpan = nil
+	}
+	return shared.TrailersStatusContinue
 }
 
 // --- cluster_callbacks ---

--- a/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
+++ b/test/extensions/dynamic_modules/test_data/go/http_integration_test/http_integration_test.go
@@ -26,6 +26,7 @@ func init() {
 		"http_callouts":                &HttpCalloutsConfigFactory{},
 		"send_response":                &SendResponseConfigFactory{},
 		"http_filter_scheduler":        &HttpFilterSchedulerConfigFactory{},
+		"span_across_callbacks":        &SpanAcrossCallbacksConfigFactory{},
 		"fake_external_cache":          &FakeExternalCacheConfigFactory{},
 		"stats_callbacks":              &StatsCallbacksConfigFactory{},
 		"streaming_terminal_filter":    &StreamingTerminalConfigFactory{},
@@ -727,6 +728,54 @@ func (p *HttpFilterSchedulerFilter) OnStreamComplete() {
 
 	// Force the GC to release the scheduler and related C resources.
 	runtime.GC()
+}
+
+// -----------------------------------------------------------------------------
+// SpanAcrossCallbacks
+// -----------------------------------------------------------------------------
+
+type SpanAcrossCallbacksConfigFactory struct {
+	shared.EmptyHttpFilterConfigFactory
+}
+
+func (f *SpanAcrossCallbacksConfigFactory) Create(handle shared.HttpFilterConfigHandle,
+	c []byte) (shared.HttpFilterFactory, error) {
+	return &SpanAcrossCallbacksFilterFactory{}, nil
+}
+
+type SpanAcrossCallbacksFilterFactory struct {
+	shared.EmptyHttpFilterFactory
+}
+
+func (f *SpanAcrossCallbacksFilterFactory) Create(h shared.HttpFilterHandle) shared.HttpFilter {
+	return &SpanAcrossCallbacksFilter{handle: h}
+}
+
+// SpanAcrossCallbacksFilter spawns a child span in OnRequestHeaders, starts off-thread work, and
+// finishes the span from the scheduled callback to show a span can cover work between event hooks.
+type SpanAcrossCallbacksFilter struct {
+	shared.EmptyHttpFilter
+	handle    shared.HttpFilterHandle
+	childSpan shared.ChildSpan
+}
+
+func (p *SpanAcrossCallbacksFilter) OnRequestHeaders(headers shared.HeaderMap,
+	endOfStream bool) shared.HeadersStatus {
+	if span := p.handle.GetActiveSpan(); span != nil {
+		p.childSpan = span.SpawnChild("off_thread_work")
+	}
+	sched := p.handle.GetScheduler()
+	go func() {
+		sched.Schedule(func() {
+			if p.childSpan != nil {
+				p.childSpan.SetTag("completed", "true")
+				p.childSpan.Finish()
+				p.childSpan = nil
+			}
+			p.handle.ContinueRequest()
+		})
+	}()
+	return shared.HeadersStatusStop
 }
 
 // -----------------------------------------------------------------------------

--- a/test/extensions/dynamic_modules/test_data/rust/http.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http.rs
@@ -87,6 +87,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     "destroy_logging" => Some(Box::new(DestroyLoggingFilterConfig {})),
     "socket_option_callbacks" => Some(Box::new(SocketOptionCallbacksFilterConfig {})),
     "span_callbacks" => Some(Box::new(SpanCallbacksFilterConfig {})),
+    "span_across_callbacks" => Some(Box::new(SpanAcrossCallbacksFilterConfig {})),
     "cluster_callbacks" => Some(Box::new(ClusterCallbacksFilterConfig {})),
     "send_response" => Some(Box::new(SendResponseFilterConfig {})),
     "dynamic_metadata_callbacks" => Some(Box::new(DynamicMetadataCallbacksFilterConfig {})),
@@ -757,6 +758,47 @@ impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SpanCallbacksFilter {
     }
     envoy_filter.set_request_header("x-span-callbacks", b"true");
     abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+}
+
+struct SpanAcrossCallbacksFilterConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for SpanAcrossCallbacksFilterConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(SpanAcrossCallbacksFilter {
+      child_span: RefCell::new(None),
+    })
+  }
+}
+
+/// Spawns a child span in on_request_headers, keeps it, and finishes it in on_request_trailers to
+/// show that a span can outlive the event hook that created it.
+struct SpanAcrossCallbacksFilter {
+  child_span: RefCell<Option<Box<dyn EnvoyChildSpan>>>,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SpanAcrossCallbacksFilter {
+  fn on_request_headers(
+    &self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    if let Some(span) = envoy_filter.get_active_span() {
+      *self.child_span.borrow_mut() = span.spawn_child("child");
+    }
+    envoy_filter.set_request_header("x-span-stored", b"true");
+    abi::envoy_dynamic_module_type_on_http_filter_request_headers_status::Continue
+  }
+
+  fn on_request_trailers(
+    &self,
+    _envoy_filter: &mut EHF,
+  ) -> abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status {
+    if let Some(mut child) = self.child_span.borrow_mut().take() {
+      child.set_tag("child-key", "child-value");
+      child.finish();
+    }
+    abi::envoy_dynamic_module_type_on_http_filter_request_trailers_status::Continue
   }
 }
 

--- a/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
+++ b/test/extensions/dynamic_modules/test_data/rust/http_integration_test.rs
@@ -43,6 +43,7 @@ fn new_http_filter_config_fn<EC: EnvoyHttpFilterConfig, EHF: EnvoyHttpFilter>(
     })),
     "send_response" => Some(Box::new(SendResponseHttpFilterConfig::new(config))),
     "http_filter_scheduler" => Some(Box::new(HttpFilterSchedulerConfig {})),
+    "span_across_callbacks" => Some(Box::new(SpanAcrossCallbacksConfig {})),
     "early_response_during_upload" => Some(Box::new(EarlyResponseDuringUploadConfig {
       response_pause_total: envoy_filter_config
         .define_counter("response_pause_total")
@@ -1309,6 +1310,58 @@ impl Drop for HttpFilterScheduler {
     assert_eq!(*self.event_ids.borrow(), vec![0, 1, 2, 3]);
     assert_eq!(self.thread_handles.borrow().len(), 2);
     for thread in self.thread_handles.borrow_mut().drain(..) {
+      thread.join().expect("Failed to join thread");
+    }
+  }
+}
+
+struct SpanAcrossCallbacksConfig {}
+
+impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for SpanAcrossCallbacksConfig {
+  fn new_http_filter(&self, _envoy: &mut EHF) -> Box<dyn HttpFilter<EHF>> {
+    Box::new(SpanAcrossCallbacksFilter {
+      child_span: RefCell::new(None),
+      thread_handle: RefCell::new(None),
+    })
+  }
+}
+
+/// Spawns a child span in on_request_headers, starts off-thread work, and finishes the span from
+/// on_scheduled to show that a span can cover work that runs between event hooks.
+struct SpanAcrossCallbacksFilter {
+  child_span: RefCell<Option<Box<dyn EnvoyChildSpan>>>,
+  thread_handle: RefCell<Option<std::thread::JoinHandle<()>>>,
+}
+
+impl<EHF: EnvoyHttpFilter> HttpFilter<EHF> for SpanAcrossCallbacksFilter {
+  fn on_request_headers(
+    &self,
+    envoy_filter: &mut EHF,
+    _end_of_stream: bool,
+  ) -> envoy_dynamic_module_type_on_http_filter_request_headers_status {
+    if let Some(span) = envoy_filter.get_active_span() {
+      *self.child_span.borrow_mut() = span.spawn_child("off_thread_work");
+    }
+    let scheduler = envoy_filter.new_scheduler();
+    let thread = std::thread::spawn(move || {
+      scheduler.commit(1);
+    });
+    *self.thread_handle.borrow_mut() = Some(thread);
+    envoy_dynamic_module_type_on_http_filter_request_headers_status::StopIteration
+  }
+
+  fn on_scheduled(&self, envoy_filter: &mut EHF, _event_id: u64) {
+    if let Some(mut child) = self.child_span.borrow_mut().take() {
+      child.set_tag("completed", "true");
+      child.finish();
+    }
+    envoy_filter.continue_decoding();
+  }
+}
+
+impl Drop for SpanAcrossCallbacksFilter {
+  fn drop(&mut self) {
+    if let Some(thread) = self.thread_handle.borrow_mut().take() {
       thread.join().expect("Failed to join thread");
     }
   }


### PR DESCRIPTION
## Description

This PR lets dynamic module HTTP filters keep a tracing span past the event hook that created it. A module can start a child span while handling request headers and finish it from a later event hook, for example after off-thread work completes. The Rust SDK previously tied spans to a single event hook, so this was not possible.

Fix https://github.com/envoyproxy/envoy/issues/47187

---

**Commit Message:** dynamic_modules: support tracing spans across event hooks
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** Added
**Release Notes:** Added