### PR TITLE
secret: add warm parameter to findOrCreateGenericSecretProvider

### DIFF
--- a/contrib/golang/filters/http/source/golang_filter.cc
+++ b/contrib/golang/filters/http/source/golang_filter.cc
@@ -2061,7 +2061,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), server_context, init_manager);
+        config.sds_config(), config.name(), server_context, init_manager, true);
   } else {
     return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }

--- a/contrib/sxg/filters/http/source/config.cc
+++ b/contrib/sxg/filters/http/source/config.cc
@@ -26,7 +26,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
                 OptRef<Init::Manager> init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), server_context, init_manager);
+        config.sds_config(), config.name(), server_context, init_manager, true);
   } else {
     return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }

--- a/contrib/sxg/filters/http/test/config_test.cc
+++ b/contrib/sxg/filters/http/test/config_test.cc
@@ -38,7 +38,7 @@ void expectCreateFilter(std::string yaml, bool is_sds_config) {
   ON_CALL(context.server_factory_context_, secretManager())
       .WillByDefault(ReturnRef(secret_manager));
   if (is_sds_config) {
-    ON_CALL(secret_manager, findOrCreateGenericSecretProvider(_, _, _, _))
+    ON_CALL(secret_manager, findOrCreateGenericSecretProvider(_, _, _, _, _))
         .WillByDefault(Return(std::make_shared<Secret::GenericSecretConfigProviderImpl>(
             envoy::extensions::transport_sockets::tls::v3::GenericSecret())));
   } else {

--- a/contrib/sxg/filters/http/test/filter_test.cc
+++ b/contrib/sxg/filters/http/test/filter_test.cc
@@ -374,11 +374,11 @@ TEST_F(FilterTest, SdsDynamicGenericSecret) {
       }));
 
   auto certificate_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "certificate", secret_context.server_context_, init_manager);
+      config_source, "certificate", secret_context.server_context_, init_manager, true);
   auto certificate_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
   auto private_key_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "private_key", secret_context.server_context_, init_manager);
+      config_source, "private_key", secret_context.server_context_, init_manager, true);
   auto private_key_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
 

--- a/envoy/secret/secret_manager.h
+++ b/envoy/secret/secret_manager.h
@@ -165,13 +165,15 @@ public:
    * secret provider.
    * @param init_manager if supplied, register to the initialization sequence; otherwise, start
    * immediately
+   * @param warm if true, wait for the update to complete initialization; otherwise, unblock
+   * immediately.
    * @return GenericSecretConfigProviderSharedPtr the dynamic generic secret provider.
    */
   virtual GenericSecretConfigProviderSharedPtr
   findOrCreateGenericSecretProvider(const envoy::config::core::v3::ConfigSource& config_source,
                                     const std::string& config_name,
                                     Server::Configuration::ServerFactoryContext& server_context,
-                                    OptRef<Init::Manager> init_manager) PURE;
+                                    OptRef<Init::Manager> init_manager, bool warm) PURE;
 };
 
 using SecretManagerPtr = std::unique_ptr<SecretManager>;

--- a/source/common/secret/secret_manager_impl.cc
+++ b/source/common/secret/secret_manager_impl.cc
@@ -153,10 +153,10 @@ SecretManagerImpl::findOrCreateTlsSessionTicketKeysContextProvider(
 
 GenericSecretConfigProviderSharedPtr SecretManagerImpl::findOrCreateGenericSecretProvider(
     const envoy::config::core::v3::ConfigSource& sds_config_source, const std::string& config_name,
-    Server::Configuration::ServerFactoryContext& server_context,
-    OptRef<Init::Manager> init_manager) {
+    Server::Configuration::ServerFactoryContext& server_context, OptRef<Init::Manager> init_manager,
+    bool warm) {
   return generic_secret_providers_.findOrCreate(sds_config_source, config_name, server_context,
-                                                init_manager, true);
+                                                init_manager, warm);
 }
 
 ProtobufTypes::MessagePtr

