### PR TITLE
Use Envoy::Logger::Levels in logger registry

### DIFF
--- a/contrib/reverse_tunnel_reporter/test/reporters/BUILD
+++ b/contrib/reverse_tunnel_reporter/test/reporters/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test(
     srcs = ["event_reporter_test.cc"],
     deps = [
         "//contrib/reverse_tunnel_reporter/source/reporters/event_reporter:event_reporter_lib",
+        "//envoy/common:logger",
         "//source/common/api:api_lib",
         "//source/common/config:utility_lib",
         "//test/mocks:common_lib",

--- a/contrib/reverse_tunnel_reporter/test/reporters/event_reporter_test.cc
+++ b/contrib/reverse_tunnel_reporter/test/reporters/event_reporter_test.cc
@@ -1,5 +1,7 @@
 #include <limits>
 
+#include "envoy/common/logger.h"
+
 #include "source/common/api/api_impl.h"
 
 #include "test/mocks/common.h"
@@ -305,7 +307,7 @@ TEST_F(EventReporterTest, PullsBeforeConnectionEvents) {
 }
 
 TEST_F(EventReporterTest, RemoveNonExistentConnection) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::warn);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::warn);
   MockLogSink sink(Envoy::Logger::Registry::getSink());
 
   EXPECT_CALL(sink, log(_, _))
@@ -344,7 +346,7 @@ TEST_F(EventReporterTest, RemoveNonExistentConnection) {
 }
 
 TEST_F(EventReporterTest, OnServerInitialized) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::info);
   MockLogSink sink(Envoy::Logger::Registry::getSink());
 
   EXPECT_CALL(sink, log(_, _))

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -232,6 +232,10 @@ void Registry::setLogLevel(Levels log_level) {
   }
 }
 
