### PR TITLE
cache_v2: fix suffix range handling in sendHeaders()

### DIFF
--- a/changelogs/current/bug_fixes/cache__suffix-range.rst
+++ b/changelogs/current/bug_fixes/cache__suffix-range.rst
@@ -1,0 +1,2 @@
+Fixed an assertion failure in the cache_v2 filter caused by ``sendHeaders()`` calling
+``firstBytePos()`` for suffix range requests such as ``Range: bytes=-2``.

--- a/source/extensions/filters/http/cache_v2/BUILD
+++ b/source/extensions/filters/http/cache_v2/BUILD
@@ -188,6 +188,7 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/common:logger_lib",
         "//source/common/http:headers_lib",
+        "//source/common/http:utility_lib",
         "@envoy_api//envoy/extensions/filters/http/cache_v2/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/http/cache_v2/cache_filter.cc
+++ b/source/extensions/filters/http/cache_v2/cache_filter.cc
@@ -288,43 +288,6 @@ void CacheFilter::getTrailers() {
       &cancel_in_flight_callback_));
 }
 
-static AdjustedByteRange rangeFromHeaders(Http::ResponseHeaderMap& response_headers) {
-  if (Http::Utility::getResponseStatus(response_headers) !=
-      static_cast<uint64_t>(Envoy::Http::Code::PartialContent)) {
-    // Don't use content-length; we can just request *all the body* from
-    // the source and it will tell us when it gets to the end.
-    return {0, std::numeric_limits<uint64_t>::max()};
-  }
-  Http::HeaderMap::GetResult content_range_result =
-      response_headers.get(Envoy::Http::Headers::get().ContentRange);
-  if (content_range_result.empty()) {
-    return {0, std::numeric_limits<uint64_t>::max()};
-  }
-  absl::string_view content_range = content_range_result[0]->value().getStringView();
-  if (!absl::ConsumePrefix(&content_range, "bytes ")) {
-    return {0, std::numeric_limits<uint64_t>::max()};
-  }
-  if (absl::ConsumePrefix(&content_range, "*/")) {
-    uint64_t len;
-    if (absl::SimpleAtoi(content_range, &len)) {
-      return {0, len};
-    }
-    return {0, std::numeric_limits<uint64_t>::max()};
-  }
-  std::pair<absl::string_view, absl::string_view> range_of = absl::StrSplit(content_range, '/');
-  std::pair<absl::string_view, absl::string_view> range = absl::StrSplit(range_of.first, '-');
-  uint64_t begin, end;
-  if (!absl::SimpleAtoi(range.first, &begin)) {
-    begin = 0;
-  }
-  if (!absl::SimpleAtoi(range.second, &end)) {
-    end = std::numeric_limits<uint64_t>::max();
-  } else {
-    end++;
-  }
-  return {begin, end};
-}
-
 void CacheFilter::onHeaders(Http::ResponseHeaderMapPtr response_headers,
                             EndStream end_stream_enum) {
   ASSERT(lookup_result_, "onHeaders should not be called with no LookupResult");
@@ -355,7 +318,7 @@ void CacheFilter::onHeaders(Http::ResponseHeaderMapPtr response_headers,
   bool end_stream = ((end_stream_enum == EndStream::End) || is_head_request_);
 
   if (!end_stream) {
-    remaining_ranges_ = {rangeFromHeaders(*response_headers)};
+    remaining_ranges_ = {RangeUtils::rangeFromHeaders(*response_headers)};
     ENVOY_STREAM_LOG(debug, "CacheFilter requesting range {}-{} {}", *decoder_callbacks_,
                      remaining_ranges_[0].begin(), remaining_ranges_[0].end(), *response_headers);
   }

--- a/source/extensions/filters/http/cache_v2/range_utils.cc
+++ b/source/extensions/filters/http/cache_v2/range_utils.cc
@@ -12,6 +12,7 @@
 #include "source/common/common/assert.h"
 #include "source/common/common/logger.h"
 #include "source/common/http/headers.h"
+#include "source/common/http/utility.h"
 #include "source/extensions/filters/http/cache_v2/cache_headers_utils.h"
 
 #include "absl/strings/str_split.h"
@@ -25,6 +26,43 @@ namespace CacheV2 {
 
 std::ostream& operator<<(std::ostream& os, const AdjustedByteRange& range) {
   return os << "[" << range.begin() << "," << range.end() << ")";
+}
+
+AdjustedByteRange RangeUtils::rangeFromHeaders(Http::ResponseHeaderMap& response_headers) {
+  if (Http::Utility::getResponseStatus(response_headers) !=
+      static_cast<uint64_t>(Envoy::Http::Code::PartialContent)) {
+    // Don't use content-length; we can just request *all the body* from
+    // the source and it will tell us when it gets to the end.
+    return {0, std::numeric_limits<uint64_t>::max()};
+  }
+  Http::HeaderMap::GetResult content_range_result =
+      response_headers.get(Envoy::Http::Headers::get().ContentRange);
+  if (content_range_result.empty()) {
+    return {0, std::numeric_limits<uint64_t>::max()};
+  }
+  absl::string_view content_range = content_range_result[0]->value().getStringView();
+  if (!absl::ConsumePrefix(&content_range, "bytes ")) {
+    return {0, std::numeric_limits<uint64_t>::max()};
+  }
+  if (absl::ConsumePrefix(&content_range, "*/")) {
+    uint64_t len;
+    if (absl::SimpleAtoi(content_range, &len)) {
+      return {0, len};
+    }
+    return {0, std::numeric_limits<uint64_t>::max()};
+  }
+  std::pair<absl::string_view, absl::string_view> range_of = absl::StrSplit(content_range, '/');
+  std::pair<absl::string_view, absl::string_view> range = absl::StrSplit(range_of.first, '-');
+  uint64_t begin, end;
+  if (!absl::SimpleAtoi(range.first, &begin)) {
+    begin = 0;
+  }
+  if (!absl::SimpleAtoi(range.second, &end)) {
+    end = std::numeric_limits<uint64_t>::max();
+  } else {
+    end++;
+  }
+  return {begin, end};
 }
 
 std::optional<RangeDetails>

--- a/source/extensions/filters/http/cache_v2/range_utils.h
+++ b/source/extensions/filters/http/cache_v2/range_utils.h
@@ -106,6 +106,10 @@ struct RangeDetails {
 };
 
 namespace RangeUtils {
+// For 206 responses, reads the byte range from Content-Range.
+// For other responses, returns [0, UINT64_MAX) to read the entire body until the stream ends.
+AdjustedByteRange rangeFromHeaders(Http::ResponseHeaderMap& response_headers);
+
 // Create a RangeDetails object from request headers and provided content
 // length to assess whether the range request can be satisfied. nullopt
 // indicates that this request should not be treated as a range request

--- a/source/extensions/filters/http/cache_v2/upstream_request_impl.cc
+++ b/source/extensions/filters/http/cache_v2/upstream_request_impl.cc
@@ -1,6 +1,6 @@
 #include "source/extensions/filters/http/cache_v2/upstream_request_impl.h"
 
-#include "range_utils.h"
+#include "source/extensions/filters/http/cache_v2/range_utils.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -51,6 +51,7 @@ void UpstreamRequestImpl::getHeaders(GetHeadersCallback&& cb) {
 
 void UpstreamRequestImpl::onHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(dispatcher_.isThreadSafe());
+  stream_pos_ = RangeUtils::rangeFromHeaders(*headers).begin();
   headers_ = std::move(headers);
   end_stream_after_headers_ = end_stream;
   return maybeDeliverHeaders();
@@ -174,14 +175,6 @@ void UpstreamRequestImpl::sendHeaders(Http::RequestHeaderMapPtr request_headers)
   // would have bypassed cache lookup and insertion, so this class wouldn't
   // be instantiated. So end_stream will always be true.
   stream_->sendHeaders(*request_headers_, /*end_stream=*/true);
-  std::optional<absl::string_view> range_header = RangeUtils::getRangeHeader(*request_headers_);
-  if (range_header) {
-    std::optional<std::vector<RawByteRange>> ranges =
-        RangeUtils::parseRangeHeader(range_header.value(), 1);
-    if (ranges) {
-      stream_pos_ = ranges.value().front().firstBytePos();
-    }
-  }
 }
 
 template <class... Ts> struct Overloaded : Ts... {

--- a/test/extensions/filters/http/cache_v2/BUILD
+++ b/test/extensions/filters/http/cache_v2/BUILD
@@ -87,6 +87,8 @@ envoy_extension_cc_test(
     rbe_pool = "linux_x64_small",
     deps = [
         ":mocks",
+        "//envoy/http:codes_interface",
+        "//source/common/http:headers_lib",
         "//source/extensions/filters/http/cache_v2:upstream_request_lib",
         "//test/mocks/http:http_mocks",
         "//test/test_common:utility_lib",

--- a/test/extensions/filters/http/cache_v2/upstream_request_test.cc
+++ b/test/extensions/filters/http/cache_v2/upstream_request_test.cc
@@ -1,3 +1,6 @@
+#include "envoy/http/codes.h"
+
+#include "source/common/http/headers.h"
 #include "source/extensions/filters/http/cache_v2/upstream_request_impl.h"
 
 #include "test/extensions/filters/http/cache_v2/mocks.h"
@@ -265,8 +268,8 @@ TEST(UpstreamRequestHeadersTest, SendsRangeHeaderUnchangedToUpstream) {
     testing::StrictMock<Http::MockAsyncClientStream> http_stream;
     testing::StrictMock<Http::MockAsyncClient> async_client;
     auto stats_provider = std::make_shared<testing::NiceMock<MockCacheFilterStatsProvider>>();
-    const Http::TestRequestHeaderMapImpl expected_headers{
-        {":method", "GET"}, {":path", "/banana"}, {"range", range}};
+    Http::TestRequestHeaderMapImpl expected_headers{{":method", "GET"}, {":path", "/banana"}};
+    expected_headers.addCopy(Http::Headers::get().Range, range);
 
     EXPECT_CALL(dispatcher, isThreadSafe()).WillRepeatedly(testing::Return(true));
     EXPECT_CALL(async_client, start(_, _)).WillOnce(testing::Return(&http_stream));
@@ -283,16 +286,16 @@ TEST(UpstreamRequestHeadersTest, SendsRangeHeaderUnchangedToUpstream) {
 class UpstreamRequestWithRangeHeaderTest : public UpstreamRequestTest {
 protected:
   void SetUp() override {
-    request_headers_.addCopy("range", "bytes=3-4");
+    request_headers_.addCopy(Http::Headers::get().Range, "bytes=3-4");
     UpstreamRequestTest::SetUp();
   }
 };
 
-TEST_F(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) {
+TEST_F(UpstreamRequestWithRangeHeaderTest, PartialResponseBodyStartsAtContentRangeOffset) {
   Buffer::OwnedImpl data{"lo"};
   MockFunction<void(Buffer::InstancePtr, EndStream)> body_cb;
-  response_headers_.setStatus("206");
-  response_headers_.addCopy("content-range", "bytes 3-4/5");
+  response_headers_.setStatus(static_cast<uint64_t>(Http::Code::PartialContent));
+  response_headers_.addCopy(Http::Headers::get().ContentRange, "bytes 3-4/5");
   http_callbacks_->onHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_),
                              false);
 
@@ -302,8 +305,8 @@ TEST_F(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) 
   http_callbacks_->onComplete();
 }
 
-TEST_F(UpstreamRequestWithRangeHeaderTest, IgnoredRangeReturnsEntireBody) {
-  response_headers_.setStatus("200");
+TEST_F(UpstreamRequestWithRangeHeaderTest, UpstreamIgnoresRangeReadsFullBodyFromStart) {
+  response_headers_.setStatus(static_cast<uint64_t>(Http::Code::OK));
   http_callbacks_->onHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_),
                              false);
 

--- a/test/extensions/filters/http/cache_v2/upstream_request_test.cc
+++ b/test/extensions/filters/http/cache_v2/upstream_request_test.cc
@@ -258,19 +258,28 @@ TEST_F(UpstreamRequestTest, DestroyedWhileBodyBufferedCorrectsStats) {
   upstream_request_.reset();
 }
 
-class UpstreamRequestWithRangeHeaderTest : public UpstreamRequestTest {
+class UpstreamRequestWithRangeHeaderTest : public UpstreamRequestTest,
+                                           public testing::WithParamInterface<const char*> {
 protected:
   void SetUp() override {
-    request_headers_.addCopy("range", "bytes=3-4");
+    request_headers_.addCopy("range", GetParam());
     UpstreamRequestTest::SetUp();
   }
 };
 
-TEST_F(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) {
-  Buffer::OwnedImpl data{"lo"};
-  MockFunction<void(Buffer::InstancePtr, EndStream)> body_cb;
+INSTANTIATE_TEST_SUITE_P(Ranges, UpstreamRequestWithRangeHeaderTest,
+                         testing::Values("bytes=3-4", "bytes=3-", "bytes=-2"));
+
+TEST_P(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) {
+  response_headers_.setStatus("206");
+  response_headers_.addCopy("content-range", "bytes 3-4/5");
+  http_callbacks_->onHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_),
+                             false);
+
+  testing::StrictMock<MockFunction<void(Buffer::InstancePtr, EndStream)>> body_cb;
   upstream_request_->getBody(AdjustedByteRange{3, 5}, body_cb.AsStdFunction());
   EXPECT_CALL(body_cb, Call(Pointee(BufferString("lo")), EndStream::End));
+  Buffer::OwnedImpl data{"lo"};
   http_callbacks_->onData(data, true);
   http_callbacks_->onComplete();
 }

--- a/test/extensions/filters/http/cache_v2/upstream_request_test.cc
+++ b/test/extensions/filters/http/cache_v2/upstream_request_test.cc
@@ -258,33 +258,51 @@ TEST_F(UpstreamRequestTest, DestroyedWhileBodyBufferedCorrectsStats) {
   upstream_request_.reset();
 }
 
-class UpstreamRequestWithRangeHeaderTest : public UpstreamRequestTest,
-                                           public testing::WithParamInterface<const char*> {
+TEST(UpstreamRequestHeadersTest, SendsRangeHeaderUnchangedToUpstream) {
+  for (const char* range : {"bytes=3-4", "bytes=3-", "bytes=-2"}) {
+    SCOPED_TRACE(range);
+    testing::StrictMock<Event::MockDispatcher> dispatcher;
+    testing::StrictMock<Http::MockAsyncClientStream> http_stream;
+    testing::StrictMock<Http::MockAsyncClient> async_client;
+    auto stats_provider = std::make_shared<testing::NiceMock<MockCacheFilterStatsProvider>>();
+    const Http::TestRequestHeaderMapImpl expected_headers{
+        {":method", "GET"}, {":path", "/banana"}, {"range", range}};
+
+    EXPECT_CALL(dispatcher, isThreadSafe()).WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(async_client, start(_, _)).WillOnce(testing::Return(&http_stream));
+    Http::AsyncClient::StreamOptions options;
+    auto upstream_request =
+        UpstreamRequestImplFactory(dispatcher, async_client, options).create(stats_provider);
+    EXPECT_CALL(http_stream, sendHeaders(HeaderMapEqualRef(&expected_headers), true));
+    upstream_request->sendHeaders(
+        Http::createHeaderMap<Http::RequestHeaderMapImpl>(expected_headers));
+    EXPECT_CALL(http_stream, reset());
+  }
+}
+
+class UpstreamRequestWithRangeHeaderTest : public UpstreamRequestTest {
 protected:
   void SetUp() override {
-    request_headers_.addCopy("range", GetParam());
+    request_headers_.addCopy("range", "bytes=3-4");
     UpstreamRequestTest::SetUp();
   }
 };
 
-INSTANTIATE_TEST_SUITE_P(Ranges, UpstreamRequestWithRangeHeaderTest,
-                         testing::Values("bytes=3-4", "bytes=3-", "bytes=-2"));
-
-TEST_P(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) {
+TEST_F(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) {
+  Buffer::OwnedImpl data{"lo"};
+  MockFunction<void(Buffer::InstancePtr, EndStream)> body_cb;
   response_headers_.setStatus("206");
   response_headers_.addCopy("content-range", "bytes 3-4/5");
   http_callbacks_->onHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_),
                              false);
 
-  testing::StrictMock<MockFunction<void(Buffer::InstancePtr, EndStream)>> body_cb;
   upstream_request_->getBody(AdjustedByteRange{3, 5}, body_cb.AsStdFunction());
   EXPECT_CALL(body_cb, Call(Pointee(BufferString("lo")), EndStream::End));
-  Buffer::OwnedImpl data{"lo"};
   http_callbacks_->onData(data, true);
   http_callbacks_->onComplete();
 }
 
-TEST_P(UpstreamRequestWithRangeHeaderTest, IgnoredRangeReturnsEntireBody) {
+TEST_F(UpstreamRequestWithRangeHeaderTest, IgnoredRangeReturnsEntireBody) {
   response_headers_.setStatus("200");
   http_callbacks_->onHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_),
                              false);

--- a/test/extensions/filters/http/cache_v2/upstream_request_test.cc
+++ b/test/extensions/filters/http/cache_v2/upstream_request_test.cc
@@ -284,6 +284,19 @@ TEST_P(UpstreamRequestWithRangeHeaderTest, RangeHeaderSkipsToExpectedStreamPos) 
   http_callbacks_->onComplete();
 }
 
+TEST_P(UpstreamRequestWithRangeHeaderTest, IgnoredRangeReturnsEntireBody) {
+  response_headers_.setStatus("200");
+  http_callbacks_->onHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(response_headers_),
+                             false);
+
+  testing::StrictMock<MockFunction<void(Buffer::InstancePtr, EndStream)>> body_cb;
+  upstream_request_->getBody(AdjustedByteRange{0, 5}, body_cb.AsStdFunction());
+  EXPECT_CALL(body_cb, Call(Pointee(BufferString("hello")), EndStream::End));
+  Buffer::OwnedImpl data{"hello"};
+  http_callbacks_->onData(data, true);
+  http_callbacks_->onComplete();
+}
+
 class UpstreamRequestWithSmallBuffersTest : public UpstreamRequestTest {
 protected:
   int bufferLimit() const override { return 3; }


### PR DESCRIPTION
Commit Message: cache_v2: fix suffix range handling in sendHeaders()
Additional Description: sendHeaders() calls firstBytePos() for suffix ranges such as "Range: bytes=-2",
triggering an assertion.

Risk Level: Low
Testing: 
To reproduce the assertion failure, check out the regression-test commit:

```bash
git checkout 346d034
bazel test -c dbg \
  //test/extensions/filters/http/cache_v2:upstream_request_test \
  --test_filter='*UpstreamRequestWithRangeHeaderTest.RangeHeaderSkipsToExpectedStreamPos*'
```

The "Range: bytes=-2" case triggers ASSERT(!isSuffix()) in firstBytePos().

Docs Changes: N/A
Release Notes: Added a bug-fix changelog for the suffix range assertion failure.
Platform Specific Features: N/A
AI assistance was used for this change.

bug details:
https://github.com/envoyproxy/envoy/blob/46b5ab37f081390ea0a404be53eea82ef01ffa72/source/extensions/filters/http/cache_v2/upstream_request_impl.cc#L177-L183

https://github.com/envoyproxy/envoy/blob/46b5ab37f081390ea0a404be53eea82ef01ffa72/source/extensions/filters/http/cache_v2/range_utils.h#L43-L46