### PR TITLE
http: don't cache responses when the request has Cache-Control: no-store

### DIFF
--- a/changelogs/current/bug_fixes/http__cache-v2-request-no-store.rst
+++ b/changelogs/current/bug_fixes/http__cache-v2-request-no-store.rst
@@ -1,0 +1,3 @@
+Fixed the cache v2 filter inserting responses into the cache when the request contains
+``Cache-Control: no-store``. The ``ignore_request_cache_control_header`` option continues to
+allow these responses to be cached when enabled.

--- a/source/extensions/filters/http/cache_v2/cache_sessions.h
+++ b/source/extensions/filters/http/cache_v2/cache_sessions.h
@@ -31,7 +31,11 @@ public:
 
   Http::RequestHeaderMap& requestHeaders() const { return *request_headers_; }
   bool isCacheableResponse(const Http::ResponseHeaderMap& headers) const {
-    return cacheable_response_checker_->isCacheableResponse(headers);
+    // Request Cache-Control: no-store forbids storing the response. When
+    // ignore_request_cache_control_header is set, request_cache_control_ is left
+    // default-initialized so this check is skipped.
+    return !request_cache_control_.no_store_ &&
+           cacheable_response_checker_->isCacheableResponse(headers);
   }
   const std::shared_ptr<const CacheableResponseChecker>& cacheableResponseChecker() const {
     return cacheable_response_checker_;

--- a/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_filter_integration_test.cc
@@ -128,6 +128,14 @@ public:
         typed_config:
            "@type": "type.googleapis.com/envoy.extensions.http.cache_v2.simple_http_cache.v3.SimpleHttpCacheV2Config"
     )EOF"};
+  const std::string ignore_request_cache_control_config{R"EOF(
+    name: "envoy.filters.http.cache_v2"
+    typed_config:
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.cache_v2.v3.CacheV2Config"
+        typed_config:
+           "@type": "type.googleapis.com/envoy.extensions.http.cache_v2.simple_http_cache.v3.SimpleHttpCacheV2Config"
+        ignore_request_cache_control_header: true
+    )EOF"};
   DateFormatter formatter_{"%a, %d %b %Y %H:%M:%S GMT"};
   OptRef<const std::string> no_body_;
   OptRef<const Http::TestResponseTrailerMapImpl> no_trailers_;
@@ -175,6 +183,85 @@ TEST_P(CacheIntegrationTest, MissInsertHit) {
     EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
                 HasSubstr("RFCF cache.response_from_cache_filter"));
   }
