### PR TITLE
dynamic_modules: avoid unnecessary allocations in shared ABI callbacks

### DIFF
--- a/source/extensions/dynamic_modules/abi_context_accessors.cc
+++ b/source/extensions/dynamic_modules/abi_context_accessors.cc
@@ -65,8 +65,10 @@ const Protobuf::Value& dynamicMetadataValue(const StreamInfo::StreamInfo& stream
                                             envoy_dynamic_module_type_module_buffer filter_name,
                                             envoy_dynamic_module_type_module_buffer path) {
   std::string filter_name_str(filter_name.ptr, filter_name.length);
-  std::string path_str(path.ptr, path.length);
-  std::vector<std::string> path_parts = absl::StrSplit(path_str, '.');
+  // Keep a non-null empty view for an absent path so the split result is unchanged.
+  const absl::string_view path_view =
+      path.ptr == nullptr ? absl::string_view("") : absl::string_view(path.ptr, path.length);
+  std::vector<std::string> path_parts = absl::StrSplit(path_view, '.');
   const auto& metadata = stream_info.dynamicMetadata();
   return Envoy::Config::Metadata::metadataValue(&metadata, filter_name_str, path_parts);
 }

--- a/source/extensions/dynamic_modules/abi_impl.cc
+++ b/source/extensions/dynamic_modules/abi_impl.cc
@@ -52,13 +52,18 @@ void envoy_dynamic_module_callback_log(envoy_dynamic_module_type_log_level level
     return;
   }
   absl::string_view message_view(message.ptr, message.length);
-  // spdlog reads the source file as a null-terminated C string, so materialize one from the
-  // module-owned buffer before building the source location.
-  const std::string source_file_str =
-      source_file.ptr == nullptr ? std::string() : std::string(source_file.ptr, source_file.length);
+  // spdlog reads the source file as a null-terminated C string. Reuse a thread-local buffer to
+  // null-terminate the module-owned bytes without allocating on each log call. The pointer only
+  // needs to stay valid for this synchronous log call.
+  thread_local std::string source_file_buffer;
+  if (source_file.ptr == nullptr) {
+    source_file_buffer.clear();
+  } else {
+    source_file_buffer.assign(source_file.ptr, source_file.length);
+  }
   // Log directly with the module source location. The ENVOY_LOG macros would bake in this file and
   // line instead.
-  logger.log(spdlog::source_loc{source_file_str.c_str(), static_cast<int>(source_line), ""},
+  logger.log(spdlog::source_loc{source_file_buffer.c_str(), static_cast<int>(source_line), ""},
              spdlog_level, "{}", message_view);
 }
 
