### PR TITLE
ip tagging: fix a bug where the stats may use incorrect stats prefix

### DIFF
--- a/changelogs/changelogs.yaml
+++ b/changelogs/changelogs.yaml
@@ -72,6 +72,8 @@ areas:
     title: http2
   http_inspector:
     title: http_inspector
+  ip_tagging:
+    title: ip_tagging
   jwt_authn:
     title: jwt_authn
   load_balancing:

--- a/changelogs/current/bug_fixes/ip_tagging__provider-cache-ignores-stat-prefix.rst
+++ b/changelogs/current/bug_fixes/ip_tagging__provider-cache-ignores-stat-prefix.rst
@@ -1,0 +1,6 @@
+Fixed a bug in the :ref:`ip_tagging <config_http_filters_ip_tagging>` filter where stats
+could be published under another listener's stats prefix.
+Filter configs that load tags from the same :ref:`ip_tags_datasource
+<envoy_v3_api_field_extensions.filters.http.ip_tagging.v3.IPTagging.ip_tags_datasource>` file
+share same cached provider and could end up publishing stats under the wrong listener's
+stats prefix.

--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.cc
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.cc
@@ -7,6 +7,7 @@
 #include "source/common/http/header_map_impl.h"
 #include "source/common/http/headers.h"
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 
 namespace Envoy {
@@ -14,9 +15,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace IpTagging {
 
-IpTagsStats::IpTagsStats(const std::string& stat_prefix, Stats::ScopeSharedPtr scope)
+IpTagsStats::IpTagsStats(Stats::ScopeSharedPtr scope)
     : scope_(std::move(scope)), stat_name_set_(scope_->symbolTable().makeSet("IpTagging")),
-      stats_prefix_(stat_name_set_->add(stat_prefix + "ip_tagging")),
       unknown_tag_(stat_name_set_->add("unknown_tag.hit")), total_(stat_name_set_->add("total")),
       no_hit_(stat_name_set_->add("no_hit")),
       reload_success_(stat_name_set_->add("reload_success")) {}
@@ -26,8 +26,8 @@ void IpTagsStats::incHit(absl::string_view tag) {
 }
 
 void IpTagsStats::incCounter(Stats::StatName name) {
-  Stats::SymbolTable::StoragePtr storage = scope_->symbolTable().join({stats_prefix_, name});
-  scope_->counterFromStatName(Stats::StatName(storage.get())).inc();
+  // `scope_` already carries the `<stat_prefix>ip_tagging` prefix, so no join is needed here.
+  scope_->counterFromStatName(name).inc();
 }
 
 absl::StatusOr<LcTrieSharedPtr> IpTagsStats::parseIpTagsAsProto(
@@ -58,9 +58,8 @@ absl::StatusOr<LcTrieSharedPtr> IpTagsStats::parseIpTagsAsProto(
 IpTagsProvider::IpTagsProvider(const envoy::config::core::v3::DataSource& ip_tags_datasource,
                                Event::Dispatcher& main_dispatcher, Api::Api& api,
                                ProtobufMessage::ValidationVisitor& validation_visitor,
-                               ThreadLocal::SlotAllocator& tls, const std::string& stat_prefix,
-                               Stats::ScopeSharedPtr scope, Singleton::InstanceSharedPtr owner,
-                               absl::Status& creation_status)
+                               ThreadLocal::SlotAllocator& tls, Stats::ScopeSharedPtr scope,
+                               Singleton::InstanceSharedPtr owner, absl::Status& creation_status)
     : owner_(owner) {
   const auto& datasource_filename = ip_tags_datasource.filename();
   if (datasource_filename.empty()) {
@@ -84,7 +83,7 @@ IpTagsProvider::IpTagsProvider(const envoy::config::core::v3::DataSource& ip_tag
   // via IpTagsRegistrySingleton).
   auto provider_or_error = Config::DataSource::DataSourceProvider<LoadedIpTags>::create(
       ip_tags_datasource, main_dispatcher, tls, api, /*allow_empty=*/false,
-      [stat_prefix, scope, &validation_visitor, datasource_filename, first_load = true](
+      [scope, &validation_visitor, datasource_filename, first_load = true](
           absl::string_view new_data) mutable -> absl::StatusOr<std::shared_ptr<LoadedIpTags>> {
         IPTagsProto ip_tags_proto;
         if (absl::EndsWith(datasource_filename, MessageUtil::FileExtensions::get().Yaml)) {
@@ -104,7 +103,7 @@ IpTagsProvider::IpTagsProvider(const envoy::config::core::v3::DataSource& ip_tag
             return load_status;
           }
         }
-        auto stats = std::make_shared<IpTagsStats>(stat_prefix, scope);
+        auto stats = std::make_shared<IpTagsStats>(scope);
         auto trie_or = stats->parseIpTagsAsProto(ip_tags_proto.ip_tags());
         if (!trie_or.ok()) {
           return trie_or.status();
@@ -132,27 +131,29 @@ absl::StatusOr<std::shared_ptr<IpTagsProvider>> IpTagsRegistrySingleton::getOrCr
     ProtobufMessage::ValidationVisitor& validation_visitor, ThreadLocal::SlotAllocator& tls,
     Event::Dispatcher& main_dispatcher, const std::string& stat_prefix, Stats::Scope& scope,
     std::shared_ptr<IpTagsRegistrySingleton> singleton) {
-  // Lazily create a singleton-owned scope on first use. Reusing it across providers
-  // keeps the stats scope alive even after the listener that first created the
-  // provider goes away, since other listeners may still share this provider.
-  if (scope_ == nullptr) {
-    scope_ = scope.createScope("");
-  }
-  const size_t key = std::hash<std::string>()(ip_tags_datasource.filename());
+  // A provider owns the stats for the tags it loads, so two configs may only share one when
+  // they agree on both the file and where its stats land. Keying on the scope prefix and the
+  // filter's stat prefix as well as the filename keeps listeners with distinct stat prefixes
+  // from silently reporting into the first one's counters. Every part is always emitted, empty
+  // or not, so the separators keep the parts unambiguous.
+  std::string key = absl::StrCat(scope.symbolTable().toString(scope.prefix()), "|", stat_prefix,
+                                 "|", ip_tags_datasource.filename());
   auto it = ip_tags_registry_.find(key);
   if (it != ip_tags_registry_.end()) {
     if (std::shared_ptr<IpTagsProvider> provider = it->second.lock()) {
       return provider;
     }
   }
+  // The provider holds this scope for its whole life, so the stats outlive the listener that
+  // happened to bootstrap it while other listeners still share the provider.
   absl::Status creation_status = absl::OkStatus();
-  auto ip_tags_provider =
-      std::make_shared<IpTagsProvider>(ip_tags_datasource, main_dispatcher, api, validation_visitor,
-                                       tls, stat_prefix, scope_, singleton, creation_status);
+  auto ip_tags_provider = std::make_shared<IpTagsProvider>(
+      ip_tags_datasource, main_dispatcher, api, validation_visitor, tls,
+      scope.createScope(absl::StrCat(stat_prefix, "ip_tagging.")), singleton, creation_status);
   if (!creation_status.ok()) {
     return creation_status;
   }
-  ip_tags_registry_[key] = ip_tags_provider;
+  ip_tags_registry_[std::move(key)] = ip_tags_provider;
   return ip_tags_provider;
 }
 
@@ -198,7 +199,8 @@ IpTaggingFilterConfig::IpTaggingFilterConfig(
   }
 
   if (!config.ip_tags().empty()) {
-    auto stats = std::make_shared<IpTagsStats>(stat_prefix, scope.createScope(""));
+    auto stats =
+        std::make_shared<IpTagsStats>(scope.createScope(absl::StrCat(stat_prefix, "ip_tagging.")));
     auto trie_or = stats->parseIpTagsAsProto(config.ip_tags());
     if (!trie_or.ok()) {
       creation_status = trie_or.status();

--- a/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
+++ b/source/extensions/filters/http/ip_tagging/ip_tagging_filter.h
@@ -22,6 +22,8 @@
 #include "source/common/network/lc_trie.h"
 #include "source/common/stats/symbol_table.h"
 
+#include "absl/container/flat_hash_map.h"
+
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -35,10 +37,13 @@ using LcTrieSharedPtr = std::shared_ptr<Network::LcTrie::LcTrie<std::string>>;
  * intern per-tag `<tag>.hit` builtins, plus the shared `total`, `no_hit`, `unknown_tag.hit`
  * and `reload_success` stat names. Also exposes the proto-to-trie parser, which is the
  * one place tag names are interned as builtins.
+ *
+ * The scope handed in is expected to already carry the `<stat_prefix>ip_tagging` prefix, so
+ * counters are named directly off it without joining a prefix on every increment.
  */
 class IpTagsStats : public Logger::Loggable<Logger::Id::ip_tagging> {
 public:
-  IpTagsStats(const std::string& stat_prefix, Stats::ScopeSharedPtr scope);
+  explicit IpTagsStats(Stats::ScopeSharedPtr scope);
 
   void incHit(absl::string_view tag);
   void incNoHit() { incCounter(no_hit_); }
@@ -61,7 +66,6 @@ private:
   // them goes away (relevant for providers shared across listeners).
   Stats::ScopeSharedPtr scope_;
   Stats::StatNameSetPtr stat_name_set_;
-  const Stats::StatName stats_prefix_;
   const Stats::StatName unknown_tag_;
   const Stats::StatName total_;
   const Stats::StatName no_hit_;
@@ -92,9 +96,8 @@ public:
   IpTagsProvider(const envoy::config::core::v3::DataSource& ip_tags_datasource,
                  Event::Dispatcher& main_dispatcher, Api::Api& api,
                  ProtobufMessage::ValidationVisitor& validation_visitor,
-                 ThreadLocal::SlotAllocator& tls, const std::string& stat_prefix,
-                 Stats::ScopeSharedPtr scope, Singleton::InstanceSharedPtr owner,
-                 absl::Status& creation_status);
+                 ThreadLocal::SlotAllocator& tls, Stats::ScopeSharedPtr scope,
+                 Singleton::InstanceSharedPtr owner, absl::Status& creation_status);
 
   ~IpTagsProvider();
 
@@ -109,8 +112,9 @@ private:
 using IpTagsProviderSharedPtr = std::shared_ptr<IpTagsProvider>;
 
 /**
- * A singleton that de-duplicates IpTagsProvider instances by data source filename so two
- * filter configs pointing at the same file share one provider (and thus one parsed trie).
+ * A singleton that de-duplicates IpTagsProvider instances so two filter configs that read the
+ * same file and report into the same stats location share one provider (and thus one parsed
+ * trie and one set of counters).
  */
 class IpTagsRegistrySingleton : public Envoy::Singleton::Instance {
 public:
@@ -125,12 +129,13 @@ public:
 
 private:
   // Each provider stores a shared_ptr to this singleton, keeping the singleton alive
-  // until no provider remains. Key is a hash of the data source filename.
-  absl::flat_hash_map<size_t, std::weak_ptr<IpTagsProvider>> ip_tags_registry_;
-  // Shared stats scope used by every provider this singleton creates. Lazily
-  // initialized as a child of the first caller's scope and kept alive by the
-  // singleton so a provider can outlive any individual listener that asked for it.
-  Stats::ScopeSharedPtr scope_;
+  // until no provider remains. The key identifies what a provider is: the file its tags come
+  // from, plus where its stats land (the caller's scope prefix and the filter's stat prefix).
+  // A provider owns the counters for the tags it loads, so configs publishing under different
+  // names must not share one even when they read the same file. Keying on the joined parts
+  // rather than a hash of them means a hash collision resolves to a miss instead of silently
+  // handing back a provider that reports into someone else's counters.
+  absl::flat_hash_map<std::string, std::weak_ptr<IpTagsProvider>> ip_tags_registry_;
 };
 
 /**

--- a/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
+++ b/test/extensions/filters/http/ip_tagging/ip_tagging_filter_test.cc
@@ -490,6 +490,67 @@ TEST_F(IpTaggingFilterTest, ReusesIpTagsProviderInstanceForSameFilePath) {
   EXPECT_EQ(provider1->loadedIpTags()->trie, provider2->loadedIpTags()->trie);
 }
 
+TEST_F(IpTaggingFilterTest, DifferentIpTagsProviderInstanceForDifferentStatPrefix) {
+  envoy::extensions::filters::http::ip_tagging::v3::IPTagging proto_config;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(internal_request_with_json_file_config),
+                            proto_config);
+  // Same file, but the two listeners report under different stat prefixes, so they must not
+  // share a provider: the provider owns the counters the tags are recorded on.
+  absl::StatusOr<IpTaggingFilterConfigSharedPtr> config1_result =
+      IpTaggingFilterConfig::create(proto_config, "prefix1.", *singleton_manager_, *scope_,
+                                    runtime_, *api_, tls_, *dispatcher_, validation_visitor_);
+  EXPECT_OK(config1_result);
+  absl::StatusOr<IpTaggingFilterConfigSharedPtr> config2_result =
+      IpTaggingFilterConfig::create(proto_config, "prefix2.", *singleton_manager_, *scope_,
+                                    runtime_, *api_, tls_, *dispatcher_, validation_visitor_);
+  EXPECT_OK(config2_result);
+  auto provider1 = IpTaggingFilterConfigPeer::ipTagsProvider(*config1_result.value());
+  auto provider2 = IpTaggingFilterConfigPeer::ipTagsProvider(*config2_result.value());
+  EXPECT_NE(nullptr, provider1);
+  EXPECT_NE(nullptr, provider2);
+  EXPECT_NE(provider1, provider2);
+
+  // Each config records into its own counters rather than the first one's.
+  Network::Address::InstanceConstSharedPtr remote_address =
+      Network::Utility::parseInternetAddressNoThrow("1.2.3.5");
+  filter_callbacks_.stream_info_.downstream_connection_info_provider_->setRemoteAddress(
+      remote_address);
+  for (const auto& config : {config1_result.value(), config2_result.value()}) {
+    auto filter = std::make_unique<IpTaggingFilter>(config);
+    filter->setDecoderFilterCallbacks(filter_callbacks_);
+    Http::TestRequestHeaderMapImpl request_headers{{"x-envoy-internal", "true"}};
+    EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter->decodeHeaders(request_headers, false));
+    filter->onDestroy();
+  }
+  EXPECT_EQ(stats_.counterFromString("prefix1.ip_tagging.internal_request.hit").value(), 1);
+  EXPECT_EQ(stats_.counterFromString("prefix1.ip_tagging.total").value(), 1);
+  EXPECT_EQ(stats_.counterFromString("prefix2.ip_tagging.internal_request.hit").value(), 1);
+  EXPECT_EQ(stats_.counterFromString("prefix2.ip_tagging.total").value(), 1);
+}
+
+TEST_F(IpTaggingFilterTest, DifferentIpTagsProviderInstanceForDifferentScope) {
+  envoy::extensions::filters::http::ip_tagging::v3::IPTagging proto_config;
+  TestUtility::loadFromYaml(TestEnvironment::substitute(internal_request_with_json_file_config),
+                            proto_config);
+  // Same file and same stat prefix, but rooted at scopes with different prefixes, which again
+  // puts the stats in different places.
+  Stats::ScopeSharedPtr scope1 = scope_->createScope("listener1");
+  Stats::ScopeSharedPtr scope2 = scope_->createScope("listener2");
+  absl::StatusOr<IpTaggingFilterConfigSharedPtr> config1_result =
+      IpTaggingFilterConfig::create(proto_config, "prefix.", *singleton_manager_, *scope1, runtime_,
+                                    *api_, tls_, *dispatcher_, validation_visitor_);
+  EXPECT_OK(config1_result);
+  absl::StatusOr<IpTaggingFilterConfigSharedPtr> config2_result =
+      IpTaggingFilterConfig::create(proto_config, "prefix.", *singleton_manager_, *scope2, runtime_,
+                                    *api_, tls_, *dispatcher_, validation_visitor_);
+  EXPECT_OK(config2_result);
+  auto provider1 = IpTaggingFilterConfigPeer::ipTagsProvider(*config1_result.value());
+  auto provider2 = IpTaggingFilterConfigPeer::ipTagsProvider(*config2_result.value());
+  EXPECT_NE(nullptr, provider1);
+  EXPECT_NE(nullptr, provider2);
+  EXPECT_NE(provider1, provider2);
+}
+
 TEST_F(IpTaggingFilterTest, DifferentIpTagsProviderInstanceForDifferentFilePath) {
   envoy::extensions::filters::http::ip_tagging::v3::IPTagging proto_config1;
   TestUtility::loadFromYaml(TestEnvironment::substitute(internal_request_with_json_file_config),


### PR DESCRIPTION
Commit Message: ip tagging: fix a bug where the stats may use incorrect stats prefix
Additional Description:

Fixed a bug in the :ref:`ip_tagging <config_http_filters_ip_tagging>` filter where stats
could be published under another listener's stats prefix.
Filter configs that load tags from the same :ref:`ip_tags_datasource
<envoy_v3_api_field_extensions.filters.http.ip_tagging.v3.IPTagging.ip_tags_datasource>` file
share same cached provider and could end up publishing stats under the wrong listener's
stats prefix.

Risk Level: low.
Testing: unit.
Docs Changes: n/a.
Release Notes: added.
Platform Specific Features: n/a.