+}
+
+TEST_P(CacheIntegrationTest, RequestNoStoreDoesNotInsert) {
+  initializeFilter(default_config);
+  Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", "RequestNoStoreDoesNotInsert");
+  request_headers.addCopy(Http::CustomHeaders::get().CacheControl, "no-store");
+  const std::string response_body = "must not be stored";
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(response_body);
+
+  IntegrationStreamDecoderPtr response = sendHeaderOnlyRequestAwaitResponse(
+      request_headers,
+      simulateUpstreamResponse(response_headers, makeOptRef(response_body), no_trailers_));
+  EXPECT_EQ(response->body(), response_body);
+  // Uncacheable pass-through logs " via_upstream". Do not match "via_upstream" alone;
+  // that substring also appears in cache.insert_via_upstream.
+  ASSERT_THAT(waitForAccessLog(access_log_name_),
+              AllOf(HasSubstr(" via_upstream"), Not(HasSubstr("cache.insert_via_upstream"))));
+
+  // Removing no-store must not serve the previous response from cache. The
+  // in-memory session for this key stays uncacheable, so this request is also a
+  // pass-through rather than an insert.
+  request_headers.remove(Http::CustomHeaders::get().CacheControl);
+  const std::string next_body = "fresh upstream response";
+  Http::TestResponseHeaderMapImpl next_headers = httpResponseHeadersForBody(next_body);
+  IntegrationStreamDecoderPtr next_response = sendHeaderOnlyRequestAwaitResponse(
+      request_headers, simulateUpstreamResponse(next_headers, makeOptRef(next_body), no_trailers_));
+  EXPECT_EQ(next_response->body(), next_body);
+  // Advance simulated time to flush the second access log entry.
+  simTime().advanceTimeWait(Seconds(1));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1),
+              AllOf(HasSubstr(" via_upstream"), Not(HasSubstr("cache.response_from_cache_filter")),
+                    Not(HasSubstr("cache.insert_via_upstream"))));
+}
+
+TEST_P(CacheIntegrationTest, IgnoringRequestCacheControlAllowsNoStoreInsert) {
+  initializeFilter(ignore_request_cache_control_config);
+  Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", "IgnoringRequestCacheControlAllowsNoStoreInsert");
+  request_headers.addCopy(Http::CustomHeaders::get().CacheControl, "no-store");
+  const std::string response_body = "explicitly allowed to be stored";
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(response_body);
+
+  IntegrationStreamDecoderPtr response = sendHeaderOnlyRequestAwaitResponse(
+      request_headers,
+      simulateUpstreamResponse(response_headers, makeOptRef(response_body), no_trailers_));
+  EXPECT_EQ(response->body(), response_body);
+  ASSERT_THAT(waitForAccessLog(access_log_name_), HasSubstr("cache.insert_via_upstream"));
+
+  IntegrationStreamDecoderPtr cached_response =
+      sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+  EXPECT_EQ(cached_response->body(), response_body);
+  // Advance simulated time to flush the second access log entry.
+  simTime().advanceTimeWait(Seconds(1));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("cache.response_from_cache_filter"));
+}
+
+TEST_P(CacheIntegrationTest, RequestNoStoreCanReadExistingCacheEntry) {
+  // Request Cache-Control: no-store forbids storing this exchange; it does not
+  // prevent serving a response that was already in the cache.
+  initializeFilter(default_config);
+  Http::TestRequestHeaderMapImpl request_headers =
+      httpRequestHeader("GET", "RequestNoStoreCanReadExistingCacheEntry");
+  const std::string response_body = "previously cached response";
+  Http::TestResponseHeaderMapImpl response_headers = httpResponseHeadersForBody(response_body);
+
+  IntegrationStreamDecoderPtr response = sendHeaderOnlyRequestAwaitResponse(
+      request_headers,
+      simulateUpstreamResponse(response_headers, makeOptRef(response_body), no_trailers_));
+  EXPECT_EQ(response->body(), response_body);
+  ASSERT_THAT(waitForAccessLog(access_log_name_), HasSubstr("cache.insert_via_upstream"));
+
+  request_headers.addCopy(Http::CustomHeaders::get().CacheControl, "no-store");
+  IntegrationStreamDecoderPtr cached_response =
+      sendHeaderOnlyRequestAwaitResponse(request_headers, serveFromCache());
+  EXPECT_EQ(cached_response->body(), response_body);
+  // Advance simulated time to flush the second access log entry.
+  simTime().advanceTimeWait(Seconds(1));
+  EXPECT_THAT(waitForAccessLog(access_log_name_, 1), HasSubstr("cache.response_from_cache_filter"));
 }
 
 TEST_P(CacheIntegrationTest, ParallelRequestsShareInsert) {

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -136,6 +136,15 @@ protected:
         api_->timeSource().systemTime(), mock_cacheable_response_checker_, cache_sessions_, false);
   }
 
+  ActiveLookupRequestPtr
+  testLookupRequestForCacheability(Http::RequestHeaderMap& headers,
+                                   bool ignore_request_cache_control_header = false) {
+    return std::make_unique<ActiveLookupRequest>(
+        headers, std::make_unique<testing::NiceMock<MockUpstreamRequestFactory>>(), "test_cluster",
+        *dispatcher_, api_->timeSource().systemTime(), mock_cacheable_response_checker_,
+        cache_sessions_, ignore_request_cache_control_header);
+  }
+
   ActiveLookupRequestPtr testLookupRequest(absl::string_view path) {
     auto headers = requestHeaders(path);
     return testLookupRequest(headers);
@@ -232,6 +241,18 @@ MATCHER_P2(HasHeader, key, matcher, "") {
   return ExplainMatchResult(GetResultHasValue(matcher),
                             arg.get(::Envoy::Http::LowerCaseString(std::string(key))),
                             result_listener);
+}
+
+TEST_F(CacheSessionsTest, RequestNoStoreMakesResponseUncacheableUnlessIgnored) {
+  Http::TestRequestHeaderMapImpl request_headers = requestHeaders("/no-store");
+  request_headers.addCopy(Http::CustomHeaders::get().CacheControl, "no-store");
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
+
+  ActiveLookupRequestPtr request = testLookupRequestForCacheability(request_headers);
+  EXPECT_FALSE(request->isCacheableResponse(response_headers));
+
+  ActiveLookupRequestPtr ignored_request = testLookupRequestForCacheability(request_headers, true);
+  EXPECT_TRUE(ignored_request->isCacheableResponse(response_headers));
 }
 
 TEST_F(CacheSessionsTest, RequestsForSeparateKeysIssueSeparateLookupRequests) {


### PR DESCRIPTION
Commit Message: http: do not cache responses when the request has Cache-Control: no-store
Additional Description: Matches RFC 9111, cache v2 docs, and cache v1. ``ignore_request_cache_control_header`` still allows caching when enabled. 
Risk Level: Low
Testing: Unit and integration tests for request no-store insert skip, ignore_request_cache_control_header, and reading an existing cache entry.
Docs Changes: N/A
Release Notes: Yes. 
Platform Specific Features: N/A
AI assistance was used; I have reviewed and understand the changes.