@@ -109,17 +114,16 @@ bool envoy_dynamic_module_callback_register_function(envoy_dynamic_module_type_m
   if (function_ptr == nullptr) {
     return false;
   }
-  std::string key_str(key.ptr, key.length);
   absl::WriterMutexLock lock(function_registry_mutex);
-  auto [it, inserted] = function_registry.try_emplace(key_str, function_ptr);
+  auto [it, inserted] =
+      function_registry.try_emplace(std::string(key.ptr, key.length), function_ptr);
   return inserted;
 }
 
 bool envoy_dynamic_module_callback_get_function(envoy_dynamic_module_type_module_buffer key,
                                                 void** function_ptr_out) {
-  std::string key_str(key.ptr, key.length);
   absl::ReaderMutexLock lock(function_registry_mutex);
-  auto it = function_registry.find(key_str);
+  auto it = function_registry.find(absl::string_view(key.ptr, key.length));
   if (it != function_registry.end()) {
     *function_ptr_out = it->second;
     return true;
@@ -134,17 +138,15 @@ bool envoy_dynamic_module_callback_register_shared_data(envoy_dynamic_module_typ
   if (data_ptr == nullptr) {
     return false;
   }
-  std::string key_str(key.ptr, key.length);
   absl::WriterMutexLock lock(shared_data_registry_mutex);
-  shared_data_registry[key_str] = data_ptr;
+  shared_data_registry[std::string(key.ptr, key.length)] = data_ptr;
   return true;
 }
 
 bool envoy_dynamic_module_callback_get_shared_data(envoy_dynamic_module_type_module_buffer key,
                                                    void** data_ptr_out) {
-  std::string key_str(key.ptr, key.length);
   absl::ReaderMutexLock lock(shared_data_registry_mutex);
-  auto it = shared_data_registry.find(key_str);
+  auto it = shared_data_registry.find(absl::string_view(key.ptr, key.length));
   if (it != shared_data_registry.end()) {
     *data_ptr_out = it->second;
     return true;

--- a/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/access_loggers/dynamic_modules/abi_impl_test.cc
@@ -1662,6 +1662,24 @@ TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNotSet) {
                                                                                 key, &result));
 }
 
+// Verifies that a null metadata path is handled without crashing and resolves to no value.
+TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNullPath) {
+  Protobuf::Struct struct_obj;
+  auto& fields = *struct_obj.mutable_fields();
+  fields["key"] = ValueUtil::stringValue("value");
+  (*stream_info_.metadata_.mutable_filter_metadata())["test_filter"] = struct_obj;
+
+  Formatter::Context log_context(nullptr, nullptr, nullptr);
+  void* env_ptr = createThreadLocalLogger(log_context, stream_info_);
+
+  envoy_dynamic_module_type_module_buffer filter = {"test_filter", 11};
+  envoy_dynamic_module_type_module_buffer key = {nullptr, 0};
+  envoy_dynamic_module_type_envoy_buffer result{};
+
+  EXPECT_FALSE(envoy_dynamic_module_callback_access_logger_get_dynamic_metadata(env_ptr, filter,
+                                                                                key, &result));
+}
+
 TEST_F(DynamicModuleAccessLogAbiTest, GetDynamicMetadataNonStringValue) {
   Protobuf::Struct struct_obj;
   auto& fields = *struct_obj.mutable_fields();

--- a/test/extensions/dynamic_modules/abi_impl_test.cc
+++ b/test/extensions/dynamic_modules/abi_impl_test.cc
@@ -205,6 +205,41 @@ TEST(CommonAbiImplTest, LogHandlesEmptySourceFile) {
   logger.set_level(original_level);
 }
 
+// Verifies that the reused source file buffer reflects only the bytes reported by each call, so a
+// shorter path never inherits stale trailing bytes from a longer one and the module-supplied
+// length is honored even when the module bytes are not null-terminated.
+TEST(CommonAbiImplTest, LogHonorsSourceFileLengthAcrossReusedBuffer) {
+  auto& logger = Logger::Registry::getLog(Logger::Id::dynamic_modules);
+  const spdlog::level::level_enum original_level = logger.level();
+  logger.set_level(spdlog::level::trace);
+  SourceLocationCapturingSink sink(Logger::Registry::getSink());
+
+  const std::string message = "reuse buffer";
+  const std::string long_file = "a/very/long/module/source/path/handler.rs";
+  const std::string short_file = "a.rs";
+  // The trailing bytes past the reported length prove only the length is copied.
+  const std::string backing = "prefix.rs_TRAILING";
+  const std::pair<absl::string_view, absl::string_view> cases[] = {
+      {long_file, long_file},
+      {short_file, short_file},
+      {absl::string_view(backing.data(), 9), "prefix.rs"},
+      {absl::string_view(nullptr, 0), ""},
+  };
+  uint32_t line = 1;
+  for (const auto& [source_file, expected_filename] : cases) {
+    sink.captured_ = false;
+    envoy_dynamic_module_callback_log(envoy_dynamic_module_type_log_level_Info,
+                                      {message.data(), message.size()},
+                                      {source_file.data(), source_file.size()}, line);
+    EXPECT_TRUE(sink.captured_);
+    EXPECT_EQ(expected_filename, sink.filename_);
+    EXPECT_EQ(static_cast<int>(line), sink.line_);
+    ++line;
+  }
+
+  logger.set_level(original_level);
+}
+
 // Verifies that Off and out-of-range levels are dropped without reaching spdlog.
 TEST(CommonAbiImplTest, LogIgnoresOffAndOutOfRangeLevels) {
   auto& logger = Logger::Registry::getLog(Logger::Id::dynamic_modules);


### PR DESCRIPTION
## Description

This PR removes unnecessary allocations in the shared dynamic module ABI callbacks. The logging callback reuses a thread local buffer for the module source file instead of allocating a string on every call. The function and shared data getters resolve their keys without allocating a temporary. The dynamic metadata accessor splits the path without copying it first.

---

**Commit Message:** dynamic_modules: avoid unnecessary allocations in shared ABI callbacks
**Risk Level:** Low
**Testing:** Added Tests
**Docs Changes:** N/A
**Release Notes**: N/A