### PR TITLE
cache_v2: evaluate Range only when the response is 200

### DIFF
--- a/changelogs/current/bug_fixes/http__cache-v2-range-non-200.rst
+++ b/changelogs/current/bug_fixes/http__cache-v2-range-non-200.rst
@@ -1,0 +1,4 @@
+Fixed the ``cache_v2`` filter incorrectly rewriting non-``200`` responses (for
+example ``404``) to ``206`` or ``416`` when the request included a ``Range`` header.
+Range is now applied only to ``200`` responses.
+See `RFC 9110 Section 14.2 <https://httpwg.org/specs/rfc9110.html#field.range>`_.

--- a/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
+++ b/source/extensions/filters/http/cache_v2/cache_sessions_impl.cc
@@ -95,6 +95,13 @@ void ActiveLookupContext::getHeaders(GetHeadersCallback&& cb) {
         [ranges = std::move(ranges.value()), cl = content_length_,
          cb = std::move(cb)](Http::ResponseHeaderMapPtr headers, EndStream end_stream) mutable {
           ASSERT(headers != nullptr, "it should be impossible for headers to be null");
+          // The Range header field is evaluated after evaluating the precondition header
+          // fields defined in Section 13.1, and only if the result in absence of the Range
+          // header field would be a 200 (OK) response.
+          // https://httpwg.org/specs/rfc9110.html#field.range
+          if (Http::Utility::getResponseStatus(*headers) != enumToInt(Http::Code::OK)) {
+            return cb(std::move(headers), end_stream);
+          }
           if (cl == 0 && headers->ContentLength()) {
             absl::SimpleAtoi(headers->getContentLengthValue(), &cl) || (cl = 0);
           }

--- a/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
+++ b/test/extensions/filters/http/cache_v2/cache_sessions_test.cc
@@ -842,6 +842,40 @@ TEST_F(CacheSessionsTest, RangeRequestWhenLengthIsUnknownReturnsNotSatisfiable) 
   Mock::VerifyAndClearExpectations(&headers_callback1);
 }
 
+// The Range header field is evaluated after evaluating the precondition header
+// fields defined in Section 13.1, and only if the result in absence of the Range
+// header field would be a 200 (OK) response.
+// https://httpwg.org/specs/rfc9110.html#field.range
+TEST_F(CacheSessionsTest, RangeRequestOnCached404DoesNotRewriteTo206) {
+  auto response_headers = cacheableResponseHeaders(100);
+  response_headers->setStatus("404");
+  EXPECT_CALL(*mock_http_cache_, lookup(LookupHasPath("/a"), _));
+  EXPECT_CALL(*mock_http_cache_, touch(KeyHasPath("/a"), _));
+  ActiveLookupResultPtr result;
+  cache_sessions_->lookup(testLookupRangeRequest("/a", 0, 5),
+                          [&result](ActiveLookupResultPtr r) { result = std::move(r); });
+  pumpDispatcher();
+  ResponseMetadata metadata;
+  metadata.response_time_ = api_->timeSource().systemTime();
+  consumeCallback(captured_lookup_callbacks_[0])(LookupResult{
+      std::make_unique<MockCacheReader>(),
+      Http::createHeaderMap<Http::ResponseHeaderMapImpl>(*response_headers),
+      nullptr,
+      std::move(metadata),
+      100,
+  });
+  pumpDispatcher();
+  ASSERT_THAT(result, NotNull());
+  EXPECT_THAT(result->status_, Eq(CacheEntryStatus::Hit));
+  MockFunction<void(Http::ResponseHeaderMapPtr, EndStream)> headers_callback;
+  EXPECT_CALL(headers_callback,
+              Call(Pointee(AllOf(HasHeader(":status", "404"), HasHeader("content-length", "100"),
+                                 HasNoHeader("content-range"))),
+                   EndStream::More));
+  result->http_source_->getHeaders(headers_callback.AsStdFunction());
+  Mock::VerifyAndClearExpectations(&headers_callback);
+}
+
 TEST_F(CacheSessionsTest, PassthroughWithUpstreamResetCallsGetHeadersCallbackWithNullPointer) {
   Mock::VerifyAndClearExpectations(mock_cacheable_response_checker_.get());
   EXPECT_CALL(*mock_cacheable_response_checker_, isCacheableResponse)


### PR DESCRIPTION
Commit Message: cache_v2: evaluate Range only when the response is 200
A Range request against a non-200 response (e.g. 404) was rewritten to 206 or 416. Range is now applied only when the response would otherwise be 200. https://httpwg.org/specs/rfc9110.html#field.range
Additional Description: Written with AI assistance; I have reviewed the change.
Risk Level: Low
Testing: Unit test that Range on a 404 keeps status 404.
Docs Changes: N/A
Release Notes: yes
Platform Specific Features: N/A