### PR TITLE
Deflake test //test/extensions/filters/http/ext_proc:ext_proc_observability_integration_test

### DIFF
--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_common.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_common.cc
@@ -741,6 +741,12 @@ void ExtProcIntegrationTest::testGetAndCloseStream() {
   processor_stream_->startGrpcStream();
   processor_stream_->finishGrpcStream(Grpc::Status::Ok);
 
+  // finishGrpcStream() only posts the response on the fake upstream's dispatcher. In
+  // observability mode, the main stream does not wait for the ext_proc stream, so wait until Envoy
+  // has processed the close before allowing the main response to complete and consume its logging
+  // info.
+  test_server_->waitForCounter("http.config_test.ext_proc.server_half_closed", Ge(1));
+
   handleUpstreamRequest();
   verifyDownstreamResponse(*response, 200);
 }


### PR DESCRIPTION
Commit Message: Deflake test //test/extensions/filters/http/ext_proc:ext_proc_observability_integration_test
Additional Description:
([flaky failure](https://github.com/envoyproxy/envoy/actions/runs/34641194427/job/103401038646#annotation:20:4227))
```
  [ RUN      ] IpVersionsClientTypeDeferredProcessing/ExtProcIntegrationTest.ObservabilityModeWithLoggingCloseStream/2
  test/extensions/filters/http/ext_proc/logging_test_filter.cc:47: Failure
  Expected equality of these values:
    ext_proc_logging_info->httpResponseCodeDetails()
      Which is: ""
    expected_rcd_
      Which is: "via_upstream"
```
finishGrpcStream() only queues the gRPC trailers. In observability mode, the main request proceeds independently and could complete first. The logging filter then inspected the side-stream StreamInfo before its response headers had been processed, so via_upstream had not yet been assigned.

AI assisted with Codex Sol.
Risk Level: test-only
Testing: yes
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
