### PR TITLE
docs: remove duplicate 'a' in ZooKeeper proxy filter fields

### DIFF
--- a/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
+++ b/docs/root/configuration/listeners/network_filters/zookeeper_proxy_filter.rst
@@ -317,4 +317,4 @@ The ZooKeeper filter emits the following dynamic metadata for each message parse
   <zxid>, string, "The zxid field in a response header"
   <error>, string, "The error field in a response header"
   <client_state>, string, "The state field in a watch event"
-  <event_type>, string, "The event type in a a watch event"
+  <event_type>, string, "The event type in a watch event"


### PR DESCRIPTION
## Description
Remove a duplicated article in the ZooKeeper proxy filter field descriptions ("a a watch event" → "a watch event").

## Risk Level
Low — documentation typo only.

## Testing/Verification
N/A (docs-only wording fix).

Signed-off-by: mrchatam <mrchatam@users.noreply.github.com>