### PR TITLE
http/cache_v2: fix Cache-Control directive name matching to be case-insensitive

### DIFF
--- a/changelogs/current/bug_fixes/http_cache__case_insensitive_cache_control.rst
+++ b/changelogs/current/bug_fixes/http_cache__case_insensitive_cache_control.rst
@@ -1,0 +1,3 @@
+http cache: fixed cache and cache_v2 to ignore case in Cache-Control directive names, as required by
+`RFC 9111 section 5.2 <https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2>`_. Responses with
+``Private`` or ``No-Store`` are now rejected by the cache, just like ``private`` or ``no-store``.

--- a/source/extensions/filters/http/cache/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache/cache_headers_utils.cc
@@ -67,20 +67,23 @@ RequestCacheControl::RequestCacheControl(absl::string_view cache_control_header)
   for (auto full_directive : directives) {
     absl::string_view directive, argument;
     std::tie(directive, argument) = separateDirectiveAndArgument(full_directive);
+    // Directive names are case-insensitive per RFC 9111 section 5.2:
+    // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2
+    const std::string lowercase_directive = absl::AsciiStrToLower(directive);
 
-    if (directive == "no-cache") {
+    if (lowercase_directive == "no-cache") {
       must_validate_ = true;
-    } else if (directive == "no-store") {
+    } else if (lowercase_directive == "no-store") {
       no_store_ = true;
-    } else if (directive == "no-transform") {
+    } else if (lowercase_directive == "no-transform") {
       no_transform_ = true;
-    } else if (directive == "only-if-cached") {
+    } else if (lowercase_directive == "only-if-cached") {
       only_if_cached_ = true;
-    } else if (directive == "max-age") {
+    } else if (lowercase_directive == "max-age") {
       max_age_ = parseDuration(argument);
-    } else if (directive == "min-fresh") {
+    } else if (lowercase_directive == "min-fresh") {
       min_fresh_ = parseDuration(argument);
-    } else if (directive == "max-stale") {
+    } else if (lowercase_directive == "max-stale") {
       max_stale_ = argument.empty() ? SystemTime::duration::max() : parseDuration(argument);
     }
   }
@@ -92,22 +95,26 @@ ResponseCacheControl::ResponseCacheControl(absl::string_view cache_control_heade
   for (auto full_directive : directives) {
     absl::string_view directive, argument;
     std::tie(directive, argument) = separateDirectiveAndArgument(full_directive);
+    // Directive names are case-insensitive per RFC 9111 section 5.2:
+    // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2
+    const std::string lowercase_directive = absl::AsciiStrToLower(directive);
 
-    if (directive == "no-cache") {
+    if (lowercase_directive == "no-cache") {
       // If no-cache directive has arguments they are ignored - not handled.
       must_validate_ = true;
-    } else if (directive == "must-revalidate" || directive == "proxy-revalidate") {
+    } else if (lowercase_directive == "must-revalidate" ||
+               lowercase_directive == "proxy-revalidate") {
       no_stale_ = true;
-    } else if (directive == "no-store" || directive == "private") {
+    } else if (lowercase_directive == "no-store" || lowercase_directive == "private") {
       // If private directive has arguments they are ignored - not handled.
       no_store_ = true;
-    } else if (directive == "no-transform") {
+    } else if (lowercase_directive == "no-transform") {
       no_transform_ = true;
-    } else if (directive == "public") {
+    } else if (lowercase_directive == "public") {
       is_public_ = true;
-    } else if (directive == "s-maxage") {
+    } else if (lowercase_directive == "s-maxage") {
       max_age_ = parseDuration(argument);
-    } else if (!max_age_.has_value() && directive == "max-age") {
+    } else if (!max_age_.has_value() && lowercase_directive == "max-age") {
       max_age_ = parseDuration(argument);
     }
   }

--- a/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
+++ b/source/extensions/filters/http/cache_v2/cache_headers_utils.cc
@@ -69,20 +69,23 @@ RequestCacheControl::RequestCacheControl(absl::string_view cache_control_header)
   for (auto full_directive : directives) {
     absl::string_view directive, argument;
     std::tie(directive, argument) = separateDirectiveAndArgument(full_directive);
+    // Directive names are case-insensitive per RFC 9111 section 5.2:
+    // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2
+    const std::string lowercase_directive = absl::AsciiStrToLower(directive);
 
-    if (directive == "no-cache") {
+    if (lowercase_directive == "no-cache") {
       must_validate_ = true;
-    } else if (directive == "no-store") {
+    } else if (lowercase_directive == "no-store") {
       no_store_ = true;
-    } else if (directive == "no-transform") {
+    } else if (lowercase_directive == "no-transform") {
       no_transform_ = true;
-    } else if (directive == "only-if-cached") {
+    } else if (lowercase_directive == "only-if-cached") {
       only_if_cached_ = true;
-    } else if (directive == "max-age") {
+    } else if (lowercase_directive == "max-age") {
       max_age_ = parseDuration(argument);
-    } else if (directive == "min-fresh") {
+    } else if (lowercase_directive == "min-fresh") {
       min_fresh_ = parseDuration(argument);
-    } else if (directive == "max-stale") {
+    } else if (lowercase_directive == "max-stale") {
       max_stale_ = argument.empty() ? SystemTime::duration::max() : parseDuration(argument);
     }
   }
@@ -94,22 +97,26 @@ ResponseCacheControl::ResponseCacheControl(absl::string_view cache_control_heade
   for (auto full_directive : directives) {
     absl::string_view directive, argument;
     std::tie(directive, argument) = separateDirectiveAndArgument(full_directive);
+    // Directive names are case-insensitive per RFC 9111 section 5.2:
+    // https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2
+    const std::string lowercase_directive = absl::AsciiStrToLower(directive);
 
-    if (directive == "no-cache") {
+    if (lowercase_directive == "no-cache") {
       // If no-cache directive has arguments they are ignored - not handled.
       must_validate_ = true;
-    } else if (directive == "must-revalidate" || directive == "proxy-revalidate") {
+    } else if (lowercase_directive == "must-revalidate" ||
+               lowercase_directive == "proxy-revalidate") {
       no_stale_ = true;
-    } else if (directive == "no-store" || directive == "private") {
+    } else if (lowercase_directive == "no-store" || lowercase_directive == "private") {
       // If private directive has arguments they are ignored - not handled.
       no_store_ = true;
-    } else if (directive == "no-transform") {
+    } else if (lowercase_directive == "no-transform") {
       no_transform_ = true;
-    } else if (directive == "public") {
+    } else if (lowercase_directive == "public") {
       is_public_ = true;
-    } else if (directive == "s-maxage") {
+    } else if (lowercase_directive == "s-maxage") {
       max_age_ = parseDuration(argument);
-    } else if (!max_age_.has_value() && directive == "max-age") {
+    } else if (!max_age_.has_value() && lowercase_directive == "max-age") {
       max_age_ = parseDuration(argument);
     }
   }

--- a/test/extensions/filters/http/cache/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache/cache_headers_utils_test.cc
@@ -180,6 +180,32 @@ TEST(ResponseCacheControl, StreamingTest) {
   EXPECT_EQ(os.str(), "{must_validate, no_store, no_transform, no_stale, max-age=0}");
 }
 
+TEST(RequestCacheControl, DirectiveNamesAreCaseInsensitive) {
+  EXPECT_EQ(RequestCacheControl("no-cache, no-store, no-transform, only-if-cached, max-age=600, "
+                                "min-fresh=10, max-stale=20"),
+            RequestCacheControl("No-Cache, No-Store, No-Transform, Only-If-Cached, Max-Age=600, "
+                                "Min-Fresh=10, Max-Stale=20"));
+}
+
+TEST(ResponseCacheControl, DirectiveNamesAreCaseInsensitive) {
+  EXPECT_EQ(ResponseCacheControl("no-cache, no-store, no-transform, must-revalidate, public, "
+                                 "max-age=600, s-maxage=300"),
+            ResponseCacheControl("No-Cache, No-Store, No-Transform, Must-Revalidate, Public, "
+                                 "Max-Age=600, S-Maxage=300"));
+  EXPECT_EQ(ResponseCacheControl("proxy-revalidate, max-age=600"),
+            ResponseCacheControl("Proxy-Revalidate, Max-Age=600"));
+}
+
+TEST(ResponseCacheControl, StorageDirectivesAreCaseInsensitive) {
+  for (const absl::string_view directive : {"private", "Private", "PRIVATE", "pRiVaTe", "no-store",
+                                            "No-Store", "NO-STORE", "nO-sToRe"}) {
+    SCOPED_TRACE(directive);
+    const ResponseCacheControl cache_control(absl::StrCat("max-age=600, ", directive));
+    EXPECT_EQ(cache_control.max_age_, Seconds(600));
+    EXPECT_TRUE(cache_control.no_store_);
+  }
+}
+
 struct TestResponseCacheControl : public ResponseCacheControl {
   TestResponseCacheControl(bool must_validate, bool no_store, bool no_transform, bool no_stale,
                            bool is_public, OptionalDuration max_age) {

--- a/test/extensions/filters/http/cache/cacheability_utils_test.cc
+++ b/test/extensions/filters/http/cache/cacheability_utils_test.cc
@@ -157,6 +157,19 @@ TEST_F(IsCacheableResponseTest, ResponsePrivate) {
   EXPECT_FALSE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
 }
 
+TEST_F(IsCacheableResponseTest, StorageDirectivesAreCaseInsensitive) {
+  response_headers_.setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=600");
+  ASSERT_TRUE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
+
+  for (const absl::string_view directive : {"private", "Private", "PRIVATE", "pRiVaTe", "no-store",
+                                            "No-Store", "NO-STORE", "nO-sToRe"}) {
+    SCOPED_TRACE(directive);
+    response_headers_.setReferenceKey(Http::CustomHeaders::get().CacheControl,
+                                      absl::StrCat("max-age=600, ", directive));
+    EXPECT_FALSE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
+  }
+}
+
 TEST_F(IsCacheableResponseTest, EmptyVary) {
   EXPECT_TRUE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
   response_headers_.setCopy(Http::CustomHeaders::get().Vary, "");

--- a/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_headers_utils_test.cc
@@ -181,6 +181,32 @@ TEST(ResponseCacheControl, StreamingTest) {
   EXPECT_EQ(os.str(), "{must_validate, no_store, no_transform, no_stale, public, max-age=0}");
 }
 
+TEST(RequestCacheControl, DirectiveNamesAreCaseInsensitive) {
+  EXPECT_EQ(RequestCacheControl("no-cache, no-store, no-transform, only-if-cached, max-age=600, "
+                                "min-fresh=10, max-stale=20"),
+            RequestCacheControl("No-Cache, No-Store, No-Transform, Only-If-Cached, Max-Age=600, "
+                                "Min-Fresh=10, Max-Stale=20"));
+}
+
+TEST(ResponseCacheControl, DirectiveNamesAreCaseInsensitive) {
+  EXPECT_EQ(ResponseCacheControl("no-cache, no-store, no-transform, must-revalidate, public, "
+                                 "max-age=600, s-maxage=300"),
+            ResponseCacheControl("No-Cache, No-Store, No-Transform, Must-Revalidate, Public, "
+                                 "Max-Age=600, S-Maxage=300"));
+  EXPECT_EQ(ResponseCacheControl("proxy-revalidate, max-age=600"),
+            ResponseCacheControl("Proxy-Revalidate, Max-Age=600"));
+}
+
+TEST(ResponseCacheControl, StorageDirectivesAreCaseInsensitive) {
+  for (const absl::string_view directive : {"private", "Private", "PRIVATE", "pRiVaTe", "no-store",
+                                            "No-Store", "NO-STORE", "nO-sToRe"}) {
+    SCOPED_TRACE(directive);
+    const ResponseCacheControl cache_control(absl::StrCat("max-age=600, ", directive));
+    EXPECT_EQ(cache_control.max_age_, Seconds(600));
+    EXPECT_TRUE(cache_control.no_store_);
+  }
+}
+
 struct TestResponseCacheControl : public ResponseCacheControl {
   TestResponseCacheControl(bool must_validate, bool no_store, bool no_transform, bool no_stale,
                            bool is_public, OptionalDuration max_age) {

--- a/test/extensions/filters/http/cache_v2/cacheability_utils_test.cc
+++ b/test/extensions/filters/http/cache_v2/cacheability_utils_test.cc
@@ -170,6 +170,19 @@ TEST_F(IsCacheableResponseTest, ResponsePrivate) {
   EXPECT_FALSE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
 }
 
+TEST_F(IsCacheableResponseTest, StorageDirectivesAreCaseInsensitive) {
+  response_headers_.setReferenceKey(Http::CustomHeaders::get().CacheControl, "max-age=600");
+  ASSERT_TRUE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
+
+  for (const absl::string_view directive : {"private", "Private", "PRIVATE", "pRiVaTe", "no-store",
+                                            "No-Store", "NO-STORE", "nO-sToRe"}) {
+    SCOPED_TRACE(directive);
+    response_headers_.setReferenceKey(Http::CustomHeaders::get().CacheControl,
+                                      absl::StrCat("max-age=600, ", directive));
+    EXPECT_FALSE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
+  }
+}
+
 TEST_F(IsCacheableResponseTest, EmptyVary) {
   EXPECT_TRUE(CacheabilityUtils::isCacheableResponse(response_headers_, vary_allow_list_));
   response_headers_.setCopy(Http::CustomHeaders::get().Vary, "");


### PR DESCRIPTION
Commit Message: cache: fix Cache-Control directive name matching to be case-insensitive
Additional Description: Change Cache-Control directive name matching from case-sensitive to case-insensitive in cache and cache_v2, as required by [RFC 9111 section 5.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2). 

Risk Level: Low
Testing: Add unit tests for case-insensitive directive parsing and response cacheability.
Docs Changes: N/A
Release Notes: Change Cache-Control directive name matching from case-sensitive to case-insensitive in cache and cache_v2.
Platform Specific Features: N/A
AI Assistance: Generative AI was used to assist with implementation and documentation. I have reviewed and understand the submitted changes.