--- a/source/common/secret/secret_manager_impl.h
+++ b/source/common/secret/secret_manager_impl.h
@@ -71,7 +71,7 @@ public:
   findOrCreateGenericSecretProvider(const envoy::config::core::v3::ConfigSource& config_source,
                                     const std::string& config_name,
                                     Server::Configuration::ServerFactoryContext& server_context,
-                                    OptRef<Init::Manager> init_manager) override;
+                                    OptRef<Init::Manager> init_manager, bool warm) override;
 
 private:
   ProtobufTypes::MessagePtr dumpSecretConfigs(const Matchers::StringMatcher& name_matcher);

--- a/source/extensions/filters/http/dynamic_modules/filter_config.cc
+++ b/source/extensions/filters/http/dynamic_modules/filter_config.cc
@@ -78,7 +78,7 @@ size_t DynamicModuleHttpFilterConfig::subscribeGenericSecret(absl::string_view n
     // and make it return a StatusOr instead, so that the exception handling can be removed here.
     TRY_ASSERT_MAIN_THREAD {
       provider = server_context_.secretManager().findOrCreateGenericSecretProvider(
-          sds_config, std::string(name), server_context_, init_manager_);
+          sds_config, std::string(name), server_context_, init_manager_, true);
     }
     END_TRY
     CATCH(const EnvoyException& e, {

--- a/source/extensions/filters/http/oauth2/config.cc
+++ b/source/extensions/filters/http/oauth2/config.cc
@@ -34,7 +34,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
                 OptRef<Init::Manager> init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), server_context, init_manager);
+        config.sds_config(), config.name(), server_context, init_manager, true);
   } else {
     return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }

--- a/source/extensions/formatter/generic_secret/config.cc
+++ b/source/extensions/formatter/generic_secret/config.cc
@@ -127,7 +127,8 @@ Envoy::Formatter::CommandParserPtr GenericSecretFormatterFactory::createCommandP
     Secret::GenericSecretConfigProviderSharedPtr provider;
     if (secret_config.has_sds_config()) {
       provider = server_context.secretManager().findOrCreateGenericSecretProvider(
-          secret_config.sds_config(), secret_config.name(), server_context, context.initManager());
+          secret_config.sds_config(), secret_config.name(), server_context, context.initManager(),
+          true);
     } else {
       provider =
           server_context.secretManager().findStaticGenericSecretProvider(secret_config.name());

--- a/source/extensions/http/injected_credentials/generic/config.cc
+++ b/source/extensions/http/injected_credentials/generic/config.cc
@@ -17,7 +17,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), server_context, init_manager);
+        config.sds_config(), config.name(), server_context, init_manager, true);
   } else {
     return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }

--- a/source/extensions/http/injected_credentials/oauth2/config.cc
+++ b/source/extensions/http/injected_credentials/oauth2/config.cc
@@ -17,7 +17,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), server_context, init_manager);
+        config.sds_config(), config.name(), server_context, init_manager, true);
   } else {
     return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }

--- a/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.cc
+++ b/source/extensions/quic/connection_id_generator/quic_lb/quic_lb.cc
@@ -132,7 +132,7 @@ secretsProvider(const envoy::extensions::transport_sockets::tls::v3::SdsSecretCo
                 Init::Manager& init_manager) {
   if (config.has_sds_config()) {
     return server_context.secretManager().findOrCreateGenericSecretProvider(
-        config.sds_config(), config.name(), server_context, init_manager);
+        config.sds_config(), config.name(), server_context, init_manager, true);
   } else {
     return server_context.secretManager().findStaticGenericSecretProvider(config.name());
   }

--- a/test/common/secret/secret_manager_impl_test.cc
+++ b/test/common/secret/secret_manager_impl_test.cc
@@ -428,7 +428,7 @@ TEST_F(SecretManagerImplTest, SdsDynamicGenericSecret) {
       }));
 
   auto secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "encryption_key", secret_context.server_context_, init_manager);
+      config_source, "encryption_key", secret_context.server_context_, init_manager, true);
 
   const std::string yaml = R"EOF(
 name: "encryption_key"
