### PR TITLE
Change changeAllLogLevels to use Logger::Levels parameter

### DIFF
--- a/mobile/library/jni/BUILD
+++ b/mobile/library/jni/BUILD
@@ -84,6 +84,7 @@ envoy_cc_library(
         "//library/common/extensions/cert_validator/platform_bridge:c_types_lib",
         "//library/common/extensions/key_value/platform:config",
         "//library/common/types:managed_types_lib",
+        "@envoy//envoy/common:logger",
         "@envoy//source/common/protobuf",
     ],
     # We need this to ensure that we link this into the .so even though there are no code references.

--- a/mobile/library/jni/jni_impl.cc
+++ b/mobile/library/jni/jni_impl.cc
@@ -1,6 +1,8 @@
 #include <cstddef>
 #include <string>
 
+#include "envoy/common/logger.h"
+
 #include "source/common/protobuf/protobuf.h"
 
 #include "library/cc/mobile_engine_builder.h"
@@ -31,7 +33,7 @@ extern "C" JNIEXPORT void JNICALL JNI_OnUnload(JavaVM*, void* /* reserved */) {
 
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_setLogLevel(JNIEnv* /*env*/, jclass, jint level) {
-  Envoy::Logger::Context::changeAllLogLevels(static_cast<spdlog::level::level_enum>(level));
+  Envoy::Logger::Context::changeAllLogLevels(static_cast<Envoy::Logger::Levels>(level));
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(

--- a/mobile/test/common/integration/BUILD
+++ b/mobile/test/common/integration/BUILD
@@ -32,6 +32,7 @@ envoy_cc_test_with_engine_builder(
         ":base_client_integration_test_lib",
         "//test/common/mocks/common:common_mocks",
         "//test/common/mocks/dns:mock_dns_resolver_lib",
+        "@envoy//envoy/common:logger",
         "@envoy//source/common/quic:active_quic_listener_lib",
         "@envoy//source/common/quic:client_connection_factory_lib",
         "@envoy//source/common/quic:quic_server_factory_lib",

--- a/mobile/test/common/integration/client_integration_test.cc
+++ b/mobile/test/common/integration/client_integration_test.cc
@@ -1,3 +1,4 @@
+#include "envoy/common/logger.h"
 #include "envoy/config/core/v3/extension.pb.h"
 
 #include "source/common/quic/quic_server_transport_socket_factory.h"
@@ -87,11 +88,11 @@ public:
     Extensions::TransportSockets::Tls::forceRegisterDefaultCertValidatorFactory();
   }
 
-  ~ClientIntegrationTest() override { Logger::Context::changeAllLogLevels(spdlog::level::info); }
+  ~ClientIntegrationTest() override { Logger::Context::changeAllLogLevels(Logger::Levels::info); }
 
   void initialize() override {
     builder_.setLogLevel(log_level_);
-    Logger::Context::changeAllLogLevels(static_cast<spdlog::level::level_enum>(log_level_));
+    Logger::Context::changeAllLogLevels(log_level_);
     builder_.enableWorkerThread(getUseWorkerThread());
     if (getUseWorkerThread()) {
       // Platform cert validation is disabled when using worker thread. The engine will use the

--- a/mobile/test/common/logger/BUILD
+++ b/mobile/test/common/logger/BUILD
@@ -13,5 +13,6 @@ envoy_cc_test(
         "//library/common/bridge:utility_lib",
         "//library/common/logger:logger_delegate_lib",
         "//library/common/types:c_types_lib",
+        "@envoy//envoy/common:logger",
     ],
 )

--- a/mobile/test/common/logger/logger_delegate_test.cc
+++ b/mobile/test/common/logger/logger_delegate_test.cc
@@ -1,3 +1,5 @@
+#include "envoy/common/logger.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "library/common/api/external.h"
@@ -19,7 +21,7 @@ public:
     Api::External::registerApi(std::string(ENVOY_EVENT_TRACKER_API_NAME), &event_tracker);
   }
 
-  void SetUp() override { Context::changeAllLogLevels(spdlog::level::info); }
+  void SetUp() override { Context::changeAllLogLevels(Levels::info); }
 };
 
 std::unique_ptr<EnvoyEventTracker> LambdaDelegateTest::event_tracker =
@@ -47,17 +49,17 @@ TEST_F(LambdaDelegateTest, LogCbWithLevels) {
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
   // Set the log to critical. The message should not be logged.
-  Context::changeAllLogLevels(spdlog::level::critical);
+  Context::changeAllLogLevels(Levels::critical);
   ENVOY_LOG_MISC(error, unexpected_msg);
   EXPECT_THAT(actual_msg, Not(HasSubstr(unexpected_msg)));
 
   // Change to error. The message should be logged.
-  Context::changeAllLogLevels(spdlog::level::err);
+  Context::changeAllLogLevels(Levels::error);
   ENVOY_LOG_MISC(error, expected_msg);
   EXPECT_THAT(actual_msg, HasSubstr(expected_msg));
 
   // Change back to critical and test one more time.
-  Context::changeAllLogLevels(spdlog::level::critical);
+  Context::changeAllLogLevels(Levels::critical);
   ENVOY_LOG_MISC(error, expected_msg);
   EXPECT_THAT(actual_msg, Not(HasSubstr(unexpected_msg)));
 }
@@ -74,17 +76,11 @@ TEST_F(LambdaDelegateTest, ReleaseCb) {
   EXPECT_TRUE(released);
 }
 
-class LambdaDelegateWithLevelTest
-    : public testing::TestWithParam<std::tuple<Levels, spdlog::level::level_enum>> {};
+class LambdaDelegateWithLevelTest : public testing::TestWithParam<Levels> {};
 
 INSTANTIATE_TEST_SUITE_P(LogLevel, LambdaDelegateWithLevelTest,
-                         testing::Values(std::make_tuple<>(Levels::trace, spdlog::level::trace),
-                                         std::make_tuple<>(Levels::debug, spdlog::level::debug),
-                                         std::make_tuple<>(Levels::info, spdlog::level::info),
-                                         std::make_tuple<>(Levels::warn, spdlog::level::warn),
-                                         std::make_tuple<>(Levels::error, spdlog::level::err),
-                                         std::make_tuple<>(Levels::critical,
-                                                           spdlog::level::critical)));
+                         testing::Values(Levels::trace, Levels::debug, Levels::info,
+                                         Levels::warn, Levels::error, Levels::critical));
 
 TEST_P(LambdaDelegateWithLevelTest, Log) {
   std::string expected_msg = "Hello LambdaDelegate";
@@ -98,10 +94,9 @@ TEST_P(LambdaDelegateWithLevelTest, Log) {
 
   LambdaDelegate delegate(std::move(logger), Registry::getSink());
 
-  Levels envoy_log_level = std::get<0>(GetParam());
-  spdlog::level::level_enum spd_log_level = std::get<1>(GetParam());
+  Levels envoy_log_level = GetParam();
 
-  Context::changeAllLogLevels(spd_log_level);
+  Context::changeAllLogLevels(envoy_log_level);
   switch (envoy_log_level) {
   case Levels::trace:
     ENVOY_LOG_MISC(trace, expected_msg);

--- a/source/common/common/logger.cc
+++ b/source/common/common/logger.cc
@@ -169,19 +169,24 @@ bool Context::useFineGrainLogger() {
   return false;
 }
 
-void Context::changeAllLogLevels(spdlog::level::level_enum level) {
+void Context::changeAllLogLevels(Levels level) {
+  const auto spdlog_level = static_cast<spdlog::level::level_enum>(level);
   if (!useFineGrainLogger()) {
     ENVOY_LOG_MISC(info, "change all log levels: level='{}'",
-                   spdlog::level::level_string_views[level]);
-    Registry::setLogLevel(static_cast<Levels>(level));
+                   spdlog::level::level_string_views[spdlog_level]);
+    Registry::setLogLevel(level);
   } else {
     // Level setting with Fine-Grain Logger.
     FINE_GRAIN_LOG(
         info, "",
         "change all log levels and default verbosity level for fine grain loggers: level='{}'",
-        spdlog::level::level_string_views[level]);
-    getFineGrainLogContext().updateVerbosityDefaultLevel(level);
+        spdlog::level::level_string_views[spdlog_level]);
+    getFineGrainLogContext().updateVerbosityDefaultLevel(spdlog_level);
   }
+}
+
+void Context::changeAllLogLevels(spdlog::level::level_enum level) {
+  changeAllLogLevels(static_cast<Levels>(level));
 }
 
 void Context::enableFineGrainLogger() {

--- a/source/common/common/logger.h
+++ b/source/common/common/logger.h
@@ -292,7 +292,9 @@ public:
   static bool useFineGrainLogger();
 
   // Change the log level for all loggers (fine grained or otherwise) to the level provided.
-  static void changeAllLogLevels(spdlog::level::level_enum level);
+  static void changeAllLogLevels(Levels level);
+  [[deprecated("Use changeAllLogLevels(Levels) instead")]] static void
+  changeAllLogLevels(spdlog::level::level_enum level);
 
   static void enableFineGrainLogger();
   static void disableFineGrainLogger();

--- a/source/server/admin/BUILD
+++ b/source/server/admin/BUILD
@@ -271,6 +271,7 @@ envoy_cc_library(
     deps = [
         ":handler_ctx_lib",
         ":utils_lib",
+        "//envoy/common:logger",
         "//envoy/http:codes_interface",
         "//envoy/server:admin_interface",
         "//envoy/server:instance_interface",

--- a/source/server/admin/logs_handler.cc
+++ b/source/server/admin/logs_handler.cc
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "envoy/common/logger.h"
+
 #include "source/common/common/fine_grain_logger.h"
 #include "source/common/common/logger.h"
 #include "source/server/admin/utils.h"
@@ -117,7 +119,7 @@ absl::Status LogsHandler::changeLogLevel(Http::Utility::QueryParamsMulti& params
       return level_to_use.status();
     }
 
-    Logger::Context::changeAllLogLevels(*level_to_use);
+    Logger::Context::changeAllLogLevels(static_cast<Logger::Levels>(*level_to_use));
     return absl::OkStatus();
   }
 

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -291,6 +291,7 @@ envoy_cc_test(
     srcs = ["logger_test.cc"],
     rbe_pool = "linux_x64_small",
     deps = [
+        "//envoy/common:logger",
         "//source/common/common:minimal_logger_lib",
         "//source/common/version:version_string_lib",
         "//test/mocks/http:http_mocks",

--- a/test/common/common/logger_test.cc
+++ b/test/common/common/logger_test.cc
@@ -2,6 +2,8 @@
 #include <memory>
 #include <string>
 
+#include "envoy/common/logger.h"
+
 #include "source/common/common/json_escape_string.h"
 #include "source/common/common/logger.h"
 #include "source/common/version/version_string.h"
@@ -290,7 +292,7 @@ TEST_F(NamedLogTest, FineGrainNamedLogsAreSentToSink) {
   EXPECT_TRUE(Context::useFineGrainLogger());
 
   // Set fine grain level to DEBUG.
-  Context::changeAllLogLevels(spdlog::level::debug);
+  Context::changeAllLogLevels(Levels::debug);
 
   EXPECT_CALL(sink, log(_, _));
   EXPECT_CALL(sink, logWithStableName("test_event", "debug", "assert", "test log 1"));
@@ -308,7 +310,7 @@ TEST_F(NamedLogTest, FineGrainTaggedLogsAreSentToSink) {
   Context::enableFineGrainLogger();
 
   // Set fine grain level to DEBUG.
-  Context::changeAllLogLevels(spdlog::level::debug);
+  Context::changeAllLogLevels(Levels::debug);
 
   EXPECT_CALL(sink, log(_, _));
   ENVOY_TAGGED_LOG(debug, (std::map<std::string, std::string>{{"key", "val"}}), "test log");


### PR DESCRIPTION
Mark existing method as deprecated to allow easier migration. Deprecated method will be removed in 6 months.

Risk Level: none
Testing: unit tests
Docs Changes: no
Release Notes: no
Platform Specific Features: no
