### PR TITLE
fix flaky tsan tests

### DIFF
--- a/source/common/http/header_utility.cc
+++ b/source/common/http/header_utility.cc
@@ -530,10 +530,10 @@ Http::Status HeaderUtility::checkRequiredRequestHeaders(const Http::RequestHeade
   return Http::okStatus();
 }
 
-bool HeaderUtility::disable_request_header_validation_for_tests_ = false;
+std::atomic<bool> HeaderUtility::disable_request_header_validation_for_tests_{false};
 
 Http::Status HeaderUtility::checkValidRequestHeaders(const Http::RequestHeaderMap& headers) {
-  if (disable_request_header_validation_for_tests_) {
+  if (disable_request_header_validation_for_tests_.load(std::memory_order_relaxed)) {
     return Http::okStatus();
   }
 

--- a/source/common/http/header_utility.h
+++ b/source/common/http/header_utility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <vector>
 
 #include "envoy/common/matchers.h"
@@ -515,8 +516,11 @@ public:
    * When set, checkValidRequestHeaders() accepts every header name and value. This lets
    * integration tests drive Envoy's own codecs to send deliberately malformed requests at
    * Envoy's server codecs. Never set this outside of tests.
+   *
+   * Atomic because tests clear it while Envoy's worker threads are still running, and those
+   * threads read it whenever they encode an upstream request.
    */
-  static bool disable_request_header_validation_for_tests_;
+  static std::atomic<bool> disable_request_header_validation_for_tests_;
 
   /**
    * Returns true if a header may be safely removed without causing additional

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -138,12 +138,11 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "ext_authz_integration_test",
-    size = "large",
     srcs = ["ext_authz_integration_test.cc"],
     data = ["ext_authz.yaml"],
     extension_names = ["envoy.filters.http.ext_authz"],
-    rbe_pool = "linux_x64_small",
-    shard_count = 4,
+    rbe_pool = "linux_x64_medium",
+    shard_count = 8,
     deps = [
         ":ext_authz_fuzz_proto_cc_proto",
         ":logging_test_filter_lib",

--- a/test/extensions/filters/http/ext_authz/BUILD
+++ b/test/extensions/filters/http/ext_authz/BUILD
@@ -138,6 +138,7 @@ envoy_extension_cc_test(
 
 envoy_extension_cc_test(
     name = "ext_authz_integration_test",
+    size = "large",
     srcs = ["ext_authz_integration_test.cc"],
     data = ["ext_authz.yaml"],
     extension_names = ["envoy.filters.http.ext_authz"],

--- a/test/extensions/filters/http/ext_authz/config_test.cc
+++ b/test/extensions/filters/http/ext_authz/config_test.cc
@@ -1,6 +1,8 @@
 // Changing the default behavior of ext_authz is generally not allowed. While you may add tests, you
 // generally should not change or remove existing tests.
 
+#include <atomic>
+
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/core/v3/grpc_service.pb.h"
 #include "envoy/extensions/filters/http/ext_authz/v3/ext_authz.pb.h"
@@ -905,7 +907,9 @@ TEST_F(ExtAuthzFilterGrpcTest, GrpcClientFactoryPerRouteGrpcServiceOverride) {
   FilterConfigPerRoute per_route_filter_config = makePerRoute(per_route_proto);
 
   auto mock_per_route_grpc_client = std::make_shared<NiceMock<Grpc::MockAsyncClient>>();
-  bool per_route_cluster_requested = false;
+  // `runOnAllWorkersBlocking()` below releases every worker into the body at once, so this is
+  // written concurrently from all of them.
+  std::atomic<bool> per_route_cluster_requested{false};
   EXPECT_CALL(context_.server_factory_context_.cluster_manager_.async_client_manager_,
               getOrCreateRawAsyncClientWithHashKey(_, _, true))
       .WillRepeatedly(

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -378,7 +378,6 @@ void HttpIntegrationTest::useAccessLog(
 }
 
 HttpIntegrationTest::~HttpIntegrationTest() {
-  Http::HeaderUtility::disable_request_header_validation_for_tests_ = false;
   // Make sure any open streams have been closed. If there's an open stream, the decoder will
   // be out of scope, and so open streams result in writing to freed memory.
   if (codec_client_) {
@@ -386,6 +385,11 @@ HttpIntegrationTest::~HttpIntegrationTest() {
         << "test requires explicit cleanupUpstreamAndDownstream";
   }
   cleanupUpstreamAndDownstream();
+  // Reset last, once the connections are torn down. The server's workers outlive this destructor
+  // (`test_server_` belongs to the base class), so they may still read the flag; it is atomic for
+  // that reason.
+  Http::HeaderUtility::disable_request_header_validation_for_tests_.store(
+      false, std::memory_order_relaxed);
 }
 
 void HttpIntegrationTest::initialize() {

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -390,10 +390,13 @@ protected:
 
   // Stops the codecs from validating the request headers they encode, so that a test can use
   // Envoy's own client codecs to send a deliberately malformed request at Envoy. Only needed in
-  // non-UHV builds, where the codecs do this check themselves; the destructor restores it.
+  // non-UHV builds, where the codecs do this check themselves; the destructor restores it. Call
+  // this before initialize(), so that the write is ordered before the workers that read the flag
+  // are created.
   // TODO(yanavlasov): fold this into `disable_client_header_validation_`.
   void disableCodecHeaderValidation() {
-    Http::HeaderUtility::disable_request_header_validation_for_tests_ = true;
+    Http::HeaderUtility::disable_request_header_validation_for_tests_.store(
+        true, std::memory_order_relaxed);
   }
 
 #ifdef ENVOY_ENABLE_QUIC

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -132,10 +132,9 @@ TEST_P(IntegrationAdminTest, Admin) {
   // flush merges the admin request/connection histograms into the parent store and marks them
   // used. The default 5s flush interval is shorter than a slow run of this test, so push it out to
   // the configurable maximum (the proto caps this just under 5m) rather than racing the timer.
-  config_helper_.addConfigModifier(
-      [](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
-        bootstrap.mutable_stats_flush_interval()->set_seconds(299);
-      });
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+    bootstrap.mutable_stats_flush_interval()->set_seconds(299);
+  });
   initialize();
 
   BufferingStreamDecoderPtr response;

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -128,6 +128,14 @@ TEST_P(IntegrationAdminTest, AdminLogging) {
 }
 
 TEST_P(IntegrationAdminTest, Admin) {
+  // The `usedonly` assertions below expect no histograms, which only holds until the first stats
+  // flush merges the admin request/connection histograms into the parent store and marks them
+  // used. The default 5s flush interval is shorter than a slow run of this test, so push it out to
+  // the configurable maximum (the proto caps this just under 5m) rather than racing the timer.
+  config_helper_.addConfigModifier(
+      [](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {
+        bootstrap.mutable_stats_flush_interval()->set_seconds(299);
+      });
   initialize();
 
   BufferingStreamDecoderPtr response;


### PR DESCRIPTION
Commit Message: fix flaky tsan tests
Additional Description:
Make `HeaderUtility::disable_request_header_validation_for_tests_` std::atomic so any read/write across threads are not tsan errors.
