### PR TITLE
Deflake //test/extensions/load_balancing_policies/load_aware_locality:integration_test

### DIFF
--- a/test/extensions/load_balancing_policies/load_aware_locality/integration_test.cc
+++ b/test/extensions/load_balancing_policies/load_aware_locality/integration_test.cc
@@ -291,6 +291,7 @@ TEST_P(LoadAwareLocalityIntegrationTest, EwmaDampensSpike) {
 }
 
 TEST_P(LoadAwareLocalityIntegrationTest, ThreeLocalityDistribution) {
+  setDeterministicSeed(12345);
   initializeConfig(/*variance_threshold=*/0.1, /*remote_probe_fraction=*/0.1,
                    /*weight_update_period_seconds=*/10, /*smoothing_time_constant_seconds=*/1,
                    /*remote_zones=*/{"zone-b", "zone-c"});
@@ -303,11 +304,12 @@ TEST_P(LoadAwareLocalityIntegrationTest, ThreeLocalityDistribution) {
   const uint64_t zone_b = zoneTraffic(usage, 1);
   const uint64_t zone_c = zoneTraffic(usage, 2);
 
-  EXPECT_GT(zone_a, 0u);
-  EXPECT_GT(zone_b, 0u);
-  EXPECT_GT(zone_c, 0u);
-  EXPECT_GT(zone_b, zone_c);
-  EXPECT_GT(zone_c, zone_a);
+  constexpr double request_count = 400.0;
+  constexpr double total_weight = 0.4 + 1.4 + 1.0;
+  constexpr double tolerance = 20.0;
+  EXPECT_NEAR(zone_a, (0.4 / total_weight) * request_count, tolerance);
+  EXPECT_NEAR(zone_b, (1.4 / total_weight) * request_count, tolerance);
+  EXPECT_NEAR(zone_c, (1.0 / total_weight) * request_count, tolerance);
 }
 
 } // namespace

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1634,6 +1634,7 @@ envoy_cc_test_library(
         "//test/test_common:test_time_system_interface",
         "//test/test_common:thread_factory_for_test_lib",
         "@abseil-cpp//absl/synchronization",
+        "@abseil-cpp//absl/types:variant",
         "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
         "@envoy_api//envoy/config/listener/v3:pkg_cc_proto",
         "@envoy_api//envoy/extensions/http/header_validators/envoy_default/v3:pkg_cc_proto",

--- a/test/integration/base_integration_test.cc
+++ b/test/integration/base_integration_test.cc
@@ -482,10 +482,10 @@ void BaseIntegrationTest::createGeneratedApiTestServer(
     Server::FieldValidationConfig validator_config, bool allow_lds_rejection,
     IntegrationTestServerPtr& test_server) {
   test_server = IntegrationTestServer::create(
-      bootstrap_path, version_, on_server_ready_function_, on_server_init_function_,
-      deterministic_value_, timeSystem(), *api_, defer_listener_finalization_, process_object_,
-      validator_config, concurrency_, drain_time_, drain_strategy_, proxy_buffer_factory_,
-      use_real_stats_, use_bootstrap_node_metadata_);
+      bootstrap_path, version_, on_server_ready_function_, on_server_init_function_, random_config_,
+      timeSystem(), *api_, defer_listener_finalization_, process_object_, validator_config,
+      concurrency_, drain_time_, drain_strategy_, proxy_buffer_factory_, use_real_stats_,
+      use_bootstrap_node_metadata_);
   if (config_helper_.bootstrap().static_resources().listeners_size() > 0 &&
       !defer_listener_finalization_) {
 

--- a/test/integration/base_integration_test.h
+++ b/test/integration/base_integration_test.h
@@ -105,7 +105,9 @@ public:
   // configuration generated in ConfigHelper::finalize.
   void skipPortUsageValidation() { config_helper_.skipPortUsageValidation(); }
   // Make test more deterministic by using a fixed RNG value.
-  void setDeterministicValue(uint64_t value = 0) { deterministic_value_ = value; }
+  void setDeterministicValue(uint64_t value = 0) { random_config_ = TestRandomValue{value}; }
+  // Make test reproducible while retaining a pseudo-random distribution.
+  void setDeterministicSeed(uint64_t seed) { random_config_ = TestRandomSeed{seed}; }
   // Get socket option for a specific listener's socket.
   bool getSocketOption(const std::string& listener_name, int level, int optname, void* optval,
                        socklen_t* optlen, int address_index = 0);
@@ -694,9 +696,7 @@ protected:
   // This does nothing if autonomous_upstream_ is false
   bool autonomous_allow_incomplete_streams_{false};
 
-  // If this member is not empty, the test will use a fixed RNG value specified
-  // by it.
-  std::optional<uint64_t> deterministic_value_;
+  TestRandomGeneratorConfig random_config_;
 
   // Set true when your test will itself take care of ensuring listeners are up, and registering
   // them in the port_map_.

--- a/test/integration/server.cc
+++ b/test/integration/server.cc
@@ -1,6 +1,7 @@
 #include "test/integration/server.h"
 
 #include <memory>
+#include <random>
 #include <string>
 
 #include "envoy/http/header_map.h"
@@ -27,6 +28,26 @@
 #include "gtest/gtest.h"
 
 namespace Envoy {
+
+namespace {
+
+class SeededRandomGenerator : public Random::RandomGenerator {
+public:
+  explicit SeededRandomGenerator(uint64_t seed) : generator_(seed) {}
+
+  uint64_t random() override {
+    Thread::LockGuard lock(mutex_);
+    return generator_();
+  }
+  std::string uuid() override { return "a121e9e1-feae-4136-9e0e-6fac343d56c9"; }
+
+private:
+  Thread::MutexBasicLockable mutex_;
+  std::mt19937_64 generator_;
+};
+
+} // namespace
+
 namespace Server {
 
 OptionsImplBase
@@ -72,7 +93,7 @@ createTestOptionsImpl(const std::string& config_path, const std::string& config_
 IntegrationTestServerPtr IntegrationTestServer::create(
     const std::string& config_path, const Network::Address::IpVersion version,
     std::function<void(IntegrationTestServer&)> server_ready_function,
-    std::function<void()> on_server_init_function, std::optional<uint64_t> deterministic_value,
+    std::function<void()> on_server_init_function, TestRandomGeneratorConfig random_config,
     Event::TestTimeSystem& time_system, Api::Api& api, bool defer_listener_finalization,
     ProcessObjectOptRef process_object, Server::FieldValidationConfig validation_config,
     uint32_t concurrency, std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
@@ -85,7 +106,7 @@ IntegrationTestServerPtr IntegrationTestServer::create(
   if (server_ready_function != nullptr) {
     server->setOnServerReadyCb(server_ready_function);
   }
-  server->start(version, on_server_init_function, deterministic_value, defer_listener_finalization,
+  server->start(version, on_server_init_function, random_config, defer_listener_finalization,
                 process_object, validation_config, concurrency, drain_time, drain_strategy,
                 watermark_factory, use_bootstrap_node_metadata, use_admin_server);
   return server;
@@ -143,7 +164,7 @@ void IntegrationTestServer::setAdsConfigSource(
 
 void IntegrationTestServer::start(
     const Network::Address::IpVersion version, std::function<void()> on_server_init_function,
-    std::optional<uint64_t> deterministic_value, bool defer_listener_finalization,
+    TestRandomGeneratorConfig random_config, bool defer_listener_finalization,
     ProcessObjectOptRef process_object, Server::FieldValidationConfig validator_config,
     uint32_t concurrency, std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
     Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_bootstrap_node_metadata,
@@ -151,10 +172,10 @@ void IntegrationTestServer::start(
   ENVOY_LOG(info, "starting integration test server");
   ASSERT(!thread_);
   thread_ = api_.threadFactory().createThread(
-      [version, deterministic_value, process_object, validator_config, concurrency, drain_time,
+      [version, random_config, process_object, validator_config, concurrency, drain_time,
        drain_strategy, watermark_factory, use_bootstrap_node_metadata, use_admin_server,
        this]() -> void {
-        threadRoutine(version, deterministic_value, process_object, validator_config, concurrency,
+        threadRoutine(version, random_config, process_object, validator_config, concurrency,
                       drain_time, drain_strategy, watermark_factory, use_bootstrap_node_metadata,
                       use_admin_server);
       });
@@ -230,7 +251,7 @@ void IntegrationTestServer::serverReady() {
 }
 
 void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion version,
-                                          std::optional<uint64_t> deterministic_value,
+                                          TestRandomGeneratorConfig random_config,
                                           ProcessObjectOptRef process_object,
                                           Server::FieldValidationConfig validation_config,
                                           uint32_t concurrency, std::chrono::seconds drain_time,
@@ -243,9 +264,11 @@ void IntegrationTestServer::threadRoutine(const Network::Address::IpVersion vers
   Thread::MutexBasicLockable lock;
 
   Random::RandomGeneratorPtr random_generator;
-  if (deterministic_value.has_value()) {
-    random_generator = std::make_unique<testing::NiceMock<Random::MockRandomGenerator>>(
-        deterministic_value.value());
+  if (const auto* value = absl::get_if<TestRandomValue>(&random_config)) {
+    random_generator =
+        std::make_unique<testing::NiceMock<Random::MockRandomGenerator>>(value->value);
+  } else if (const auto* seed = absl::get_if<TestRandomSeed>(&random_config)) {
+    random_generator = std::make_unique<SeededRandomGenerator>(seed->value);
   } else {
     random_generator = std::make_unique<Random::RandomGeneratorImpl>();
   }

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -32,6 +32,7 @@
 #include "test/test_common/utility.h"
 
 #include "absl/synchronization/notification.h"
+#include "absl/types/variant.h"
 
 namespace Envoy {
 namespace Server {
@@ -441,6 +442,14 @@ private:
 class IntegrationTestServer;
 using IntegrationTestServerPtr = std::unique_ptr<IntegrationTestServer>;
 
+struct TestRandomValue {
+  uint64_t value;
+};
+struct TestRandomSeed {
+  uint64_t value;
+};
+using TestRandomGeneratorConfig = absl::variant<absl::monostate, TestRandomValue, TestRandomSeed>;
+
 /**
  * Wrapper for running the real server for the purpose of integration tests.
  * This class is an Abstract Base Class and delegates ownership and management
@@ -455,7 +464,7 @@ public:
   static IntegrationTestServerPtr
   create(const std::string& config_path, const Network::Address::IpVersion version,
          std::function<void(IntegrationTestServer&)> on_server_ready_function,
-         std::function<void()> on_server_init_function, std::optional<uint64_t> deterministic_value,
+         std::function<void()> on_server_init_function, TestRandomGeneratorConfig random_config,
          Event::TestTimeSystem& time_system, Api::Api& api,
          bool defer_listener_finalization = false,
          ProcessObjectOptRef process_object = std::nullopt,
@@ -493,11 +502,10 @@ public:
   void onWorkersStarted() override {}
 
   void start(const Network::Address::IpVersion version,
-             std::function<void()> on_server_init_function,
-             std::optional<uint64_t> deterministic_value, bool defer_listener_finalization,
-             ProcessObjectOptRef process_object, Server::FieldValidationConfig validation_config,
-             uint32_t concurrency, std::chrono::seconds drain_time,
-             Server::DrainStrategy drain_strategy,
+             std::function<void()> on_server_init_function, TestRandomGeneratorConfig random_config,
+             bool defer_listener_finalization, ProcessObjectOptRef process_object,
+             Server::FieldValidationConfig validation_config, uint32_t concurrency,
+             std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
              Buffer::WatermarkFactorySharedPtr watermark_factory, bool use_bootstrap_node_metadata,
              bool use_admin_server);
 
@@ -655,8 +663,7 @@ private:
    * Runs the real server on a thread.
    */
   void threadRoutine(const Network::Address::IpVersion version,
-                     std::optional<uint64_t> deterministic_value,
-                     ProcessObjectOptRef process_object,
+                     TestRandomGeneratorConfig random_config, ProcessObjectOptRef process_object,
                      Server::FieldValidationConfig validation_config, uint32_t concurrency,
                      std::chrono::seconds drain_time, Server::DrainStrategy drain_strategy,
                      Buffer::WatermarkFactorySharedPtr watermark_factory,


### PR DESCRIPTION
Commit Message: Deflake //test/extensions/load_balancing_policies/load_aware_locality:integration_test
Additional Description:
([example flake](https://github.com/envoyproxy/envoy/actions/runs/34626187984/job/103351808438#annotation:20:1527))

```
  [ RUN      ] IpVersions/LoadAwareLocalityIntegrationTest.ThreeLocalityDistribution/IPv6
  test/extensions/load_balancing_policies/load_aware_locality/integration_test.cc:309: Failure
  Expected: (zone_b) > (zone_c), actual: 173 vs 181
```

This test had approximately a 1/1000 chance of failing due to random numbers being used for load distribution potentially making `zone_b` receive less requests than `zone_c` despite a higher weight (and a smaller but still nonzero chance of `zone_a` crossing `zone_b`). The coherent fix is to use deterministic random numbers for the test, so we can ensure (more accurately than before!) that the zones get approximately the expected distribution, and still avoid failing by chance, because the test random numbers will always be the same set.

This requires wiring through a deterministic seeded random number generator into the integration test framework, alongside the existing deterministic always-the-same-number generator.

AI assisted with Codex Sol, but I had to argue with it a lot to get it to give us a test that still makes sense rather than going wild on overfitting the test to the implementation.
Risk Level: test-only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