+void Registry::setLogLevel(spdlog::level::level_enum log_level) {
+  setLogLevel(static_cast<Levels>(log_level));
+}
+
 void Registry::setLogFormat(const std::string& log_format) {
   for (Logger& logger : allLoggers()) {
     Utility::setLogFormatForLogger(logger.getLogger(), log_format);

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -147,7 +147,7 @@ Context::~Context() {
 void Context::activate() {
   Registry::getSink()->setLock(lock_);
   Registry::getSink()->setShouldEscape(should_escape_);
-  Registry::setLogLevel(log_level_);
+  Registry::setLogLevel(static_cast<Levels>(log_level_));
   Registry::setLogFormat(log_format_);
 
   // sets level and format for Fine-grain Logger
@@ -173,7 +173,7 @@ void Context::changeAllLogLevels(spdlog::level::level_enum level) {
   if (!useFineGrainLogger()) {
     ENVOY_LOG_MISC(info, "change all log levels: level='{}'",
                    spdlog::level::level_string_views[level]);
-    Registry::setLogLevel(level);
+    Registry::setLogLevel(static_cast<Levels>(level));
   } else {
     // Level setting with Fine-Grain Logger.
     FINE_GRAIN_LOG(
@@ -226,7 +226,7 @@ std::vector<Logger>& Registry::allLoggers() {
 
 spdlog::logger& Registry::getLog(Id id) { return allLoggers()[static_cast<int>(id)].getLogger(); }
 
-void Registry::setLogLevel(spdlog::level::level_enum log_level) {
+void Registry::setLogLevel(Levels log_level) {
   for (Logger& logger : allLoggers()) {
     logger.getLogger().set_level(static_cast<spdlog::level::level_enum>(log_level));
   }

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -338,7 +338,7 @@ public:
    * Sets the minimum log severity required to print messages.
    * Messages below this loglevel will be suppressed.
    */
-  static void setLogLevel(spdlog::level::level_enum log_level);
+  static void setLogLevel(Levels log_level);
 
   /**
    * Sets the log format.

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -339,6 +339,8 @@ public:
    * Messages below this loglevel will be suppressed.
    */
   static void setLogLevel(Levels log_level);
+  [[deprecated("Use setLogLevel(Levels) instead")]] static void
+  setLogLevel(spdlog::level::level_enum log_level);
 
   /**
    * Sets the log format.

--- a/test/benchmark/BUILD
+++ b/test/benchmark/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test_library(
     srcs = ["main.cc"],
     hdrs = ["main.h"],
     deps = [
+        "//envoy/common:logger",
         "//source/common/common:minimal_logger_lib",
         "//source/common/common:thread_lib",
         "//test/test_common:environment_lib",

--- a/test/benchmark/main.cc
+++ b/test/benchmark/main.cc
@@ -2,6 +2,8 @@
 // This is an Envoy driver for benchmarks.
 #include "test/benchmark/main.h"
 
+#include "envoy/common/logger.h"
+
 #include "source/common/common/logger.h"
 #include "source/common/common/thread.h"
 
@@ -51,8 +53,7 @@ int main(int argc, char** argv) {
   // messages that appear when using a runtime feature when there isn't an initialized
   // runtime, and may have non-negligible impact on performance.
   // TODO(adisuissa): This should be configurable, similarly to unit tests.
-  const spdlog::level::level_enum default_log_level = spdlog::level::err;
-  Envoy::Logger::Registry::setLogLevel(default_log_level);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::error);
 
   // NOLINTNEXTLINE(clang-analyzer-optin.cplusplus.VirtualCall)
   TCLAP::CmdLine cmd("envoy-benchmark-test", ' ', "0.1");

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -262,11 +262,11 @@ class NamedLogTest : public Loggable<Id::assert>, public testing::Test {};
 TEST_F(NamedLogTest, NamedLogsAreSentToSink) {
   MockLogSink sink(Envoy::Logger::Registry::getSink());
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   // Log level is above debug, so we shouldn't get any logs.
   ENVOY_LOG_EVENT(debug, "test_event", "not logged");
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+  Envoy::Logger::Registry::setLogLevel(Levels::debug);
 
   EXPECT_CALL(sink, log(_, _));
   EXPECT_CALL(sink, logWithStableName("test_event", "debug", "assert", "test log 1"));
@@ -283,7 +283,7 @@ TEST_F(NamedLogTest, NamedLogsAreSentToSink) {
 TEST_F(NamedLogTest, FineGrainNamedLogsAreSentToSink) {
   MockLogSink sink(Envoy::Logger::Registry::getSink());
 
-  Registry::setLogLevel(spdlog::level::info);
+  Registry::setLogLevel(Levels::info);
 
   // Enable fine grain logging.
   Context::enableFineGrainLogger();
@@ -302,7 +302,7 @@ TEST_F(NamedLogTest, FineGrainNamedLogsAreSentToSink) {
 TEST_F(NamedLogTest, FineGrainTaggedLogsAreSentToSink) {
   MockLogSink sink(Envoy::Logger::Registry::getSink());
 
-  Registry::setLogLevel(spdlog::level::info);
+  Registry::setLogLevel(Levels::info);
 
   // Enable fine grain logging.
   Context::enableFineGrainLogger();
@@ -317,7 +317,7 @@ TEST_F(NamedLogTest, FineGrainTaggedLogsAreSentToSink) {
 }
 
 TEST(LoggerTest, LogWithLogDetails) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
 
   MockLogSink sink(Envoy::Logger::Registry::getSink());
 
@@ -343,7 +343,7 @@ TEST(LoggerTest, TestJsonFormatError) {
 }
 
 TEST(LoggerTest, TestJsonFormatNonEscapedThrows) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
 
   {
     Protobuf::Struct log_struct;
@@ -370,7 +370,7 @@ TEST(LoggerTest, TestJsonFormatNonEscapedThrows) {
 
 TEST(LoggerTest, TestJsonFormatEmptyStruct) {
   Protobuf::Struct log_struct;
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -388,7 +388,7 @@ TEST(LoggerTest, TestJsonFormatNullAndFixedField) {
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
   (*log_struct.mutable_fields())["FixedValue"].set_string_value("Fixed");
   (*log_struct.mutable_fields())["NullField"].set_null_value(Protobuf::NULL_VALUE);
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -407,7 +407,7 @@ TEST(LoggerTest, TestJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -442,7 +442,7 @@ TEST(LoggerTest, TestJsonFormatWithNestedJsonMessage) {
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
   (*log_struct.mutable_fields())["FixedValue"].set_string_value("Fixed");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -638,7 +638,7 @@ TEST(TaggedLogTest, TestConnEventLogWithJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -722,7 +722,7 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -755,7 +755,7 @@ TEST(TaggedLogTest, TestTaggedConnLogWithJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -799,7 +799,7 @@ TEST(TaggedLogTest, TestConnLogWithJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -824,7 +824,7 @@ TEST(TaggedLogTest, TestTaggedStreamLogWithJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -871,7 +871,7 @@ TEST(TaggedLogTest, TestStreamLogWithJsonFormat) {
   Protobuf::Struct log_struct;
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 
@@ -898,7 +898,7 @@ TEST(TaggedLogTest, TestTaggedLogWithJsonFormatMultipleJFlags) {
   (*log_struct.mutable_fields())["Level"].set_string_value("%l");
   (*log_struct.mutable_fields())["Message1"].set_string_value("%j");
   (*log_struct.mutable_fields())["Message2"].set_string_value("%j");
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Levels::info);
   EXPECT_OK(Envoy::Logger::Registry::setJsonLogFormat(log_struct));
   EXPECT_TRUE(Envoy::Logger::Registry::jsonLogFormatSet());
 

--- a/test/extensions/common/aws/BUILD
+++ b/test/extensions/common/aws/BUILD
@@ -34,6 +34,7 @@ envoy_cc_test(
     srcs = ["credential_provider_chains_test.cc"],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//source/extensions/common/aws:credential_provider_chains_lib",
         "//source/extensions/common/aws/credential_providers:inline_credentials_provider_lib",
         "//test/extensions/common/aws:aws_mocks",

--- a/test/extensions/common/aws/credential_provider_chains_test.cc
+++ b/test/extensions/common/aws/credential_provider_chains_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/common/logger.h"
+
 #include "source/extensions/common/aws/credential_provider_chains.h"
 #include "source/extensions/common/aws/credential_providers/instance_profile_credentials_provider.h"
 
@@ -62,7 +64,7 @@ public:
 };
 
 TEST_F(DefaultCredentialsProviderChainTest, NoEnvironmentVars) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
   MockCredentialsProvider mock_provider;
 
   EXPECT_CALL(factories_, mockCreateCredentialsFileCredentialsProvider(Ref(context_), _))

--- a/test/extensions/common/aws/credential_providers/BUILD
+++ b/test/extensions/common/aws/credential_providers/BUILD
@@ -119,6 +119,7 @@ envoy_cc_test(
     srcs = ["iam_roles_anywhere_credentials_provider_test.cc"],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//source/extensions/common/aws:utility_lib",
         "//source/extensions/common/aws/credential_providers:credentials_file_credentials_provider_lib",
         "//source/extensions/common/aws/credential_providers:iam_roles_anywhere_credentials_provider_lib",

--- a/test/extensions/common/aws/credential_providers/iam_roles_anywhere_credentials_provider_test.cc
+++ b/test/extensions/common/aws/credential_providers/iam_roles_anywhere_credentials_provider_test.cc
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 
+#include "envoy/common/logger.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/core/v3/base.pb.validate.h"
 #include "envoy/extensions/common/aws/v3/credential_provider.pb.h"
@@ -1209,7 +1210,7 @@ public:
 };
 
 TEST_F(IamRolesAnywhereCredentialsProviderBasicTests, SignEmptyPayload) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
 
   auto mock_credentials_provider = std::make_shared<MockX509CredentialsProvider>();
 
@@ -1234,7 +1235,7 @@ TEST_F(IamRolesAnywhereCredentialsProviderBasicTests, SignEmptyPayload) {
 }
 
 TEST_F(IamRolesAnywhereCredentialsProviderBasicTests, SignUnsignedPayload) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
 
   auto mock_credentials_provider = std::make_shared<MockX509CredentialsProvider>();
   X509Credentials creds =

--- a/test/extensions/dynamic_modules/http/BUILD
+++ b/test/extensions/dynamic_modules/http/BUILD
@@ -119,6 +119,7 @@ envoy_cc_test(
     # http_mocks needs this.
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//envoy/registry",
         "//source/common/network:address_lib",
         "//source/common/router:string_accessor_lib",

--- a/test/extensions/dynamic_modules/http/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/http/abi_impl_test.cc
@@ -6,6 +6,7 @@
 #include <set>
 #include <thread>
 
+#include "envoy/common/logger.h"
 #include "envoy/extensions/transport_sockets/tls/v3/secret.pb.h"
 #include "envoy/registry/registry.h"
 
@@ -2785,7 +2786,7 @@ TEST(ABIImpl, HttpCallout) {
 }
 
 TEST(ABIImpl, Log) {
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::error);
   EXPECT_FALSE(
       envoy_dynamic_module_callback_log_enabled(envoy_dynamic_module_type_log_level_Trace));
   EXPECT_FALSE(

--- a/test/extensions/filters/network/rbac/BUILD
+++ b/test/extensions/filters/network/rbac/BUILD
@@ -32,6 +32,7 @@ envoy_extension_cc_test(
     rbe_pool = "linux_x64_small",
     tags = ["skip_on_windows"],
     deps = [
+        "//envoy/common:logger",
         "//source/extensions/filters/common/rbac:utility_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/rbac:rbac_filter",
@@ -53,6 +54,7 @@ envoy_extension_cc_test(
     rbe_pool = "linux_x64_small",
     tags = ["skip_on_windows"],
     deps = [
+        "//envoy/common:logger",
         "//source/extensions/filters/network/echo:config",
         "//source/extensions/filters/network/rbac:config",
         "//source/extensions/filters/network/set_filter_state:config",

--- a/test/extensions/filters/network/rbac/filter_test.cc
+++ b/test/extensions/filters/network/rbac/filter_test.cc
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include "envoy/common/logger.h"
 #include "envoy/config/rbac/v3/rbac.pb.h"
 #include "envoy/extensions/filters/network/rbac/v3/rbac.pb.h"
 #include "envoy/extensions/matching/common_inputs/network/v3/network_inputs.pb.h"
@@ -36,7 +37,7 @@ class RoleBasedAccessControlNetworkFilterTest : public testing::Test {
 public:
   static void SetUpTestSuite() {
     // Set debug log level to ensure coverage of debug log statements
-    Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+    Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
   }
 
   RoleBasedAccessControlNetworkFilterTest() = default;
@@ -713,7 +714,7 @@ TEST_F(RoleBasedAccessControlNetworkFilterTest, DebugLogLevel) {
   setRequestedServerName("www.cncf.io");
 
   // Force debug level on
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
 
   // Mock SSL setup
   auto connection_info = std::make_shared<NiceMock<Ssl::MockConnectionInfo>>();

--- a/test/extensions/filters/network/rbac/integration_test.cc
+++ b/test/extensions/filters/network/rbac/integration_test.cc
@@ -1,3 +1,4 @@
+#include "envoy/common/logger.h"
 #include "envoy/config/bootstrap/v3/bootstrap.pb.h"
 #include "envoy/config/listener/v3/listener_components.pb.h"
 #include "envoy/extensions/filters/network/rbac/v3/rbac.pb.h"
@@ -42,7 +43,7 @@ public:
 
   static void SetUpTestSuite() { // NOLINT(readability-identifier-naming)
     // Enable debug logging for all loggers to ensure coverage of debug log statements
-    Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+    Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
 
     rbac_config = absl::StrCat(ConfigHelper::baseConfig(), R"EOF(
     filter_chains:

--- a/test/extensions/health_checkers/redis/BUILD
+++ b/test/extensions/health_checkers/redis/BUILD
@@ -17,6 +17,7 @@ envoy_extension_cc_test(
     extension_names = ["envoy.health_checkers.redis"],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//source/common/api:api_lib",
         "//source/extensions/health_checkers/redis",
         "//source/extensions/health_checkers/redis:utility",

--- a/test/extensions/health_checkers/redis/redis_test.cc
+++ b/test/extensions/health_checkers/redis/redis_test.cc
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "envoy/api/api.h"
+#include "envoy/common/logger.h"
 #include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.h"
 #include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.validate.h"
 
@@ -734,7 +735,7 @@ TEST_F(RedisHealthCheckerTest, NoConnectionReuse) {
 
 TEST(RedisHealthCheckerIamAuthTest, CheckTokenIsRetrieved) {
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::debug);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::debug);
 
   auto cluster = new NiceMock<Upstream::MockClusterMockPrioritySet>();
   NiceMock<Event::MockDispatcher> dispatcher;

--- a/test/server/BUILD
+++ b/test/server/BUILD
@@ -403,6 +403,7 @@ envoy_cc_test(
     ],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//source/common/common:notification_lib",
         "//source/common/runtime:runtime_features_lib",
         "//source/common/stats:allocator_lib",

--- a/test/server/config_validation/BUILD
+++ b/test/server/config_validation/BUILD
@@ -44,6 +44,7 @@ envoy_cc_test(
     env = {"CONFIGS_TAR_PATH": "$(location //configs)"},
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//source/extensions/access_loggers/stream:config",
         "//source/extensions/clusters/dns:dns_cluster_lib",
         "//source/extensions/clusters/original_dst:original_dst_cluster_lib",

--- a/test/server/config_validation/server_test.cc
+++ b/test/server/config_validation/server_test.cc
@@ -1,6 +1,7 @@
 #include <memory>
 #include <vector>
 
+#include "envoy/common/logger.h"
 #include "envoy/server/filter_config.h"
 
 #include "source/extensions/listener_managers/validation_listener_manager/validation_listener_manager.h"
@@ -363,7 +364,7 @@ TEST_P(JsonApplicationLogsValidationServerTest, JsonApplicationLogs) {
                             access_log_lock, component_factory_, Thread::threadFactoryForTest(),
                             Filesystem::fileSystemForTest());
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::info);
   MockLogSink sink(Envoy::Logger::Registry::getSink());
   EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto& log) {
     EXPECT_THAT(msg, HasSubstr("{\"MessageFromProto\":\"hello\"}"));
@@ -423,7 +424,7 @@ TEST_P(TextApplicationLogsValidationServerTest, TextApplicationLogs) {
                             access_log_lock, component_factory_, Thread::threadFactoryForTest(),
                             Filesystem::fileSystemForTest());
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::info);
   MockLogSink sink(Envoy::Logger::Registry::getSink());
   EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto& log) {
     EXPECT_THAT(msg, HasSubstr("[lvl: info][msg: hello]"));

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -5,6 +5,7 @@
 #include <memory>
 #include <vector>
 
+#include "envoy/common/logger.h"
 #include "envoy/common/scope_tracker.h"
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/config/xds_config_tracker.h"
@@ -1872,7 +1873,7 @@ TEST_P(ServerInstanceImplTest, BootstrapApplicationLogsAndCLIThrows) {
 TEST_P(ServerInstanceImplTest, JsonApplicationLog) {
   EXPECT_NO_THROW(initialize("test/server/test_data/server/json_application_log.yaml"));
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::info);
   MockLogSink sink(Envoy::Logger::Registry::getSink());
   EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto& log) {
     EXPECT_OK(Json::Factory::loadFromString(std::string(msg)).status());
@@ -1900,7 +1901,7 @@ TEST_P(ServerInstanceImplTest, JsonApplicationLogFailWithForbiddenFlagUnderscore
 TEST_P(ServerInstanceImplTest, TextApplicationLog) {
   EXPECT_NO_THROW(initialize("test/server/test_data/server/text_application_log.yaml"));
 
-  Envoy::Logger::Registry::setLogLevel(spdlog::level::info);
+  Envoy::Logger::Registry::setLogLevel(Logger::Levels::info);
   MockLogSink sink(Envoy::Logger::Registry::getSink());
   EXPECT_CALL(sink, log(_, _)).WillOnce(Invoke([](auto msg, auto& log) {
     EXPECT_THAT(msg, HasSubstr("[lvl: info][msg: hello]"));


### PR DESCRIPTION
Deprecate the old method to make transition easier. Will remove deprecated method after 6 months.
I will migrate Context in the next PR to minimize size of the change.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