@@ -645,7 +645,7 @@ dynamic_active_secrets:
   // Add a dynamic generic secret provider.
   time_system_.setSystemTime(std::chrono::milliseconds(1234567900000));
   auto generic_secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "signing_key", secret_context.server_context_, init_manager);
+      config_source, "signing_key", secret_context.server_context_, init_manager, true);
 
   const std::string generic_secret_yaml = R"EOF(
 name: "signing_key"
@@ -826,7 +826,7 @@ dynamic_warming_secrets:
 
   time_system_.setSystemTime(std::chrono::milliseconds(1234567900000));
   auto generic_secret_provider = secret_manager->findOrCreateGenericSecretProvider(
-      config_source, "signing_key", secret_context.server_context_, init_manager);
+      config_source, "signing_key", secret_context.server_context_, init_manager, true);
   init_target_handle->initialize(init_watcher);
   const std::string config_dump_with_generic_secret = R"EOF(
 dynamic_warming_secrets:

--- a/test/extensions/filters/http/oauth2/filter_test.cc
+++ b/test/extensions/filters/http/oauth2/filter_test.cc
@@ -611,11 +611,11 @@ TEST_F(OAuth2Test, SdsDynamicGenericSecret) {
       }));
 
   auto client_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "client", secret_context.server_context_, init_manager);
+      config_source, "client", secret_context.server_context_, init_manager, true);
   auto client_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
   auto token_secret_provider = secret_manager.findOrCreateGenericSecretProvider(
-      config_source, "token", secret_context.server_context_, init_manager);
+      config_source, "token", secret_context.server_context_, init_manager, true);
   auto token_callback =
       secret_context.server_context_.cluster_manager_.subscription_factory_.callbacks_;
 

--- a/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
+++ b/test/extensions/quic/connection_id_generator/quic_lb/quic_lb_test.cc
@@ -451,7 +451,7 @@ TEST(QuicLbTest, EmptySecretCallback) {
   factory_context.server_factory_context_.secret_manager_ = std::move(secret_mgr_unique);
   auto secret_provider = std::make_shared<Secret::MockGenericSecretConfigProvider>();
 
-  EXPECT_CALL(*secret_manager, findOrCreateGenericSecretProvider(_, _, _, _))
+  EXPECT_CALL(*secret_manager, findOrCreateGenericSecretProvider(_, _, _, _, _))
       .WillOnce(testing::Return(secret_provider));
 
   EXPECT_CALL(*secret_provider, addValidationCallback(_));

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -77,7 +77,7 @@ public:
     auto secret_provider =
         factory_context.serverFactoryContext().secretManager().findOrCreateGenericSecretProvider(
             config_source_, "encryption_key", factory_context.serverFactoryContext(),
-            factory_context.initManager());
+            factory_context.initManager(), true);
     return
         [&factory_context, secret_provider](Http::FilterChainFactoryCallbacks& callbacks) -> void {
           callbacks.addStreamDecoderFilter(std::make_shared<::Envoy::SdsGenericSecretTestFilter>(

--- a/test/mocks/secret/mocks.h
+++ b/test/mocks/secret/mocks.h
@@ -56,7 +56,8 @@ public:
                Server::Configuration::ServerFactoryContext&, Init::Manager& init_manager));
   MOCK_METHOD(GenericSecretConfigProviderSharedPtr, findOrCreateGenericSecretProvider,
               (const envoy::config::core::v3::ConfigSource&, const std::string&,
-               Server::Configuration::ServerFactoryContext&, OptRef<Init::Manager> init_manager));
+               Server::Configuration::ServerFactoryContext&, OptRef<Init::Manager> init_manager,
+               bool warm));
 };
 
 class MockSecretCallbacks : public SecretCallbacks {


### PR DESCRIPTION
Add a bool `warm` parameter to `SecretManager::findOrCreateGenericSecretProvider` to allow callers to control whether generic secret providers block initialization before receiving secrets, matching the signature pattern of `findOrCreateTlsCertificateProvider`.

AI assistance was used; I reviewed and understand the changes.

Risk Level: low
Testing: existing tests updated
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a

